### PR TITLE
Support PutObject & Multipart Threshold

### DIFF
--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -77,7 +77,7 @@ impl InputStream {
         Self::read_from().path(path).build()
     }
 
-    /// Converts `InputStream` to ByteStream that can be used in PutObject. 
+    /// Converts `InputStream` to ByteStream that can be used in PutObject.
     pub(crate) async fn into_byte_stream(self) -> Result<ByteStream, error::Error> {
         match self.inner {
             // TODO: will this read the whole file into memory?

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -82,7 +82,7 @@ impl InputStream {
         match self.inner {
             RawInputStream::Fs(path_body) => ByteStream::from_path(path_body.path)
                 .await
-                .map_err(error::from_kind(error::ErrorKind::InputInvalid)),
+                .map_err( error::from_kind(error::ErrorKind::IOError)),
             RawInputStream::Buf(bytes) => Ok(ByteStream::from(bytes)),
         }
     }

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -80,7 +80,6 @@ impl InputStream {
     /// Converts `InputStream` to ByteStream that can be used in PutObject.
     pub(crate) async fn into_byte_stream(self) -> Result<ByteStream, error::Error> {
         match self.inner {
-            // TODO: will this read the whole file into memory?
             RawInputStream::Fs(path_body) => ByteStream::from_path(path_body.path)
                 .await
                 .map_err(error::from_kind(error::ErrorKind::InputInvalid)),

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -6,9 +6,10 @@
 use std::default::Default;
 use std::path::Path;
 
+use aws_sdk_s3::primitives::ByteStream;
 use bytes::{Buf, Bytes};
 
-use crate::io::error::Error;
+use crate::error;
 use crate::io::path_body::PathBody;
 use crate::io::path_body::PathBodyBuilder;
 use crate::io::size_hint::SizeHint;
@@ -72,8 +73,19 @@ impl InputStream {
     ///     InputStream::from_path("docs/rows.csv").expect("file should be readable")
     /// }
     /// ```
-    pub fn from_path(path: impl AsRef<Path>) -> Result<InputStream, Error> {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<InputStream, crate::io::error::Error> {
         Self::read_from().path(path).build()
+    }
+
+    /// Converts `InputStream` to ByteStream that can be used in PutObject. 
+    pub(crate) async fn into_byte_stream(self) -> Result<ByteStream, error::Error> {
+        match self.inner {
+            // TODO: will this read the whole file into memory?
+            RawInputStream::Fs(path_body) => ByteStream::from_path(path_body.path)
+                .await
+                .map_err(error::from_kind(error::ErrorKind::InputInvalid)),
+            RawInputStream::Buf(bytes) => Ok(ByteStream::from(bytes)),
+        }
     }
 }
 

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -82,7 +82,7 @@ impl InputStream {
         match self.inner {
             RawInputStream::Fs(path_body) => ByteStream::from_path(path_body.path)
                 .await
-                .map_err( error::from_kind(error::ErrorKind::IOError)),
+                .map_err(error::from_kind(error::ErrorKind::IOError)),
             RawInputStream::Buf(bytes) => Ok(ByteStream::from(bytes)),
         }
     }

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -85,19 +85,42 @@ async fn put_object(
     // FIXME - This affects performance in a lot of small file case in ram workload. We need a way to schedule more
     // work for a lot of small files.
     let _permit = ctx.handle.scheduler.acquire_permit().await.unwrap();
-    // TODO: add all the fields
     let resp = ctx
         .client()
         .put_object()
-        .set_bucket(ctx.request.bucket.clone())
-        .set_key(ctx.request.key.clone())
-        .content_length(content_length)
+        .set_acl(ctx.request.acl.clone())
         .body(body)
+        .set_bucket(ctx.request.bucket.clone())
+        .set_cache_control(ctx.request.cache_control.clone())
+        .set_content_disposition(ctx.request.content_disposition.clone())
+        .set_content_encoding(ctx.request.content_encoding.clone())
+        .set_content_language(ctx.request.content_language.clone())
+        .content_length(content_length)
+        .set_content_md5(ctx.request.content_md5.clone())
+        .set_content_type(ctx.request.content_type.clone())
+        .set_expires(ctx.request.expires)
+        .set_grant_full_control(ctx.request.grant_full_control.clone())
+        .set_grant_read(ctx.request.grant_read.clone())
+        .set_grant_read_acp(ctx.request.grant_read_acp.clone())
+        .set_grant_write_acp(ctx.request.grant_write_acp.clone())
+        .set_key(ctx.request.key.clone())
+        .set_metadata(ctx.request.metadata.clone())
+        .set_server_side_encryption(ctx.request.server_side_encryption.clone())
+        .set_storage_class(ctx.request.storage_class.clone())
+        .set_website_redirect_location(ctx.request.website_redirect_location.clone())
         .set_sse_customer_algorithm(ctx.request.sse_customer_algorithm.clone())
         .set_sse_customer_key(ctx.request.sse_customer_key.clone())
         .set_sse_customer_key_md5(ctx.request.sse_customer_key_md5.clone())
+        .set_ssekms_key_id(ctx.request.sse_kms_key_id.clone())
+        .set_ssekms_encryption_context(ctx.request.sse_kms_encryption_context.clone())
+        .set_bucket_key_enabled(ctx.request.bucket_key_enabled)
         .set_request_payer(ctx.request.request_payer.clone())
+        .set_tagging(ctx.request.tagging.clone())
+        .set_object_lock_mode(ctx.request.object_lock_mode.clone())
+        .set_object_lock_retain_until_date(ctx.request.object_lock_retain_until_date)
+        .set_object_lock_legal_hold_status(ctx.request.object_lock_legal_hold_status.clone())
         .set_expected_bucket_owner(ctx.request.expected_bucket_owner.clone())
+        .set_checksum_algorithm(ctx.request.checksum_algorithm.clone())
         .send()
         .await?;
     let upload_output: UploadOutputBuilder = resp.into();
@@ -268,7 +291,6 @@ mod test {
         assert_eq!(expected_e_tag.deref(), resp.e_tag.unwrap().deref());
     }
 
-    // TODO: Fix test to not do auto upload
     #[tokio::test]
     async fn test_basic_upload_object() {
         let body = Bytes::from_static(b"every adolescent dog goes bonkers early");

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -84,7 +84,7 @@ async fn put_object(
 ) -> Result<UploadOutput, error::Error> {
     // FIXME - This affects performance in cases with a lot of small files workloads. We need a way to schedule
     // more work for a lot of small files.
-    let _permit = ctx.handle.scheduler.acquire_permit().await.unwrap();
+    let _permit = ctx.handle.scheduler.acquire_permit().await?;
     let resp = ctx
         .client()
         .put_object()

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -123,8 +123,7 @@ async fn put_object(
         .set_checksum_algorithm(ctx.request.checksum_algorithm.clone())
         .send()
         .await?;
-    let upload_output: UploadOutputBuilder = resp.into();
-    Ok(upload_output.build()?)
+    Ok(UploadOutputBuilder::from(resp).build()?)
 }
 
 /// Start a multipart upload

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -67,7 +67,6 @@ async fn try_start_put_object(
     stream: InputStream,
     content_length: u64,
 ) -> Result<(), crate::error::Error> {
-    //TODO: Need to acquire a permit
     let byte_stream = stream.into_byte_stream().await?;
     let content_length: i64 = content_length.try_into().map_err(|_| {
         error::invalid_input(format!("content_length:{} is invalid.", content_length))
@@ -85,6 +84,8 @@ async fn put_object(
     body: ByteStream,
     content_length: i64,
 ) -> Result<UploadOutput, error::Error> {
+    // FIXME - This affects performance in a lot of small file case in ram workload. We need a way to schedule more
+    // work for a lot of small files.
     let _permit = ctx.handle.scheduler.acquire_permit().await.unwrap();
     // TODO: add all the fields
     let resp = ctx

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -85,6 +85,7 @@ async fn put_object(
     body: ByteStream,
     content_length: i64,
 ) -> Result<UploadOutput, error::Error> {
+    let _permit = ctx.handle.scheduler.acquire_permit().await.unwrap();
     // TODO: add all the fields
     let resp = ctx
         .client()

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -14,7 +14,7 @@ mod service;
 
 use crate::error;
 use crate::io::InputStream;
-use aws_sdk_s3::primitives::ByteStream;
+use aws_smithy_types::byte_stream::ByteStream;
 use context::UploadContext;
 pub use handle::UploadHandle;
 /// Request type for uploads to Amazon S3

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -13,32 +13,53 @@ use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use tokio::sync::Mutex;
 use tokio::task::{self, JoinHandle};
 
+#[derive(Debug)]
+// TODO: Non_exhaustive?
+pub(crate) enum UploadType {
+    MultipartUpload {
+        /// All child multipart upload tasks spawned for this upload
+        upload_tasks: Arc<Mutex<task::JoinSet<Result<CompletedPart, crate::error::Error>>>>,
+        /// All child read body tasks spawned for this upload
+        read_tasks: task::JoinSet<Result<(), crate::error::Error>>,
+    },
+    PutObject {
+        task: JoinHandle<Result<UploadOutput, crate::error::Error>>,
+    },
+}
 
 /// Response type for a single upload object request.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct UploadHandle {
-    /// All child multipart upload tasks spawned for this upload
-    pub(crate) upload_tasks: Arc<Mutex<task::JoinSet<Result<CompletedPart, crate::error::Error>>>>,
-    /// All child read body tasks spawned for this upload
-    pub(crate) read_tasks: task::JoinSet<Result<(), crate::error::Error>>,
+    pub(crate) tasks: UploadType,
     /// The context used to drive an upload to completion
     pub(crate) ctx: UploadContext,
     /// The response that will eventually be yielded to the caller.
     response: Option<UploadOutputBuilder>,
-
-    pub(crate) put_object_task: Option<JoinHandle<Result<UploadOutput, crate::error::Error>>>,
 }
 
 impl UploadHandle {
-    /// Create a new upload handle with the given request context
-    pub(crate) fn new(ctx: UploadContext) -> Self {
+    /// Create a new multipart upload handle with the given request context
+    pub(crate) fn new_multipart(ctx: UploadContext) -> Self {
         Self {
-            upload_tasks: Arc::new(Mutex::new(task::JoinSet::new())),
-            read_tasks: task::JoinSet::new(),
+            tasks: UploadType::MultipartUpload {
+                upload_tasks: Arc::new(Mutex::new(task::JoinSet::new())),
+                read_tasks: task::JoinSet::new(),
+            },
             ctx,
             response: None,
-            put_object_task: None,
+        }
+    }
+
+    /// Create a new put_object upload handle with the given request context
+    pub(crate) fn new_put_object(
+        ctx: UploadContext,
+        task: JoinHandle<Result<UploadOutput, crate::error::Error>>,
+    ) -> Self {
+        Self {
+            tasks: UploadType::PutObject { task },
+            ctx,
+            response: None,
         }
     }
 
@@ -63,23 +84,27 @@ impl UploadHandle {
     /// Abort the upload and cancel any in-progress part uploads.
     pub async fn abort(&mut self) -> Result<AbortedUpload, crate::error::Error> {
         // TODO(aws-sdk-rust#1159) - handle already completed upload
-        if !self.ctx.is_multipart_upload() {
-            let put_object_task = self.put_object_task.take().unwrap();
-            put_object_task.abort();
-            let _ = put_object_task.await?;
-            return Ok(AbortedUpload::default());
-        }
+        match &mut self.tasks {
+            UploadType::PutObject { task } => {
+                task.abort();
+                let _ = task.await?;
+            }
+            UploadType::MultipartUpload {
+                upload_tasks,
+                read_tasks,
+            } => {
+                // cancel in-progress read_body tasks
+                read_tasks.abort_all();
+                while (read_tasks.join_next().await).is_some() {}
 
-        // cancel in-progress read_body tasks
-        self.read_tasks.abort_all();
-        while (self.read_tasks.join_next().await).is_some() {}
+                // cancel in-progress upload tasks
+                let mut tasks = upload_tasks.lock().await;
+                tasks.abort_all();
 
-        // cancel in-progress upload tasks
-        let mut tasks = self.upload_tasks.lock().await;
-        tasks.abort_all();
-
-        // join all tasks
-        while (tasks.join_next().await).is_some() {}
+                // join all tasks
+                while (tasks.join_next().await).is_some() {}
+            }
+        };
 
         if !self.ctx.is_multipart_upload() {
             return Ok(AbortedUpload::default());
@@ -121,85 +146,90 @@ async fn abort_upload(handle: &UploadHandle) -> Result<AbortedUpload, crate::err
 }
 
 async fn complete_upload(mut handle: UploadHandle) -> Result<UploadOutput, crate::error::Error> {
-    if !handle.ctx.is_multipart_upload() {
-        return handle.put_object_task.unwrap().await?;
-    }
-
-    let span = tracing::debug_span!("joining upload", upload_id = handle.ctx.upload_id);
-    let _enter = span.enter();
-
-    while let Some(join_result) = handle.read_tasks.join_next().await {
-        if let Err(err) = join_result.expect("task completed") {
-            tracing::error!("multipart upload failed while trying to read the body, aborting");
-            // TODO(aws-sdk-rust#1159) - if cancelling causes an error we want to propagate that in the returned error somehow?
-            if let Err(err) = handle.abort().await {
-                tracing::error!("failed to abort upload: {}", DisplayErrorContext(err))
-            };
-            return Err(err);
-        }
-    }
-
-    let mut all_parts = Vec::new();
-    // join all the upload tasks. We can safely grab the lock since all the read_tasks are done.
-    let mut tasks = handle.upload_tasks.lock().await;
-    while let Some(join_result) = tasks.join_next().await {
-        let result = join_result.expect("task completed");
-        match result {
-            Ok(completed_part) => all_parts.push(completed_part),
-            // TODO(aws-sdk-rust#1159, design) - do we want to return first error or collect all errors?
-            Err(err) => {
-                tracing::error!("multipart upload failed, aborting");
-                // TODO(aws-sdk-rust#1159) - if cancelling causes an error we want to propagate that in the returned error somehow?
-                drop(tasks);
-                if let Err(err) = handle.abort().await {
-                    tracing::error!("failed to abort upload: {}", DisplayErrorContext(err))
-                };
-                return Err(err);
+    match &mut handle.tasks {
+        UploadType::PutObject { task } => task.await?,
+        UploadType::MultipartUpload {
+            upload_tasks,
+            read_tasks,
+        } => {
+            let span = tracing::debug_span!("joining upload", upload_id = handle.ctx.upload_id);
+            let _enter = span.enter();
+            while let Some(join_result) = read_tasks.join_next().await {
+                if let Err(err) = join_result.expect("task completed") {
+                    tracing::error!(
+                        "multipart upload failed while trying to read the body, aborting"
+                    );
+                    // TODO(aws-sdk-rust#1159) - if cancelling causes an error we want to propagate that in the returned error somehow?
+                    if let Err(err) = handle.abort().await {
+                        tracing::error!("failed to abort upload: {}", DisplayErrorContext(err))
+                    };
+                    return Err(err);
+                }
             }
+
+            let mut all_parts = Vec::new();
+            // join all the upload tasks. We can safely grab the lock since all the read_tasks are done.
+            let mut tasks = upload_tasks.lock().await;
+            while let Some(join_result) = tasks.join_next().await {
+                let result = join_result.expect("task completed");
+                match result {
+                    Ok(completed_part) => all_parts.push(completed_part),
+                    // TODO(aws-sdk-rust#1159, design) - do we want to return first error or collect all errors?
+                    Err(err) => {
+                        tracing::error!("multipart upload failed, aborting");
+                        // TODO(aws-sdk-rust#1159) - if cancelling causes an error we want to propagate that in the returned error somehow?
+                        drop(tasks);
+                        if let Err(err) = handle.abort().await {
+                            tracing::error!("failed to abort upload: {}", DisplayErrorContext(err))
+                        };
+                        return Err(err);
+                    }
+                }
+            }
+
+            tracing::trace!("completing multipart upload");
+
+            // parts must be sorted
+            all_parts.sort_by_key(|p| p.part_number.expect("part number set"));
+
+            // complete the multipart upload
+            let complete_mpu_resp = handle
+                .ctx
+                .client()
+                .complete_multipart_upload()
+                .set_bucket(handle.ctx.request.bucket.clone())
+                .set_key(handle.ctx.request.key.clone())
+                .set_upload_id(handle.ctx.upload_id.clone())
+                .multipart_upload(
+                    CompletedMultipartUpload::builder()
+                        .set_parts(Some(all_parts))
+                        .build(),
+                )
+                // TODO(aws-sdk-rust#1159) - implement checksums
+                // .set_checksum_crc32()
+                // .set_checksum_crc32_c()
+                // .set_checksum_sha1()
+                // .set_checksum_sha256()
+                .set_request_payer(handle.ctx.request.request_payer.clone())
+                .set_expected_bucket_owner(handle.ctx.request.expected_bucket_owner.clone())
+                .set_sse_customer_algorithm(handle.ctx.request.sse_customer_algorithm.clone())
+                .set_sse_customer_key(handle.ctx.request.sse_customer_key.clone())
+                .set_sse_customer_key_md5(handle.ctx.request.sse_customer_key_md5.clone())
+                .send()
+                .await?;
+
+            // set remaining fields from completing the multipart upload
+            let resp = handle
+                .response
+                .take()
+                .expect("response set")
+                .set_e_tag(complete_mpu_resp.e_tag.clone())
+                .set_expiration(complete_mpu_resp.expiration.clone())
+                .set_version_id(complete_mpu_resp.version_id.clone());
+
+            tracing::trace!("upload completed successfully");
+
+            Ok(resp.build().expect("valid response"))
         }
     }
-
-    tracing::trace!("completing multipart upload");
-
-    // parts must be sorted
-    all_parts.sort_by_key(|p| p.part_number.expect("part number set"));
-
-    // complete the multipart upload
-    let complete_mpu_resp = handle
-        .ctx
-        .client()
-        .complete_multipart_upload()
-        .set_bucket(handle.ctx.request.bucket.clone())
-        .set_key(handle.ctx.request.key.clone())
-        .set_upload_id(handle.ctx.upload_id.clone())
-        .multipart_upload(
-            CompletedMultipartUpload::builder()
-                .set_parts(Some(all_parts))
-                .build(),
-        )
-        // TODO(aws-sdk-rust#1159) - implement checksums
-        // .set_checksum_crc32()
-        // .set_checksum_crc32_c()
-        // .set_checksum_sha1()
-        // .set_checksum_sha256()
-        .set_request_payer(handle.ctx.request.request_payer.clone())
-        .set_expected_bucket_owner(handle.ctx.request.expected_bucket_owner.clone())
-        .set_sse_customer_algorithm(handle.ctx.request.sse_customer_algorithm.clone())
-        .set_sse_customer_key(handle.ctx.request.sse_customer_key.clone())
-        .set_sse_customer_key_md5(handle.ctx.request.sse_customer_key_md5.clone())
-        .send()
-        .await?;
-
-    // set remaining fields from completing the multipart upload
-    let resp = handle
-        .response
-        .take()
-        .expect("response set")
-        .set_e_tag(complete_mpu_resp.e_tag.clone())
-        .set_expiration(complete_mpu_resp.expiration.clone())
-        .set_version_id(complete_mpu_resp.version_id.clone());
-
-    tracing::trace!("upload completed successfully");
-
-    Ok(resp.build().expect("valid response"))
 }

--- a/aws-s3-transfer-manager/src/operation/upload/output.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/output.rs
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_sdk_s3::operation::{create_multipart_upload::CreateMultipartUploadOutput, put_object::PutObjectOutput};
+use aws_sdk_s3::operation::{
+    create_multipart_upload::CreateMultipartUploadOutput, put_object::PutObjectOutput,
+};
 use std::fmt::{Debug, Formatter};
 
 /// Common response fields for uploading an object to Amazon S3

--- a/aws-s3-transfer-manager/src/operation/upload/output.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/output.rs
@@ -518,7 +518,6 @@ impl UploadOutputBuilder {
 
 impl From<PutObjectOutput> for UploadOutputBuilder {
     fn from(value: PutObjectOutput) -> Self {
-        // TODO: verify the fields
         UploadOutputBuilder {
             upload_id: None,
             server_side_encryption: value.server_side_encryption,

--- a/aws-s3-transfer-manager/src/operation/upload/output.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/output.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
+use aws_sdk_s3::operation::{create_multipart_upload::CreateMultipartUploadOutput, put_object::PutObjectOutput};
 use std::fmt::{Debug, Formatter};
 
 /// Common response fields for uploading an object to Amazon S3
@@ -511,6 +511,29 @@ impl UploadOutputBuilder {
             request_charged: self.request_charged,
             upload_id: self.upload_id,
         })
+    }
+}
+
+impl From<PutObjectOutput> for UploadOutputBuilder {
+    fn from(value: PutObjectOutput) -> Self {
+        // TODO: verify the fields
+        UploadOutputBuilder {
+            upload_id: None,
+            server_side_encryption: value.server_side_encryption,
+            sse_customer_algorithm: value.sse_customer_algorithm,
+            sse_customer_key_md5: value.sse_customer_key_md5,
+            sse_kms_key_id: value.ssekms_key_id,
+            sse_kms_encryption_context: value.ssekms_encryption_context,
+            bucket_key_enabled: value.bucket_key_enabled,
+            request_charged: value.request_charged,
+            checksum_sha256: value.checksum_sha256,
+            expiration: value.expiration,
+            e_tag: value.e_tag,
+            checksum_crc32: value.checksum_crc32,
+            checksum_crc32_c: value.checksum_crc32_c,
+            checksum_sha1: value.checksum_sha1,
+            version_id: value.version_id,
+        }
     }
 }
 

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -15,7 +15,7 @@ use tokio::{sync::Mutex, task};
 use tower::{service_fn, Service, ServiceBuilder, ServiceExt};
 use tracing::Instrument;
 
-use super::UploadHandle;
+use super::{handle::UploadType, UploadHandle};
 
 /// Request/input type for our "upload_part" service.
 #[derive(Debug, Clone)]
@@ -106,10 +106,10 @@ pub(super) fn distribute_work(
             .build(),
     );
     match &mut handle.upload_type {
-        crate::operation::upload::handle::UploadType::PutObject { .. } => {
+        UploadType::PutObject { .. } => {
             panic!("distribute_work must not be called for PutObject.")
         }
-        crate::operation::upload::handle::UploadType::MultipartUpload {
+        UploadType::MultipartUpload {
             upload_part_tasks,
             read_body_tasks,
         } => {

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -107,7 +107,7 @@ pub(super) fn distribute_work(
     );
     match &mut handle.tasks {
         crate::operation::upload::handle::UploadType::PutObject { .. } => {
-            panic!("distribute_work mut not needed for PutObject")
+            panic!("distribute_work must not be called for PutObject.")
         }
         crate::operation::upload::handle::UploadType::MultipartUpload {
             upload_tasks,

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -111,7 +111,7 @@ pub(super) fn distribute_work(
         }
         crate::operation::upload::handle::UploadType::MultipartUpload {
             upload_part_tasks,
-            read_tasks,
+            read_body_tasks,
         } => {
             let svc = upload_part_service(&handle.ctx);
             let n_workers = handle.ctx.handle.num_workers();
@@ -123,7 +123,7 @@ pub(super) fn distribute_work(
                     upload_part_tasks.clone(),
                 )
                 .instrument(tracing::debug_span!("read_body", worker = i));
-                read_tasks.spawn(worker);
+                read_body_tasks.spawn(worker);
             }
             tracing::trace!("work distributed for uploading parts");
             Ok(())

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -105,7 +105,7 @@ pub(super) fn distribute_work(
             .part_size(part_size.try_into().expect("valid part size"))
             .build(),
     );
-    match &mut handle.tasks {
+    match &mut handle.upload_type {
         crate::operation::upload::handle::UploadType::PutObject { .. } => {
             panic!("distribute_work must not be called for PutObject.")
         }


### PR DESCRIPTION
*Issue #, if available:*
#12 

*Description of changes:*
This PR adds support to do PutObject while respecting the Multipart threshold.

Initial benchmark with PutObject:
```
Upload 10_000 256KB files from RAM with 125 concurrency:
Run:1 Secs:9.792966 Gb/s:2.141488
Run:2 Secs:20.843134 Gb/s:1.006160
Run:3 Secs:9.793479 Gb/s:2.141376
Run:4 Secs:9.595989 Gb/s:2.185447
Run:5 Secs:9.707330 Gb/s:2.160380
Run:6 Secs:9.740116 Gb/s:2.153108
Run:7 Secs:9.445230 Gb/s:2.220329
2024-10-14T17:55:44.503263Z  INFO aws_smithy_runtime_api::client::connection: Connection encountered an issue and should not be re-used. Marking it for closure see_for_more_info="https://smithy-lang.github.io/smithy-rs/design/client/detailed_error_explan
ations.html"
Run:8 Secs:9.643272 Gb/s:2.174731
Run:9 Secs:9.513162 Gb/s:2.204474
Run:10 Secs:9.583759 Gb/s:2.188235


Upload 10_000 256KB files from RAM with 250 concurrency:
Run:1 Secs:5.757202 Gb/s:3.642658
Run:2 Secs:4.878657 Gb/s:4.298626
Run:3 Secs:5.431388 Gb/s:3.861171
Run:4 Secs:4.923572 Gb/s:4.259412
Run:5 Secs:4.987405 Gb/s:4.204896
Run:6 Secs:4.948379 Gb/s:4.238058
Run:7 Secs:5.068493 Gb/s:4.137624
Run:8 Secs:4.845315 Gb/s:4.328206
Run:9 Secs:4.879404 Gb/s:4.297968
Run:10 Secs:5.023103 Gb/s:4.175013


Upload 10_000 256KB files from RAM with 500 concurrency:
Run:1 Secs:4.095234 Gb/s:5.120958
Run:2 Secs:3.293060 Gb/s:6.368400
Run:3 Secs:2.942297 Gb/s:7.127602
Run:4 Secs:2.711900 Gb/s:7.733147
Run:5 Secs:2.698568 Gb/s:7.771351
Run:6 Secs:2.754285 Gb/s:7.614143
Run:7 Secs:2.823813 Gb/s:7.426667
2024-10-14T17:58:10.653559Z  INFO aws_smithy_runtime_api::client::connection: Connection encountered an issue and should not be re-used. Marking it for closure see_for_more_info="https://smithy-lang.github.io/smithy-rs/design/client/detailed_error_explan
ations.html"
Run:8 Secs:17.495260 Gb/s:1.198697
Run:9 Secs:2.769159 Gb/s:7.573246
Run:10 Secs:6.031129 Gb/s:3.477213
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
