### PR TITLE
Curate tracing spans

### DIFF
--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -17,7 +17,7 @@ use bytes::Buf;
 use clap::{CommandFactory, Parser};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
-use tracing::{debug_span, Instrument};
+use tracing::Instrument;
 
 type BoxError = Box<dyn Error + Send + Sync>;
 
@@ -174,7 +174,7 @@ async fn do_download(args: Args) -> Result<(), BoxError> {
     let mut handle = tm.download().bucket(bucket).key(key).send().await?;
 
     write_body(handle.body_mut(), dest)
-        .instrument(debug_span!("write-output"))
+        .instrument(tracing::debug_span!("write-output"))
         .await?;
 
     let elapsed = start.elapsed();

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -69,7 +69,6 @@ impl Download {
             .handle
             .scheduler
             .acquire_permit()
-            .instrument(tracing::debug_span!("acquire-permit-for-discovery"))
             .await?;
 
         // make initial discovery about the object size, metadata, possibly first chunk

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -65,11 +65,7 @@ impl Download {
         parent_span_for_tasks.follows_from(tracing::Span::current());
 
         // acquire a permit for discovery
-        let permit = ctx
-            .handle
-            .scheduler
-            .acquire_permit()
-            .await?;
+        let permit = ctx.handle.scheduler.acquire_permit().await?;
 
         // make initial discovery about the object size, metadata, possibly first chunk
         let mut discovery = discover_obj(&ctx, &input).await?;

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -69,13 +69,11 @@ impl Download {
             .handle
             .scheduler
             .acquire_permit()
-            .instrument(tracing::debug_span!("download-discovery-permit"))
+            .instrument(tracing::debug_span!("acquire-permit-for-discovery"))
             .await?;
 
         // make initial discovery about the object size, metadata, possibly first chunk
-        let mut discovery = discover_obj(&ctx, &input)
-            .instrument(tracing::debug_span!("download-discovery"))
-            .await?;
+        let mut discovery = discover_obj(&ctx, &input).await?;
         let (comp_tx, comp_rx) = mpsc::channel(concurrency);
 
         let initial_chunk = discovery.initial_chunk.take();
@@ -141,7 +139,7 @@ fn handle_discovery_chunk(
                     &DisplayErrorContext(send_err)
                 );
             }
-        }.instrument(tracing::debug_span!(parent: handle.parent_span_for_tasks.clone(), "download-discovery-chunk", seq)));
+        }.instrument(tracing::debug_span!(parent: handle.parent_span_for_tasks.clone(), "collect-body-from-discovery", seq)));
     }
     handle.ctx.current_seq()
 }

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -59,8 +59,8 @@ impl Download {
         let parent_span_for_tasks = tracing::debug_span!(
             parent: existing_span_for_tasks,
             "download-tasks",
-            bucket = input.bucket.as_deref().unwrap_or(""),
-            key = input.key.as_deref().unwrap_or(""),
+            bucket = input.bucket().unwrap_or_default(),
+            key = input.key().unwrap_or_default(),
         );
         parent_span_for_tasks.follows_from(tracing::Span::current());
 
@@ -69,12 +69,12 @@ impl Download {
             .handle
             .scheduler
             .acquire_permit()
-            .instrument(tracing::debug_span!("acquire-permit"))
+            .instrument(tracing::debug_span!("download-discovery-permit"))
             .await?;
 
         // make initial discovery about the object size, metadata, possibly first chunk
         let mut discovery = discover_obj(&ctx, &input)
-            .instrument(tracing::debug_span!("discovery"))
+            .instrument(tracing::debug_span!("download-discovery"))
             .await?;
         let (comp_tx, comp_rx) = mpsc::channel(concurrency);
 

--- a/aws-s3-transfer-manager/src/operation/download/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/download/builders.rs
@@ -22,7 +22,7 @@ impl DownloadFluentBuilder {
     }
 
     /// Initiate a download transfer for a single object
-    #[tracing::instrument(skip_all, level = "debug", name = "download-initial-send", fields(
+    #[tracing::instrument(skip_all, level = "debug", name = "initiate-download", fields(
         bucket = self.inner.bucket.as_deref().unwrap_or_default(),
         key = self.inner.key.as_deref().unwrap_or_default(),
     ))]

--- a/aws-s3-transfer-manager/src/operation/download/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/download/builders.rs
@@ -22,9 +22,10 @@ impl DownloadFluentBuilder {
     }
 
     /// Initiate a download transfer for a single object
+    #[tracing::instrument(skip_all, level="debug", fields(bucket=self.inner.bucket.as_deref().unwrap_or(""), key=self.inner.key.as_deref().unwrap_or("")))]
     pub async fn send(self) -> Result<DownloadHandle, crate::error::Error> {
         let input = self.inner.build()?;
-        crate::operation::download::Download::orchestrate(self.handle, input).await
+        crate::operation::download::Download::orchestrate(self.handle, input, None).await
     }
 
     /// <p>The bucket name containing the object.</p>

--- a/aws-s3-transfer-manager/src/operation/download/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/download/builders.rs
@@ -28,7 +28,7 @@ impl DownloadFluentBuilder {
     ))]
     pub async fn send(self) -> Result<DownloadHandle, crate::error::Error> {
         let input = self.inner.build()?;
-        crate::operation::download::Download::orchestrate(self.handle, input, None).await
+        crate::operation::download::Download::orchestrate(self.handle, input, false).await
     }
 
     /// <p>The bucket name containing the object.</p>

--- a/aws-s3-transfer-manager/src/operation/download/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/download/builders.rs
@@ -22,7 +22,10 @@ impl DownloadFluentBuilder {
     }
 
     /// Initiate a download transfer for a single object
-    #[tracing::instrument(skip_all, level="debug", fields(bucket=self.inner.bucket.as_deref().unwrap_or(""), key=self.inner.key.as_deref().unwrap_or("")))]
+    #[tracing::instrument(skip_all, level = "debug", name = "download-initial-send", fields(
+        bucket = self.inner.bucket.as_deref().unwrap_or_default(),
+        key = self.inner.key.as_deref().unwrap_or_default(),
+    ))]
     pub async fn send(self) -> Result<DownloadHandle, crate::error::Error> {
         let input = self.inner.build()?;
         crate::operation::download::Download::orchestrate(self.handle, input, None).await

--- a/aws-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download/handle.rs
@@ -45,7 +45,7 @@ impl DownloadHandle {
     }
 
     /// Consume the handle and wait for download transfer to complete
-    #[tracing::instrument(skip_all, level = "debug")]
+    #[tracing::instrument(skip_all, level = "debug", name = "download-join")]
     pub async fn join(mut self) -> Result<(), crate::error::Error> {
         self.body.close();
         while let Some(join_result) = self.tasks.join_next().await {

--- a/aws-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download/handle.rs
@@ -21,6 +21,9 @@ pub struct DownloadHandle {
     /// All child tasks spawned for this download
     pub(crate) tasks: task::JoinSet<()>,
 
+    /// Parent tracing span for spawned child tasks.
+    pub(crate) parent_span_for_tasks: tracing::Span,
+
     /// The context used to drive an upload to completion
     pub(crate) ctx: DownloadContext,
 }
@@ -42,6 +45,7 @@ impl DownloadHandle {
     }
 
     /// Consume the handle and wait for download transfer to complete
+    #[tracing::instrument(skip_all, level = "debug")]
     pub async fn join(mut self) -> Result<(), crate::error::Error> {
         self.body.close();
         while let Some(join_result) = self.tasks.join_next().await {

--- a/aws-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download/handle.rs
@@ -45,7 +45,7 @@ impl DownloadHandle {
     }
 
     /// Consume the handle and wait for download transfer to complete
-    #[tracing::instrument(skip_all, level = "debug", name = "download-join")]
+    #[tracing::instrument(skip_all, level = "debug", name = "join-download")]
     pub async fn join(mut self) -> Result<(), crate::error::Error> {
         self.body.close();
         while let Some(join_result) = self.tasks.join_next().await {

--- a/aws-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download/handle.rs
@@ -21,9 +21,6 @@ pub struct DownloadHandle {
     /// All child tasks spawned for this download
     pub(crate) tasks: task::JoinSet<()>,
 
-    /// Parent tracing span for spawned child tasks.
-    pub(crate) parent_span_for_tasks: tracing::Span,
-
     /// The context used to drive an upload to completion
     pub(crate) ctx: DownloadContext,
 }

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -43,8 +43,19 @@ fn next_chunk(
 async fn download_chunk_handler(
     request: DownloadChunkRequest,
 ) -> Result<ChunkResponse, error::Error> {
+    let seq: u64 = request.ctx.next_seq();
+
+    // the rest of the work is in its own fn, so we can log `seq` in the tracing span
+    download_specific_chunk(request, seq)
+        .instrument(tracing::debug_span!("download-chunk", seq))
+        .await
+}
+
+async fn download_specific_chunk(
+    request: DownloadChunkRequest,
+    seq: u64,
+) -> Result<ChunkResponse, error::Error> {
     let ctx = request.ctx;
-    let seq = ctx.next_seq();
     let part_size = ctx.handle.download_part_size_bytes();
     let input = next_chunk(
         seq,
@@ -120,7 +131,7 @@ pub(super) fn distribute_work(
 
     let size = *remaining.end() - *remaining.start() + 1;
     let num_parts = size.div_ceil(part_size);
-    for seq in 0..num_parts {
+    for _ in 0..num_parts {
         let req = DownloadChunkRequest {
             ctx: handle.ctx.clone(),
             remaining: remaining.clone(),
@@ -136,9 +147,10 @@ pub(super) fn distribute_work(
             if let Err(err) = comp_tx.send(resp).await {
                 tracing::debug!(error = ?err, "chunk send failed, channel closed");
             }
-        }
-        .instrument(tracing::debug_span!("download-chunk", seq = seq));
-        handle.tasks.spawn(task);
+        };
+        handle
+            .tasks
+            .spawn(task.instrument(handle.parent_span_for_tasks.clone()));
     }
 
     tracing::trace!("work fully distributed");

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -75,7 +75,7 @@ async fn download_specific_chunk(
 
     let bytes = body
         .collect()
-        .instrument(tracing::debug_span!("collect-body", seq = seq))
+        .instrument(tracing::debug_span!("download-chunk-collect-body", seq))
         .await
         .map_err(error::from_kind(error::ErrorKind::ChunkFailed))?;
 

--- a/aws-s3-transfer-manager/src/operation/download_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects.rs
@@ -47,8 +47,9 @@ impl DownloadObjects {
         let parent_span_for_tasks = tracing::debug_span!(
             parent: None,
             "download-objects-tasks",
-            bucket=input.bucket.as_deref().unwrap_or(""),
-            key_prefix=input.key_prefix.as_deref().unwrap_or(""),
+            bucket = input.bucket().unwrap_or_default(),
+            destination = input.destination().map(|p| p.to_str().unwrap_or_default()).unwrap_or_default(),
+            key_prefix = input.key_prefix().unwrap_or_default(),
         );
         parent_span_for_tasks.follows_from(tracing::Span::current());
 

--- a/aws-s3-transfer-manager/src/operation/download_objects/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/builders.rs
@@ -24,7 +24,11 @@ impl DownloadObjectsFluentBuilder {
     }
 
     /// Initiate a download transfer for multiple objects
-    #[tracing::instrument(skip_all, level="debug", fields(bucket=self.inner.bucket.as_deref().unwrap_or(""), key_prefix=self.inner.key_prefix.as_deref().unwrap_or("")))]
+    #[tracing::instrument(skip_all, level = "debug", name = "download-objects-initial-send", fields(
+        bucket = self.inner.bucket.as_deref().unwrap_or_default(),
+        destination = self.inner.destination.as_deref().map(|p| p.to_str().unwrap_or_default()).unwrap_or_default(),
+        key_prefix = self.inner.key_prefix.as_deref().unwrap_or_default(),
+    ))]
     pub async fn send(self) -> Result<DownloadObjectsHandle, crate::error::Error> {
         let input = self.inner.build()?;
         crate::operation::download_objects::DownloadObjects::orchestrate(self.handle, input).await

--- a/aws-s3-transfer-manager/src/operation/download_objects/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/builders.rs
@@ -24,6 +24,7 @@ impl DownloadObjectsFluentBuilder {
     }
 
     /// Initiate a download transfer for multiple objects
+    #[tracing::instrument(skip_all, level="debug", fields(bucket=self.inner.bucket.as_deref().unwrap_or(""), key_prefix=self.inner.key_prefix.as_deref().unwrap_or("")))]
     pub async fn send(self) -> Result<DownloadObjectsHandle, crate::error::Error> {
         let input = self.inner.build()?;
         crate::operation::download_objects::DownloadObjects::orchestrate(self.handle, input).await

--- a/aws-s3-transfer-manager/src/operation/download_objects/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/builders.rs
@@ -24,7 +24,7 @@ impl DownloadObjectsFluentBuilder {
     }
 
     /// Initiate a download transfer for multiple objects
-    #[tracing::instrument(skip_all, level = "debug", name = "download-objects-initial-send", fields(
+    #[tracing::instrument(skip_all, level = "debug", name = "initiate-download-objects", fields(
         bucket = self.inner.bucket.as_deref().unwrap_or_default(),
         destination = self.inner.destination.as_deref().map(|p| p.to_str().unwrap_or_default()).unwrap_or_default(),
         key_prefix = self.inner.key_prefix.as_deref().unwrap_or_default(),

--- a/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
@@ -21,7 +21,7 @@ pub struct DownloadObjectsHandle {
 
 impl DownloadObjectsHandle {
     /// Consume the handle and wait for download transfer to complete
-    #[tracing::instrument(skip_all, level = "debug")]
+    #[tracing::instrument(skip_all, level = "debug", name = "download-objects-join")]
     pub async fn join(mut self) -> Result<DownloadObjectsOutput, crate::error::Error> {
         // join all tasks
         while let Some(join_result) = self.tasks.join_next().await {

--- a/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
@@ -21,7 +21,7 @@ pub struct DownloadObjectsHandle {
 
 impl DownloadObjectsHandle {
     /// Consume the handle and wait for download transfer to complete
-    #[tracing::instrument(skip_all, level = "debug", name = "download-objects-join")]
+    #[tracing::instrument(skip_all, level = "debug", name = "join-download-objects")]
     pub async fn join(mut self) -> Result<DownloadObjectsOutput, crate::error::Error> {
         // join all tasks
         while let Some(join_result) = self.tasks.join_next().await {

--- a/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
@@ -21,6 +21,7 @@ pub struct DownloadObjectsHandle {
 
 impl DownloadObjectsHandle {
     /// Consume the handle and wait for download transfer to complete
+    #[tracing::instrument(skip_all, level = "debug")]
     pub async fn join(mut self) -> Result<DownloadObjectsOutput, crate::error::Error> {
         // join all tasks
         while let Some(join_result) = self.tasks.join_next().await {

--- a/aws-s3-transfer-manager/src/operation/download_objects/list_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/list_objects.rs
@@ -11,6 +11,7 @@ use aws_sdk_s3::{
 };
 use aws_smithy_runtime_api::http::Response;
 use std::mem;
+use tracing::Instrument;
 
 use super::DownloadObjectsContext;
 
@@ -126,7 +127,10 @@ impl ListObjectsPaginator {
                 .set_delimiter(input.delimiter.to_owned()),
         };
 
-        let list_result = request.send_with(self.context.client()).await;
+        let list_result = request
+            .send_with(self.context.client())
+            .instrument(tracing::debug_span!("list-objects-v2"))
+            .await;
         match list_result {
             Ok(output) => {
                 let prev_state = self.state.take().expect("state set");

--- a/aws-s3-transfer-manager/src/operation/download_objects/list_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/list_objects.rs
@@ -129,7 +129,7 @@ impl ListObjectsPaginator {
 
         let list_result = request
             .send_with(self.context.client())
-            .instrument(tracing::debug_span!("list-objects-v2"))
+            .instrument(tracing::debug_span!("send-list-objects-v2"))
             .await;
         match list_result {
             Ok(output) => {

--- a/aws-s3-transfer-manager/src/operation/download_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/worker.rs
@@ -142,12 +142,8 @@ async fn download_single_obj(
     let delim = ctx.state.input.delimiter();
 
     let key_path = local_key_path(root_dir, key.as_str(), prefix, delim)?;
-    let mut handle = crate::operation::download::Download::orchestrate(
-        ctx.handle.clone(),
-        input,
-        tracing::Span::current().id(),
-    )
-    .await?;
+    let mut handle =
+        crate::operation::download::Download::orchestrate(ctx.handle.clone(), input, true).await?;
     let mut body = mem::replace(&mut handle.body, Body::empty());
 
     let parent_dir = key_path.parent().expect("valid parent dir for key");

--- a/aws-s3-transfer-manager/src/operation/download_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/worker.rs
@@ -142,8 +142,12 @@ async fn download_single_obj(
     let delim = ctx.state.input.delimiter();
 
     let key_path = local_key_path(root_dir, key.as_str(), prefix, delim)?;
-    let mut handle =
-        crate::operation::download::Download::orchestrate(ctx.handle.clone(), input).await?;
+    let mut handle = crate::operation::download::Download::orchestrate(
+        ctx.handle.clone(),
+        input,
+        tracing::Span::current().id(),
+    )
+    .await?;
     let mut body = mem::replace(&mut handle.body, Body::empty());
 
     let parent_dir = key_path.parent().expect("valid parent dir for key");

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -138,7 +138,7 @@ async fn start_mpu(handle: &UploadHandle) -> Result<UploadOutputBuilder, crate::
         .set_expected_bucket_owner(req.expected_bucket_owner.clone())
         .set_checksum_algorithm(req.checksum_algorithm.clone())
         .send()
-        .instrument(tracing::debug_span!("create-multipart-upload"))
+        .instrument(tracing::debug_span!("send-create-multipart-upload"))
         .await?;
 
     Ok(resp.into())

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -123,6 +123,11 @@ async fn put_object(
         .set_expected_bucket_owner(ctx.request.expected_bucket_owner.clone())
         .set_checksum_algorithm(ctx.request.checksum_algorithm.clone())
         .send()
+        .instrument(tracing::info_span!(
+            "send-upload-part",
+            bucket = ctx.request.bucket().unwrap_or_default(),
+            key = ctx.request.key().unwrap_or_default()
+        ))
         .await?;
     Ok(UploadOutputBuilder::from(resp).build()?)
 }

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -21,6 +21,7 @@ pub use input::{UploadInput, UploadInputBuilder};
 /// Response type for uploads to Amazon S3
 pub use output::{UploadOutput, UploadOutputBuilder};
 use service::distribute_work;
+use tracing::Instrument;
 
 use std::cmp;
 use std::sync::Arc;
@@ -137,6 +138,7 @@ async fn start_mpu(handle: &UploadHandle) -> Result<UploadOutputBuilder, crate::
         .set_expected_bucket_owner(req.expected_bucket_owner.clone())
         .set_checksum_algorithm(req.checksum_algorithm.clone())
         .send()
+        .instrument(tracing::debug_span!("create-multipart-upload"))
         .await?;
 
     Ok(resp.into())

--- a/aws-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/builders.rs
@@ -25,7 +25,10 @@ impl UploadFluentBuilder {
     }
 
     /// Initiate an upload transfer for a single object
-    #[tracing::instrument(skip_all, level="debug", fields(bucket=self.inner.bucket.as_deref().unwrap_or(""), key=self.inner.key.as_deref().unwrap_or("")))]
+    #[tracing::instrument(skip_all, level = "debug", name = "upload-initial-send", fields(
+        bucket = self.inner.bucket.as_deref().unwrap_or_default(),
+        key = self.inner.key.as_deref().unwrap_or_default(),
+    ))]
     pub async fn send(self) -> Result<UploadHandle, crate::error::Error> {
         let input = self.inner.build()?;
         crate::operation::upload::Upload::orchestrate(self.handle, input).await

--- a/aws-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/builders.rs
@@ -25,6 +25,7 @@ impl UploadFluentBuilder {
     }
 
     /// Initiate an upload transfer for a single object
+    #[tracing::instrument(skip_all, level="debug", fields(bucket=self.inner.bucket.as_deref().unwrap_or(""), key=self.inner.key.as_deref().unwrap_or("")))]
     pub async fn send(self) -> Result<UploadHandle, crate::error::Error> {
         let input = self.inner.build()?;
         crate::operation::upload::Upload::orchestrate(self.handle, input).await

--- a/aws-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/builders.rs
@@ -25,7 +25,7 @@ impl UploadFluentBuilder {
     }
 
     /// Initiate an upload transfer for a single object
-    #[tracing::instrument(skip_all, level = "debug", name = "upload-initial-send", fields(
+    #[tracing::instrument(skip_all, level = "debug", name = "initiate-upload", fields(
         bucket = self.inner.bucket.as_deref().unwrap_or_default(),
         key = self.inner.key.as_deref().unwrap_or_default(),
     ))]

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -78,13 +78,13 @@ impl UploadHandle {
     }
 
     /// Consume the handle and wait for upload to complete
-    #[tracing::instrument(skip_all, level = "debug", name = "upload-join")]
+    #[tracing::instrument(skip_all, level = "debug", name = "join-upload")]
     pub async fn join(self) -> Result<UploadOutput, crate::error::Error> {
         complete_upload(self).await
     }
 
     /// Abort the upload and cancel any in-progress part uploads.
-    #[tracing::instrument(skip_all, level = "debug", name = "upload-abort")]
+    #[tracing::instrument(skip_all, level = "debug", name = "abort-upload")]
     pub async fn abort(&mut self) -> Result<AbortedUpload, crate::error::Error> {
         // TODO(aws-sdk-rust#1159) - handle already completed upload
 
@@ -128,7 +128,7 @@ async fn abort_upload(handle: &UploadHandle) -> Result<AbortedUpload, crate::err
         .set_request_payer(handle.ctx.request.request_payer.clone())
         .set_expected_bucket_owner(handle.ctx.request.expected_bucket_owner.clone())
         .send()
-        .instrument(tracing::debug_span!("abort-multipart-upload"))
+        .instrument(tracing::debug_span!("send-abort-multipart-upload"))
         .await?;
 
     let aborted_upload = AbortedUpload {
@@ -204,7 +204,7 @@ async fn complete_upload(mut handle: UploadHandle) -> Result<UploadOutput, crate
         .set_sse_customer_key(handle.ctx.request.sse_customer_key.clone())
         .set_sse_customer_key_md5(handle.ctx.request.sse_customer_key_md5.clone())
         .send()
-        .instrument(tracing::debug_span!("complete-multipart-upload"))
+        .instrument(tracing::debug_span!("send-complete-multipart-upload"))
         .await?;
 
     // set remaining fields from completing the multipart upload

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -20,12 +20,8 @@ use tracing::Instrument;
 pub struct UploadHandle {
     /// All child multipart upload tasks spawned for this upload
     pub(crate) upload_tasks: Arc<Mutex<task::JoinSet<Result<CompletedPart, crate::error::Error>>>>,
-    /// Parent tracing span for spawned upload tasks.
-    pub(crate) parent_span_for_upload_tasks: tracing::Span,
     /// All child read body tasks spawned for this upload
     pub(crate) read_tasks: task::JoinSet<Result<(), crate::error::Error>>,
-    /// Parent tracing span for spawned read body tasks.
-    pub(crate) parent_span_for_read_tasks: tracing::Span,
     /// The context used to drive an upload to completion
     pub(crate) ctx: UploadContext,
     /// The response that will eventually be yielded to the caller.
@@ -35,30 +31,9 @@ pub struct UploadHandle {
 impl UploadHandle {
     /// Create a new upload handle with the given request context
     pub(crate) fn new(ctx: UploadContext) -> Self {
-        let parent_span_for_all_tasks = tracing::debug_span!(
-            parent: None, "upload-tasks", // TODO: for upload_objects, parent should be upload-objects-tasks
-            bucket = ctx.request.bucket.as_deref().unwrap_or_default(),
-            key = ctx.request.key.as_deref().unwrap_or_default(),
-        );
-        parent_span_for_all_tasks.follows_from(tracing::Span::current());
-
-        // group read tasks together
-        let parent_span_for_read_tasks = tracing::debug_span!(
-            parent: parent_span_for_all_tasks.clone(),
-            "upload-read-tasks"
-        );
-
-        // group upload tasks together
-        let parent_span_for_upload_tasks = tracing::debug_span!(
-            parent: parent_span_for_all_tasks,
-            "upload-net-tasks"
-        );
-
         Self {
             upload_tasks: Arc::new(Mutex::new(task::JoinSet::new())),
-            parent_span_for_upload_tasks,
             read_tasks: task::JoinSet::new(),
-            parent_span_for_read_tasks,
             ctx,
             response: None,
         }

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -139,7 +139,7 @@ pub(super) async fn read_body(
 ) -> Result<(), error::Error> {
     while let Some(part_data) = part_reader
         .next_part()
-        .instrument(tracing::debug_span!("read-next-part"))
+        .instrument(tracing::debug_span!("upload-read-next-part"))
         .await?
     {
         let req = UploadPartRequest {

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -47,7 +47,7 @@ async fn upload_part_handler(request: UploadPartRequest) -> Result<CompletedPart
         .set_request_payer(ctx.request.request_payer.clone())
         .set_expected_bucket_owner(ctx.request.expected_bucket_owner.clone())
         .send()
-        .instrument(tracing::debug_span!("upload-part", part_number))
+        .instrument(tracing::debug_span!("send-upload-part", part_number))
         .await?;
 
     tracing::trace!("completed upload of part number {}", part_number);
@@ -139,7 +139,7 @@ pub(super) async fn read_body(
 ) -> Result<(), error::Error> {
     while let Some(part_data) = part_reader
         .next_part()
-        .instrument(tracing::debug_span!("upload-read-next-part"))
+        .instrument(tracing::debug_span!("read-upload-body"))
         .await?
     {
         let req = UploadPartRequest {

--- a/aws-s3-transfer-manager/src/operation/upload_objects/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/builders.rs
@@ -28,6 +28,7 @@ impl UploadObjectsFluentBuilder {
     }
 
     /// Initiate upload of multiple objects
+    #[tracing::instrument(skip_all, level = "debug")]
     pub async fn send(self) -> Result<UploadObjectsHandle, UploadObjectsError> {
         // FIXME - Err(UploadObjectsError) instead of .expect()
         let input = self.inner.build().expect("valid input");

--- a/aws-s3-transfer-manager/src/operation/upload_objects/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/builders.rs
@@ -28,7 +28,7 @@ impl UploadObjectsFluentBuilder {
     }
 
     /// Initiate upload of multiple objects
-    #[tracing::instrument(skip_all, level = "debug", name = "upload-objects-initial-send", fields(
+    #[tracing::instrument(skip_all, level = "debug", name = "initiate-upload-objects", fields(
         bucket = self.inner.bucket.as_deref().unwrap_or_default(),
         source = self.inner.source.as_deref().map(|p| p.to_str().unwrap_or_default()).unwrap_or_default(),
         key_prefix = self.inner.key_prefix.as_deref().unwrap_or_default(),

--- a/aws-s3-transfer-manager/src/operation/upload_objects/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/builders.rs
@@ -28,7 +28,11 @@ impl UploadObjectsFluentBuilder {
     }
 
     /// Initiate upload of multiple objects
-    #[tracing::instrument(skip_all, level = "debug")]
+    #[tracing::instrument(skip_all, level = "debug", name = "upload-objects-initial-send", fields(
+        bucket = self.inner.bucket.as_deref().unwrap_or_default(),
+        source = self.inner.source.as_deref().map(|p| p.to_str().unwrap_or_default()).unwrap_or_default(),
+        key_prefix = self.inner.key_prefix.as_deref().unwrap_or_default(),
+    ))]
     pub async fn send(self) -> Result<UploadObjectsHandle, UploadObjectsError> {
         // FIXME - Err(UploadObjectsError) instead of .expect()
         let input = self.inner.build().expect("valid input");

--- a/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
@@ -12,6 +12,7 @@ pub struct UploadObjectsHandle {}
 
 impl UploadObjectsHandle {
     /// Consume the handle and wait for the upload to complete
+    #[tracing::instrument(skip_all, level = "debug")]
     pub async fn join(self) -> Result<UploadObjectsOutput, UploadObjectsError> {
         unimplemented!()
     }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
@@ -12,7 +12,7 @@ pub struct UploadObjectsHandle {}
 
 impl UploadObjectsHandle {
     /// Consume the handle and wait for the upload to complete
-    #[tracing::instrument(skip_all, level = "debug", name = "upload-objects-join")]
+    #[tracing::instrument(skip_all, level = "debug", name = "join-upload-objects-")]
     pub async fn join(self) -> Result<UploadObjectsOutput, UploadObjectsError> {
         unimplemented!()
     }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
@@ -12,7 +12,7 @@ pub struct UploadObjectsHandle {}
 
 impl UploadObjectsHandle {
     /// Consume the handle and wait for the upload to complete
-    #[tracing::instrument(skip_all, level = "debug")]
+    #[tracing::instrument(skip_all, level = "debug", name = "upload-objects-join")]
     pub async fn join(self) -> Result<UploadObjectsOutput, UploadObjectsError> {
         unimplemented!()
     }


### PR DESCRIPTION
*Description of changes:*
- Each major operation has a "parent" span it assigns to the tasks it spawns. Otherwise, spans from spawned tasks have no parent, which makes them a disorganized mess in visualizations.
- Ensure there's a span for each HTTP request, because these are often the bottleneck.
- Ensure spans have important key/value pairs (e.g. seq, part_number, bucket, key), so when a bunch of spans with the same name are together, we tell what each one is up to.
- **debatable:** gave names that stand on their own. For example: the function `aws_s3_transfer_manager::operation::upload::builders::send()` is named "initiate-download", instead of just "send", so a visualization doesn't need to show the full (very very wide) namespace to explain what's going on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
