### PR TITLE
Add mechanism to cancel the operation of uploading directory

### DIFF
--- a/aws-s3-transfer-manager/src/config.rs
+++ b/aws-s3-transfer-manager/src/config.rs
@@ -128,7 +128,7 @@ impl Builder {
         self
     }
 
-    /// Consumes the builder and constructs a [`Config`](crate::config::Config)
+    /// Consumes the builder and constructs a [`Config`]
     pub fn build(self) -> Config {
         Config {
             multipart_threshold: self.multipart_threshold_part_size,

--- a/aws-s3-transfer-manager/src/error.rs
+++ b/aws-s3-transfer-manager/src/error.rs
@@ -44,6 +44,11 @@ pub enum ErrorKind {
 
     /// child operation failed (e.g. download of a single object as part of downloading all objects from a bucket)
     ChildOperationFailed,
+
+    /// The operation is being canceled because the user explicitly called `.abort` on the handle,
+    /// or a child operation failed with the abort policy. The operation is now transitioning into
+    /// a graceful shutdown mode.
+    OperationCancelled,
 }
 
 impl Error {
@@ -75,6 +80,7 @@ impl fmt::Display for Error {
             ErrorKind::ChunkFailed => write!(f, "failed to process chunk"),
             ErrorKind::NotFound => write!(f, "resource not found"),
             ErrorKind::ChildOperationFailed => write!(f, "child operation failed"),
+            ErrorKind::OperationCancelled => write!(f, "operation cancelled"),
         }
     }
 }

--- a/aws-s3-transfer-manager/src/error.rs
+++ b/aws-s3-transfer-manager/src/error.rs
@@ -46,8 +46,7 @@ pub enum ErrorKind {
     ChildOperationFailed,
 
     /// The operation is being canceled because the user explicitly called `.abort` on the handle,
-    /// or a child operation failed with the abort policy. The operation is now transitioning into
-    /// a graceful shutdown mode.
+    /// or a child operation failed with the abort policy.
     OperationCancelled,
 }
 

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -28,6 +28,22 @@ pub(crate) enum UploadType {
 }
 
 /// Response type for a single upload object request.
+/// 
+/// # Cancellation
+///
+/// The operation can be cancelled either by dropping this handle or by calling
+/// [`Self::abort`]. In both cases, any ongoing tasks will stop processing future work
+/// and will not start processing anything new. However, there are subtle differences in
+/// how each method cancels ongoing tasks.
+///
+/// When the handle is dropped, in-progress tasks are cancelled at their await points,
+/// meaning read body tasks may be interrupted mid-processing, or upload parts may be
+/// terminated without calling `AbortMultipartUpload` for multipart uploads.
+///
+/// In contrast, calling [`Self::abort`] attempts to cancel ongoing tasks more explicitly.
+/// It first calls `.abort_all` on the tasks it owns, and then invokes `AbortMultipartUpload`
+/// to abort any in-progress multipart uploads. Errors encountered during `AbortMultipartUpload`
+/// are logged, but do not affect the overall cancellation flow.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct UploadHandle {

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -28,7 +28,7 @@ pub(crate) enum UploadType {
 }
 
 /// Response type for a single upload object request.
-/// 
+///
 /// # Cancellation
 ///
 /// The operation can be cancelled either by dropping this handle or by calling

--- a/aws-s3-transfer-manager/src/operation/upload_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects.rs
@@ -16,7 +16,10 @@ pub use handle::UploadObjectsHandle;
 
 mod output;
 pub use output::{UploadObjectsOutput, UploadObjectsOutputBuilder};
-use tokio::task::JoinSet;
+use tokio::{
+    sync::watch::{self, Sender},
+    task::JoinSet,
+};
 use tracing::Instrument;
 
 mod worker;
@@ -52,9 +55,9 @@ impl UploadObjects {
                 return Err(e);
             }
         };
-
+        let (cancel_tx, cancel_rx) = watch::channel(false);
         let concurrency = handle.num_workers();
-        let ctx = UploadObjectsContext::new(handle.clone(), input);
+        let ctx = UploadObjectsContext::new(handle.clone(), input, cancel_tx);
 
         // spawn all work into the same JoinSet such that when the set is dropped all tasks are cancelled.
         let mut tasks = JoinSet::new();
@@ -62,13 +65,15 @@ impl UploadObjects {
 
         // spawn worker to discover/distribute work
         tasks.spawn(worker::list_directory_contents(
-            ctx.state.input.clone(),
+            ctx.state.clone(),
             list_directory_tx,
+            cancel_rx.clone(),
         ));
 
         for i in 0..concurrency {
-            let worker = worker::upload_objects(ctx.clone(), list_directory_rx.clone())
-                .instrument(tracing::debug_span!("object-uploader", worker = i));
+            let worker =
+                worker::upload_objects(ctx.clone(), list_directory_rx.clone(), cancel_rx.clone())
+                    .instrument(tracing::debug_span!("object-uploader", worker = i));
             tasks.spawn(worker);
         }
 
@@ -83,21 +88,33 @@ pub(crate) struct UploadObjectsState {
     // TODO - Determine if `input` should be separated from this struct
     // https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/67#discussion_r1821661603
     input: UploadObjectsInput,
+    cancel_tx: Sender<bool>,
     failed_uploads: Mutex<Vec<FailedUpload>>,
     successful_uploads: AtomicU64,
     total_bytes_transferred: AtomicU64,
 }
 
-type UploadObjectsContext = TransferContext<UploadObjectsState>;
-
-impl UploadObjectsContext {
-    fn new(handle: Arc<crate::client::Handle>, input: UploadObjectsInput) -> Self {
-        let state = Arc::new(UploadObjectsState {
+impl UploadObjectsState {
+    pub(crate) fn new(input: UploadObjectsInput, cancel_tx: Sender<bool>) -> Self {
+        Self {
             input,
+            cancel_tx,
             failed_uploads: Mutex::new(Vec::new()),
             successful_uploads: AtomicU64::default(),
             total_bytes_transferred: AtomicU64::default(),
-        });
+        }
+    }
+}
+
+type UploadObjectsContext = TransferContext<UploadObjectsState>;
+
+impl UploadObjectsContext {
+    fn new(
+        handle: Arc<crate::client::Handle>,
+        input: UploadObjectsInput,
+        cancel_tx: Sender<bool>,
+    ) -> Self {
+        let state = Arc::new(UploadObjectsState::new(input, cancel_tx));
         TransferContext { handle, state }
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload_objects.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects.rs
@@ -55,9 +55,8 @@ impl UploadObjects {
                 return Err(e);
             }
         };
-        let (cancel_tx, cancel_rx) = watch::channel(false);
         let concurrency = handle.num_workers();
-        let ctx = UploadObjectsContext::new(handle.clone(), input, cancel_tx, cancel_rx);
+        let ctx = UploadObjectsContext::new(handle.clone(), input);
 
         // spawn all work into the same JoinSet such that when the set is dropped all tasks are cancelled.
         let mut tasks = JoinSet::new();
@@ -113,12 +112,8 @@ impl UploadObjectsState {
 type UploadObjectsContext = TransferContext<UploadObjectsState>;
 
 impl UploadObjectsContext {
-    fn new(
-        handle: Arc<crate::client::Handle>,
-        input: UploadObjectsInput,
-        cancel_tx: Sender<bool>,
-        cancel_rx: Receiver<bool>,
-    ) -> Self {
+    fn new(handle: Arc<crate::client::Handle>, input: UploadObjectsInput) -> Self {
+        let (cancel_tx, cancel_rx) = watch::channel(false);
         let state = Arc::new(UploadObjectsState::new(input, cancel_tx, cancel_rx));
         TransferContext { handle, state }
     }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs
@@ -3,10 +3,34 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::{error::ErrorKind, types::FailedTransferPolicy};
+
 use super::{UploadObjectsContext, UploadObjectsOutput};
 use tokio::task;
 
 /// Handle for `UploadObjects` operation
+///
+/// # Cancellation
+///
+/// The operation can be cancelled by either by dropping this handle or by calling
+/// [`Self::abort`]. In both cases, any ongoing tasks will ignore future work and
+/// will not start processing anything new. However, there are subtle differences
+/// in how each cancels ongoing tasks.
+///
+/// When the handle is dropped, in-progress tasks will be cancelled at the await
+/// points where their futures are waiting. This means a particular upload
+/// operation may be terminated mid-process, without completing the upload or
+/// calling `AbortMultipartUpload` for multipart uploads (if the upload is
+/// multipart, as opposed to a simple `PutObject`). In the case of `Drop`,
+/// tasks will be forcefully terminated, regardless of the `FailedTransferPolicy`
+/// associated with the handle.
+///
+/// Calling [`Self::abort`], on the other hand, provides more deterministic cancellation
+/// behavior. If the `FailedTransferPolicy` for the handle is set to `Abort`, the
+/// individual upload task can either complete the current upload operation or call
+/// `AbortMultipartUpload` in the case of multipart uploads. Errors encountered during
+/// `AbortMultipartUpload` will be logged, but will not affect the program's cancellation
+/// control flow.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct UploadObjectsHandle {
@@ -18,13 +42,61 @@ pub struct UploadObjectsHandle {
 
 impl UploadObjectsHandle {
     /// Consume the handle and wait for the upload to complete
+    ///
+    /// When the `FailedTransferPolicy` is set to [`FailedTransferPolicy::Abort`], this method
+    /// will return an error if any of the spawned tasks encounter one. The other tasks will
+    /// be canceled, but their cancellations will not be reported as errors by this method;
+    /// they will be logged as errors, instead.
+    ///
+    /// If the `FailedTransferPolicy` is set to [`FailedTransferPolicy::Continue`], the
+    /// [`UploadObjectsOutput`] will include a detailed breakdown, such as the number of
+    /// successful uploads and the number of failed ones.
+    ///
+    // TODO(aws-sdk-rust#1159) - Consider if we want to return failed `AbortMultipartUpload` during cancellation.
     #[tracing::instrument(skip_all, level = "debug", name = "join-upload-objects-")]
     pub async fn join(mut self) -> Result<UploadObjectsOutput, crate::error::Error> {
-        // TODO - Consider implementing more sophisticated error handling such as canceling in-progress transfers
+        let mut first_error_to_report = None;
         while let Some(join_result) = self.tasks.join_next().await {
-            join_result??;
+            let result = join_result.expect("task completed");
+            if let Err(e) = result {
+                match self.ctx.state.input.failure_policy() {
+                    FailedTransferPolicy::Abort
+                        if first_error_to_report.is_none()
+                            && e.kind() != &ErrorKind::OperationCancelled =>
+                    {
+                        first_error_to_report = Some(e);
+                    }
+                    FailedTransferPolicy::Continue => {
+                        tracing::warn!("encountered but dismissed error when the failure policy is `Continue`: {e}")
+                    }
+                    _ => {}
+                }
+            }
         }
 
-        Ok(UploadObjectsOutput::from(self.ctx.state.as_ref()))
+        if let Some(e) = first_error_to_report {
+            Err(e)
+        } else {
+            Ok(UploadObjectsOutput::from(self.ctx.state.as_ref()))
+        }
+    }
+
+    /// Aborts all tasks owned by the handle.
+    ///
+    /// Unlike `Drop`, calling `abort` gracefully shuts down any in-progress tasks.
+    /// Specifically, ongoing upload tasks will be allowed to complete their current work,
+    /// but any future uploads will be ignored. The task of listing directory contents will
+    /// stop yielding new directory contents.
+    pub async fn abort(&mut self) -> Result<(), crate::error::Error> {
+        if self.ctx.state.input.failure_policy() == &FailedTransferPolicy::Abort {
+            if self.ctx.state.cancel_tx.send(true).is_err() {
+                tracing::warn!(
+                    "all receiver ends have been dropped, unable to send a cancellation signal"
+                );
+            }
+            while (self.tasks.join_next().await).is_some() {}
+        }
+
+        Ok(())
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -331,7 +331,6 @@ mod tests {
     use aws_sdk_s3::operation::put_object::PutObjectOutput;
     use aws_smithy_mocks_experimental::{mock, mock_client, RuleMode};
     use bytes::Bytes;
-    use tokio::sync::watch;
 
     use crate::{
         client::Handle,
@@ -714,7 +713,6 @@ mod tests {
         let s3_client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[put_object]);
         let config = crate::Config::builder().client(s3_client).build();
 
-        let (cancel_tx, cancel_rx) = watch::channel(false);
         let scheduler = Scheduler::new(DEFAULT_CONCURRENCY);
 
         let handle = std::sync::Arc::new(Handle { config, scheduler });
@@ -723,7 +721,7 @@ mod tests {
             .bucket(bucket)
             .build()
             .unwrap();
-        let ctx = UploadObjectsContext::new(handle, input, cancel_tx, cancel_rx);
+        let ctx = UploadObjectsContext::new(handle, input);
         let job = UploadObjectJob {
             object: InputStream::from(Bytes::from_static(b"doesnotmatter")),
             key: "doesnotmatter".to_owned(),

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -231,6 +231,7 @@ pub(super) async fn upload_objects(
         }
     }
 
+    tracing::trace!("ls channel closed, worker finished");
     Ok(())
 }
 

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -258,6 +258,9 @@ async fn upload_single_obj(
     let mut handle =
         crate::operation::upload::Upload::orchestrate(ctx.handle.clone(), input).await?;
 
+    // The cancellation process would work fine without this if statement.
+    // It's here so we can save a single upload operation that would otherwise
+    // be wasted if the system is already in graceful shutdown mode.
     if ctx
         .state
         .cancel_rx

--- a/aws-s3-transfer-manager/tests/upload_objects_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_objects_test.rs
@@ -506,8 +506,12 @@ async fn test_failed_child_operation_should_cause_ongoing_requests_to_be_cancell
         &ErrorKind::ChildOperationFailed,
         handle.join().await.unwrap_err().kind()
     );
-    // the execution should see at least one cancellation signal being delivered.
-    assert!(rx.contents().contains("received cancellation signal"));
+    // The execution should either receive at least one cancellation signal or successfully complete the current task.
+    let logs = rx.contents();
+    assert!(
+        logs.contains("received cancellation signal")
+            || logs.contains("ls channel closed, worker finished")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
*Issue #, if available:*
Resolves a subtask in #65 

*Description of changes:*
This PR introduces a mechanism to cancel the upload of multiple objects within a directory. It distinguishes between aborting and dropping a handle for both `UploadHandle` and `UploadObjectsHandle`. Note that this PR does not modify the `UploadHandle` functionality, except for adding some comments to the struct.

For both of the handles, the basic idea is
- Dropping a handle abruptly terminates in-progress tasks. This occurs either when the handle is destroyed via [RAII](https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization) or when `.drop()` is called explicitly. The tasks will be canceled at the points where their futures are waiting, and we don't have much control over the cleanup process, which is left to the underlying async runtime.
- Aborting a handle (via calling `.abort()` on it) allows tasks to complete their current work while ignoring any future tasks. The word "complete" has different meanings depending on whether the handle is an `UploadHandle` or an `UploadObjectsHandle`.
  - For an `UploadHandle`, it means that the control flow attempts to abort ongoing read and upload tasks, and it will invoke `AbortMultipartUpload` in the case of MPU.
  - For an `UploadObjectsHandle`, it means that each upload task either finishes uploading the current object or invokes `.abort()` on its respective single upload operation down the line.

For `UploadObjectsHandle`, this PR introduces a watch channel that signals when the operation enters cancellation mode and needs to be terminated gracefully. There are two ways to trigger cancellation:
- A user explicitly calls `.abort()` on the `UploadObjectsHandle`.
- A child operation fails while running with the abort policy.

Both cases are covered by newly added integration tests.

**Design Discussions:**
- I once considered making the behavior of `Drop` the same as calling `.abort()`—for example, having fn `drop(&mut self)` call `.abort()`. However, since `.drop` is a synchronous method and `.abort()` is asynchronous, this led me to implement separate behaviors for the two.
- Once the operation enters cancellation mode, `.abort()` (for both `UploadHandle` and `UploadObjectsHandle`) will only return the error that triggered the cancellation and will log any additional errors encountered along the way (e.g., errors from AbortMultipartUpload). We have [TODO](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/main/aws-s3-transfer-manager/src/operation/upload/handle.rs#L163) and I also left [TODO](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/55f8ce77f50467066dfacad22cee629952a83c18/aws-s3-transfer-manager/src/operation/upload_objects/handle.rs#L55) to assess this behavior, but for now, the code after this PR "swallows" and logs any new errors encountered during the cancellation process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
