### PR TITLE
Add user agent

### DIFF
--- a/aws-s3-transfer-manager/Cargo.toml
+++ b/aws-s3-transfer-manager/Cargo.toml
@@ -15,6 +15,7 @@ aws-config = { version = "1.5.6", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1.51.0", features = ["behavior-version-latest"] }
 aws-smithy-async = "1.2.1"
 aws-smithy-experimental = { version = "0.1.3", features = ["crypto-aws-lc"] }
+aws-smithy-runtime = { version = "1.7.1", features = ["client", "connector-hyper-0-14-x", "test-util", "wire-mock"] }
 aws-smithy-runtime-api = "1.7.1"
 aws-smithy-types = "1.2.6"
 aws-types = "1.3.3"

--- a/aws-s3-transfer-manager/Cargo.toml
+++ b/aws-s3-transfer-manager/Cargo.toml
@@ -15,8 +15,8 @@ aws-config = { version = "1.5.6", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1.51.0", features = ["behavior-version-latest"] }
 aws-smithy-async = "1.2.1"
 aws-smithy-experimental = { version = "0.1.3", features = ["crypto-aws-lc"] }
-aws-smithy-runtime = { version = "1.7.1", features = ["client", "connector-hyper-0-14-x", "test-util", "wire-mock"] }
-aws-smithy-runtime-api = "1.7.1"
+aws-smithy-runtime-api = "1.7.3"
+aws-runtime = "1.4.4"
 aws-smithy-types = "1.2.6"
 aws-types = "1.3.3"
 blocking = "1.6.0"
@@ -33,7 +33,7 @@ walkdir = "2"
 [dev-dependencies]
 aws-sdk-s3 = { version = "1.51.0", features = ["behavior-version-latest", "test-util"] }
 aws-smithy-mocks-experimental = "0.2.1"
-aws-smithy-runtime = { version = "1.7.1", features = ["client", "connector-hyper-0-14-x", "test-util", "wire-mock"] }
+aws-smithy-runtime = { version = "1.7.4", features = ["client", "connector-hyper-0-14-x", "test-util", "wire-mock"] }
 clap = { version = "4.5.7", default-features = false, features = ["derive", "std", "help"] }
 console-subscriber = "0.4.0"
 http-02x = { package = "http", version = "0.2.9" }

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -153,9 +153,6 @@ async fn do_download(args: Args) -> Result<(), BoxError> {
     let tm_config = aws_s3_transfer_manager::from_env()
         .concurrency(ConcurrencySetting::Explicit(args.concurrency))
         .part_size(PartSize::Target(args.part_size))
-        .frame_metadata(Some(
-            FrameworkMetadata::new("some-framework", Some(Cow::Borrowed("1.3"))).unwrap(),
-        ))
         .load()
         .await;
 
@@ -233,9 +230,6 @@ async fn do_upload(args: Args) -> Result<(), BoxError> {
     let tm_config = aws_s3_transfer_manager::from_env()
         .concurrency(ConcurrencySetting::Explicit(args.concurrency))
         .part_size(PartSize::Target(args.part_size))
-        .frame_metadata(Some(
-            FrameworkMetadata::new("some-framework", Some(Cow::Borrowed("1.3"))).unwrap(),
-        ))
         .load()
         .await;
 

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -8,7 +7,6 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time;
 
-use aws_runtime::user_agent::FrameworkMetadata;
 use aws_s3_transfer_manager::io::InputStream;
 use aws_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_s3_transfer_manager::metrics::Throughput;
@@ -280,7 +278,6 @@ async fn main() -> Result<(), BoxError> {
         tracing_subscriber::fmt()
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .with_thread_ids(true)
-            .with_ansi(false) // Disable ANSI colors
             .init();
     }
 

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -152,7 +152,7 @@ async fn do_download(args: Args) -> Result<(), BoxError> {
     let tm_config = aws_s3_transfer_manager::from_env()
         .concurrency(ConcurrencySetting::Explicit(args.concurrency))
         .part_size(PartSize::Target(args.part_size))
-        .app_name(Some(AppName::new("rust_ts_cp").unwrap()))
+        .app_name(Some(AppName::new("transfer_manager_example_cp").unwrap()))
         .load()
         .await;
 
@@ -230,7 +230,7 @@ async fn do_upload(args: Args) -> Result<(), BoxError> {
     let tm_config = aws_s3_transfer_manager::from_env()
         .concurrency(ConcurrencySetting::Explicit(args.concurrency))
         .part_size(PartSize::Target(args.part_size))
-        .app_name(Some(AppName::new("rust_ts_cp").unwrap()))
+        .app_name(Some(AppName::new("transfer_manager_example_cp").unwrap()))
         .load()
         .await;
 

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time;
 
+use aws_config::AppName;
 use aws_s3_transfer_manager::io::InputStream;
 use aws_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_s3_transfer_manager::metrics::Throughput;
@@ -151,6 +152,7 @@ async fn do_download(args: Args) -> Result<(), BoxError> {
     let tm_config = aws_s3_transfer_manager::from_env()
         .concurrency(ConcurrencySetting::Explicit(args.concurrency))
         .part_size(PartSize::Target(args.part_size))
+        .app_name(Some(AppName::new("rust_ts_cp").unwrap()))
         .load()
         .await;
 
@@ -228,6 +230,7 @@ async fn do_upload(args: Args) -> Result<(), BoxError> {
     let tm_config = aws_s3_transfer_manager::from_env()
         .concurrency(ConcurrencySetting::Explicit(args.concurrency))
         .part_size(PartSize::Target(args.part_size))
+        .app_name(Some(AppName::new("rust_ts_cp").unwrap()))
         .load()
         .await;
 
@@ -278,6 +281,7 @@ async fn main() -> Result<(), BoxError> {
         tracing_subscriber::fmt()
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
             .with_thread_ids(true)
+            .with_ansi(false) // Disable ANSI colors
             .init();
     }
 

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -7,13 +8,13 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time;
 
+use aws_runtime::user_agent::FrameworkMetadata;
 use aws_s3_transfer_manager::io::InputStream;
 use aws_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_s3_transfer_manager::metrics::Throughput;
 use aws_s3_transfer_manager::operation::download::body::Body;
 use aws_s3_transfer_manager::types::{ConcurrencySetting, PartSize};
 use aws_sdk_s3::error::DisplayErrorContext;
-use aws_types::app_name::AppName;
 use bytes::Buf;
 use clap::{CommandFactory, Parser};
 use tokio::fs;
@@ -152,7 +153,9 @@ async fn do_download(args: Args) -> Result<(), BoxError> {
     let tm_config = aws_s3_transfer_manager::from_env()
         .concurrency(ConcurrencySetting::Explicit(args.concurrency))
         .part_size(PartSize::Target(args.part_size))
-        .app_name(Some(AppName::new("transfer_manager_example_cp").unwrap()))
+        .frame_metadata(Some(
+            FrameworkMetadata::new("some-framework", Some(Cow::Borrowed("1.3"))).unwrap(),
+        ))
         .load()
         .await;
 
@@ -230,7 +233,9 @@ async fn do_upload(args: Args) -> Result<(), BoxError> {
     let tm_config = aws_s3_transfer_manager::from_env()
         .concurrency(ConcurrencySetting::Explicit(args.concurrency))
         .part_size(PartSize::Target(args.part_size))
-        .app_name(Some(AppName::new("transfer_manager_example_cp").unwrap()))
+        .frame_metadata(Some(
+            FrameworkMetadata::new("some-framework", Some(Cow::Borrowed("1.3"))).unwrap(),
+        ))
         .load()
         .await;
 

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -7,13 +7,13 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time;
 
-use aws_config::AppName;
 use aws_s3_transfer_manager::io::InputStream;
 use aws_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_s3_transfer_manager::metrics::Throughput;
 use aws_s3_transfer_manager::operation::download::body::Body;
 use aws_s3_transfer_manager::types::{ConcurrencySetting, PartSize};
 use aws_sdk_s3::error::DisplayErrorContext;
+use aws_types::app_name::AppName;
 use bytes::Buf;
 use clap::{CommandFactory, Parser};
 use tokio::fs;

--- a/aws-s3-transfer-manager/external-types.toml
+++ b/aws-s3-transfer-manager/external-types.toml
@@ -8,5 +8,6 @@ allowed_external_types = [
     "bytes::bytes::Bytes",
     "bytes::buf::buf_impl::Buf",
     "aws_types::request_id::RequestId",
-    "aws_types::request_id::RequestIdExt"
+    "aws_types::request_id::RequestIdExt",
+    "aws_types::app_name::AppName",
 ]

--- a/aws-s3-transfer-manager/external-types.toml
+++ b/aws-s3-transfer-manager/external-types.toml
@@ -9,5 +9,4 @@ allowed_external_types = [
     "bytes::buf::buf_impl::Buf",
     "aws_types::request_id::RequestId",
     "aws_types::request_id::RequestIdExt",
-    "aws_types::app_name::AppName",
 ]

--- a/aws-s3-transfer-manager/src/config.rs
+++ b/aws-s3-transfer-manager/src/config.rs
@@ -20,7 +20,7 @@ pub struct Config {
     multipart_threshold: PartSize,
     target_part_size: PartSize,
     concurrency: ConcurrencySetting,
-    frame_metadata: Option<FrameworkMetadata>,
+    framework_metadata: Option<FrameworkMetadata>,
     client: aws_sdk_s3::client::Client,
 }
 
@@ -46,9 +46,10 @@ impl Config {
         &self.concurrency
     }
 
-    /// Returns the name of the app that is using the transfer manager, if it was provided.
-    pub fn frame_metadata(&self) -> Option<&FrameworkMetadata> {
-        self.frame_metadata.as_ref()
+    #[doc(hidden)]
+    /// Returns the framework metadata setting when using transfer manager.
+    pub fn framework_metadata(&self) -> Option<&FrameworkMetadata> {
+        self.framework_metadata.as_ref()
     }
 
     /// The Amazon S3 client instance that will be used to send requests to S3.
@@ -63,7 +64,7 @@ pub struct Builder {
     multipart_threshold_part_size: PartSize,
     target_part_size: PartSize,
     concurrency: ConcurrencySetting,
-    frame_metadata: Option<FrameworkMetadata>,
+    framework_metadata: Option<FrameworkMetadata>,
     client: Option<aws_sdk_s3::Client>,
 }
 
@@ -131,12 +132,13 @@ impl Builder {
         self
     }
 
-    /// Sets the name of the app that is using the client.
+    #[doc(hidden)]
+    /// Sets the framework metadata for the transfer manager.
     ///
-    /// This _optional_ name is used to identify the application in the user agent that
+    /// This _optional_ name is used to identify the framework using transfer manager in the user agent that
     /// gets sent along with requests.
-    pub fn frame_metadata(mut self, frame_metadata: Option<FrameworkMetadata>) -> Self {
-        self.frame_metadata = frame_metadata;
+    pub fn framework_metadata(mut self, framework_metadata: Option<FrameworkMetadata>) -> Self {
+        self.framework_metadata = framework_metadata;
         self
     }
 
@@ -155,7 +157,7 @@ impl Builder {
             multipart_threshold: self.multipart_threshold_part_size,
             target_part_size: self.target_part_size,
             concurrency: self.concurrency,
-            frame_metadata: self.frame_metadata,
+            framework_metadata: self.framework_metadata,
             client: self.client.expect("client set"),
         }
     }

--- a/aws-s3-transfer-manager/src/config.rs
+++ b/aws-s3-transfer-manager/src/config.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_config::AppName;
+use aws_types::app_name::AppName;
 
 use crate::metrics::unit::ByteUnit;
 use crate::types::{ConcurrencySetting, PartSize};

--- a/aws-s3-transfer-manager/src/config.rs
+++ b/aws-s3-transfer-manager/src/config.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_types::app_name::AppName;
+use aws_runtime::user_agent::FrameworkMetadata;
 
 use crate::metrics::unit::ByteUnit;
 use crate::types::{ConcurrencySetting, PartSize};
@@ -20,7 +20,7 @@ pub struct Config {
     multipart_threshold: PartSize,
     target_part_size: PartSize,
     concurrency: ConcurrencySetting,
-    app_name: Option<AppName>,
+    frame_metadata: Option<FrameworkMetadata>,
     client: aws_sdk_s3::client::Client,
 }
 
@@ -47,8 +47,8 @@ impl Config {
     }
 
     /// Returns the name of the app that is using the transfer manager, if it was provided.
-    pub fn app_name(&self) -> Option<&AppName> {
-        self.app_name.as_ref()
+    pub fn frame_metadata(&self) -> Option<&FrameworkMetadata> {
+        self.frame_metadata.as_ref()
     }
 
     /// The Amazon S3 client instance that will be used to send requests to S3.
@@ -63,7 +63,7 @@ pub struct Builder {
     multipart_threshold_part_size: PartSize,
     target_part_size: PartSize,
     concurrency: ConcurrencySetting,
-    app_name: Option<AppName>,
+    frame_metadata: Option<FrameworkMetadata>,
     client: Option<aws_sdk_s3::Client>,
 }
 
@@ -135,8 +135,8 @@ impl Builder {
     ///
     /// This _optional_ name is used to identify the application in the user agent that
     /// gets sent along with requests.
-    pub fn app_name(mut self, app_name: Option<AppName>) -> Self {
-        self.app_name = app_name;
+    pub fn frame_metadata(mut self, frame_metadata: Option<FrameworkMetadata>) -> Self {
+        self.frame_metadata = frame_metadata;
         self
     }
 
@@ -155,7 +155,7 @@ impl Builder {
             multipart_threshold: self.multipart_threshold_part_size,
             target_part_size: self.target_part_size,
             concurrency: self.concurrency,
-            app_name: self.app_name,
+            frame_metadata: self.frame_metadata,
             client: self.client.expect("client set"),
         }
     }

--- a/aws-s3-transfer-manager/src/config.rs
+++ b/aws-s3-transfer-manager/src/config.rs
@@ -46,8 +46,8 @@ impl Config {
         &self.concurrency
     }
 
-    #[doc(hidden)]
     /// Returns the framework metadata setting when using transfer manager.
+    #[doc(hidden)]
     pub fn framework_metadata(&self) -> Option<&FrameworkMetadata> {
         self.framework_metadata.as_ref()
     }
@@ -132,11 +132,11 @@ impl Builder {
         self
     }
 
-    #[doc(hidden)]
     /// Sets the framework metadata for the transfer manager.
     ///
     /// This _optional_ name is used to identify the framework using transfer manager in the user agent that
     /// gets sent along with requests.
+    #[doc(hidden)]
     pub fn framework_metadata(mut self, framework_metadata: Option<FrameworkMetadata>) -> Self {
         self.framework_metadata = framework_metadata;
         self

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -159,6 +159,7 @@ mod tests {
             ))
             .load()
             .await;
+        // Inject the captured request to the http client to capture the request made from transfer manager.
         let sdk_s3_config = config
             .client()
             .config()
@@ -184,6 +185,7 @@ mod tests {
             .unwrap();
         // Expect to fail
         let _ = handle.body_mut().next().await;
+        // Check the request made contains the expected framework meta data in user agent.
         let expected_req = captured_request.expect_request();
         let user_agent = expected_req.headers().get("x-amz-user-agent").unwrap();
         assert!(user_agent.contains("lib/some-framework/1.3"));

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -163,8 +163,9 @@ mod tests {
             .client()
             .config()
             .to_builder()
-            .region(Region::from_static("us-west-2"))
             .http_client(http_client)
+            .region(Region::from_static("us-west-2"))
+            .with_test_defaults()
             .build();
 
         let capture_request_config = crate::Config::builder()

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -129,6 +129,7 @@ mod tests {
     use std::borrow::Cow;
 
     use crate::types::{ConcurrencySetting, PartSize};
+    use aws_config::Region;
     use aws_runtime::user_agent::FrameworkMetadata;
     use aws_sdk_s3::config::Intercept;
     use aws_smithy_runtime::client::http::test_util::capture_request;
@@ -162,6 +163,7 @@ mod tests {
             .client()
             .config()
             .to_builder()
+            .region(Region::from_static("us-west-2"))
             .http_client(http_client)
             .build();
 

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -91,11 +91,11 @@ impl ConfigLoader {
         self
     }
 
-    #[doc(hidden)]
     /// Sets the framework metadata for the transfer manager.
     ///
     /// This _optional_ name is used to identify the framework using transfer manager in the user agent that
     /// gets sent along with requests.
+    #[doc(hidden)]
     pub fn framework_metadata(mut self, framework_metadata: Option<FrameworkMetadata>) -> Self {
         self.builder = self.builder.framework_metadata(framework_metadata);
         self

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -174,14 +174,14 @@ mod tests {
 
         let transfer_manager = crate::Client::new(capture_request_config);
 
-        let handle = transfer_manager
+        let mut handle = transfer_manager
             .download()
             .bucket("foo")
             .key("bar")
             .initiate()
             .unwrap();
         // Expect to fail
-        let _ = handle.join().await;
+        let _ = handle.body_mut().next().await;
         let expected_req = captured_request.expect_request();
         let user_agent = expected_req.headers().get("x-amz-user-agent").unwrap();
         assert!(user_agent.contains("lib/some-framework/1.3"));

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -180,7 +180,8 @@ mod tests {
             .initiate()
             .unwrap();
         // Expect to fail
-        let _ = handle.body_mut().next().await;
+        let output = handle.body_mut().next().await;
+        print!("{:#?}", output);
         let expected_req = captured_request.expect_request();
         let user_agent = expected_req.headers().get("x-amz-user-agent").unwrap();
         assert!(user_agent.contains("lib/some-framework/1.3"));

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -91,12 +91,13 @@ impl ConfigLoader {
         self
     }
 
-    /// Sets the name of the app that is using the client.
+    #[doc(hidden)]
+    /// Sets the framework metadata for the transfer manager.
     ///
-    /// This _optional_ name is used to identify the application in the user agent that
+    /// This _optional_ name is used to identify the framework using transfer manager in the user agent that
     /// gets sent along with requests.
-    pub fn frame_metadata(mut self, frame_metadata: Option<FrameworkMetadata>) -> Self {
-        self.builder = self.builder.frame_metadata(frame_metadata);
+    pub fn framework_metadata(mut self, framework_metadata: Option<FrameworkMetadata>) -> Self {
+        self.builder = self.builder.framework_metadata(framework_metadata);
         self
     }
 
@@ -113,7 +114,7 @@ impl ConfigLoader {
         let mut sdk_client_builder = aws_sdk_s3::config::Builder::from(&shared_config);
 
         let interceptor = S3TransferManagerInterceptor {
-            frame_work_meta_data: self.builder.frame_metadata.clone(),
+            frame_work_meta_data: self.builder.framework_metadata.clone(),
         };
         sdk_client_builder.push_interceptor(S3TransferManagerInterceptor::into_shared(interceptor));
         let builder = self
@@ -129,7 +130,7 @@ mod tests {
     use aws_sdk_s3::config::Intercept;
 
     #[tokio::test]
-    async fn load_with_frame_metadata_and_interceptor() {
+    async fn load_with_framework_metadata_and_interceptor() {
         let config = crate::from_env()
             .concurrency(ConcurrencySetting::Explicit(123))
             .part_size(PartSize::Target(8))

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -180,9 +180,7 @@ mod tests {
             .key("bar")
             .initiate()
             .unwrap();
-
-        // let body = drain(&mut handle).await.unwrap();
-
+        // Expect to fail
         let _ = handle.join().await;
         let expected_req = captured_request.expect_request();
         let user_agent = expected_req.headers().get("x-amz-user-agent").unwrap();

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -183,8 +183,7 @@ mod tests {
             .initiate()
             .unwrap();
         // Expect to fail
-        let output = handle.body_mut().next().await;
-        print!("{:#?}", output);
+        let _ = handle.body_mut().next().await;
         let expected_req = captured_request.expect_request();
         let user_agent = expected_req.headers().get("x-amz-user-agent").unwrap();
         assert!(user_agent.contains("lib/some-framework/1.3"));

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_config::{AppName, BehaviorVersion};
+use aws_config::BehaviorVersion;
 use aws_runtime::sdk_feature::AwsSdkFeature;
 use aws_sdk_s3::config::{Intercept, IntoShared};
+use aws_types::app_name::AppName;
 
 use crate::config::Builder;
 use crate::{
@@ -28,7 +29,7 @@ impl Intercept for TransferManagerFeatureInterceptor {
         cfg: &mut aws_sdk_s3::config::ConfigBag,
     ) -> Result<(), aws_sdk_s3::error::BoxError> {
         cfg.interceptor_state()
-            .store_append(AwsSdkFeature::S3Transfer);
+            .store_append::<AwsSdkFeature>(AwsSdkFeature::S3Transfer);
         Ok(())
     }
 }

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -147,7 +147,6 @@ mod tests {
         assert!(tm_interceptor_exists);
     }
 
-    /* TODO: test the framework metadata added correctly */
     #[tokio::test]
     async fn load_with_interceptor_and_framework_metadata() {
         let (http_client, captured_request) = capture_request(None);

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -4,8 +4,8 @@
  */
 
 use aws_config::{AppName, BehaviorVersion};
+use aws_runtime::sdk_feature::AwsSdkFeature;
 use aws_sdk_s3::config::{Intercept, IntoShared};
-use aws_smithy_runtime::client::sdk_feature::SmithySdkFeature;
 
 use crate::config::Builder;
 use crate::{
@@ -28,10 +28,7 @@ impl Intercept for TransferManagerFeatureInterceptor {
         cfg: &mut aws_sdk_s3::config::ConfigBag,
     ) -> Result<(), aws_sdk_s3::error::BoxError> {
         cfg.interceptor_state()
-            // .store_put(AppName::new("crt-dengket").unwrap())
-            // .store_append(AwsSdkFeature::S3Transfer)
-            .store_append::<SmithySdkFeature>(SmithySdkFeature::ProtocolRpcV2Cbor)
-            .store_append::<SmithySdkFeature>(SmithySdkFeature::Waiter);
+            .store_append(AwsSdkFeature::S3Transfer);
         Ok(())
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/34


*Description of changes:*

- Add an interceptor when we load the config to add the transfer manager metric for user agent
- Add a framework metadata for the transfer manager config and pass it down to the sdk s3 client as the framework name in the user agent.
- Only added for the `ConfigLoader`, we can decide what to do when user pass in their own client via config directly later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
