### PR TITLE
Allow InputStream from a custom stream of parts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
         rust:
           # `check-external-types` requires a specific Rust nightly version. See
           # the README for details: https://github.com/awslabs/cargo-check-external-types
-          - nightly-2024-05-01
+          - nightly-2024-06-30
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust ${{ matrix.rust }}
@@ -175,7 +175,7 @@ jobs:
       - name: Install cargo-check-external-types
         uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: cargo-check-external-types@0.1.12
+          tool: cargo-check-external-types@0.1.13
       - name: check-external-types
         run: cargo check-external-types --all-features --config external-types.toml
         working-directory: aws-s3-transfer-manager

--- a/aws-s3-transfer-manager/external-types.toml
+++ b/aws-s3-transfer-manager/external-types.toml
@@ -4,5 +4,6 @@ allowed_external_types = [
     "aws_smithy_runtime_api::*",
     "aws_smithy_types::*",
     "tokio::runtime::task::error::JoinError",
+    "tokio::io::async_read::AsyncRead",
     "bytes::bytes::Bytes",
 ]

--- a/aws-s3-transfer-manager/src/io/adapters.rs
+++ b/aws-s3-transfer-manager/src/io/adapters.rs
@@ -16,7 +16,6 @@ use std::task::Poll;
 use bytes::Bytes;
 use pin_project_lite::pin_project;
 
-// TODO - add feature gate for this?
 pin_project! {
     /// A wrapper that implements [`PartStream`] trait for an inner type
     /// that implements Tokio's IO traits.

--- a/aws-s3-transfer-manager/src/io/adapters.rs
+++ b/aws-s3-transfer-manager/src/io/adapters.rs
@@ -113,7 +113,7 @@ where
                         }
 
                         // full part available or EOF with partial data already buffered
-                        if inner_buf.len() >= stream_cx.part_size()
+                        if inner_buf.len() == stream_cx.part_size()
                             || (n == 0 && inner_buf.len() > 0)
                         {
                             let data: Bytes = inner_buf.into();

--- a/aws-s3-transfer-manager/src/io/adapters.rs
+++ b/aws-s3-transfer-manager/src/io/adapters.rs
@@ -1,0 +1,232 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::io::stream::StreamContext;
+use crate::io::Buffer;
+use crate::io::PartStream;
+use crate::io::SizeHint;
+
+use crate::io::PartData;
+
+use std::mem;
+use std::task::Poll;
+
+use bytes::Bytes;
+use pin_project_lite::pin_project;
+
+// TODO - add feature gate for this?
+pin_project! {
+    /// A wrapper that implements [`PartStream`] trait for an inner type
+    /// that implements Tokio's IO traits.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aws_s3_transfer_manager::io::adapters::TokioIo;
+    /// use aws_s3_transfer_manager::io::{InputStream, SizeHint};
+    /// use tokio::io::AsyncRead;
+    ///
+    /// fn into_input_stream<T: AsyncRead + Send + Sync + 'static>(inner: T, content_length: u64) -> InputStream {
+    ///     InputStream::from_part_stream(TokioIo::new(inner, SizeHint::exact(content_length)))
+    /// }
+    /// ```
+    #[derive(Debug)]
+    pub struct TokioIo<T> {
+        #[pin]
+        inner: T,
+        size_hint: SizeHint,
+        buf: BufState,
+        next_part: u64,
+    }
+}
+
+#[derive(Debug)]
+enum BufState {
+    /// No buffer acquired
+    Unset,
+    /// Buffer acquired and possibly partially filled
+    Acquired(Buffer),
+}
+
+impl BufState {
+    /// Take the current buffer if already set or acquire a new one
+    fn take_or_acquire(&mut self, stream_cx: &StreamContext) -> Buffer {
+        let current = mem::replace(self, BufState::Unset);
+        match current {
+            BufState::Unset => stream_cx.new_buffer(stream_cx.part_size()),
+            BufState::Acquired(buffer) => buffer,
+        }
+    }
+}
+
+impl<T> TokioIo<T> {
+    /// Wrap a type implementing Tokio's IO traits.
+    pub fn new(inner: T, size_hint: SizeHint) -> Self {
+        Self {
+            inner,
+            size_hint,
+            buf: BufState::Unset,
+            next_part: 1,
+        }
+    }
+
+    /// Borrow the inner type
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    /// Mutably borrow the inner type
+    pub fn inner_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T> PartStream for TokioIo<T>
+where
+    T: tokio::io::AsyncRead,
+{
+    fn poll_part(
+        self: std::pin::Pin<&mut Self>,
+        stream_cx: &StreamContext,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<std::io::Result<PartData>>> {
+        use bytes::BufMut;
+        let mut this = self.project();
+        let mut inner_buf = this.buf.take_or_acquire(stream_cx);
+
+        println!("loop outer");
+        loop {
+            // SAFETY: `ReadBuf` and `poll_read` promise not to set any uninitialized bytes into `dst`.
+            let dst = unsafe { inner_buf.chunk_mut().as_uninit_slice_mut() };
+            let mut buf = tokio::io::ReadBuf::uninit(dst);
+
+            match this.inner.as_mut().poll_read(cx, &mut buf) {
+                Poll::Ready(result) => match result {
+                    Ok(_) => {
+                        let n = buf.filled().len();
+                        println!("read {} bytes", n);
+                        if n > 0 {
+                            // SAFETY: we just read that many bytes into the uninitialized part of the buffer
+                            unsafe {
+                                inner_buf.advance_mut(n);
+                            }
+                        }
+
+                        // full part available or EOF with partial data already buffered
+                        if inner_buf.len() >= stream_cx.part_size()
+                            || (n == 0 && inner_buf.len() > 0)
+                        {
+                            let data: Bytes = inner_buf.into();
+                            let part_number = *this.next_part;
+                            *this.next_part += 1;
+                            let part = PartData { part_number, data };
+                            return Poll::Ready(Some(Ok(part)));
+                        } else if n == 0 {
+                            // EOF
+                            return Poll::Ready(None);
+                        }
+                    }
+                    Err(err) => return Poll::Ready(Some(Err(err))),
+                },
+                Poll::Pending => {
+                    // store already acquired, possibly partially filled buffer for next poll
+                    *this.buf = BufState::Acquired(inner_buf);
+                    return Poll::Pending;
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> crate::io::SizeHint {
+        self.size_hint
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TokioIo;
+    use crate::io::stream::StreamContext;
+    use crate::io::PartData;
+    use crate::io::PartStream;
+    use crate::io::SizeHint;
+    use futures_test::task::new_count_waker;
+    use std::pin::pin;
+    use std::task::Context;
+    use tokio_test::io::Builder;
+    use tokio_test::{assert_pending, assert_ready};
+
+    #[tokio::test]
+    async fn test_tokio_adapter_e2e() {
+        let (mock, mut handle) = Builder::new().build_with_handle();
+        let part_size = 5;
+        let mut io = pin!(TokioIo::new(mock, SizeHint::exact(10)));
+
+        let (waker, awoken_cnt) = new_count_waker();
+        let mut task_cx = Context::from_waker(&waker);
+        let stream_cx = StreamContext::new(part_size);
+
+        assert_pending!(io.as_mut().poll_part(&stream_cx, &mut task_cx));
+        handle.read(b"hello");
+        assert_eq!(awoken_cnt.get(), 1);
+
+        let result = assert_ready!(io.as_mut().poll_part(&stream_cx, &mut task_cx))
+            .unwrap()
+            .unwrap();
+        let expected = PartData::new(1, "hello");
+        assert_eq!(expected, result);
+
+        assert_pending!(io.as_mut().poll_part(&stream_cx, &mut task_cx));
+        handle.read(b"world");
+        assert_eq!(awoken_cnt.get(), 2);
+
+        let result = assert_ready!(io.as_mut().poll_part(&stream_cx, &mut task_cx))
+            .unwrap()
+            .unwrap();
+        let expected = PartData::new(2, "world");
+        assert_eq!(expected, result);
+
+        drop(handle);
+        let result = assert_ready!(io.as_mut().poll_part(&stream_cx, &mut task_cx));
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_tokio_adapter_partial_reads() {
+        let (mock, mut handle) = Builder::new().build_with_handle();
+        let part_size = 10;
+        let mut io = pin!(TokioIo::new(mock, SizeHint::exact(16)));
+
+        let (waker, awoken_cnt) = new_count_waker();
+        let mut task_cx = Context::from_waker(&waker);
+        let stream_cx = StreamContext::new(part_size);
+
+        // partial read
+        handle.read(b"hello");
+        assert_pending!(io.as_mut().poll_part(&stream_cx, &mut task_cx));
+
+        handle.read(b"world"); // full part available
+        handle.read(b"second"); // last part less than part size
+        drop(handle);
+        assert_eq!(awoken_cnt.get(), 1);
+
+        // we have a full part available at this point so it should be yielded
+        let result = assert_ready!(io.as_mut().poll_part(&stream_cx, &mut task_cx))
+            .unwrap()
+            .unwrap();
+        let expected = PartData::new(1, "helloworld");
+        assert_eq!(expected, result);
+
+        // should hit EOF and get the last part less than configured part size
+        let result = assert_ready!(io.as_mut().poll_part(&stream_cx, &mut task_cx))
+            .unwrap()
+            .unwrap();
+        let expected = PartData::new(2, "second");
+        assert_eq!(expected, result);
+
+        // one final poll to actual get done signal
+        let result = assert_ready!(io.as_mut().poll_part(&stream_cx, &mut task_cx));
+        assert!(result.is_none());
+    }
+}

--- a/aws-s3-transfer-manager/src/io/adapters.rs
+++ b/aws-s3-transfer-manager/src/io/adapters.rs
@@ -96,7 +96,6 @@ where
         let mut this = self.project();
         let mut inner_buf = this.buf.take_or_acquire(stream_cx);
 
-        println!("loop outer");
         loop {
             // SAFETY: `ReadBuf` and `poll_read` promise not to set any uninitialized bytes into `dst`.
             let dst = unsafe { inner_buf.chunk_mut().as_uninit_slice_mut() };
@@ -106,7 +105,6 @@ where
                 Poll::Ready(result) => match result {
                     Ok(_) => {
                         let n = buf.filled().len();
-                        println!("read {} bytes", n);
                         if n > 0 {
                             // SAFETY: we just read that many bytes into the uninitialized part of the buffer
                             unsafe {

--- a/aws-s3-transfer-manager/src/io/buffer.rs
+++ b/aws-s3-transfer-manager/src/io/buffer.rs
@@ -15,6 +15,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 // our path to pooling buffers (for uploads at least).
 
 /// A mutable buffer for writing sequential bytes to.
+#[derive(Debug)]
 pub(crate) struct Buffer {
     inner: BytesMut,
 }

--- a/aws-s3-transfer-manager/src/io/buffer.rs
+++ b/aws-s3-transfer-manager/src/io/buffer.rs
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::ops::{Deref, DerefMut};
+
+use bytes::{BufMut, Bytes, BytesMut};
+
+// Akin to tokio::ReadBuf or the proposed [RFC](https://github.com/rust-lang/rfcs/blob/master/text/2930-read-buf.md#summary)
+// but a type we own and can control allocations for.
+
+// TODO - provide a way to create a Buffer from our own allocation/memory pool. The
+// `Bytes::from_owner` implementation (see https://github.com/tokio-rs/bytes/pull/742) will provide
+// our path to pooling buffers (for uploads at least).
+
+/// A mutable buffer for writing sequential bytes to.
+pub(crate) struct Buffer {
+    inner: BytesMut,
+}
+
+impl Buffer {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            inner: BytesMut::with_capacity(capacity),
+        }
+    }
+
+    /// Returns the number of bytes this buffer can hold without reallocating.
+    pub(crate) fn capacity(&self) -> usize {
+        self.inner.capacity()
+    }
+
+    /// Sets the length of the buffer. This will explicitly set the size of the buffer without
+    /// actually modifying the data. It is up to the caller to ensure the data has been
+    /// initialized.
+    pub(crate) unsafe fn set_len(&mut self, len: usize) {
+        self.inner.set_len(len)
+    }
+}
+
+impl AsRef<[u8]> for Buffer {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        self.inner.as_ref()
+    }
+}
+
+impl Deref for Buffer {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &[u8] {
+        self.inner.deref()
+    }
+}
+
+impl DerefMut for Buffer {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [u8] {
+        self.inner.deref_mut()
+    }
+}
+
+unsafe impl BufMut for Buffer {
+    fn remaining_mut(&self) -> usize {
+        self.inner.remaining_mut()
+    }
+
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        self.inner.advance_mut(cnt)
+    }
+
+    fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
+        self.inner.chunk_mut()
+    }
+}
+
+// we purposefully don't implement `From<Bytes>` here as we want to control the allocation
+#[allow(clippy::from_over_into)]
+impl Into<Bytes> for Buffer {
+    fn into(self) -> Bytes {
+        self.inner.into()
+    }
+}

--- a/aws-s3-transfer-manager/src/io/mod.rs
+++ b/aws-s3-transfer-manager/src/io/mod.rs
@@ -6,6 +6,7 @@
 pub(crate) mod part_reader;
 mod path_body;
 mod stream;
+//mod part_stream;
 
 /// Error types related to I/O abstractions
 pub mod error;

--- a/aws-s3-transfer-manager/src/io/mod.rs
+++ b/aws-s3-transfer-manager/src/io/mod.rs
@@ -21,3 +21,4 @@ pub use self::size_hint::SizeHint;
 pub use self::stream::InputStream;
 pub use self::stream::PartData;
 pub use self::stream::PartStream;
+pub use self::stream::StreamContext;

--- a/aws-s3-transfer-manager/src/io/mod.rs
+++ b/aws-s3-transfer-manager/src/io/mod.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/// Adapters for other IO library traits to map to `InputStream`
+pub mod adapters;
 mod buffer;
 pub(crate) mod part_reader;
 mod path_body;
@@ -17,4 +19,5 @@ pub(crate) use self::buffer::Buffer;
 pub use self::path_body::PathBodyBuilder;
 pub use self::size_hint::SizeHint;
 pub use self::stream::InputStream;
+pub use self::stream::PartData;
 pub use self::stream::PartStream;

--- a/aws-s3-transfer-manager/src/io/mod.rs
+++ b/aws-s3-transfer-manager/src/io/mod.rs
@@ -3,16 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+mod buffer;
 pub(crate) mod part_reader;
 mod path_body;
 mod stream;
-//mod part_stream;
 
 /// Error types related to I/O abstractions
 pub mod error;
 mod size_hint;
 
 // re-exports
+pub(crate) use self::buffer::Buffer;
 pub use self::path_body::PathBodyBuilder;
 pub use self::size_hint::SizeHint;
 pub use self::stream::InputStream;

--- a/aws-s3-transfer-manager/src/io/mod.rs
+++ b/aws-s3-transfer-manager/src/io/mod.rs
@@ -16,3 +16,4 @@ mod size_hint;
 pub use self::path_body::PathBodyBuilder;
 pub use self::size_hint::SizeHint;
 pub use self::stream::InputStream;
+pub use self::stream::PartStream;

--- a/aws-s3-transfer-manager/src/io/part_reader.rs
+++ b/aws-s3-transfer-manager/src/io/part_reader.rs
@@ -52,6 +52,7 @@ impl Builder {
             RawInputStream::Fs(path_body) => {
                 PartReader::Fs(PathBodyPartReader::new(path_body, self.part_size))
             }
+            RawInputStream::Dyn(_) => todo!(),
         }
     }
 }
@@ -71,9 +72,10 @@ impl ReadPart for PartReader {
     }
 }
 
+// TODO - relocate type and add new(...) methods
 /// Data for a single part
 #[derive(Debug, Clone)]
-pub(crate) struct PartData {
+pub struct PartData {
     // 1-indexed
     pub(crate) part_number: u64,
     pub(crate) data: Bytes,

--- a/aws-s3-transfer-manager/src/io/part_reader.rs
+++ b/aws-s3-transfer-manager/src/io/part_reader.rs
@@ -366,8 +366,8 @@ mod test {
     impl PartStream for TestStream {
         fn poll_part(
             mut self: std::pin::Pin<&mut Self>,
-            _stream_cx: &StreamContext,
             _cx: &mut std::task::Context<'_>,
+            _stream_cx: &StreamContext,
         ) -> Poll<Option<std::io::Result<PartData>>> {
             if self.idx < self.data.len() {
                 let part = PartData::new(self.idx as u64 + 1, self.data[self.idx].clone());

--- a/aws-s3-transfer-manager/src/io/path_body.rs
+++ b/aws-s3-transfer-manager/src/io/path_body.rs
@@ -127,6 +127,7 @@ mod test {
     fn path_body(stream: &InputStream) -> &PathBody {
         match &stream.inner {
             crate::io::stream::RawInputStream::Buf(_) => panic!("unexpected inner body"),
+            crate::io::stream::RawInputStream::Dyn(_) => panic!("unexpected inner body"),
             crate::io::stream::RawInputStream::Fs(path_body) => path_body,
         }
     }

--- a/aws-s3-transfer-manager/src/io/size_hint.rs
+++ b/aws-s3-transfer-manager/src/io/size_hint.rs
@@ -4,7 +4,7 @@
  */
 
 /// A body size hint
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Copy)]
 pub struct SizeHint {
     lower: u64,
     upper: Option<u64>,

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -175,7 +175,11 @@ pub struct PartData {
 
 impl PartData {
     /// Create a new part
-    pub(super) fn new(part_number: u64, data: impl Into<Bytes>) -> Self {
+    pub fn new(part_number: u64, data: impl Into<Bytes>) -> Self {
+        debug_assert!(
+            part_number > 0,
+            "part numbers are 1-indexed and must be greater than zero"
+        );
         Self {
             part_number,
             data: data.into(),

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -198,8 +198,8 @@ pub trait PartStream {
     /// than the full part size.
     fn poll_part(
         self: std::pin::Pin<&mut Self>,
-        stream_cx: &StreamContext,
         cx: &mut std::task::Context<'_>,
+        stream_cx: &StreamContext,
     ) -> std::task::Poll<Option<std::io::Result<PartData>>>;
 
     /// Returns the bounds on the total size of the stream
@@ -221,7 +221,7 @@ impl BoxStream {
         &mut self,
         stream_cx: &StreamContext,
     ) -> Option<std::io::Result<PartData>> {
-        poll_fn(|cx| self.inner.as_mut().poll_part(stream_cx, cx)).await
+        poll_fn(|cx| self.inner.as_mut().poll_part(cx, stream_cx)).await
     }
 }
 

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -13,11 +13,11 @@ use aws_sdk_s3::primitives::ByteStream;
 use bytes::{Buf, Bytes};
 
 use crate::error;
+use crate::io::part_reader::PartData;
 use crate::io::path_body::PathBody;
 use crate::io::path_body::PathBodyBuilder;
 use crate::io::size_hint::SizeHint;
-
-use super::part_reader::PartData;
+use crate::io::Buffer;
 
 /// Source of binary data.
 ///
@@ -152,10 +152,12 @@ impl StreamContext {
         self.part_size
     }
 
-    // TODO - add a way to get a new buffer allocation to fill from this context
-    // fn new_buffer(&self) -> impl bytes::BufMut {
-    //     todo!()
-    // }
+    // TODO - eventually make the ability to allocate a buffer public after carefully review of the `Buffer` API.
+    /// Request a new buffer to fill
+    pub(crate) fn new_buffer(&self, capacity: usize) -> Buffer {
+        // TODO - replace allocation with memory pool
+        Buffer::new(capacity)
+    }
 }
 
 /// Trait representing a stream of object parts (streaming body).

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -101,10 +101,18 @@ impl InputStream {
                 .await
                 .map_err(error::from_kind(error::ErrorKind::IOError)),
             RawInputStream::Buf(bytes) => Ok(ByteStream::from(bytes)),
-            // FIXME - if we add checksums this conversion wouldn't be valid, we need to check in
-            // upload if it's a dyn stream or not as well as part size
-            RawInputStream::Dyn(_) => todo!(),
+            RawInputStream::Dyn(_) => {
+                unreachable!("dyn InputStream should not have into_byte_stream called on it!")
+            }
         }
+    }
+
+    /// Test if this InputStream can only be uploaded via MPU (e.g. a custom `PartStream`
+    /// implementation from a user can only be a MPU due to the ability to provide custom
+    /// metadata like checksums).
+    pub(crate) fn is_mpu_only(&self) -> bool {
+        // TODO - for our own wrappers we can probably be smarter
+        matches!(self.inner, RawInputStream::Dyn(_))
     }
 
     /// Create a new `InputStream` that reads data from the given [`PartStream`] implementation

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -51,6 +51,7 @@ impl Upload {
             .upper()
             .ok_or_else(crate::io::error::Error::upper_bound_size_hint_required)?;
 
+        // FIXME - investigate what it would take to allow non mpu uploads for `PartStream` implementations
         let handle = if content_length < min_mpu_threshold && !stream.is_mpu_only() {
             tracing::trace!("upload request content size hint ({content_length}) less than min part size threshold ({min_mpu_threshold}); sending as single PutObject request");
             try_start_put_object(ctx, stream, content_length).await?

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -51,7 +51,7 @@ impl Upload {
             .upper()
             .ok_or_else(crate::io::error::Error::upper_bound_size_hint_required)?;
 
-        let handle = if content_length < min_mpu_threshold {
+        let handle = if content_length < min_mpu_threshold && !stream.is_mpu_only() {
             tracing::trace!("upload request content size hint ({content_length}) less than min part size threshold ({min_mpu_threshold}); sending as single PutObject request");
             try_start_put_object(ctx, stream, content_length).await?
         } else {

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -56,6 +56,8 @@ impl Upload {
             tracing::trace!("upload request content size hint ({content_length}) less than min part size threshold ({min_mpu_threshold}); sending as single PutObject request");
             try_start_put_object(ctx, stream, content_length).await?
         } else {
+            // TODO - to upload a 0 byte object via MPU you have to send [CreateMultipartUpload, UploadPart(part=1, 0 bytes), CompleteMultipartUpload]
+            //        we should add tests for this and hide this edge case from the user (e.g. send an empty part when a custom PartStream returns `None` immediately)
             try_start_mpu_upload(ctx, stream, content_length).await?
         };
 

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use crate::{
     error,
     io::{
-        part_reader::{Builder as PartReaderBuilder, PartData, PartReader},
-        InputStream,
+        part_reader::{Builder as PartReaderBuilder, PartReader},
+        InputStream, PartData,
     },
     middleware::{hedge, limit::concurrency::ConcurrencyLimitLayer},
     operation::upload::UploadContext,

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -108,7 +108,7 @@ pub(super) fn distribute_work(
     );
     match &mut handle.upload_type {
         UploadType::PutObject { .. } => {
-            panic!("distribute_work must not be called for PutObject.")
+            unreachable!("distribute_work must not be called for PutObject.")
         }
         UploadType::MultipartUpload {
             upload_part_tasks,

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::{
     error,
     io::{
-        part_reader::{Builder as PartReaderBuilder, PartData, ReadPart},
+        part_reader::{Builder as PartReaderBuilder, PartData, PartReader},
         InputStream,
     },
     middleware::{hedge, limit::concurrency::ConcurrencyLimitLayer},
@@ -155,7 +155,7 @@ pub(super) fn distribute_work(
 /// Worker function that pulls part data from the `part_reader` and spawns tasks to upload each part until the reader
 /// is exhausted. If any part fails, the worker will return the error and stop processing.
 pub(super) async fn read_body(
-    part_reader: Arc<impl ReadPart>,
+    part_reader: Arc<PartReader>,
     ctx: UploadContext,
     svc: impl Service<UploadPartRequest, Response = CompletedPart, Error = error::Error, Future: Send>
         + Clone

--- a/aws-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_test.rs
@@ -1,0 +1,183 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::cmp;
+use std::task::ready;
+use std::{task::Poll, time::Duration};
+
+use aws_s3_transfer_manager::io::{InputStream, PartData, PartStream, SizeHint, StreamContext};
+use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadOutput;
+use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
+use aws_sdk_s3::operation::upload_part::UploadPartOutput;
+use aws_smithy_mocks_experimental::{mock, mock_client, RuleMode};
+use aws_smithy_runtime::client::http::test_util::infallible_client_fn;
+use aws_smithy_runtime::test_util::capture_test_logs::capture_test_logs;
+use bytes::Bytes;
+use pin_project_lite::pin_project;
+use tokio::sync::mpsc;
+
+/// number of simultaneous uploads to create
+const MANY_ASYNC_UPLOADS_CNT: usize = 200;
+/// number of bytes to upload per transfer
+const MANY_ASYNC_UPLOADS_OBJECT_SIZE: usize = 100;
+/// bytes per write
+const MANY_ASYNC_UPLOADS_BYTES_PER_WRITE: usize = 10;
+/// how long to spend before assuming we're deadlocked
+const SEND_DATA_TIMEOUT_S: u64 = 10;
+
+pin_project! {
+    #[derive(Debug)]
+    struct TestStream {
+        next_part_num: u64,
+        rx: mpsc::Receiver<Bytes>,
+        content_len: usize,
+    }
+}
+
+impl TestStream {
+    fn new(rx: mpsc::Receiver<Bytes>, content_len: usize) -> Self {
+        Self {
+            next_part_num: 1,
+            rx,
+            content_len,
+        }
+    }
+}
+
+impl PartStream for TestStream {
+    fn poll_part(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        _stream_cx: &StreamContext,
+    ) -> Poll<Option<std::io::Result<PartData>>> {
+        let this = self.project();
+        let data = ready!(this.rx.poll_recv(cx));
+        let part = data.map(|b| {
+            let part_num = *this.next_part_num;
+            *this.next_part_num += 1;
+            Ok(PartData::new(part_num, b))
+        });
+        Poll::Ready(part)
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::exact(self.content_len as u64)
+    }
+}
+
+fn mock_s3_client_for_multipart_upload() -> aws_sdk_s3::Client {
+    let upload_id = "test-upload-id".to_owned();
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+
+    let upload_part = mock!(aws_sdk_s3::Client::upload_part)
+        .match_requests({
+            let upload_id = upload_id.clone();
+            move |input| input.upload_id.as_ref() == Some(&upload_id)
+        })
+        .then_output(|| UploadPartOutput::builder().build());
+
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .match_requests({
+            let upload_id = upload_id.clone();
+            move |r| r.upload_id.as_ref() == Some(&upload_id)
+        })
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[create_mpu, upload_part, complete_mpu]
+    )
+}
+
+// Regression test for deadlock discovered by a user of Mountpoint
+// The user opens MANY files at once. The user wrote data to some of the later files they opened,
+// and waited for those writes to complete.
+//
+// If we wait on data from the first few files then both sides
+// are waiting on each other causing deadlock.
+//
+// This test starts N uploads then only processes them starting from the last one created.
+// If the test times out, then we suffer from deadlock.
+//
+// See https://github.com/awslabs/aws-c-s3/blob/5d8d4205e7de4e152bf26bb27d86f3acfa8cd5d2/tests/s3_many_async_uploads_without_data_test.c
+#[tokio::test]
+async fn test_many_uploads_no_deadlock() {
+    let (_guard, _rx) = capture_test_logs();
+    let client = mock_s3_client_for_multipart_upload();
+    let client = aws_sdk_s3::Client::from_conf(
+        client
+            .config()
+            .to_builder()
+            .http_client(infallible_client_fn(|_req| {
+                http_02x::Response::builder().status(200).body("").unwrap()
+            }))
+            .build(),
+    );
+    let config = aws_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+
+    let tm = aws_s3_transfer_manager::Client::new(config);
+
+    let mut transfers = Vec::with_capacity(MANY_ASYNC_UPLOADS_CNT);
+    for i in 0..MANY_ASYNC_UPLOADS_CNT {
+        let (tx, rx) = mpsc::channel(1);
+        let stream = TestStream::new(rx, MANY_ASYNC_UPLOADS_OBJECT_SIZE);
+
+        let handle = tm
+            .upload()
+            .bucket("test-bucket")
+            .key(format!("many-async-uploads-{}.txt", i))
+            .body(InputStream::from_part_stream(stream))
+            .send()
+            .await
+            .unwrap();
+
+        transfers.push((handle, tx));
+    }
+
+    let mut handles = Vec::with_capacity(MANY_ASYNC_UPLOADS_CNT);
+
+    // process transfers in reverse order
+    while let Some((handle, tx)) = transfers.pop() {
+        let mut bytes_written = 0;
+        let mut eof = false;
+        while !eof {
+            let wc = cmp::min(
+                MANY_ASYNC_UPLOADS_BYTES_PER_WRITE,
+                MANY_ASYNC_UPLOADS_OBJECT_SIZE - bytes_written,
+            );
+            eof = (bytes_written + wc) == MANY_ASYNC_UPLOADS_OBJECT_SIZE;
+
+            let data = vec![b'z'; wc];
+            let buf = Bytes::from(data);
+            match tx
+                .send_timeout(buf, Duration::from_secs(SEND_DATA_TIMEOUT_S))
+                .await
+            {
+                Ok(_) => {}
+                Err(err) => panic!("failed to send due to timeout or closed channel: {}", err),
+            }
+            bytes_written += wc;
+        }
+
+        drop(tx);
+        handles.push(handle);
+    }
+
+    // wait for everything to finish
+    while let Some(handle) = handles.pop() {
+        handle.join().await.unwrap();
+    }
+}


### PR DESCRIPTION
**Description of changes:**

This PR replaces the internal `ReadPart` trait with a new public `PartStream` trait to allow users to create and supply an `InputStream` from an arbitrary source. This should allow us to expand to supporting custom checksums for individual parts from a user as well when we're ready for that.

Also added a convenience adapter for `tokio::io::AsyncRead` to be used this way. I expect we can/would expand this (possibly feature gated) for other 3P types if demand was there for it.

There are some caveats currently, namely you are forced to use a MPU when a custom stream is supplied. We can probably work around this I just need to mull it over, open to ideas.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
