### PR TITLE
support if-match for get objects

### DIFF
--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -100,7 +100,7 @@ async fn send_discovery(
     ctx: DownloadContext,
     comp_tx: mpsc::Sender<Result<ChunkOutput, crate::error::Error>>,
     object_meta_tx: oneshot::Sender<ObjectMetadata>,
-    input: DownloadInput,
+    mut input: DownloadInput,
     use_current_span_as_parent_for_tasks: bool,
 ) {
     // create span to serve as parent of spawned child tasks.
@@ -139,7 +139,7 @@ async fn send_discovery(
         }
     };
 
-    if object_meta_tx.send(discovery.object_meta).is_err() {
+    if object_meta_tx.send(discovery.object_meta.clone()).is_err() {
         tracing::debug!(
             "Download handle for key({:?}) has been dropped, aborting during the discovery phase",
             input.key
@@ -163,6 +163,10 @@ async fn send_discovery(
     );
 
     if !discovery.remaining.is_empty() {
+        // Add if_match to the rest of the requests using the etag
+        // we got from discovery to ensure the object stays the same
+        // during the download process.
+        input.if_match = discovery.object_meta.e_tag.clone();
         distribute_work(
             &mut tasks,
             ctx.clone(),

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -142,7 +142,7 @@ async fn send_discovery(
     // Add if_match to the rest of the requests using the etag
     // we got from discovery to ensure the object stays the same
     // during the download process.
-    input.if_match = discovery.object_meta.e_tag.clone();
+    input.if_match.clone_from(&discovery.object_meta.e_tag);
 
     if object_meta_tx.send(discovery.object_meta).is_err() {
         tracing::debug!(

--- a/aws-s3-transfer-manager/tests/download_test.rs
+++ b/aws-s3-transfer-manager/tests/download_test.rs
@@ -9,15 +9,16 @@ use aws_s3_transfer_manager::{
     operation::download::DownloadHandle,
     types::{ConcurrencySetting, PartSize},
 };
-use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClient};
-use aws_smithy_types::body::SdkBody;
-use bytes::{BufMut, Bytes, BytesMut};
 use pin_project_lite::pin_project;
 use std::{
     cmp,
     iter::{self, repeat_with},
     task::Poll,
 };
+
+use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClient};
+use aws_smithy_types::body::SdkBody;
+use bytes::{BufMut, Bytes, BytesMut};
 
 /// NOTE: these tests are somewhat brittle as they assume particular paths through the codebase.
 /// As an example we generally assume object discovery goes through `GetObject` with a ranged get

--- a/aws-s3-transfer-manager/tests/download_test.rs
+++ b/aws-s3-transfer-manager/tests/download_test.rs
@@ -463,11 +463,11 @@ async fn test_download_object_modified() {
     let data = rand_data(12 * MEBIBYTE);
     let part_size = 5 * MEBIBYTE;
 
-    /// Create a static replay client (http connector) to mock the S3 response when object modified during download.
-    ///
-    /// Assumptions:
-    ///     1. First request for discovery, succeed with etag
-    ///     2. Followed requests fail to mock the object changed during download.
+    // Create a static replay client (http connector) to mock the S3 response when object modified during download.
+    //
+    // Assumptions:
+    //     1. First request for discovery, succeed with etag
+    //     2. Followed requests fail to mock the object changed during download.
     let events = data
         .chunks(part_size)
         .enumerate()


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/69

*Description of changes:*
- Adding if-match to the following downloads with the etag we received from the discovery stage.
- If user already have the if-match in the download input, it will only succeed if it matches the etag we received. So, it's safe to overwrite it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
