### PR TITLE
Add support for uploading files from a directory to S3

### DIFF
--- a/aws-s3-transfer-manager/Cargo.toml
+++ b/aws-s3-transfer-manager/Cargo.toml
@@ -36,12 +36,13 @@ clap = { version = "4.5.7", default-features = false, features = ["derive", "std
 console-subscriber = "0.4.0"
 http-02x = { package = "http", version = "0.2.9" }
 http-body-1x = { package = "http-body", version = "1" }
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tempfile = "3.12.0"
 fastrand = "2.1.1"
 futures-test = "0.3.30"
-tower-test = "0.4.0"
+tempfile = "3.12.0"
+test-common = { path = "./test-common" }
 tokio-test = "0.4.4"
+tower-test = "0.4.0"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
 jemallocator = "0.5.4"

--- a/aws-s3-transfer-manager/Cargo.toml
+++ b/aws-s3-transfer-manager/Cargo.toml
@@ -18,6 +18,7 @@ aws-smithy-experimental = { version = "0.1.3", features = ["crypto-aws-lc"] }
 aws-smithy-runtime-api = "1.7.1"
 aws-smithy-types = "1.2.6"
 aws-types = "1.3.3"
+blocking = "1.6.0"
 bytes = "1"
 futures-util = "0.3.30"
 path-clean = "1.0.1"

--- a/aws-s3-transfer-manager/Cargo.toml
+++ b/aws-s3-transfer-manager/Cargo.toml
@@ -39,7 +39,7 @@ http-body-1x = { package = "http-body", version = "1" }
 fastrand = "2.1.1"
 futures-test = "0.3.30"
 tempfile = "3.12.0"
-test-common = { path = "./test-common" }
+test-common = { path = "./test-common", version = "0.1.0" }
 tokio-test = "0.4.4"
 tower-test = "0.4.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/aws-s3-transfer-manager/Cargo.toml
+++ b/aws-s3-transfer-manager/Cargo.toml
@@ -25,6 +25,7 @@ pin-project-lite = "0.2.14"
 tokio = { version = "1.40.0", features = ["rt-multi-thread", "io-util", "sync", "fs", "macros"] }
 tower = { version = "0.5.1", features = ["limit", "retry", "util", "hedge", "buffer"] }
 tracing = "0.1"
+walkdir = "2"
 
 [dev-dependencies]
 aws-sdk-s3 = { version = "1.51.0", features = ["behavior-version-latest", "test-util"] }
@@ -38,7 +39,6 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tempfile = "3.12.0"
 fastrand = "2.1.1"
 futures-test = "0.3.30"
-walkdir = "2"
 tower-test = "0.4.0"
 tokio-test = "0.4.4"
 

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -205,8 +205,7 @@ async fn do_recursive_upload(
         .key_prefix(key_prefix)
         .recursive(true)
         .send()
-        .await
-        .unwrap();
+        .await?;
 
     let output = handle.join().await?;
     tracing::info!("recursive upload output: {output:?}");

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -195,18 +195,20 @@ async fn do_recursive_upload(
 ) -> Result<(), BoxError> {
     let Args { source, dest, .. } = args;
     let source_dir = source.expect_local();
-    let (bucket, _) = dest.expect_s3().parts();
+    let (bucket, key_prefix) = dest.expect_s3().parts();
 
     let start = time::Instant::now();
     let handle = tm
         .upload_objects()
         .source(source_dir)
         .bucket(bucket)
+        .key_prefix(key_prefix)
+        .recursive(true)
         .send()
         .await
         .unwrap();
 
-    let output = handle.join().await.unwrap();
+    let output = handle.join().await?;
     tracing::info!("recursive upload output: {output:?}");
 
     let elapsed = start.elapsed();

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -189,11 +189,39 @@ async fn do_download(args: Args) -> Result<(), BoxError> {
     Ok(())
 }
 
-async fn do_upload(args: Args) -> Result<(), BoxError> {
-    if args.recursive {
-        unimplemented!("recursive upload not supported yet")
-    }
+async fn do_recursive_upload(
+    args: Args,
+    tm: aws_s3_transfer_manager::Client,
+) -> Result<(), BoxError> {
+    let Args { source, dest, .. } = args;
+    let source_dir = source.expect_local();
+    let (bucket, _) = dest.expect_s3().parts();
 
+    let start = time::Instant::now();
+    let handle = tm
+        .upload_objects()
+        .source(source_dir)
+        .bucket(bucket)
+        .send()
+        .await
+        .unwrap();
+
+    let output = handle.join().await.unwrap();
+    tracing::info!("recursive upload output: {output:?}");
+
+    let elapsed = start.elapsed();
+    let transfer_size_bytes = output.total_bytes_transferred();
+    let throughput = Throughput::new(transfer_size_bytes, elapsed);
+
+    println!(
+        "uploaded {} objects totalling {transfer_size_bytes} bytes ({}) in {elapsed:?}; {throughput}",
+        output.objects_uploaded(),
+        ByteUnit::display(transfer_size_bytes)
+    );
+    Ok(())
+}
+
+async fn do_upload(args: Args) -> Result<(), BoxError> {
     let (bucket, key) = args.dest.expect_s3().parts();
 
     let tm_config = aws_s3_transfer_manager::from_env()
@@ -205,6 +233,10 @@ async fn do_upload(args: Args) -> Result<(), BoxError> {
     warmup(&tm_config, bucket).await?;
 
     let tm = aws_s3_transfer_manager::Client::new(tm_config);
+
+    if args.recursive {
+        return do_recursive_upload(args, tm).await;
+    }
 
     let path = args.source.expect_local();
     let file_meta = fs::metadata(path).await.expect("file metadata");

--- a/aws-s3-transfer-manager/src/client.rs
+++ b/aws-s3-transfer-manager/src/client.rs
@@ -193,12 +193,12 @@ impl Client {
     /// Examples
     /// ```no_run
     /// use std::path::Path;
-    /// use aws_s3_transfer_manager::operation::upload_objects::UploadObjectsError;
+    /// use aws_s3_transfer_manager::error::Error;
     ///
     /// async fn upload_directory(
     ///     client: &aws_s3_transfer_manager::Client,
     ///     source: &Path,
-    /// ) -> Result<(), UploadObjectsError> {
+    /// ) -> Result<(), Error> {
     ///
     ///     let handle = client
     ///         .upload_objects()

--- a/aws-s3-transfer-manager/src/error.rs
+++ b/aws-s3-transfer-manager/src/error.rs
@@ -21,7 +21,7 @@ pub struct Error {
 }
 
 /// General categories of transfer errors.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ErrorKind {
     /// Operation input validation issues

--- a/aws-s3-transfer-manager/src/io/path_body.rs
+++ b/aws-s3-transfer-manager/src/io/path_body.rs
@@ -41,6 +41,7 @@ pub struct PathBodyBuilder {
     path: Option<PathBuf>,
     length: Option<u64>,
     offset: Option<u64>,
+    metadata: Option<fs::Metadata>,
 }
 
 impl PathBodyBuilder {
@@ -81,6 +82,12 @@ impl PathBodyBuilder {
         self
     }
 
+    /// Provide `metadata` for `self.path`, potentially reducing system calls during `build` if pre-set.
+    pub(crate) fn metadata(mut self, metadata: fs::Metadata) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
     /// Returns a [`InputStream`] from this builder.
     pub fn build(self) -> Result<InputStream, Error> {
         let path = self.path.expect("path set");
@@ -89,7 +96,7 @@ impl PathBodyBuilder {
         let length = match self.length {
             None => {
                 // TODO(aws-sdk-rust#1159, design) - evaluate if we want build() to be async and to use tokio for stat() call (bytestream FsBuilder::build() is async)
-                let metadata = fs::metadata(path.clone())?;
+                let metadata = self.metadata.unwrap_or(fs::metadata(path.clone())?);
                 let file_size = metadata.len();
 
                 if offset >= file_size {

--- a/aws-s3-transfer-manager/src/operation.rs
+++ b/aws-s3-transfer-manager/src/operation.rs
@@ -21,6 +21,7 @@ pub mod download_objects;
 /// Types for multiple object upload operation
 pub mod upload_objects;
 
+// The default delimiter of the S3 object key
 pub(crate) const DEFAULT_DELIMITER: &str = "/";
 
 /// Container for maintaining context required to carry out a single operation/transfer.

--- a/aws-s3-transfer-manager/src/operation.rs
+++ b/aws-s3-transfer-manager/src/operation.rs
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
+
+use tokio::fs;
+
+use crate::error;
 
 /// Types for single object upload operation
 pub mod upload;
@@ -16,6 +20,8 @@ pub mod download_objects;
 
 /// Types for multiple object upload operation
 pub mod upload_objects;
+
+pub(crate) const DEFAULT_DELIMITER: &str = "/";
 
 /// Container for maintaining context required to carry out a single operation/transfer.
 ///
@@ -40,4 +46,16 @@ impl<State> Clone for TransferContext<State> {
             state: self.state.clone(),
         }
     }
+}
+
+pub(crate) async fn validate_target_is_dir(path: &Path) -> Result<(), error::Error> {
+    let meta = fs::metadata(path).await?;
+
+    if !meta.is_dir() {
+        return Err(error::invalid_input(format!(
+            "destination is not a directory: {path:?}"
+        )));
+    }
+
+    Ok(())
 }

--- a/aws-s3-transfer-manager/src/operation.rs
+++ b/aws-s3-transfer-manager/src/operation.rs
@@ -53,7 +53,7 @@ pub(crate) async fn validate_target_is_dir(path: &Path) -> Result<(), error::Err
 
     if !meta.is_dir() {
         return Err(error::invalid_input(format!(
-            "destination is not a directory: {path:?}"
+            "target is not a directory: {path:?}"
         )));
     }
 

--- a/aws-s3-transfer-manager/src/operation/download_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects.rs
@@ -78,6 +78,8 @@ impl DownloadObjects {
 /// DownloadObjects operation specific state
 #[derive(Debug)]
 pub(crate) struct DownloadObjectsState {
+    // TODO - Determine if `input` should be separated from this struct
+    // https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/67#discussion_r1821661603
     input: DownloadObjectsInput,
     failed_downloads: Mutex<Vec<FailedDownloadTransfer>>,
     successful_downloads: AtomicU64,

--- a/aws-s3-transfer-manager/src/operation/download_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects.rs
@@ -79,7 +79,7 @@ impl DownloadObjects {
 #[derive(Debug)]
 pub(crate) struct DownloadObjectsState {
     input: DownloadObjectsInput,
-    failed_downloads: Mutex<Option<Vec<FailedDownloadTransfer>>>,
+    failed_downloads: Mutex<Vec<FailedDownloadTransfer>>,
     successful_downloads: AtomicU64,
     total_bytes_transferred: AtomicU64,
 }
@@ -90,7 +90,7 @@ impl DownloadObjectsContext {
     fn new(handle: Arc<crate::client::Handle>, input: DownloadObjectsInput) -> Self {
         let state = Arc::new(DownloadObjectsState {
             input,
-            failed_downloads: Mutex::new(None),
+            failed_downloads: Mutex::new(Vec::new()),
             successful_downloads: AtomicU64::default(),
             total_bytes_transferred: AtomicU64::default(),
         });

--- a/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
@@ -28,7 +28,8 @@ impl DownloadObjectsHandle {
             join_result??;
         }
 
-        let failed_downloads = self.ctx.state.failed_downloads.lock().unwrap().take();
+        let failed_downloads =
+            std::mem::take(&mut *self.ctx.state.failed_downloads.lock().unwrap());
         let successful_downloads = self.ctx.state.successful_downloads.load(Ordering::SeqCst);
         let total_bytes_transferred = self
             .ctx

--- a/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
@@ -23,6 +23,7 @@ impl DownloadObjectsHandle {
     /// Consume the handle and wait for download transfer to complete
     #[tracing::instrument(skip_all, level = "debug", name = "join-download-objects")]
     pub async fn join(mut self) -> Result<DownloadObjectsOutput, crate::error::Error> {
+        // TODO - Consider implementing more sophisticated error handling such as canceling in-progress transfers
         // join all tasks
         while let Some(join_result) = self.tasks.join_next().await {
             join_result??;

--- a/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/handle.rs
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::sync::atomic::Ordering;
-
 use tokio::task;
 
 use super::{DownloadObjectsContext, DownloadObjectsOutput};
@@ -29,21 +27,6 @@ impl DownloadObjectsHandle {
             join_result??;
         }
 
-        let failed_downloads =
-            std::mem::take(&mut *self.ctx.state.failed_downloads.lock().unwrap());
-        let successful_downloads = self.ctx.state.successful_downloads.load(Ordering::SeqCst);
-        let total_bytes_transferred = self
-            .ctx
-            .state
-            .total_bytes_transferred
-            .load(Ordering::SeqCst);
-
-        let output = DownloadObjectsOutput::builder()
-            .objects_downloaded(successful_downloads)
-            .set_failed_transfers(failed_downloads)
-            .total_bytes_transferred(total_bytes_transferred)
-            .build();
-
-        Ok(output)
+        Ok(DownloadObjectsOutput::from(self.ctx.state.as_ref()))
     }
 }

--- a/aws-s3-transfer-manager/src/operation/download_objects/output.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/output.rs
@@ -71,9 +71,9 @@ impl DownloadObjectsOutputBuilder {
     /// To override the contents of this collection use
     /// [`set_failed_transfers`](Self::set_failed_transfers)
     pub fn failed_transfers(mut self, input: FailedDownloadTransfer) -> Self {
-        let mut v = self.failed_transfers.unwrap_or_default();
-        v.push(input);
-        self.failed_transfers = Some(v);
+        self.failed_transfers
+            .get_or_insert_with(Vec::new)
+            .push(input);
         self
     }
 

--- a/aws-s3-transfer-manager/src/operation/download_objects/output.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/output.rs
@@ -13,7 +13,7 @@ pub struct DownloadObjectsOutput {
     pub objects_downloaded: u64,
 
     /// A list of failed object transfers
-    pub failed_transfers: Option<Vec<FailedDownloadTransfer>>,
+    pub failed_transfers: Vec<FailedDownloadTransfer>,
 
     // FIXME - likely remove when progress is implemented?
     /// Total number of bytes transferred
@@ -32,11 +32,8 @@ impl DownloadObjectsOutput {
     }
 
     /// A slice of failed object transfers
-    ///
-    /// If no value was sent for this field, a default will be set. If you want to determine if no value was
-    /// set, use `.failed_transfers.is_none()`
     pub fn failed_transfers(&self) -> &[FailedDownloadTransfer] {
-        self.failed_transfers.as_deref().unwrap_or_default()
+        self.failed_transfers.as_slice()
     }
 
     /// The number of bytes successfully transferred (downloaded)
@@ -50,7 +47,7 @@ impl DownloadObjectsOutput {
 #[derive(Debug, Default)]
 pub struct DownloadObjectsOutputBuilder {
     pub(crate) objects_downloaded: u64,
-    pub(crate) failed_transfers: Option<Vec<FailedDownloadTransfer>>,
+    pub(crate) failed_transfers: Vec<FailedDownloadTransfer>,
     pub(crate) total_bytes_transferred: u64,
 }
 
@@ -71,21 +68,19 @@ impl DownloadObjectsOutputBuilder {
     /// To override the contents of this collection use
     /// [`set_failed_transfers`](Self::set_failed_transfers)
     pub fn failed_transfers(mut self, input: FailedDownloadTransfer) -> Self {
-        self.failed_transfers
-            .get_or_insert_with(Vec::new)
-            .push(input);
+        self.failed_transfers.push(input);
         self
     }
 
-    /// A list of failed object transfers
-    pub fn set_failed_transfers(mut self, input: Option<Vec<FailedDownloadTransfer>>) -> Self {
+    /// Set a list of failed object transfers
+    pub fn set_failed_transfers(mut self, input: Vec<FailedDownloadTransfer>) -> Self {
         self.failed_transfers = input;
         self
     }
 
-    /// A list of failed object transfers
-    pub fn get_failed_transfers(&self) -> &Option<Vec<FailedDownloadTransfer>> {
-        &self.failed_transfers
+    /// Get a list of failed object transfers
+    pub fn get_failed_transfers(&self) -> &[FailedDownloadTransfer] {
+        self.failed_transfers.as_slice()
     }
 
     /// The number of bytes successfully transferred (downloaded)

--- a/aws-s3-transfer-manager/src/operation/download_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/worker.rs
@@ -111,8 +111,7 @@ pub(super) async fn download_objects(
                     // the tasks on error rather than relying on join and then drop.
                     FailedTransferPolicy::Abort => return Err(err),
                     FailedTransferPolicy::Continue => {
-                        let mut guard = ctx.state.failed_downloads.lock().unwrap();
-                        let mut failures = mem::take(&mut *guard).unwrap_or_default();
+                        let mut failures = ctx.state.failed_downloads.lock().unwrap();
 
                         let failed_transfer = FailedDownloadTransfer {
                             input: job.input(&ctx),
@@ -120,8 +119,6 @@ pub(super) async fn download_objects(
                         };
 
                         failures.push(failed_transfer);
-
-                        let _ = mem::replace(&mut *guard, Some(failures));
                     }
                 }
             }

--- a/aws-s3-transfer-manager/src/operation/download_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects/worker.rs
@@ -14,6 +14,7 @@ use tokio::io::AsyncWriteExt;
 use crate::error;
 use crate::operation::download::body::Body;
 use crate::operation::download::{DownloadInput, DownloadInputBuilder};
+use crate::operation::DEFAULT_DELIMITER;
 use crate::types::{DownloadFilter, FailedDownloadTransfer, FailedTransferPolicy};
 
 use super::list_objects::ListObjectsStream;
@@ -161,8 +162,6 @@ async fn download_single_obj(
 
     Ok(())
 }
-
-const DEFAULT_DELIMITER: &str = "/";
 
 /// If the prefix is not empty AND the key contains the delimiter, strip the prefix from the key.
 ///

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -46,6 +46,7 @@ impl Upload {
         let ctx = new_context(handle, input);
 
         // MPU has max of 10K parts which requires us to know the upper bound on the content length (today anyway)
+        // While true for file-based workloads, the upper `size_hint` might not be equal to the actual bytes transferred.
         let content_length = stream
             .size_hint()
             .upper()

--- a/aws-s3-transfer-manager/src/operation/upload_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects.rs
@@ -44,16 +44,16 @@ impl UploadObjects {
 
         // spawn all work into the same JoinSet such that when the set is dropped all tasks are cancelled.
         let mut tasks = JoinSet::new();
-        let (work_tx, work_rx) = async_channel::bounded(concurrency);
+        let (list_directory_tx, list_directory_rx) = async_channel::bounded(concurrency);
 
         // spawn worker to discover/distribute work
         tasks.spawn(worker::list_directory_contents(
             ctx.state.input.clone(),
-            work_tx,
+            list_directory_tx,
         ));
 
         for i in 0..concurrency {
-            let worker = worker::upload_objects(ctx.clone(), work_rx.clone())
+            let worker = worker::upload_objects(ctx.clone(), list_directory_rx.clone())
                 .instrument(tracing::debug_span!("object-uploader", worker = i));
             tasks.spawn(worker);
         }

--- a/aws-s3-transfer-manager/src/operation/upload_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects.rs
@@ -34,10 +34,10 @@ impl UploadObjects {
     pub(crate) async fn orchestrate(
         handle: Arc<crate::client::Handle>,
         input: UploadObjectsInput,
-    ) -> Result<UploadObjectsHandle, UploadObjectsError> {
+    ) -> Result<UploadObjectsHandle, crate::error::Error> {
         //  validate existence of source and return error if it's not a directory
         let source = input.source().expect("source set");
-        validate_target_is_dir(source).await.unwrap();
+        validate_target_is_dir(source).await?;
 
         let concurrency = handle.num_workers();
         let ctx = UploadObjectsContext::new(handle.clone(), input);

--- a/aws-s3-transfer-manager/src/operation/upload_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::sync::Arc;
+use std::sync::{atomic::AtomicU64, Arc, Mutex};
 
 /// Operation builders
 pub mod builders;
@@ -16,6 +16,14 @@ pub use handle::UploadObjectsHandle;
 
 mod output;
 pub use output::{UploadObjectsOutput, UploadObjectsOutputBuilder};
+use tokio::task::JoinSet;
+use tracing::Instrument;
+
+mod worker;
+
+use crate::types::FailedUploadTransfer;
+
+use super::{validate_target_is_dir, TransferContext};
 
 /// Operation struct for uploading multiple objects to Amazon S3
 #[derive(Clone, Default, Debug)]
@@ -24,10 +32,31 @@ pub(crate) struct UploadObjects;
 impl UploadObjects {
     /// Execute a single `UploadObjects` transfer operation
     pub(crate) async fn orchestrate(
-        _handle: Arc<crate::client::Handle>,
-        _input: UploadObjectsInput,
+        handle: Arc<crate::client::Handle>,
+        input: UploadObjectsInput,
     ) -> Result<UploadObjectsHandle, UploadObjectsError> {
-        unimplemented!()
+        //  validate existence of source and return error if it's not a directory
+        let source = input.source().expect("source set");
+        validate_target_is_dir(source).await.unwrap();
+
+        let concurrency = handle.num_workers();
+        let ctx = UploadObjectsContext::new(handle.clone(), input);
+
+        // spawn all work into the same JoinSet such that when the set is dropped all tasks are cancelled.
+        let mut tasks = JoinSet::new();
+        let (work_tx, work_rx) = async_channel::bounded(concurrency);
+
+        // spawn worker to discover/distribute work
+        tasks.spawn(worker::list_directory_contents(ctx.clone(), work_tx));
+
+        for i in 0..concurrency {
+            let worker = worker::upload_objects(ctx.clone(), work_rx.clone())
+                .instrument(tracing::debug_span!("object-uploader", worker = i));
+            tasks.spawn(worker);
+        }
+
+        let handle = UploadObjectsHandle { tasks, ctx };
+        Ok(handle)
     }
 }
 
@@ -35,3 +64,26 @@ impl UploadObjects {
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum UploadObjectsError {}
+
+/// DownloadObjects operation specific state
+#[derive(Debug)]
+pub(crate) struct UploadObjectsState {
+    input: UploadObjectsInput,
+    failed_uploads: Mutex<Option<Vec<FailedUploadTransfer>>>,
+    successful_uploads: AtomicU64,
+    total_bytes_transferred: AtomicU64,
+}
+
+type UploadObjectsContext = TransferContext<UploadObjectsState>;
+
+impl UploadObjectsContext {
+    fn new(handle: Arc<crate::client::Handle>, input: UploadObjectsInput) -> Self {
+        let state = Arc::new(UploadObjectsState {
+            input,
+            failed_uploads: Mutex::new(None),
+            successful_uploads: AtomicU64::default(),
+            total_bytes_transferred: AtomicU64::default(),
+        });
+        TransferContext { handle, state }
+    }
+}

--- a/aws-s3-transfer-manager/src/operation/upload_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects.rs
@@ -47,7 +47,10 @@ impl UploadObjects {
         let (work_tx, work_rx) = async_channel::bounded(concurrency);
 
         // spawn worker to discover/distribute work
-        tasks.spawn(worker::list_directory_contents(ctx.clone(), work_tx));
+        tasks.spawn(worker::list_directory_contents(
+            ctx.state.input.clone(),
+            work_tx,
+        ));
 
         for i in 0..concurrency {
             let worker = worker::upload_objects(ctx.clone(), work_rx.clone())

--- a/aws-s3-transfer-manager/src/operation/upload_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects.rs
@@ -66,6 +66,8 @@ impl UploadObjects {
 /// UploadObjects operation specific state
 #[derive(Debug)]
 pub(crate) struct UploadObjectsState {
+    // TODO - Determine if `input` should be separated from this struct
+    // https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/67#discussion_r1821661603
     input: UploadObjectsInput,
     failed_uploads: Mutex<Vec<FailedUploadTransfer>>,
     successful_uploads: AtomicU64,

--- a/aws-s3-transfer-manager/src/operation/upload_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects.rs
@@ -60,11 +60,6 @@ impl UploadObjects {
     }
 }
 
-/// Error type for `UploadObjects` operation
-#[non_exhaustive]
-#[derive(Debug)]
-pub enum UploadObjectsError {}
-
 /// DownloadObjects operation specific state
 #[derive(Debug)]
 pub(crate) struct UploadObjectsState {

--- a/aws-s3-transfer-manager/src/operation/upload_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects.rs
@@ -63,11 +63,11 @@ impl UploadObjects {
     }
 }
 
-/// DownloadObjects operation specific state
+/// UploadObjects operation specific state
 #[derive(Debug)]
 pub(crate) struct UploadObjectsState {
     input: UploadObjectsInput,
-    failed_uploads: Mutex<Option<Vec<FailedUploadTransfer>>>,
+    failed_uploads: Mutex<Vec<FailedUploadTransfer>>,
     successful_uploads: AtomicU64,
     total_bytes_transferred: AtomicU64,
 }
@@ -78,7 +78,7 @@ impl UploadObjectsContext {
     fn new(handle: Arc<crate::client::Handle>, input: UploadObjectsInput) -> Self {
         let state = Arc::new(UploadObjectsState {
             input,
-            failed_uploads: Mutex::new(None),
+            failed_uploads: Mutex::new(Vec::new()),
             successful_uploads: AtomicU64::default(),
             total_bytes_transferred: AtomicU64::default(),
         });

--- a/aws-s3-transfer-manager/src/operation/upload_objects/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/builders.rs
@@ -16,6 +16,9 @@ pub struct UploadObjectsFluentBuilder {
     inner: UploadObjectsInputBuilder,
 }
 
+// TODO(https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/68):
+// Use `Option<&str>` instead of `&Option<String>` consistently throughout the codebase
+
 impl UploadObjectsFluentBuilder {
     pub(crate) fn new(handle: Arc<crate::client::Handle>) -> Self {
         Self {

--- a/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
@@ -3,16 +3,42 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use super::{UploadObjectsError, UploadObjectsOutput};
+use std::sync::atomic::Ordering;
+
+use super::{UploadObjectsContext, UploadObjectsError, UploadObjectsOutput};
+use tokio::task;
 
 /// Handle for `UploadObjects` operation
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct UploadObjectsHandle {}
+pub struct UploadObjectsHandle {
+    /// All child tasks spawned for this download
+    pub(crate) tasks: task::JoinSet<Result<(), crate::error::Error>>,
+    /// The context used to drive an upload to completion
+    pub(crate) ctx: UploadObjectsContext,
+}
 
 impl UploadObjectsHandle {
     /// Consume the handle and wait for the upload to complete
-    pub async fn join(self) -> Result<UploadObjectsOutput, UploadObjectsError> {
-        unimplemented!()
+    pub async fn join(mut self) -> Result<UploadObjectsOutput, UploadObjectsError> {
+        while let Some(join_result) = self.tasks.join_next().await {
+            join_result.unwrap().unwrap();
+        }
+
+        let failed_uploads = self.ctx.state.failed_uploads.lock().unwrap().take();
+        let successful_uploads = self.ctx.state.successful_uploads.load(Ordering::SeqCst);
+        let total_bytes_transferred = self
+            .ctx
+            .state
+            .total_bytes_transferred
+            .load(Ordering::SeqCst);
+
+        let output = UploadObjectsOutput::builder()
+            .objects_uploaded(successful_uploads)
+            .set_failed_transfers(failed_uploads)
+            .total_bytes_transferred(total_bytes_transferred)
+            .build();
+
+        Ok(output)
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
@@ -22,6 +22,7 @@ impl UploadObjectsHandle {
     /// Consume the handle and wait for the upload to complete
     #[tracing::instrument(skip_all, level = "debug", name = "join-upload-objects-")]
     pub async fn join(mut self) -> Result<UploadObjectsOutput, crate::error::Error> {
+        // TODO - Consider implementing more sophisticated error handling such as canceling in-progress transfers
         while let Some(join_result) = self.tasks.join_next().await {
             join_result??;
         }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
@@ -5,7 +5,7 @@
 
 use std::sync::atomic::Ordering;
 
-use super::{UploadObjectsContext, UploadObjectsError, UploadObjectsOutput};
+use super::{UploadObjectsContext, UploadObjectsOutput};
 use tokio::task;
 
 /// Handle for `UploadObjects` operation
@@ -20,9 +20,9 @@ pub struct UploadObjectsHandle {
 
 impl UploadObjectsHandle {
     /// Consume the handle and wait for the upload to complete
-    pub async fn join(mut self) -> Result<UploadObjectsOutput, UploadObjectsError> {
+    pub async fn join(mut self) -> Result<UploadObjectsOutput, crate::error::Error> {
         while let Some(join_result) = self.tasks.join_next().await {
-            join_result.unwrap().unwrap();
+            join_result??;
         }
 
         let failed_uploads = self.ctx.state.failed_uploads.lock().unwrap().take();

--- a/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
@@ -26,7 +26,7 @@ impl UploadObjectsHandle {
             join_result??;
         }
 
-        let failed_uploads = self.ctx.state.failed_uploads.lock().unwrap().take();
+        let failed_uploads = std::mem::take(&mut *self.ctx.state.failed_uploads.lock().unwrap());
         let successful_uploads = self.ctx.state.successful_uploads.load(Ordering::SeqCst);
         let total_bytes_transferred = self
             .ctx

--- a/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::sync::atomic::Ordering;
-
 use super::{UploadObjectsContext, UploadObjectsOutput};
 use tokio::task;
 
@@ -27,20 +25,6 @@ impl UploadObjectsHandle {
             join_result??;
         }
 
-        let failed_uploads = std::mem::take(&mut *self.ctx.state.failed_uploads.lock().unwrap());
-        let successful_uploads = self.ctx.state.successful_uploads.load(Ordering::SeqCst);
-        let total_bytes_transferred = self
-            .ctx
-            .state
-            .total_bytes_transferred
-            .load(Ordering::SeqCst);
-
-        let output = UploadObjectsOutput::builder()
-            .objects_uploaded(successful_uploads)
-            .set_failed_transfers(failed_uploads)
-            .total_bytes_transferred(total_bytes_transferred)
-            .build();
-
-        Ok(output)
+        Ok(UploadObjectsOutput::from(self.ctx.state.as_ref()))
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/input.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/input.rs
@@ -8,8 +8,6 @@ use aws_smithy_types::error::operation::BuildError;
 
 use std::path::{Path, PathBuf};
 
-// TODO - docs and examples on the interaction of key_prefix & delimiter
-
 /// Input type for uploading multiple objects
 #[non_exhaustive]
 #[derive(Clone, Debug)]

--- a/aws-s3-transfer-manager/src/operation/upload_objects/input.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/input.rs
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::path::{Path, PathBuf};
-
 use crate::types::{FailedTransferPolicy, UploadFilter};
+use aws_smithy_types::error::operation::BuildError;
+
+use std::path::{Path, PathBuf};
 
 // TODO - docs and examples on the interaction of key_prefix & delimiter
 
@@ -80,7 +81,7 @@ impl UploadObjectsInput {
     }
 }
 
-/// A builder for [UploadObjectsInput]
+/// A builder for [`UploadObjectsInput`]
 #[non_exhaustive]
 #[derive(Clone, Default, Debug)]
 pub struct UploadObjectsInputBuilder {
@@ -99,7 +100,16 @@ impl UploadObjectsInputBuilder {
     pub fn build(
         self,
     ) -> Result<UploadObjectsInput, ::aws_smithy_types::error::operation::BuildError> {
-        // TODO - validate required stuff (i.e. bucket)
+        if self.bucket.is_none() {
+            return Err(BuildError::missing_field("bucket", "A bucket is required"));
+        }
+
+        if self.source.is_none() {
+            return Err(BuildError::missing_field(
+                "source",
+                "Source directory to upload is required",
+            ));
+        }
 
         Ok(UploadObjectsInput {
             bucket: self.bucket,
@@ -199,8 +209,8 @@ impl UploadObjectsInputBuilder {
     }
 
     /// The S3 key prefix to use for each object.
-    pub fn get_key_prefix(&self) -> &Option<String> {
-        &self.key_prefix
+    pub fn get_key_prefix(&self) -> Option<&str> {
+        self.key_prefix.as_deref()
     }
 
     /// Character used to group keys.
@@ -216,8 +226,8 @@ impl UploadObjectsInputBuilder {
     }
 
     /// Character used to group keys.
-    pub fn get_delimiter(&self) -> &Option<String> {
-        &self.delimiter
+    pub fn get_delimiter(&self) -> Option<&str> {
+        self.delimiter.as_deref()
     }
 
     /// The failure policy to use when any individual object upload fails.

--- a/aws-s3-transfer-manager/src/operation/upload_objects/input.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/input.rs
@@ -9,9 +9,6 @@ use crate::types::{FailedTransferPolicy, UploadFilter};
 
 // TODO - docs and examples on the interaction of key_prefix & delimiter
 
-// TODO - upload_objects has recursive option (defaulting to false, per SEP)
-// but download_objects currently has no such option. Be consistent.
-
 /// Input type for uploading multiple objects
 #[non_exhaustive]
 #[derive(Clone, Debug)]
@@ -111,7 +108,7 @@ impl UploadObjectsInputBuilder {
             follow_symlinks: self.follow_symlinks,
             filter: self.filter,
             key_prefix: self.key_prefix,
-            delimiter: self.delimiter.or(Some("/".into())),
+            delimiter: self.delimiter,
             failure_policy: self.failure_policy,
         })
     }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/output.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/output.rs
@@ -36,7 +36,7 @@ impl UploadObjectsOutput {
         self.failed_transfers.as_deref().unwrap_or_default()
     }
 
-    /// The number of bytes successfully transferred (downloaded)
+    /// The number of bytes successfully transferred (uploaded)
     pub fn total_bytes_transferred(&self) -> u64 {
         self.total_bytes_transferred
     }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/output.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/output.rs
@@ -10,11 +10,14 @@ use crate::types::FailedUploadTransfer;
 #[derive(Debug)]
 pub struct UploadObjectsOutput {
     /// The number of objects successfully uploaded
-    pub objects_uploaded: u64,
+    objects_uploaded: u64,
 
     /// The list of failed uploads
-    pub failed_transfers: Vec<FailedUploadTransfer>,
-    // TODO - DownloadObjectsOutput did Option<Vec<>> instead of just Vec<>. Be consistent
+    failed_transfers: Option<Vec<FailedUploadTransfer>>,
+
+    // FIXME - likely remove when progress is implemented (let's be consistent with downloads for now)?
+    /// Total number of bytes transferred
+    total_bytes_transferred: u64,
 }
 
 impl UploadObjectsOutput {
@@ -30,7 +33,12 @@ impl UploadObjectsOutput {
 
     /// The list of failed uploads
     pub fn failed_transfers(&self) -> &[FailedUploadTransfer] {
-        &self.failed_transfers
+        self.failed_transfers.as_deref().unwrap_or_default()
+    }
+
+    /// The number of bytes successfully transferred (downloaded)
+    pub fn total_bytes_transferred(&self) -> u64 {
+        self.total_bytes_transferred
     }
 }
 
@@ -39,7 +47,8 @@ impl UploadObjectsOutput {
 #[derive(Debug, Default)]
 pub struct UploadObjectsOutputBuilder {
     pub(crate) objects_uploaded: u64,
-    pub(crate) failed_transfers: Vec<FailedUploadTransfer>,
+    pub(crate) failed_transfers: Option<Vec<FailedUploadTransfer>>,
+    pub(crate) total_bytes_transferred: u64,
 }
 
 impl UploadObjectsOutputBuilder {
@@ -58,13 +67,35 @@ impl UploadObjectsOutputBuilder {
     ///
     /// To override the contents of this collection use [`set_failed_transfers`](Self::set_failed_transfers)
     pub fn failed_transfers(mut self, input: FailedUploadTransfer) -> Self {
-        self.failed_transfers.push(input);
+        self.failed_transfers
+            .get_or_insert_with(Vec::new)
+            .push(input);
         self
     }
 
     /// The list of any failed uploads
-    pub fn set_failed_transfers(mut self, input: Vec<FailedUploadTransfer>) -> Self {
+    pub fn set_failed_transfers(mut self, input: Option<Vec<FailedUploadTransfer>>) -> Self {
         self.failed_transfers = input;
         self
+    }
+
+    /// The number of bytes successfully transferred (uploaded)
+    pub fn total_bytes_transferred(mut self, input: u64) -> Self {
+        self.total_bytes_transferred = input;
+        self
+    }
+
+    /// The number of bytes successfully transferred (uploaded)
+    pub fn get_total_bytes_transferred(&self) -> u64 {
+        self.total_bytes_transferred
+    }
+
+    /// Consume the builder and return the output
+    pub fn build(self) -> UploadObjectsOutput {
+        UploadObjectsOutput {
+            objects_uploaded: self.objects_uploaded,
+            failed_transfers: self.failed_transfers,
+            total_bytes_transferred: self.total_bytes_transferred,
+        }
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/output.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/output.rs
@@ -13,7 +13,7 @@ pub struct UploadObjectsOutput {
     objects_uploaded: u64,
 
     /// The list of failed uploads
-    failed_transfers: Option<Vec<FailedUploadTransfer>>,
+    failed_transfers: Vec<FailedUploadTransfer>,
 
     // FIXME - likely remove when progress is implemented (let's be consistent with downloads for now)?
     /// Total number of bytes transferred
@@ -33,7 +33,7 @@ impl UploadObjectsOutput {
 
     /// The list of failed uploads
     pub fn failed_transfers(&self) -> &[FailedUploadTransfer] {
-        self.failed_transfers.as_deref().unwrap_or_default()
+        self.failed_transfers.as_slice()
     }
 
     /// The number of bytes successfully transferred (uploaded)
@@ -47,7 +47,7 @@ impl UploadObjectsOutput {
 #[derive(Debug, Default)]
 pub struct UploadObjectsOutputBuilder {
     pub(crate) objects_uploaded: u64,
-    pub(crate) failed_transfers: Option<Vec<FailedUploadTransfer>>,
+    pub(crate) failed_transfers: Vec<FailedUploadTransfer>,
     pub(crate) total_bytes_transferred: u64,
 }
 
@@ -67,14 +67,12 @@ impl UploadObjectsOutputBuilder {
     ///
     /// To override the contents of this collection use [`set_failed_transfers`](Self::set_failed_transfers)
     pub fn failed_transfers(mut self, input: FailedUploadTransfer) -> Self {
-        self.failed_transfers
-            .get_or_insert_with(Vec::new)
-            .push(input);
+        self.failed_transfers.push(input);
         self
     }
 
-    /// The list of any failed uploads
-    pub fn set_failed_transfers(mut self, input: Option<Vec<FailedUploadTransfer>>) -> Self {
+    /// Set a list of failed uploads
+    pub fn set_failed_transfers(mut self, input: Vec<FailedUploadTransfer>) -> Self {
         self.failed_transfers = input;
         self
     }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -4,7 +4,7 @@
  */
 
 use std::borrow::Cow;
-use std::path::MAIN_SEPARATOR;
+use std::path::{MAIN_SEPARATOR, MAIN_SEPARATOR_STR};
 use std::sync::atomic::Ordering;
 
 use super::{UploadObjectsContext, UploadObjectsInput};
@@ -110,7 +110,7 @@ fn derive_object_key<'a>(
 
     let delim = object_key_delimiter.unwrap_or(DEFAULT_DELIMITER);
 
-    let relative_filename = if delim.starts_with(MAIN_SEPARATOR) {
+    let relative_filename = if delim == MAIN_SEPARATOR_STR {
         Cow::Borrowed(relative_filename)
     } else {
         Cow::Owned(relative_filename.replace(MAIN_SEPARATOR, delim))
@@ -268,6 +268,10 @@ mod unit {
             assert_eq!(
                 "foobar--2023-Jan-1.png",
                 derive_object_key("2023/Jan/1.png", Some("foobar--"), Some("-")).unwrap()
+            );
+            assert_eq!(
+                "2023/MYLONGDELIMJan/MYLONGDELIM1.png",
+                derive_object_key("2023/Jan/1.png", None, Some("/MYLONGDELIM")).unwrap()
             );
             {
                 let err = derive_object_key("2023/Jan-1.png", None, Some("-"))

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -9,12 +9,13 @@ use std::sync::atomic::Ordering;
 
 use super::{UploadObjectsContext, UploadObjectsInput};
 use async_channel::{Receiver, Sender};
+use aws_smithy_types::error::operation::BuildError;
 use walkdir::WalkDir;
 
 use crate::io::InputStream;
 use crate::operation::upload::UploadInputBuilder;
 use crate::operation::DEFAULT_DELIMITER;
-use crate::types::UploadFilter;
+use crate::types::{FailedTransferPolicy, FailedUploadTransfer, UploadFilter};
 use crate::{error, types::UploadFilterItem};
 
 #[derive(Debug)]
@@ -29,8 +30,55 @@ impl UploadObjectJob {
     }
 }
 
+pub(super) async fn list_directory_contents(
+    ctx: UploadObjectsContext,
+    work_tx: Sender<Result<UploadObjectJob, error::Error>>,
+) -> Result<(), error::Error> {
+    let walker = walker(&ctx.state.input);
+
+    let default_filter = &UploadFilter::default();
+    let filter = ctx.state.input.filter().unwrap_or(default_filter);
+
+    for entry in walker {
+        let job = match entry {
+            Ok(entry) => {
+                if !(filter.predicate)(&UploadFilterItem::new(
+                    entry.path(),
+                    tokio::fs::metadata(entry.path()).await?,
+                )) {
+                    tracing::debug!("skipping object due to filter: {:?}", entry.path());
+                    continue;
+                }
+
+                let recursion_root_dir_path = ctx.state.input.source().expect("source set");
+                let entry_path = entry.path();
+                let relative_filename = entry_path
+                    .strip_prefix(recursion_root_dir_path)
+                    .expect("{entry_path:?} should be a path entry directly or indirectly under {recursion_root_dir_path:?}")
+                    .to_str()
+                    .expect("valid utf-8 path");
+                let object_key = derive_object_key(
+                    relative_filename,
+                    ctx.state.input.key_prefix(),
+                    ctx.state.input.delimiter(),
+                )?;
+                tracing::info!("uploading {relative_filename} with object key {object_key}...");
+
+                Ok(UploadObjectJob::new(
+                    object_key.into_owned(),
+                    InputStream::from_path(entry.path())?,
+                ))
+            }
+            Err(e) => Err(crate::error::Error::from(BuildError::other(e))),
+        };
+        work_tx.send(job).await.expect("channel valid");
+    }
+
+    Ok(())
+}
+
 fn walker(input: &UploadObjectsInput) -> WalkDir {
-    let source = input.source().unwrap();
+    let source = input.source().expect("source set");
     let mut walker = WalkDir::new(source);
     if input.follow_symlinks() {
         walker = walker.follow_links(true);
@@ -39,102 +87,6 @@ fn walker(input: &UploadObjectsInput) -> WalkDir {
         walker = walker.max_depth(1);
     }
     walker
-}
-
-pub(super) async fn list_directory_contents(
-    ctx: UploadObjectsContext,
-    work_tx: Sender<UploadObjectJob>,
-) -> Result<(), error::Error> {
-    let walker = walker(&ctx.state.input);
-
-    let default_filter = &UploadFilter::default();
-    let filter = ctx.state.input.filter().unwrap_or(default_filter);
-
-    for entry in walker {
-        let entry = entry.unwrap();
-        if !(filter.predicate)(&UploadFilterItem::new(
-            entry.path(),
-            tokio::fs::metadata(entry.path()).await?,
-        )) {
-            tracing::debug!("skipping object due to filter: {:?}", entry.path());
-            continue;
-        }
-
-        let recursion_root_dir_path = ctx.state.input.source().expect("source set");
-        let entry_path = entry.path();
-        let relative_filename = entry_path
-            .strip_prefix(recursion_root_dir_path)
-            .expect("{entry_path:?} should be a path entry directly or indirectly under {recursion_root_dir_path:?}")
-            .to_str()
-            .expect("valid utf-8 path");
-
-        let object_key = derive_object_key(
-            relative_filename,
-            ctx.state.input.key_prefix(),
-            ctx.state.input.delimiter(),
-        )
-        .unwrap();
-        tracing::info!("uploading {relative_filename} with object key {object_key}...");
-
-        let job = UploadObjectJob::new(
-            object_key.into_owned(),
-            InputStream::from_path(entry.path()).unwrap(),
-        );
-        work_tx.send(job).await.expect("channel valid");
-    }
-
-    Ok(())
-}
-
-pub(super) async fn upload_objects(
-    ctx: UploadObjectsContext,
-    work_rx: Receiver<UploadObjectJob>,
-) -> Result<(), error::Error> {
-    while let Ok(job) = work_rx.recv().await {
-        let bytes_transferred: u64 = job
-            .object
-            .size_hint()
-            .upper()
-            .ok_or_else(crate::io::error::Error::upper_bound_size_hint_required)
-            .unwrap();
-        let key = job.key.clone();
-        let result = upload_single_obj(&ctx, job).await;
-        match result {
-            Ok(_) => {
-                ctx.state.successful_uploads.fetch_add(1, Ordering::SeqCst);
-
-                ctx.state
-                    .total_bytes_transferred
-                    .fetch_add(bytes_transferred, Ordering::SeqCst);
-
-                tracing::debug!("worker finished uploading object {:?}", key);
-            }
-            Err(err) => {
-                tracing::debug!("worker failed to upload object {:?}: {}", key, err);
-            }
-        }
-    }
-
-    tracing::trace!("req channel closed, worker finished");
-    Ok(())
-}
-
-async fn upload_single_obj(
-    ctx: &UploadObjectsContext,
-    job: UploadObjectJob,
-) -> Result<(), error::Error> {
-    let input = UploadInputBuilder::default()
-        .set_bucket(ctx.state.input.bucket.to_owned())
-        .set_body(Some(job.object))
-        .set_key(Some(job.key))
-        .build()
-        .expect("valid input");
-
-    let handle = crate::operation::upload::Upload::orchestrate(ctx.handle.clone(), input).await?;
-
-    handle.join().await?;
-
-    Ok(())
 }
 
 fn derive_object_key<'a>(
@@ -169,4 +121,104 @@ fn derive_object_key<'a>(
     };
 
     Ok(object_key)
+}
+
+pub(super) async fn upload_objects(
+    ctx: UploadObjectsContext,
+    work_rx: Receiver<Result<UploadObjectJob, error::Error>>,
+) -> Result<(), error::Error> {
+    while let Ok(job) = work_rx.recv().await {
+        match job {
+            Ok(job) => {
+                let key = job.key.clone();
+                let result = upload_single_obj(&ctx, job).await;
+                match result {
+                    Ok(bytes_transferred) => {
+                        ctx.state.successful_uploads.fetch_add(1, Ordering::SeqCst);
+
+                        ctx.state
+                            .total_bytes_transferred
+                            .fetch_add(bytes_transferred, Ordering::SeqCst);
+
+                        tracing::debug!("worker finished uploading object {:?}", key);
+                    }
+                    Err(err) => {
+                        tracing::debug!("worker failed to upload object {:?}: {}", key, err);
+                        handle_failed_upload(err, &ctx, Some(key))?;
+                    }
+                }
+            }
+            Err(err) => handle_failed_upload(err, &ctx, None)?,
+        }
+    }
+
+    tracing::trace!("req channel closed, worker finished");
+    Ok(())
+}
+
+async fn upload_single_obj(
+    ctx: &UploadObjectsContext,
+    job: UploadObjectJob,
+) -> Result<u64, error::Error> {
+    let UploadObjectJob { object, key } = job;
+
+    // `object` gets consumed by `input` so calculate the content length in advance
+    let bytes_transferred: u64 = object
+        .size_hint()
+        .upper()
+        .ok_or_else(crate::io::error::Error::upper_bound_size_hint_required)
+        .unwrap();
+
+    let input = UploadInputBuilder::default()
+        .set_bucket(ctx.state.input.bucket.to_owned())
+        .set_body(Some(object))
+        .set_key(Some(key))
+        .build()
+        .expect("valid input");
+
+    let handle = crate::operation::upload::Upload::orchestrate(ctx.handle.clone(), input).await?;
+
+    handle.join().await?;
+
+    Ok(bytes_transferred)
+}
+
+fn handle_failed_upload(
+    err: error::Error,
+    ctx: &UploadObjectsContext,
+    object_key: Option<String>,
+) -> Result<(), error::Error> {
+    match ctx.state.input.failure_policy() {
+        // TODO - this will abort this worker, the rest of the workers will be aborted
+        // when the handle is joined and the error is propagated and the task set is
+        // dropped. This _may_ be later/too passive and we might consider aborting all
+        // the tasks on error rather than relying on join and then drop.
+        FailedTransferPolicy::Abort => Err(err),
+        FailedTransferPolicy::Continue => {
+            let mut guard = ctx.state.failed_uploads.lock().unwrap();
+            let mut failures = std::mem::take(&mut *guard).unwrap_or_default();
+
+            let failed_transfer = FailedUploadTransfer {
+                input: match object_key {
+                    key @ Some(_) => Some(
+                        UploadInputBuilder::default()
+                            .set_bucket(ctx.state.input.bucket.to_owned())
+                            // We avoid creating a new `InputStream` to pass to `set_body`, as it incurs unnecessary
+                            // overhead just for error reporting purposes.
+                            .set_key(key)
+                            .build()
+                            .expect("valid input"),
+                    ),
+                    None => None,
+                },
+                error: err,
+            };
+
+            failures.push(failed_transfer);
+
+            let _ = std::mem::replace(&mut *guard, Some(failures));
+
+            Ok(())
+        }
+    }
 }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -33,44 +33,47 @@ impl UploadObjectJob {
 }
 
 pub(super) async fn list_directory_contents(
-    ctx: UploadObjectsContext,
+    input: UploadObjectsInput,
     work_tx: Sender<Result<UploadObjectJob, error::Error>>,
 ) -> Result<(), error::Error> {
     // Move a blocking I/O to a dedicated thread pool
-    let mut walker = Unblock::new(walker(&ctx.state.input).into_iter());
+    let mut walker = Unblock::new(walker(&input).into_iter());
 
     let default_filter = &UploadFilter::default();
-    let filter = ctx.state.input.filter().unwrap_or(default_filter);
+    let filter = input.filter().unwrap_or(default_filter);
 
     while let Some(entry) = walker.next().await {
         let job = match entry {
             Ok(entry) => {
-                if !(filter.predicate)(&UploadFilterItem::new(
-                    entry.path(),
-                    tokio::fs::metadata(entry.path()).await?,
-                )) {
+                let metadata = tokio::fs::metadata(entry.path()).await?;
+                if !(filter.predicate)(&UploadFilterItem::new(entry.path(), metadata.clone())) {
                     tracing::debug!("skipping object due to filter: {:?}", entry.path());
                     continue;
                 }
 
-                let recursion_root_dir_path = ctx.state.input.source().expect("source set");
+                let recursion_root_dir_path = input.source().expect("source set");
                 let entry_path = entry.path();
                 let relative_filename = entry_path
                     .strip_prefix(recursion_root_dir_path)
                     .expect("{entry_path:?} should be a path entry directly or indirectly under {recursion_root_dir_path:?}")
                     .to_str()
                     .expect("valid utf-8 path");
-                let object_key = derive_object_key(
-                    relative_filename,
-                    ctx.state.input.key_prefix(),
-                    ctx.state.input.delimiter(),
-                )?;
-                tracing::info!("uploading {relative_filename} with object key {object_key}...");
+                let object_key =
+                    derive_object_key(relative_filename, input.key_prefix(), input.delimiter())?;
+                let object = InputStream::read_from()
+                    .path(entry.path())
+                    .metadata(metadata)
+                    .build();
 
-                Ok(UploadObjectJob::new(
-                    object_key.into_owned(),
-                    InputStream::from_path(entry.path())?,
-                ))
+                match object {
+                    Ok(object) => {
+                        tracing::info!(
+                            "uploading {relative_filename} with object key {object_key}..."
+                        );
+                        Ok(UploadObjectJob::new(object_key.into_owned(), object))
+                    }
+                    Err(e) => Err(crate::error::Error::from(BuildError::other(e))),
+                }
             }
             Err(e) => Err(crate::error::Error::from(BuildError::other(e))),
         };
@@ -98,9 +101,9 @@ fn derive_object_key<'a>(
     object_key_delimiter: Option<&str>,
 ) -> Result<Cow<'a, str>, error::Error> {
     if let Some(delim) = object_key_delimiter {
-        if relative_filename.contains(delim) {
+        if delim != DEFAULT_DELIMITER && relative_filename.contains(delim) {
             return Err(error::invalid_input(format!(
-                "a custom delimiter {delim} should not appear in {relative_filename}"
+                "a custom delimiter `{delim}` should not appear in `{relative_filename}`"
             )));
         }
     }
@@ -223,5 +226,317 @@ fn handle_failed_upload(
 
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operation::upload_objects::UploadObjectsInputBuilder;
+    use std::collections::BTreeMap;
+    use std::error::Error as _;
+    use std::fs;
+    use std::io::Write;
+    use tempfile::{tempdir, TempDir};
+
+    #[cfg(target_family = "unix")]
+    #[test]
+    fn test_derive_object_key() {
+        assert_eq!(
+            "2023/Jan/1.png",
+            derive_object_key("2023/Jan/1.png", None, None).unwrap()
+        );
+        assert_eq!(
+            "foobar/2023/Jan/1.png",
+            derive_object_key("2023/Jan/1.png", Some("foobar"), None).unwrap()
+        );
+        assert_eq!(
+            "foobar/2023/Jan/1.png",
+            derive_object_key("2023/Jan/1.png", Some("foobar/"), None).unwrap()
+        );
+        assert_eq!(
+            "2023-Jan-1.png",
+            derive_object_key("2023/Jan/1.png", None, Some("-")).unwrap()
+        );
+        assert_eq!(
+            "foobar-2023-Jan-1.png",
+            derive_object_key("2023/Jan/1.png", Some("foobar"), Some("-")).unwrap()
+        );
+        assert_eq!(
+            "foobar-2023-Jan-1.png",
+            derive_object_key("2023/Jan/1.png", Some("foobar-"), Some("-")).unwrap()
+        );
+        assert_eq!(
+            "foobar--2023-Jan-1.png",
+            derive_object_key("2023/Jan/1.png", Some("foobar--"), Some("-")).unwrap()
+        );
+        {
+            let err = derive_object_key("2023/Jan-1.png", None, Some("-"))
+                .err()
+                .unwrap();
+            assert_eq!(
+                "a custom delimiter `-` should not appear in `2023/Jan-1.png`",
+                format!("{}", err.source().unwrap())
+            );
+        }
+
+        // Should not replace the path separator in prefix with a custom delimiter
+        assert_eq!(
+            "foo/bar-2023-Jan-1.png",
+            derive_object_key("2023/Jan/1.png", Some("foo/bar"), Some("-")).unwrap()
+        );
+
+        // Should not fail if the user specifies the default delimiter as a custom delimiter
+        assert_eq!(
+            "2023/Jan/1.png",
+            derive_object_key("2023/Jan/1.png", None, Some(DEFAULT_DELIMITER)).unwrap()
+        );
+    }
+
+    #[cfg(target_family = "windows")]
+    #[test]
+    fn test_derive_object_key() {
+        assert_eq!(
+            "2023/Jan/1.png",
+            derive_object_key("2023\\Jan\\1.png", None, None).unwrap()
+        );
+    }
+
+    #[cfg(target_family = "unix")]
+    fn create_test_dir(
+        recursion_root: Option<&str>,
+        files: Vec<(&str, usize)>,
+        inaccessible_dir_relative_paths: &[&str],
+    ) -> TempDir {
+        let temp_dir = match recursion_root {
+            Some(root) => TempDir::with_prefix(root).unwrap(),
+            None => tempdir().unwrap(),
+        };
+
+        // Create the directory structure and files
+        for (path, size) in files {
+            let full_path = temp_dir.path().join(path);
+            let parent = full_path.parent().unwrap();
+
+            // Create the parent directories if they don't exist
+            fs::create_dir_all(parent).unwrap();
+
+            // Create the .jpg file with the specified size
+            let mut file = fs::File::create(&full_path).unwrap();
+            file.write_all(&vec![0; size]).unwrap(); // Writing `size` byte
+        }
+
+        // Set the directories in `inaccessible_dir_relative_paths` to be inaccessible,
+        // which will in turn render the files within those directories inaccessible
+        for dir_relative_path in inaccessible_dir_relative_paths {
+            let dir_path = temp_dir.path().join(*dir_relative_path);
+            let mut permissions = fs::metadata(&dir_path).unwrap().permissions();
+            std::os::unix::fs::PermissionsExt::set_mode(&mut permissions, 0o000); // No permissions for anyone
+            fs::set_permissions(dir_path, permissions).unwrap();
+        }
+
+        temp_dir
+    }
+
+    async fn exercise_list_directory_contents(
+        input: UploadObjectsInput,
+    ) -> (BTreeMap<String, usize>, Vec<error::Error>) {
+        let (work_tx, work_rx) = async_channel::unbounded();
+
+        let join_handle = tokio::spawn(list_directory_contents(input, work_tx));
+
+        let mut successes = BTreeMap::new();
+        let mut errors = Vec::new();
+        while let Ok(job) = work_rx.recv().await {
+            match job {
+                Ok(job) => {
+                    successes.insert(job.key, job.object.size_hint().upper().unwrap() as usize);
+                }
+                Err(e) => errors.push(e),
+            }
+        }
+
+        let _ = join_handle.await.unwrap();
+
+        (successes, errors)
+    }
+
+    #[cfg(target_family = "unix")]
+    #[tokio::test]
+    async fn test_list_directory_contents_should_send_upload_object_jobs_from_traversed_path_entries(
+    ) {
+        let recursion_root = "test";
+        let files = vec![
+            ("sample.jpg", 1),
+            ("photos/2022/January/sample.jpg", 1),
+            ("photos/2022/February/sample1.jpg", 1),
+            ("photos/2022/February/sample2.jpg", 1),
+            ("photos/2022/February/sample3.jpg", 1),
+        ];
+        let test_dir = create_test_dir(Some(&recursion_root), files.clone(), &[]);
+
+        // Test with only required input fields (no recursion)
+        {
+            let input = UploadObjectsInputBuilder::default()
+                .bucket("doesnotmatter")
+                .source(test_dir.path())
+                .build()
+                .unwrap();
+
+            let (actual, errors) = exercise_list_directory_contents(input).await;
+
+            let expected = files
+                .iter()
+                .take(1)
+                .map(|(entry_path, value)| ((*entry_path).to_owned(), *value))
+                .collect::<BTreeMap<_, _>>();
+
+            assert_eq!(expected, actual);
+            assert!(errors.is_empty());
+        }
+
+        // Test with recursion
+        {
+            let input = UploadObjectsInputBuilder::default()
+                .bucket("doesnotmatter")
+                .source(test_dir.path())
+                .recursive(true)
+                .build()
+                .unwrap();
+
+            let (actual, errors) = exercise_list_directory_contents(input).await;
+
+            let expected = files
+                .iter()
+                .map(|(entry_path, value)| ((*entry_path).to_owned(), *value))
+                .collect::<BTreeMap<_, _>>();
+
+            assert_eq!(expected, actual);
+            assert!(errors.is_empty());
+        }
+
+        // Test with recursion, a custom key prefix, and a custom delimiter
+        {
+            let key_prefix = "test";
+            let delimiter = "-";
+            let input = UploadObjectsInputBuilder::default()
+                .bucket("doesnotmatter")
+                .source(test_dir.path())
+                .recursive(true)
+                .key_prefix(key_prefix)
+                .delimiter(delimiter)
+                .build()
+                .unwrap();
+
+            let (actual, errors) = exercise_list_directory_contents(input).await;
+
+            let expected = files
+                .iter()
+                .map(|(entry_path, value)| {
+                    (
+                        // For verification purporses, we manually derive object key without using `derive_object_key`
+                        format!(
+                            "{key_prefix}{delimiter}{key_suffix}",
+                            key_suffix = entry_path.replace("/", delimiter)
+                        ),
+                        *value,
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+
+            assert_eq!(expected, actual);
+            assert!(errors.is_empty());
+        }
+    }
+
+    #[cfg(target_family = "unix")]
+    #[tokio::test]
+    async fn test_list_directory_contents_should_send_both_upload_object_jobs_and_errors() {
+        let recursion_root = "test";
+        let files = vec![
+            ("sample.jpg", 1),
+            ("photos/2022/January/sample.jpg", 1),
+            ("photos/2022/February/sample1.jpg", 1),
+            ("photos/2022/February/sample2.jpg", 1),
+            ("photos/2022/February/sample3.jpg", 1),
+        ];
+        // Make all files inaccessible under `photos/2022/February`
+        let inaccessible_dir_relative_path = "photos/2022/February";
+        let test_dir = create_test_dir(
+            Some(&recursion_root),
+            files.clone(),
+            &[inaccessible_dir_relative_path],
+        );
+
+        let input = UploadObjectsInputBuilder::default()
+            .bucket("doesnotmatter")
+            .source(test_dir.path())
+            .recursive(true)
+            .build()
+            .unwrap();
+
+        let (actual, errors) = exercise_list_directory_contents(input).await;
+
+        let expected = files
+            .iter()
+            .filter(|(entry_path, _)| !entry_path.starts_with(inaccessible_dir_relative_path))
+            .map(|(entry_path, value)| ((*entry_path).to_owned(), *value))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(expected, actual);
+        assert_eq!(1, errors.len());
+        let build_error = errors[0]
+            .source()
+            .unwrap()
+            .downcast_ref::<aws_smithy_types::error::operation::BuildError>()
+            .expect("should downcast to `aws_smithy_types::error::operation::BuildError`");
+        let walkdir_error = build_error
+            .source()
+            .unwrap()
+            .downcast_ref::<walkdir::Error>()
+            .expect("should downcast to `walkdir::Error`");
+        assert!(walkdir_error
+            .path()
+            .unwrap()
+            .ends_with(inaccessible_dir_relative_path));
+        assert_eq!(
+            std::io::ErrorKind::PermissionDenied,
+            walkdir_error.io_error().unwrap().kind()
+        );
+    }
+
+    #[cfg(target_family = "unix")]
+    #[tokio::test]
+    async fn test_upload_filter() {
+        let recursion_root = "test";
+        let files = vec![
+            ("sample.jpg", 1),
+            ("photos/2022/January/sample.jpg", 1),
+            ("photos/2022/February/sample1.jpg", 1),
+            ("photos/2022/February/sample2.jpg", 1),
+            ("photos/2022/February/sample3.jpg", 1),
+        ];
+        let test_dir = create_test_dir(Some(&recursion_root), files.clone(), &[]);
+
+        let input = UploadObjectsInputBuilder::default()
+            .bucket("doesnotmatter")
+            .source(test_dir.path())
+            .recursive(true)
+            .filter(|item: &UploadFilterItem<'_>| {
+                !item.path().to_str().unwrap().contains("February") && item.metadata().is_file()
+            })
+            .build()
+            .unwrap();
+
+        let (actual, errors) = exercise_list_directory_contents(input).await;
+
+        let expected = files
+            .iter()
+            .filter(|(entry_path, _)| !entry_path.contains("February"))
+            .map(|(entry_path, value)| ((*entry_path).to_owned(), *value))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(expected, actual);
+        assert!(errors.is_empty());
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -335,7 +335,7 @@ mod tests {
             ("photos/2022/February/sample2.jpg", 1),
             ("photos/2022/February/sample3.jpg", 1),
         ];
-        let test_dir = create_test_dir(Some(&recursion_root), files.clone(), &[]);
+        let test_dir = create_test_dir(Some(recursion_root), files.clone(), &[]);
 
         // Test with only required input fields (no recursion)
         {
@@ -399,7 +399,7 @@ mod tests {
                         // For verification purporses, we manually derive object key without using `derive_object_key`
                         format!(
                             "{key_prefix}{delimiter}{key_suffix}",
-                            key_suffix = entry_path.replace("/", delimiter)
+                            key_suffix = entry_path.replace('/', delimiter)
                         ),
                         *value,
                     )
@@ -425,7 +425,7 @@ mod tests {
         // Make all files inaccessible under `photos/2022/February`
         let inaccessible_dir_relative_path = "photos/2022/February";
         let test_dir = create_test_dir(
-            Some(&recursion_root),
+            Some(recursion_root),
             files.clone(),
             &[inaccessible_dir_relative_path],
         );
@@ -478,7 +478,7 @@ mod tests {
             ("photos/2022/February/sample2.jpg", 1),
             ("photos/2022/February/sample3.jpg", 1),
         ];
-        let test_dir = create_test_dir(Some(&recursion_root), files.clone(), &[]);
+        let test_dir = create_test_dir(Some(recursion_root), files.clone(), &[]);
 
         let input = UploadObjectsInputBuilder::default()
             .bucket("doesnotmatter")

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -72,7 +72,7 @@ pub(super) async fn list_directory_contents(
                         );
                         Ok(UploadObjectJob::new(object_key.into_owned(), object))
                     }
-                    Err(e) => Err(crate::error::Error::from(BuildError::other(e))),
+                    Err(e) => Err(e.into()),
                 }
             }
             Err(e) => Err(crate::error::Error::from(BuildError::other(e))),

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -54,19 +54,19 @@ pub(super) async fn list_directory_contents(
         let entry = entry.unwrap();
         if !(filter.predicate)(&UploadFilterItem::new(
             entry.path(),
-            tokio::fs::metadata(entry.path()).await.unwrap(),
+            tokio::fs::metadata(entry.path()).await?,
         )) {
             tracing::debug!("skipping object due to filter: {:?}", entry.path());
             continue;
         }
 
-        let recursion_root_dir_path = ctx.state.input.source().unwrap();
-        let relative_filename = entry
-            .path()
+        let recursion_root_dir_path = ctx.state.input.source().expect("source set");
+        let entry_path = entry.path();
+        let relative_filename = entry_path
             .strip_prefix(recursion_root_dir_path)
-            .unwrap()
+            .expect("{entry_path:?} should be a path entry directly or indirectly under {recursion_root_dir_path:?}")
             .to_str()
-            .unwrap();
+            .expect("valid utf-8 path");
 
         let object_key = derive_object_key(
             relative_filename,

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -146,15 +146,18 @@ pub(super) async fn upload_objects(
                             .total_bytes_transferred
                             .fetch_add(bytes_transferred, Ordering::SeqCst);
 
-                        tracing::debug!("worker finished uploading object {:?}", key);
+                        tracing::debug!("worker finished uploading object {key:?}");
                     }
                     Err(err) => {
-                        tracing::debug!("worker failed to upload object {:?}: {}", key, err);
+                        tracing::debug!("worker failed to upload object {key:?}: {err}");
                         handle_failed_upload(err, &ctx, Some(key))?;
                     }
                 }
             }
-            Err(err) => handle_failed_upload(err, &ctx, None)?,
+            Err(err) => {
+                tracing::debug!("worker received an error from the `list_directory` task: {err}");
+                handle_failed_upload(err, &ctx, None)?;
+            }
         }
     }
 

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -36,6 +36,12 @@ pub(super) async fn list_directory_contents(
     input: UploadObjectsInput,
     list_directory_tx: Sender<Result<UploadObjectJob, error::Error>>,
 ) -> Result<(), error::Error> {
+    // TODO - Reevaluate the need for the `blocking` crate once we implement stricter task cancellation for download and upload.
+    // If we switch to using `tokio::task::spawn_blocking` instead of the `blocking` crate, the entire `list_directory_contents` function
+    // would need to be passed to `spawn_blocking`, which implies the following:
+    // - `list_directory_contents` would need to become a regular, non-async function, complicating the use of `async_channel::Sender` within it.
+    // - The `AbortHandle` returned by `spawn_blocking` would not have any effect when calling `abort`, which may impact our task cancellation behavior.
+
     // Move a blocking I/O to a dedicated thread pool
     let mut walker = Unblock::new(walker(&input).into_iter());
 

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -494,6 +494,8 @@ mod unit {
 
     #[cfg(target_family = "windows")]
     mod window_tests {
+        use crate::operation::upload_objects::worker::*;
+
         #[test]
         fn test_derive_object_key() {
             assert_eq!(

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -1,0 +1,172 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::borrow::Cow;
+use std::path::MAIN_SEPARATOR;
+use std::sync::atomic::Ordering;
+
+use super::{UploadObjectsContext, UploadObjectsInput};
+use async_channel::{Receiver, Sender};
+use walkdir::WalkDir;
+
+use crate::io::InputStream;
+use crate::operation::upload::UploadInputBuilder;
+use crate::operation::DEFAULT_DELIMITER;
+use crate::types::UploadFilter;
+use crate::{error, types::UploadFilterItem};
+
+#[derive(Debug)]
+pub(super) struct UploadObjectJob {
+    key: String,
+    object: InputStream,
+}
+
+impl UploadObjectJob {
+    fn new(key: String, object: InputStream) -> Self {
+        Self { key, object }
+    }
+}
+
+fn walker(input: &UploadObjectsInput) -> WalkDir {
+    let source = input.source().unwrap();
+    let mut walker = WalkDir::new(source);
+    if input.follow_symlinks() {
+        walker = walker.follow_links(true);
+    }
+    if !input.recursive() {
+        walker = walker.max_depth(1);
+    }
+    walker
+}
+
+pub(super) async fn list_directory_contents(
+    ctx: UploadObjectsContext,
+    work_tx: Sender<UploadObjectJob>,
+) -> Result<(), error::Error> {
+    let walker = walker(&ctx.state.input);
+
+    let default_filter = &UploadFilter::default();
+    let filter = ctx.state.input.filter().unwrap_or(default_filter);
+
+    for entry in walker {
+        let entry = entry.unwrap();
+        if !(filter.predicate)(&UploadFilterItem::new(
+            entry.path(),
+            tokio::fs::metadata(entry.path()).await.unwrap(),
+        )) {
+            tracing::debug!("skipping object due to filter: {:?}", entry.path());
+            continue;
+        }
+
+        let recursion_root_dir_path = ctx.state.input.source().unwrap();
+        let relative_filename = entry
+            .path()
+            .strip_prefix(recursion_root_dir_path)
+            .unwrap()
+            .to_str()
+            .unwrap();
+
+        let object_key = derive_object_key(
+            relative_filename,
+            ctx.state.input.key_prefix(),
+            ctx.state.input.delimiter(),
+        )
+        .unwrap();
+        tracing::info!("uploading {relative_filename} with object key {object_key}...");
+
+        let job = UploadObjectJob::new(
+            object_key.into_owned(),
+            InputStream::from_path(entry.path()).unwrap(),
+        );
+        work_tx.send(job).await.expect("channel valid");
+    }
+
+    Ok(())
+}
+
+pub(super) async fn upload_objects(
+    ctx: UploadObjectsContext,
+    work_rx: Receiver<UploadObjectJob>,
+) -> Result<(), error::Error> {
+    while let Ok(job) = work_rx.recv().await {
+        let bytes_transferred: u64 = job
+            .object
+            .size_hint()
+            .upper()
+            .ok_or_else(crate::io::error::Error::upper_bound_size_hint_required)
+            .unwrap();
+        let key = job.key.clone();
+        let result = upload_single_obj(&ctx, job).await;
+        match result {
+            Ok(_) => {
+                ctx.state.successful_uploads.fetch_add(1, Ordering::SeqCst);
+
+                ctx.state
+                    .total_bytes_transferred
+                    .fetch_add(bytes_transferred, Ordering::SeqCst);
+
+                tracing::debug!("worker finished uploading object {:?}", key);
+            }
+            Err(err) => {
+                tracing::debug!("worker failed to upload object {:?}: {}", key, err);
+            }
+        }
+    }
+
+    tracing::trace!("req channel closed, worker finished");
+    Ok(())
+}
+
+async fn upload_single_obj(
+    ctx: &UploadObjectsContext,
+    job: UploadObjectJob,
+) -> Result<(), error::Error> {
+    let input = UploadInputBuilder::default()
+        .set_bucket(ctx.state.input.bucket.to_owned())
+        .set_body(Some(job.object))
+        .set_key(Some(job.key))
+        .build()
+        .expect("valid input");
+
+    let handle = crate::operation::upload::Upload::orchestrate(ctx.handle.clone(), input).await?;
+
+    handle.join().await?;
+
+    Ok(())
+}
+
+fn derive_object_key<'a>(
+    relative_filename: &'a str,
+    object_key_prefix: Option<&str>,
+    object_key_delimiter: Option<&str>,
+) -> Result<Cow<'a, str>, error::Error> {
+    if let Some(delim) = object_key_delimiter {
+        if relative_filename.contains(delim) {
+            return Err(error::invalid_input(format!(
+                "a custom delimiter {delim} should not appear in {relative_filename}"
+            )));
+        }
+    }
+
+    let delim = object_key_delimiter.unwrap_or(DEFAULT_DELIMITER);
+
+    let relative_filename = if delim.starts_with(MAIN_SEPARATOR) {
+        Cow::Borrowed(relative_filename)
+    } else {
+        Cow::Owned(relative_filename.replace(MAIN_SEPARATOR, delim))
+    };
+
+    let object_key = if let Some(prefix) = object_key_prefix {
+        if prefix.ends_with(delim) {
+            Cow::Owned(format!("{prefix}{relative_filename}"))
+        } else {
+            Cow::Owned(format!("{prefix}{delim}{relative_filename}"))
+        }
+    } else {
+        relative_filename
+    };
+
+    Ok(object_key)
+}

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -235,9 +235,7 @@ mod tests {
     use crate::operation::upload_objects::UploadObjectsInputBuilder;
     use std::collections::BTreeMap;
     use std::error::Error as _;
-    use std::fs;
-    use std::io::Write;
-    use tempfile::{tempdir, TempDir};
+    use test_common::create_test_dir;
 
     #[cfg(target_family = "unix")]
     #[test]
@@ -300,42 +298,6 @@ mod tests {
             "2023/Jan/1.png",
             derive_object_key("2023\\Jan\\1.png", None, None).unwrap()
         );
-    }
-
-    #[cfg(target_family = "unix")]
-    fn create_test_dir(
-        recursion_root: Option<&str>,
-        files: Vec<(&str, usize)>,
-        inaccessible_dir_relative_paths: &[&str],
-    ) -> TempDir {
-        let temp_dir = match recursion_root {
-            Some(root) => TempDir::with_prefix(root).unwrap(),
-            None => tempdir().unwrap(),
-        };
-
-        // Create the directory structure and files
-        for (path, size) in files {
-            let full_path = temp_dir.path().join(path);
-            let parent = full_path.parent().unwrap();
-
-            // Create the parent directories if they don't exist
-            fs::create_dir_all(parent).unwrap();
-
-            // Create the .jpg file with the specified size
-            let mut file = fs::File::create(&full_path).unwrap();
-            file.write_all(&vec![0; size]).unwrap(); // Writing `size` byte
-        }
-
-        // Set the directories in `inaccessible_dir_relative_paths` to be inaccessible,
-        // which will in turn render the files within those directories inaccessible
-        for dir_relative_path in inaccessible_dir_relative_paths {
-            let dir_path = temp_dir.path().join(*dir_relative_path);
-            let mut permissions = fs::metadata(&dir_path).unwrap().permissions();
-            std::os::unix::fs::PermissionsExt::set_mode(&mut permissions, 0o000); // No permissions for anyone
-            fs::set_permissions(dir_path, permissions).unwrap();
-        }
-
-        temp_dir
     }
 
     async fn exercise_list_directory_contents(

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -210,8 +210,7 @@ fn handle_failed_upload(
         // the tasks on error rather than relying on join and then drop.
         FailedTransferPolicy::Abort => Err(err),
         FailedTransferPolicy::Continue => {
-            let mut guard = ctx.state.failed_uploads.lock().unwrap();
-            let mut failures = std::mem::take(&mut *guard).unwrap_or_default();
+            let mut failures = ctx.state.failed_uploads.lock().unwrap();
 
             let failed_transfer = FailedUploadTransfer {
                 input: match object_key {
@@ -230,8 +229,6 @@ fn handle_failed_upload(
             };
 
             failures.push(failed_transfer);
-
-            let _ = std::mem::replace(&mut *guard, Some(failures));
 
             Ok(())
         }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -177,7 +177,8 @@ async fn upload_single_obj(
 ) -> Result<u64, error::Error> {
     let UploadObjectJob { object, key } = job;
 
-    // `object` gets consumed by `input` so calculate the content length in advance
+    // `object` gets consumed by `input` so calculate the content length in advance.
+    // While true for file-based workloads, the upper `size_hint` might not be equal to the actual bytes transferred.
     let bytes_transferred: u64 = object
         .size_hint()
         .upper()

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -190,9 +190,7 @@ impl Default for UploadFilter {
 pub struct UploadFilterItem<'a> {
     pub(crate) path: Cow<'a, Path>,
 
-    // TODO - Should we be passing std::fs::Metadata? It avoids additional syscalls
-    // from naive calls to path.is_dir(), path.is_symlink(), etc. Should
-    // we pass our own custom type so we're not tied to std::fs::Metadata?
+    // TODO - Should we pass our own custom type so we're not tied to std::fs::Metadata?
     pub(crate) metadata: Metadata,
 }
 
@@ -222,15 +220,7 @@ impl<'a> UploadFilterItem<'a> {
 #[non_exhaustive]
 #[derive(Debug)]
 pub struct FailedUploadTransfer {
-    // TODO - should we include path? should we wrap UploadInput in an Option?
-    // there could be an error with the file before we even assemble an UploadInput
-
-    // TODO - what about an error caused by a directory?
-    // like, user doesn't have permission to read subdirectory,
-    // but they're using FailedTransferPolicy::Continue, so
-    // it probably shouldn't be fatal, but they'd probably
-    // want the failure list to indicate that it wasn't a perfect run
-    pub(crate) input: crate::operation::upload::UploadInput,
+    pub(crate) input: Option<crate::operation::upload::UploadInput>,
     pub(crate) error: crate::error::Error,
 }
 
@@ -238,8 +228,8 @@ pub struct FailedUploadTransfer {
 // "Transfer" is generic for "upload or download" but this already has "Upload" in the name
 impl FailedUploadTransfer {
     /// The input for the failed object upload
-    pub fn input(&self) -> &crate::operation::upload::UploadInput {
-        &self.input
+    pub fn input(&self) -> Option<&crate::operation::upload::UploadInput> {
+        self.input.as_ref()
     }
 
     /// The error encountered uploading the object

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -189,14 +189,12 @@ impl Default for UploadFilter {
 #[derive(Debug)]
 pub struct UploadFilterItem<'a> {
     pub(crate) path: Cow<'a, Path>,
-
-    // TODO - Should we pass our own custom type so we're not tied to std::fs::Metadata?
     pub(crate) metadata: Metadata,
 }
 
 impl<'a> UploadFilterItem<'a> {
     /// Create a new upload filter from `path` and `metadata`
-    pub fn new(path: impl Into<Cow<'a, Path>>, metadata: Metadata) -> Self {
+    pub(crate) fn new(path: impl Into<Cow<'a, Path>>, metadata: Metadata) -> Self {
         Self {
             path: path.into(),
             metadata,

--- a/aws-s3-transfer-manager/test-common/Cargo.toml
+++ b/aws-s3-transfer-manager/test-common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test-common"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 publish = false
 
 [dependencies]

--- a/aws-s3-transfer-manager/test-common/Cargo.toml
+++ b/aws-s3-transfer-manager/test-common/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test-common"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+tempfile = "3.12.0"

--- a/aws-s3-transfer-manager/test-common/src/lib.rs
+++ b/aws-s3-transfer-manager/test-common/src/lib.rs
@@ -32,7 +32,7 @@ pub fn create_test_dir(
         // Create the parent directories if they don't exist
         fs::create_dir_all(parent).unwrap();
 
-        // Create the .jpg file with the specified size
+        // Create the file with the specified size
         let mut file = fs::File::create(&full_path).unwrap();
         file.write_all(&vec![0; size]).unwrap(); // Writing `size` byte
     }

--- a/aws-s3-transfer-manager/test-common/src/lib.rs
+++ b/aws-s3-transfer-manager/test-common/src/lib.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#![cfg(target_family = "unix")]
+
+use std::{fs, io::Write};
+use tempfile::{tempdir, TempDir};
+
+/// Create a directory structure rooted at `recursion_root`, containing files with sizes
+/// specified in `files`
+/// 
+/// For testing purposes, certain directories (and all files within them) can be made 
+/// inaccessible by providing `inaccessible_dir_relative_paths`, which should be relative 
+/// to `recursion_root`.
+pub fn create_test_dir(
+    recursion_root: Option<&str>,
+    files: Vec<(&str, usize)>,
+    inaccessible_dir_relative_paths: &[&str],
+) -> TempDir {
+    let temp_dir = match recursion_root {
+        Some(root) => TempDir::with_prefix(root).unwrap(),
+        None => tempdir().unwrap(),
+    };
+
+    // Create the directory structure and files
+    for (path, size) in files {
+        let full_path = temp_dir.path().join(path);
+        let parent = full_path.parent().unwrap();
+
+        // Create the parent directories if they don't exist
+        fs::create_dir_all(parent).unwrap();
+
+        // Create the .jpg file with the specified size
+        let mut file = fs::File::create(&full_path).unwrap();
+        file.write_all(&vec![0; size]).unwrap(); // Writing `size` byte
+    }
+
+    // Set the directories in `inaccessible_dir_relative_paths` to be inaccessible,
+    // which will in turn render the files within those directories inaccessible
+    for dir_relative_path in inaccessible_dir_relative_paths {
+        let dir_path = temp_dir.path().join(*dir_relative_path);
+        let mut permissions = fs::metadata(&dir_path).unwrap().permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut permissions, 0o000); // No permissions for anyone
+        fs::set_permissions(dir_path, permissions).unwrap();
+    }
+
+    temp_dir
+}

--- a/aws-s3-transfer-manager/test-common/src/lib.rs
+++ b/aws-s3-transfer-manager/test-common/src/lib.rs
@@ -10,9 +10,9 @@ use tempfile::{tempdir, TempDir};
 
 /// Create a directory structure rooted at `recursion_root`, containing files with sizes
 /// specified in `files`
-/// 
-/// For testing purposes, certain directories (and all files within them) can be made 
-/// inaccessible by providing `inaccessible_dir_relative_paths`, which should be relative 
+///
+/// For testing purposes, certain directories (and all files within them) can be made
+/// inaccessible by providing `inaccessible_dir_relative_paths`, which should be relative
 /// to `recursion_root`.
 pub fn create_test_dir(
     recursion_root: Option<&str>,

--- a/aws-s3-transfer-manager/tests/download_objects_test.rs
+++ b/aws-s3-transfer-manager/tests/download_objects_test.rs
@@ -401,5 +401,5 @@ async fn test_destination_dir_not_valid() {
         .unwrap_err();
 
     let err_str = format!("{}", DisplayErrorContext(err));
-    assert!(err_str.contains("destination is not a directory"));
+    assert!(err_str.contains("is not a directory"));
 }

--- a/aws-s3-transfer-manager/tests/download_objects_test.rs
+++ b/aws-s3-transfer-manager/tests/download_objects_test.rs
@@ -401,5 +401,5 @@ async fn test_destination_dir_not_valid() {
         .unwrap_err();
 
     let err_str = format!("{}", DisplayErrorContext(err));
-    assert!(err_str.contains("is not a directory"));
+    assert!(err_str.contains("target is not a directory"));
 }

--- a/aws-s3-transfer-manager/tests/upload_objects_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_objects_test.rs
@@ -81,7 +81,7 @@ async fn test_successful_multiple_objects_upload_via_put_object() {
         ("photos/2022/February/sample2.jpg", 1),
         ("photos/2022/February/sample3.jpg", 1),
     ];
-    let test_dir = create_test_dir(Some(&recursion_root), files.clone(), &[]);
+    let test_dir = create_test_dir(Some(recursion_root), files.clone(), &[]);
 
     let bucket_name = "test-bucket";
     let config = aws_s3_transfer_manager::Config::builder()
@@ -116,7 +116,7 @@ async fn test_successful_multiple_objects_upload_via_multipart_upload() {
             MIN_MULTIPART_PART_SIZE_BYTES as usize,
         ),
     ];
-    let test_dir = create_test_dir(Some(&recursion_root), files.clone(), &[]);
+    let test_dir = create_test_dir(Some(recursion_root), files.clone(), &[]);
 
     let bucket_name = "test-bucket";
     let config = aws_s3_transfer_manager::Config::builder()
@@ -156,7 +156,7 @@ async fn test_failed_upload_policy_continue() {
     // Make all files inaccessible under `photos/2022/February`
     let inaccessible_dir_relative_path = "photos/2022/February";
     let test_dir = create_test_dir(
-        Some(&recursion_root),
+        Some(recursion_root),
         files.clone(),
         &[inaccessible_dir_relative_path],
     );
@@ -216,7 +216,7 @@ async fn test_error_when_custom_delimiter_appears_in_filename() {
         ("photos/2022-February/sample2.jpg", 1),
         ("photos/2022-February/sample3.jpg", 1),
     ];
-    let test_dir = create_test_dir(Some(&recursion_root), files.clone(), &[]);
+    let test_dir = create_test_dir(Some(recursion_root), files.clone(), &[]);
 
     let bucket_name = "test-bucket";
     let config = aws_s3_transfer_manager::Config::builder()

--- a/aws-s3-transfer-manager/tests/upload_objects_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_objects_test.rs
@@ -1,0 +1,191 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#![cfg(target_family = "unix")]
+
+use aws_s3_transfer_manager::{error::ErrorKind, types::FailedTransferPolicy};
+use aws_sdk_s3::{
+    error::DisplayErrorContext,
+    operation::{
+        complete_multipart_upload::CompleteMultipartUploadOutput,
+        create_multipart_upload::CreateMultipartUploadOutput, upload_part::UploadPartOutput,
+    },
+    Client,
+};
+use aws_smithy_mocks_experimental::{mock, mock_client, RuleMode};
+use test_common::create_test_dir;
+
+// Create an S3 client with mock behavior configured
+//
+// We intentionally avoid being specific about the expected input and output for mocks,
+// as long as the execution of uploading multiple objects completes successfully.
+// Setting expectations that are too precise can lead to brittle tests.
+fn mock_s3_client(bucket_name: String) -> Client {
+    let upload_id = "test-upload-id".to_owned();
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+
+    let upload_part = mock!(aws_sdk_s3::Client::upload_part)
+        .match_requests({
+            let upload_id = upload_id.clone();
+            move |input| {
+                input.upload_id.as_ref() == Some(&upload_id) && input.bucket() == Some(&bucket_name)
+            }
+        })
+        .then_output(|| UploadPartOutput::builder().build());
+
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .match_requests({
+            let upload_id = upload_id.clone();
+            move |r| r.upload_id.as_ref() == Some(&upload_id)
+        })
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[create_mpu, upload_part, complete_mpu]
+    )
+}
+
+#[tokio::test]
+async fn test_successful_multiple_objects_upload() {
+    let recursion_root = "test";
+    let files = vec![
+        ("sample.jpg", 1),
+        ("photos/2022/January/sample.jpg", 1),
+        ("photos/2022/February/sample1.jpg", 1),
+        ("photos/2022/February/sample2.jpg", 1),
+        ("photos/2022/February/sample3.jpg", 1),
+    ];
+    let test_dir = create_test_dir(Some(&recursion_root), files.clone(), &[]);
+
+    let bucket_name = "test-bucket";
+    let config = aws_s3_transfer_manager::Config::builder()
+        .client(mock_s3_client(bucket_name.to_owned()))
+        .build();
+    let sut = aws_s3_transfer_manager::Client::new(config);
+
+    let handle = sut
+        .upload_objects()
+        .bucket(bucket_name)
+        .source(test_dir.path())
+        .recursive(true)
+        .send()
+        .await
+        .unwrap();
+
+    let output = handle.join().await.unwrap();
+    assert_eq!(5, output.objects_uploaded());
+    assert!(output.failed_transfers().is_empty());
+    assert_eq!(5, output.total_bytes_transferred());
+}
+
+#[tokio::test]
+async fn test_failed_upload_policy_continue() {
+    let recursion_root = "test";
+    let files = vec![
+        ("sample.jpg", 1),
+        ("photos/2022/January/sample.jpg", 1),
+        ("photos/2022/February/sample1.jpg", 1),
+        ("photos/2022/February/sample2.jpg", 1),
+        ("photos/2022/February/sample3.jpg", 1),
+    ];
+    // Make all files inaccessible under `photos/2022/February`
+    let inaccessible_dir_relative_path = "photos/2022/February";
+    let test_dir = create_test_dir(
+        Some(&recursion_root),
+        files.clone(),
+        &[inaccessible_dir_relative_path],
+    );
+
+    let bucket_name = "test-bucket";
+    let config = aws_s3_transfer_manager::Config::builder()
+        .client(mock_s3_client(bucket_name.to_owned()))
+        .build();
+    let sut = aws_s3_transfer_manager::Client::new(config);
+
+    let handle = sut
+        .upload_objects()
+        .bucket(bucket_name)
+        .source(test_dir.path())
+        .recursive(true)
+        .failure_policy(FailedTransferPolicy::Continue)
+        .send()
+        .await
+        .unwrap();
+
+    let output = handle.join().await.unwrap();
+    assert_eq!(2, output.objects_uploaded());
+    assert_eq!(1, output.failed_transfers().len()); // Cannot traverse inaccessible dir to count how many files are in it
+    assert_eq!(2, output.total_bytes_transferred());
+}
+
+/// Fail when source is not a directory
+#[tokio::test]
+async fn test_source_dir_not_valid() {
+    let source = tempfile::NamedTempFile::new().unwrap();
+
+    let bucket_name = "test-bucket";
+    let config = aws_s3_transfer_manager::Config::builder()
+        .client(mock_s3_client(bucket_name.to_owned()))
+        .build();
+    let sut = aws_s3_transfer_manager::Client::new(config);
+
+    let err = sut
+        .upload_objects()
+        .bucket(bucket_name)
+        .source(source.path())
+        .send()
+        .await
+        .unwrap_err();
+
+    assert_eq!(&ErrorKind::InputInvalid, err.kind());
+    assert!(format!("{}", DisplayErrorContext(err)).contains("is not a directory"));
+}
+
+#[tokio::test]
+async fn test_error_when_custom_delimiter_appears_in_filename() {
+    let recursion_root = "test";
+    let files = vec![
+        ("sample.jpg", 1),
+        ("photos/2022-January/sample.jpg", 1),
+        ("photos/2022-February/sample1.jpg", 1),
+        ("photos/2022-February/sample2.jpg", 1),
+        ("photos/2022-February/sample3.jpg", 1),
+    ];
+    let test_dir = create_test_dir(Some(&recursion_root), files.clone(), &[]);
+
+    let bucket_name = "test-bucket";
+    let config = aws_s3_transfer_manager::Config::builder()
+        .client(mock_s3_client(bucket_name.to_owned()))
+        .build();
+    let sut = aws_s3_transfer_manager::Client::new(config);
+
+    // Getting `handle` is ok, i.e., tasks should be spawned from `UploadObjects::orchestrate`
+    let handle = sut
+        .upload_objects()
+        .bucket(bucket_name)
+        .source(test_dir.path())
+        .recursive(true)
+        .delimiter("-")
+        .send()
+        .await
+        .unwrap();
+
+    // But unwrapping it should fail
+    let err = handle.join().await.unwrap_err();
+
+    assert_eq!(&ErrorKind::InputInvalid, err.kind());
+    assert!(format!("{}", DisplayErrorContext(err))
+        .contains("a custom delimiter `-` should not appear"));
+}

--- a/aws-s3-transfer-manager/tests/upload_objects_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_objects_test.rs
@@ -217,7 +217,7 @@ async fn test_server_error_should_be_recorded_as_such_in_failed_transfers() {
     assert_eq!(1, output.failed_transfers().len());
     assert!(output.failed_transfers()[0]
         .input()
-        .map(|input| input.bucket() == Some(bucket_name))
+        .map(|input| input.bucket() == Some(bucket_name) && input.key() == Some("sample.jpg"))
         .unwrap_or_default());
     assert_eq!(0, output.total_bytes_transferred());
 }


### PR DESCRIPTION
*Description of changes*
This PR adds support for uploading files from a specified directory to S3. Example usages can be found in [the example](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/0f4d2ecdcf5103d5c1eaf7789af0c2a911d31d07/aws-s3-transfer-manager/examples/cp.rs#L192-L222) as well as in [integration tests](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/0f4d2ecdcf5103d5c1eaf7789af0c2a911d31d07/aws-s3-transfer-manager/tests/upload_objects_test.rs).
 
This implementation mirrors the pattern used for downloading multiple objects from S3, but in the opposite direction.

Given a `UploadObjectsInput`, `UploadObjects::orchestrate`  spawns a producer task, `list_directory_contents`, and consumer tasks, `upload_objects`. The producer task retrieves files from the specified target directory (non-recursively by default) and yields them to the consumer tasks, which upload them to S3 using the existing functionality for uploading a single object. A `UploadObjectsHandle` manages these tasks ~and joining this handle will drive the async tasks~.

A couple of details. First, for yielding files to upload, we use the [walkdir](https://docs.rs/walkdir/latest/walkdir/) crate, which supports following symbolic links and recursive traversal natively. Since this crate offers a synchronous API, we integrate the [blocking](https://github.com/smol-rs/blocking) crate to handle blocking I/O tasks in a dedicated pool. ~If you think this approach is unnecessary, I’m open to either retaining or removing the `blocking` crate.~ Using something like `spawn_blocking` would require the whole directory traversal task to be a sync function to be passed to `spawn_blocking`, which complicates the use of the `async_channel` within the function (that said we left `TODO` to reevaluate the need for the `blocking` crate).

Second, during directory traversal, I/O errors may occur, such as being unable to read directories/files or failing to construct an `InputStream`. These client-side errors are sent to the consumer task, which records them in `FailedUploadTransfer` (in which case the `input` field will be `None` for client-side errors) but we proceed with the rest of the "good" files if we employ `FailedTransferPolicy::Continue`. Deriving an object key from a relative filename may also fail; however, since this is a user input error, we will fail the upload operation even with `FailedTransferPolicy::Continue`.
 
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._