### PR TITLE
Improve Download Memory Usage

### DIFF
--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -152,7 +152,7 @@ impl DownloadContext {
         self.state.current_seq.fetch_add(1, Ordering::SeqCst)
     }
 
-    /// Returns the current to download
+    /// Returns the current seq
     fn current_seq(&self) -> u64 {
         self.state.current_seq.load(Ordering::SeqCst)
     }

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -98,7 +98,7 @@ fn handle_discovery_chunk(
 ) -> u64 {
     let mut start_seq = 0;
     if let Some(stream) = initial_chunk {
-        let part_number = handle.ctx.next_seq();
+        let seq = handle.ctx.next_seq();
         let completed = completed.clone();
         // spawn a task to actually read the discovery chunk without waiting for it so we
         // can get started sooner on any remaining work (if any)
@@ -107,7 +107,7 @@ fn handle_discovery_chunk(
                 .collect()
                 .await
                 .map(|aggregated| ChunkResponse {
-                    seq: part_number,
+                    seq,
                     data: Some(aggregated),
                 })
                 .map_err(error::discovery_failed);

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -29,7 +29,7 @@ use body::Body;
 use discovery::discover_obj;
 use service::{distribute_work, ChunkResponse};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -73,11 +73,11 @@ impl Download {
 
         // spawn a task (if necessary) to handle the discovery chunk. This returns immediately so
         // that we can begin concurrently downloading any reamining chunks/parts ASAP
-        handle_discovery_chunk(&mut handle, initial_chunk, &comp_tx, permit);
+        let start_seq = handle_discovery_chunk(&mut handle, initial_chunk, &comp_tx, permit);
 
         if !discovery.remaining.is_empty() {
             let remaining = discovery.remaining.clone();
-            distribute_work(&mut handle, remaining, input, comp_tx)
+            distribute_work(&mut handle, remaining, input, start_seq, comp_tx)
         }
 
         Ok(handle)
@@ -96,9 +96,10 @@ fn handle_discovery_chunk(
     initial_chunk: Option<ByteStream>,
     completed: &mpsc::Sender<Result<ChunkResponse, crate::error::Error>>,
     permit: OwnedWorkPermit,
-) {
+) -> u64 {
+    let mut start_seq = 0;
     if let Some(stream) = initial_chunk {
-        handle.ctx.next_part();
+        let part_number = handle.ctx.next_seq();
         let completed = completed.clone();
         // spawn a task to actually read the discovery chunk without waiting for it so we
         // can get started sooner on any remaining work (if any)
@@ -107,7 +108,7 @@ fn handle_discovery_chunk(
                 .collect()
                 .await
                 .map(|aggregated| ChunkResponse {
-                    seq: 0,
+                    seq: part_number,
                     data: Some(aggregated),
                 })
                 .map_err(error::discovery_failed);
@@ -122,20 +123,22 @@ fn handle_discovery_chunk(
                 );
             }
         });
+        start_seq = 1;
     }
+    start_seq
 }
 
 /// Download operation specific state
 #[derive(Debug)]
 pub(crate) struct DownloadState {
-    part_number: u32,
+    current_seq: u64,
 }
 
 type DownloadContext = TransferContext<Mutex<DownloadState>>;
 
 impl DownloadContext {
     fn new(handle: Arc<crate::client::Handle>) -> Self {
-        let state = Arc::new(Mutex::new(DownloadState { part_number: 0 }));
+        let state = Arc::new(Mutex::new(DownloadState { current_seq: 0 }));
         TransferContext { handle, state }
     }
 
@@ -145,12 +148,12 @@ impl DownloadContext {
     }
 
     /// Returns the next part to download
-    fn next_part(&self) -> u32 {
+    fn next_seq(&self) -> u64 {
         let state = self.state.clone();
         let mut state = state.lock().unwrap();
 
-        let part_number = state.part_number;
-        state.part_number += 1;
+        let part_number = state.current_seq;
+        state.current_seq += 1;
         part_number
     }
 }

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -28,7 +28,6 @@ use aws_smithy_types::byte_stream::ByteStream;
 use body::Body;
 use discovery::discover_obj;
 use service::{distribute_work, ChunkResponse};
-use std::ops::RangeInclusive;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -146,13 +146,13 @@ impl DownloadContext {
         self.handle.download_part_size_bytes()
     }
 
-    /// Returns the next part to download
+    /// Returns the next seq to download
     fn next_seq(&self) -> u64 {
         let state = self.state.clone();
         let mut state = state.lock().unwrap();
 
-        let part_number = state.current_seq;
+        let seq = state.current_seq;
         state.current_seq += 1;
-        part_number
+        seq
     }
 }

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -119,7 +119,7 @@ pub(super) fn distribute_work(
     let input: DownloadInputBuilder = input.into();
 
     let size = *remaining.end() - *remaining.start() + 1;
-    let num_parts = (size + part_size - 1) / part_size;
+    let num_parts = size.div_ceil(part_size);
     for seq in 0..num_parts {
         let req = DownloadChunkRequest {
             ctx: handle.ctx.clone(),

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -39,6 +39,7 @@ async fn download_chunk_handler(
     let end_inclusive = cmp::min(start + part_size - 1, end);
     let request = next_chunk(start, end_inclusive, part_number, request.input.clone());
 
+    //println!("{0}-{1}={2}", start, end_inclusive, part_number);
     let op = request.input.into_sdk_operation(ctx.client());
     let mut resp = op
         .send()
@@ -132,6 +133,7 @@ pub(super) fn distribute_work(
         let end_inclusive = cmp::min(pos + part_size - 1, end);
 
         let chunk_req = next_chunk(start, end_inclusive, seq, input.clone());
+        //println!("{0}-{1}={2}", start, end_inclusive, seq);
         tracing::trace!(
             "distributing chunk(size={}): {:?}",
             chunk_req.size(),
@@ -156,7 +158,6 @@ pub(super) fn distribute_work(
             }
         }
         .instrument(tracing::debug_span!("download-chunk", seq = seq));
-        println!("spawn={seq}");
         handle.tasks.spawn(task);
 
         seq += 1;

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -46,7 +46,13 @@ async fn download_chunk_handler(
     let ctx = request.ctx;
     let seq = ctx.next_seq();
     let part_size = ctx.handle.download_part_size_bytes();
-    let input = next_chunk(seq, request.remaining, part_size, request.start_seq, request.input);
+    let input = next_chunk(
+        seq,
+        request.remaining,
+        part_size,
+        request.start_seq,
+        request.input,
+    );
 
     let op = input.into_sdk_operation(ctx.client());
     let mut resp = op

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -33,7 +33,7 @@ async fn download_chunk_handler(
     let request = request.request;
 
     let op = request.input.into_sdk_operation(ctx.client());
-
+    println!("start={request.seq}");
     let mut resp = op
         .send()
         .await
@@ -147,7 +147,7 @@ pub(super) fn distribute_work(
             }
         }
         .instrument(tracing::debug_span!("download-chunk", seq = seq));
-
+        println!("spawn={seq}");
         handle.tasks.spawn(task);
 
         seq += 1;

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -120,7 +120,7 @@ pub(super) fn distribute_work(
             ctx: handle.ctx.clone(),
             range: range.clone(),
             input: input.clone(),
-            start_seq: start_seq,
+            start_seq,
         };
 
         let svc = svc.clone();

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -44,7 +44,7 @@ async fn download_chunk_handler(
     request: DownloadChunkRequest,
 ) -> Result<ChunkResponse, error::Error> {
     let ctx = request.ctx;
-    let seq = ctx.next_part();
+    let seq = ctx.next_seq();
     let part_size = ctx.handle.download_part_size_bytes();
     let input = next_chunk(seq, request.range, part_size, request.start_seq, request.input);
 

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -112,8 +112,8 @@ pub(super) fn distribute_work(
     let part_size = handle.ctx.target_part_size_bytes();
     let input: DownloadInputBuilder = input.into();
 
-    let remaining_length = *remaining.end() - *remaining.start() + 1;
-    let num_parts = (remaining_length + part_size - 1) / part_size;
+    let size = *remaining.end() - *remaining.start() + 1;
+    let num_parts = (size + part_size - 1) / part_size;
     for seq in 0..num_parts {
         let req = DownloadChunkRequest {
             ctx: handle.ctx.clone(),


### PR DESCRIPTION
*Description of changes:*
`Tokio.spawn` doesn't respect the spawn order, which can result in us downloading the first `num_concurrency` parts in random order. For a workload of 5GB * 100 files, this can lead to very high memory usage, as seen in the diagram below. This PR refactors the exact part to be determined only once the task has been scheduled.

Uploads can also have a similar issue where we read too many parts into memory. To fix that, we will need to refactor our scheduler to be smarter so that we only read the part when we have the permit. (Created: https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/60)

![memory_usage_comparison](https://github.com/user-attachments/assets/8ce8e085-8167-4eec-bf52-7509840842a8)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
