### PR TITLE
Handle symlinks while uploading files in directory

### DIFF
--- a/aws-s3-transfer-manager/src/operation/download_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/download_objects.rs
@@ -15,6 +15,7 @@ pub use output::{DownloadObjectsOutput, DownloadObjectsOutputBuilder};
 
 mod handle;
 pub use handle::DownloadObjectsHandle;
+use tokio::fs;
 
 mod list_objects;
 mod worker;
@@ -40,7 +41,8 @@ impl DownloadObjects {
     ) -> Result<DownloadObjectsHandle, crate::error::Error> {
         //  validate existence of destination and return error if it's not a directory
         let destination = input.destination().expect("destination set");
-        validate_target_is_dir(destination).await?;
+        let metadata = fs::metadata(destination).await?;
+        validate_target_is_dir(&metadata, destination)?;
 
         // create span to serve as parent of spawned child tasks
         let parent_span_for_tasks = tracing::debug_span!(

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -470,7 +470,7 @@ mod unit {
             symlink(&temp_dir2, temp_dir1.path().join("symlink"))
                 .await
                 .unwrap();
-            // Crate a symbolic link from `temp1/symlink2` to `temp3/sample.png`
+            // Create a symbolic link from `temp1/symlink2` to `temp3/sample.png`
             symlink(
                 temp_dir3.path().join("sample3.png"),
                 temp_dir1.path().join("symlink2"),

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -52,7 +52,16 @@ pub(super) async fn list_directory_contents(
         let job = match entry {
             Ok(entry) => {
                 let metadata = tokio::fs::metadata(entry.path()).await?;
-                if !(filter.predicate)(&UploadFilterItem::new(entry.path(), metadata.clone())) {
+                let filter_item = UploadFilterItem::builder()
+                    .path(entry.path())
+                    .metadata(metadata.clone());
+                let filter_item = if !input.follow_symlinks() {
+                    filter_item.symlink_metadata(tokio::fs::symlink_metadata(entry.path()).await?)
+                } else {
+                    filter_item
+                }
+                .build();
+                if !(filter.predicate)(&filter_item) {
                     tracing::debug!("skipping object due to filter: {:?}", entry.path());
                     continue;
                 }
@@ -255,6 +264,7 @@ mod unit {
         use std::collections::BTreeMap;
         use std::error::Error as _;
         use test_common::create_test_dir;
+        use tokio::fs::symlink;
 
         #[test]
         fn test_derive_object_key() {
@@ -416,6 +426,87 @@ mod unit {
                             *value,
                         )
                     })
+                    .collect::<BTreeMap<_, _>>();
+
+                assert_eq!(expected, actual);
+                assert!(errors.is_empty());
+            }
+        }
+
+        #[tokio::test]
+        async fn test_list_directory_contents_with_symlinks() {
+            let files1 = vec![("sample.jpg", 1)];
+            let temp_dir1 = create_test_dir(Some("temp1"), files1.clone(), &[]);
+
+            let files2 = vec![
+                ("sample.txt", 1),
+                ("docs/2022/January/sample.txt", 1),
+                ("docs/2022/February/sample1.txt", 1),
+                ("docs/2022/February/sample2.txt", 1),
+                ("docs/2022/February/sample3.txt", 1),
+            ];
+            let temp_dir2 = create_test_dir(Some("temp2"), files2.clone(), &[]);
+
+            let files3 = vec![("sample3.png", 1)];
+            let temp_dir3 = create_test_dir(Some("temp3"), files3.clone(), &[]);
+
+            // Crate a symbolic link from `temp1/symlink` to `temp2`
+            symlink(&temp_dir2, temp_dir1.path().join("symlink"))
+                .await
+                .unwrap();
+            // Crate a symbolic link from `temp1/symlink2` to `temp3/sample.png`
+            symlink(
+                temp_dir3.path().join("sample3.png"),
+                temp_dir1.path().join("symlink2"),
+            )
+            .await
+            .unwrap();
+
+            // Test with following symlinks
+            {
+                let input = UploadObjectsInputBuilder::default()
+                    .bucket("doesnotmatter")
+                    .source(temp_dir1.path())
+                    .recursive(true)
+                    .follow_symlinks(true)
+                    .build()
+                    .unwrap();
+
+                let (actual, errors) = exercise_list_directory_contents(input).await;
+
+                let expected = files1
+                    .iter()
+                    .map(|(entry_path, size)| ((*entry_path).to_owned(), *size))
+                    .chain(
+                        files2
+                            .iter()
+                            .map(|(entry_path, size)| ("symlink/".to_owned() + *entry_path, *size)),
+                    )
+                    .chain(
+                        files3
+                            .iter()
+                            .map(|(_, size)| ("symlink2".to_owned(), *size)),
+                    )
+                    .collect::<BTreeMap<_, _>>();
+
+                assert_eq!(expected, actual);
+                assert!(errors.is_empty());
+            }
+
+            // Test without following symlinks
+            {
+                let input = UploadObjectsInputBuilder::default()
+                    .bucket("doesnotmatter")
+                    .source(temp_dir1.path())
+                    .recursive(true)
+                    .build()
+                    .unwrap();
+
+                let (actual, errors) = exercise_list_directory_contents(input).await;
+
+                let expected = files1
+                    .iter()
+                    .map(|(entry_path, size)| ((*entry_path).to_owned(), *size))
                     .collect::<BTreeMap<_, _>>();
 
                 assert_eq!(expected, actual);

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -466,7 +466,7 @@ mod unit {
             let files3 = vec![("sample3.png", 1)];
             let temp_dir3 = create_test_dir(Some("temp3"), files3.clone(), &[]);
 
-            // Crate a symbolic link from `temp1/symlink` to `temp2`
+            // Create a symbolic link from `temp1/symlink` to `temp2`
             symlink(&temp_dir2, temp_dir1.path().join("symlink"))
                 .await
                 .unwrap();

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -170,16 +170,22 @@ where
     }
 }
 
-fn is_hidden(path: &Path) -> bool {
+fn is_hidden_file_name(path: &Path) -> bool {
     path.file_name()
         .map(|name| name.to_string_lossy().starts_with('.'))
         .unwrap_or(false)
 }
 
+// This default filter does not exclude hidden directories. For example, if an `UploadFilterItem` corresponds to the path
+//   path/to/.hidden/ignore-me.txt
+// the item will not be filtered out and will be uploaded to S3.
+// https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/72#discussion_r1835109128
 impl Default for UploadFilter {
     fn default() -> Self {
         Self {
-            predicate: Arc::new(|item| item.metadata().is_file() && !is_hidden(item.path())),
+            predicate: Arc::new(|item| {
+                item.metadata().is_file() && !is_hidden_file_name(item.path())
+            }),
         }
     }
 }

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -179,20 +179,7 @@ fn is_hidden(path: &Path) -> bool {
 impl Default for UploadFilter {
     fn default() -> Self {
         Self {
-            predicate: Arc::new(|item| {
-                if is_hidden(item.path()) {
-                    return false;
-                }
-                if item.symlink_metadata.is_symlink() {
-                    // `item` represents a symbolic link, so fall back to `item.metadata` (if set)
-                    // to determine the file type of the target of the symlink.
-                    // If `item.metadata` is unset, we don't know the target file type, so return false.
-                    item.metadata.as_ref().map_or(false, |meta| meta.is_file())
-                } else {
-                    // If `symlink_metadata` can say it's either a file or a directory, just trust it.
-                    item.symlink_metadata.is_file()
-                }
-            }),
+            predicate: Arc::new(|item| item.metadata().is_file() && !is_hidden(item.path())),
         }
     }
 }
@@ -202,8 +189,7 @@ impl Default for UploadFilter {
 #[derive(Debug)]
 pub struct UploadFilterItem<'a> {
     pub(crate) path: Cow<'a, Path>,
-    pub(crate) symlink_metadata: Metadata,
-    pub(crate) metadata: Option<Metadata>,
+    pub(crate) metadata: Metadata,
 }
 
 impl<'a> UploadFilterItem<'a> {
@@ -216,31 +202,20 @@ impl<'a> UploadFilterItem<'a> {
         &self.path
     }
 
-    /// Metadata about the file located at `self.path`, without following symbolic links.
-    ///
-    /// This `Metadata` can be used for queries such as `is_file()`, `is_dir()`, and `is_symlink()`.
-    /// If `is_symlink()` returns `true`, it indicates that `self.path` is a symbolic link,
-    /// but no further details are available; `is_file()` and `is_dir()` will return `false`.
-    /// In such cases, use [`Self::metadata`] and call respective methods on the returned `Metadata`
-    /// if it is `Some`.
-    pub fn symlink_metadata(&self) -> &Metadata {
-        &self.symlink_metadata
-    }
-
-    /// Metadata about the file located at `self.path`, following symbolic links.
+    /// Metadata about the file located at `self.path`.
     ///
     /// Use this `Metadata` for queries `is_dir()` and `is_file()`. However, it cannot
     /// be used to determine whether `self.path` is a symbolic link because the metadata
-    /// was obtained using `fs::metadata()`, which follows symlinks.
-    pub fn metadata(&self) -> Option<&Metadata> {
-        self.metadata.as_ref()
+    /// set in this struct is assumed to return true for either `is_dir()` or `is_file()`,
+    /// but not for `is_symlink()`.
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
     }
 }
 
 #[derive(Debug, Default)]
 pub(crate) struct UploadFilterItemBuilder<'a> {
     pub(crate) path: Option<Cow<'a, Path>>,
-    pub(crate) symlink_metadata: Option<Metadata>,
     pub(crate) metadata: Option<Metadata>,
 }
 
@@ -253,20 +228,14 @@ impl<'a> UploadFilterItemBuilder<'a> {
         self
     }
 
-    // Set the `Metadata` for `self.path`, obtained via a call to `fs::symlink_metadata()`,
-    // which does not follow symbolic links.
+    // Set the `Metadata` for `self.path`.
     //
-    // NOTE: A symlink metadata is required.
-    pub(crate) fn symlink_metadata(mut self, symlink_metadata: Metadata) -> Self {
-        self.symlink_metadata = Some(symlink_metadata);
-        self
-    }
-
-    // Set the `Metadata` for `self.path`, obtained via a call to `fs::metadata()`,
-    // which follows symbolic links.
+    // This `Metadata` must be one of the following:
+    // - Obtained via `fs::metadata()`, which follows symbolic links.
+    // - Obtained via `fs::symlink_metadata()`, which is guaranteed to return true for either `is_dir()` or `is_file()`,
+    //   but not for `is_symlink()`.
     //
-    // This method should be used when the upload operation follows symbolic links,
-    // as it needs to know the file type of the target of the symlink.
+    // NOTE: A metadata is required.
     pub(crate) fn metadata(mut self, metadata: Metadata) -> Self {
         self.metadata = Some(metadata);
         self
@@ -275,10 +244,9 @@ impl<'a> UploadFilterItemBuilder<'a> {
     pub(crate) fn build(self) -> UploadFilterItem<'a> {
         UploadFilterItem {
             path: self.path.expect("required field `path` should be set"),
-            symlink_metadata: self
-                .symlink_metadata
-                .expect("required field `symlink_metadata` should be set"),
-            metadata: self.metadata,
+            metadata: self
+                .metadata
+                .expect("required field `metadata` should be set"),
         }
     }
 }


### PR DESCRIPTION
~~**Will update this PR, since with the first commit, the default case (not following symlinks) has to pay the price of getting metadata twice which is inefficient**~~

*Description of changes:*
This PR is a follow-up on #67 and handles uploading files with symbolic links.

The primary change is to use `fs::symbolink_metadata` to property detect whether a given path entry represents a symbolic link. Unlike `fs::metadata`, which follows symbolic links and returns metadata about the target, `fs::symlink_metadata` retrieves metadata about the symlink itself.

Also added `test_source_dir_is_symlink`, adapted from the [Java SDK V2
](https://github.com/aws/aws-sdk-java-v2/blob/master/services-custom/s3-transfer-manager/src/test/java/software/amazon/awssdk/transfer/s3/internal/UploadDirectoryHelperTest.java#L398-L413)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
