### PR TITLE
disable payload signing for uploads by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ env:
   # Change to specific Rust release to pin
   rust_stable: stable
   rust_nightly: nightly-2024-07-07
-  rust_clippy: '1.79'
+  rust_clippy: '1.81'
   # When updating this, also update relevant docs
-  rust_min: '1.79'
+  rust_min: '1.81'
 
 
 defaults:

--- a/aws-s3-transfer-manager/Cargo.toml
+++ b/aws-s3-transfer-manager/Cargo.toml
@@ -10,30 +10,30 @@ publish = false
 
 [dependencies]
 async-channel = "2.3.1"
-async-trait = "0.1.82"
-aws-config = { version = "1.5.6", features = ["behavior-version-latest"] }
-aws-sdk-s3 = { version = "1.51.0", features = ["behavior-version-latest"] }
-aws-smithy-async = "1.2.1"
+async-trait = "0.1.83"
+aws-config = { version = "1.5.11", features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1.66.0", features = ["behavior-version-latest"] }
+aws-smithy-async = "1.2.2"
 aws-smithy-experimental = { version = "0.1.3", features = ["crypto-aws-lc"] }
 aws-smithy-runtime-api = "1.7.3"
-aws-runtime = "1.4.4"
-aws-smithy-types = "1.2.6"
+aws-runtime = "1.5.1"
+aws-smithy-types = "1.2.10"
 aws-types = "1.3.3"
-blocking = "1.6.0"
+blocking = "1.6.1"
 bytes = "1"
 bytes-utils = "0.1.4"
-futures-util = "0.3.30"
+futures-util = "0.3.31"
 path-clean = "1.0.1"
-pin-project-lite = "0.2.14"
-tokio = { version = "1.40.0", features = ["rt-multi-thread", "io-util", "sync", "fs", "macros"] }
-tower = { version = "0.5.1", features = ["limit", "retry", "util", "hedge", "buffer"] }
+pin-project-lite = "0.2.15"
+tokio = { version = "1.42.0", features = ["rt-multi-thread", "io-util", "sync", "fs", "macros"] }
+tower = { version = "0.5.2", features = ["limit", "retry", "util", "hedge", "buffer"] }
 tracing = "0.1"
 walkdir = "2"
 
 [dev-dependencies]
-aws-sdk-s3 = { version = "1.51.0", features = ["behavior-version-latest", "test-util"] }
+aws-sdk-s3 = { version = "1.66.0", features = ["behavior-version-latest", "test-util"] }
 aws-smithy-mocks-experimental = "0.2.1"
-aws-smithy-runtime = { version = "1.7.4", features = ["client", "connector-hyper-0-14-x", "test-util", "wire-mock"] }
+aws-smithy-runtime = { version = "1.7.5", features = ["client", "connector-hyper-0-14-x", "test-util", "wire-mock"] }
 clap = { version = "4.5.7", default-features = false, features = ["derive", "std", "help"] }
 console-subscriber = "0.4.0"
 http-02x = { package = "http", version = "0.2.9" }

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -126,6 +126,8 @@ async fn put_object(
         .set_object_lock_legal_hold_status(ctx.request.object_lock_legal_hold_status.clone())
         .set_expected_bucket_owner(ctx.request.expected_bucket_owner.clone())
         .set_checksum_algorithm(ctx.request.checksum_algorithm.clone())
+        .customize()
+        .disable_payload_signing()
         .send()
         .instrument(tracing::info_span!(
             "send-upload-part",

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -30,7 +30,6 @@ async fn upload_part_handler(request: UploadPartRequest) -> Result<CompletedPart
     let part_data = request.part_data;
     let part_number = part_data.part_number as i32;
 
-    // TODO(aws-sdk-rust#1159): disable payload signing
     // TODO(aws-sdk-rust#1159): set checksum fields if applicable
     let resp = ctx
         .client()
@@ -46,6 +45,8 @@ async fn upload_part_handler(request: UploadPartRequest) -> Result<CompletedPart
         .set_sse_customer_key_md5(ctx.request.sse_customer_key_md5.clone())
         .set_request_payer(ctx.request.request_payer.clone())
         .set_expected_bucket_owner(ctx.request.expected_bucket_owner.clone())
+        .customize()
+        .disable_payload_signing()
         .send()
         .instrument(tracing::debug_span!("send-upload-part", part_number))
         .await?;


### PR DESCRIPTION
**Issue #, if available:**
closes https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/16

**Description of changes:**
Disable payload signing by default for uploads.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
