### PR TITLE
Make createMPU Call Async

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ env:
   # Change to specific Rust release to pin
   rust_stable: stable
   rust_nightly: nightly-2024-07-07
-  rust_clippy: '1.79'
+  rust_clippy: '1.81'
   # When updating this, also update relevant docs
-  rust_min: '1.79'
+  rust_min: '1.81'
 
 
 defaults:
@@ -55,7 +55,7 @@ jobs:
       - docs
       - minrust
     steps:
-      - run: exit 0 
+      - run: exit 0
 
   test-hll:
     name: Test S3 transfer manager HLL
@@ -133,7 +133,7 @@ jobs:
         run: |
           cargo doc --lib --no-deps --all-features --document-private-items
         env:
-          RUSTFLAGS: --cfg docsrs 
+          RUSTFLAGS: --cfg docsrs
           RUSTDOCFLAGS: --cfg docsrs
 
   minrust:
@@ -246,7 +246,7 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
-      - name: check --feature-powerset 
+      - name: check --feature-powerset
         run: cargo hack check --all --feature-powerset
 
   # TODO - get cross check working

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -252,8 +252,7 @@ async fn do_upload(args: Args) -> Result<(), BoxError> {
         .bucket(bucket)
         .key(key)
         .body(stream)
-        .send()
-        .await?;
+        .initiate()?;
 
     let _resp = handle.join().await?;
     let elapsed = start.elapsed();

--- a/aws-s3-transfer-manager/src/client.rs
+++ b/aws-s3-transfer-manager/src/client.rs
@@ -100,10 +100,9 @@ impl Client {
     ///         .bucket("my-bucket")
     ///         .key("my-key")
     ///         .body(stream)
-    ///         .send()
-    ///         .await?;
+    ///         .initiate()?;
     ///
-    ///     // send() may return before the transfer is complete.
+    ///     // initiate() will return before the transfer is complete.
     ///     // Call the `join()` method on the returned handle to drive the transfer to completion.
     ///     // The handle can also be used to get progress, pause, or cancel the transfer, etc.
     ///     let response = handle.join().await?;

--- a/aws-s3-transfer-manager/src/operation/download/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/download/builders.rs
@@ -524,7 +524,10 @@ impl DownloadFluentBuilder {
 
 impl crate::operation::download::input::DownloadInputBuilder {
     /// Initiate a download transfer for a single object with this input using the given client.
-    pub fn send_with(self, client: &crate::Client) -> Result<DownloadHandle, crate::error::Error> {
+    pub fn initiate_with(
+        self,
+        client: &crate::Client,
+    ) -> Result<DownloadHandle, crate::error::Error> {
         let mut fluent_builder = client.download();
         fluent_builder.inner = self;
         fluent_builder.initiate()

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -380,14 +380,14 @@ mod test {
 
         let client = mock_client_with_stubbed_http_client!(
             aws_sdk_s3,
-            RuleMode::MatchAny,
+            RuleMode::Sequential,
             &[create_mpu, upload_part, abort_mpu]
         );
 
         let tm_config = crate::Config::builder()
             .concurrency(ConcurrencySetting::Explicit(1))
             .set_multipart_threshold(PartSize::Target(10))
-            .set_target_part_size(PartSize::Target(30))
+            .set_target_part_size(PartSize::Target(5 * 1024 * 1024))
             .client(client)
             .build();
 

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -243,7 +243,7 @@ mod test {
     #[tokio::test]
     async fn test_basic_mpu() {
         let expected_upload_id = Arc::new("test-upload".to_owned());
-        let body: Bytes = Bytes::from_static(b"every adolescent dog goes bonkers early");
+        let body = Bytes::from_static(b"every adolescent dog goes bonkers early");
         let stream = InputStream::from(body);
 
         let upload_id = expected_upload_id.clone();
@@ -312,7 +312,7 @@ mod test {
     #[tokio::test]
     async fn test_basic_upload_object() {
         let body = Bytes::from_static(b"every adolescent dog goes bonkers early");
-        let stream: InputStream = InputStream::from(body);
+        let stream = InputStream::from(body);
         let expected_e_tag = Arc::new("test-etag".to_owned());
 
         let e_tag = expected_e_tag.clone();
@@ -345,13 +345,13 @@ mod test {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_abort_multipart_upload() {
         let expected_upload_id = Arc::new("test-upload".to_owned());
-        let body: Bytes = Bytes::from_static(b"every adolescent dog goes bonkers early");
+        let body  = Bytes::from_static(b"every adolescent dog goes bonkers early");
         let stream = InputStream::from(body);
         let bucket = "test-bucket";
         let key = "test-key";
         let wait_till_create_mpu = Arc::new(Barrier::new(2));
 
-        let upload_id: Arc<String> = expected_upload_id.clone();
+        let upload_id= expected_upload_id.clone();
         let create_mpu =
             mock!(aws_sdk_s3::Client::create_multipart_upload).then_output(move || {
                 CreateMultipartUploadOutput::builder()

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -16,7 +16,7 @@ use crate::error;
 use crate::io::InputStream;
 use context::UploadContext;
 pub use handle::UploadHandle;
-use handle::{MultipartUploadContext, UploadType};
+use handle::{MultipartUploadData, UploadType};
 /// Request type for uploads to Amazon S3
 pub use input::{UploadInput, UploadInputBuilder};
 /// Response type for uploads to Amazon S3
@@ -158,14 +158,14 @@ async fn try_start_mpu_upload(
     );
     let upload_id = mpu.upload_id.clone().expect("upload_id is present");
 
-    let mut mpu_context = MultipartUploadContext {
+    let mut mpu_data = MultipartUploadData {
         upload_part_tasks: Default::default(),
         read_body_tasks: Default::default(),
         response: Some(mpu),
         upload_id: upload_id.clone(),
     };
-    distribute_work(&mut mpu_context, ctx, stream, part_size, upload_id)?;
-    Ok(UploadType::MultipartUpload(mpu_context))
+    distribute_work(&mut mpu_data, ctx, stream, part_size, upload_id)?;
+    Ok(UploadType::MultipartUpload(mpu_data))
 }
 
 fn new_context(handle: Arc<crate::client::Handle>, req: UploadInput) -> UploadContext {

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -302,7 +302,7 @@ mod test {
             .key("test-key")
             .body(stream);
 
-        let handle = request.initiate_with(&tm).await.unwrap();
+        let handle = request.initiate_with(&tm).unwrap();
 
         let resp = handle.join().await.unwrap();
         assert_eq!(expected_upload_id.deref(), resp.upload_id.unwrap().deref());
@@ -336,7 +336,7 @@ mod test {
             .bucket("test-bucket")
             .key("test-key")
             .body(stream);
-        let handle = request.initiate_with(&tm).await.unwrap();
+        let handle = request.initiate_with(&tm).unwrap();
         let resp = handle.join().await.unwrap();
         assert_eq!(resp.upload_id(), None);
         assert_eq!(expected_e_tag.deref(), resp.e_tag().unwrap());
@@ -397,7 +397,7 @@ mod test {
             .bucket("test-bucket")
             .key("test-key")
             .body(stream);
-        let handle = request.initiate_with(&tm).await.unwrap();
+        let handle = request.initiate_with(&tm).unwrap();
         wait_till_create_mpu.wait();
         let abort = handle.abort().await.unwrap();
         assert_eq!(abort.upload_id().unwrap(), expected_upload_id.deref());

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -171,12 +171,13 @@ async fn try_start_mpu_upload(
         "multipart upload started with upload id: {:?}",
         mpu.upload_id
     );
+    let upload_id = mpu.upload_id.clone().expect("upload_id is present");
 
     let mut upload_type = UploadType::MultipartUpload { upload_part_tasks: Default::default(), read_body_tasks: Default::default(), response: Some(mpu) };
     //let mut handle = UploadHandle::new_multipart(ctx);
     // TODO: Fix
     //handle.set_response(mpu);
-    distribute_work(&mut upload_type, ctx, stream, part_size)?;
+    distribute_work(&mut upload_type, ctx, stream, part_size, upload_id)?;
     Ok(upload_type)
 }
 
@@ -184,7 +185,6 @@ fn new_context(handle: Arc<crate::client::Handle>, req: UploadInput) -> UploadCo
     UploadContext {
         handle,
         request: Arc::new(req),
-        upload_id: None,
     }
 }
 

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -228,6 +228,7 @@ mod test {
     use crate::io::InputStream;
     use crate::operation::upload::UploadInput;
     use crate::types::{ConcurrencySetting, PartSize};
+    use aws_sdk_s3::operation::abort_multipart_upload::AbortMultipartUploadOutput;
     use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadOutput;
     use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
     use aws_sdk_s3::operation::put_object::PutObjectOutput;
@@ -236,12 +237,13 @@ mod test {
     use bytes::Bytes;
     use std::ops::Deref;
     use std::sync::Arc;
+    use std::sync::Barrier;
     use test_common::mock_client_with_stubbed_http_client;
 
     #[tokio::test]
     async fn test_basic_mpu() {
         let expected_upload_id = Arc::new("test-upload".to_owned());
-        let body = Bytes::from_static(b"every adolescent dog goes bonkers early");
+        let body: Bytes = Bytes::from_static(b"every adolescent dog goes bonkers early");
         let stream = InputStream::from(body);
 
         let upload_id = expected_upload_id.clone();
@@ -310,7 +312,7 @@ mod test {
     #[tokio::test]
     async fn test_basic_upload_object() {
         let body = Bytes::from_static(b"every adolescent dog goes bonkers early");
-        let stream = InputStream::from(body);
+        let stream: InputStream = InputStream::from(body);
         let expected_e_tag = Arc::new("test-etag".to_owned());
 
         let e_tag = expected_e_tag.clone();
@@ -339,4 +341,67 @@ mod test {
         assert_eq!(resp.upload_id(), None);
         assert_eq!(expected_e_tag.deref(), resp.e_tag().unwrap());
     }
+
+    // #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    // async fn test_abort_multipart_upload() {
+    //     let expected_upload_id = Arc::new("test-upload".to_owned());
+    //     let body: Bytes = Bytes::from_static(b"every adolescent dog goes bonkers early");
+    //     let stream = InputStream::from(body);
+    //     let bucket = "test-bucket";
+    //     let key = "test-key";
+    //     let wait_till_create_mpu = Arc::new(Barrier::new(2));
+
+    //     let upload_id: Arc<String> = expected_upload_id.clone();
+    //     let create_mpu =
+    //         mock!(aws_sdk_s3::Client::create_multipart_upload).then_output(move || {
+    //             CreateMultipartUploadOutput::builder()
+    //                 .upload_id(upload_id.as_ref().to_owned())
+    //                 .build()
+    //         });
+
+    //     let upload_part = mock!(aws_sdk_s3::Client::upload_part).then_output({
+    //         let wait_till_create_mpu = wait_till_create_mpu.clone();
+    //         move || {
+    //             wait_till_create_mpu.wait();
+    //             UploadPartOutput::builder().build()
+    //         }
+    //     });
+
+    //     let abort_mpu = mock!(aws_sdk_s3::Client::abort_multipart_upload)
+    //         .match_requests({
+    //             let upload_id: Arc<String> = expected_upload_id.clone();
+    //             move |input| {
+    //                 input.upload_id.as_ref() == Some(&upload_id)
+    //                     && input.bucket() == Some(bucket)
+    //                     && input.key() == Some(key)
+    //             }
+    //         })
+    //         .then_output(|| AbortMultipartUploadOutput::builder().build());
+
+    //     let client = mock_client_with_stubbed_http_client!(
+    //         aws_sdk_s3,
+    //         RuleMode::MatchAny,
+    //         &[create_mpu, upload_part, abort_mpu]
+    //     );
+
+    //     let tm_config = crate::Config::builder()
+    //         .concurrency(ConcurrencySetting::Explicit(1))
+    //         .set_multipart_threshold(PartSize::Target(10))
+    //         .set_target_part_size(PartSize::Target(30))
+    //         .client(client)
+    //         .build();
+
+    //     let tm = crate::Client::new(tm_config);
+
+    //     let request = UploadInput::builder()
+    //         .bucket("test-bucket")
+    //         .key("test-key")
+    //         .body(stream);
+
+    //     let handle = request.send_with(&tm).await.unwrap();
+    //     wait_till_create_mpu.wait();
+    //     let abort = handle.abort().await.unwrap();
+
+    //     assert_eq!(abort.upload_id().unwrap(), expected_upload_id.deref());
+    // }
 }

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -345,13 +345,13 @@ mod test {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_abort_multipart_upload() {
         let expected_upload_id = Arc::new("test-upload".to_owned());
-        let body  = Bytes::from_static(b"every adolescent dog goes bonkers early");
+        let body = Bytes::from_static(b"every adolescent dog goes bonkers early");
         let stream = InputStream::from(body);
         let bucket = "test-bucket";
         let key = "test-key";
         let wait_till_create_mpu = Arc::new(Barrier::new(2));
 
-        let upload_id= expected_upload_id.clone();
+        let upload_id = expected_upload_id.clone();
         let create_mpu =
             mock!(aws_sdk_s3::Client::create_multipart_upload).then_output(move || {
                 CreateMultipartUploadOutput::builder()

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -397,11 +397,9 @@ mod test {
             .bucket("test-bucket")
             .key("test-key")
             .body(stream);
-
         let handle = request.send_with(&tm).await.unwrap();
         wait_till_create_mpu.wait();
         let abort = handle.abort().await.unwrap();
-
         assert_eq!(abort.upload_id().unwrap(), expected_upload_id.deref());
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -302,7 +302,7 @@ mod test {
             .key("test-key")
             .body(stream);
 
-        let handle = request.send_with(&tm).await.unwrap();
+        let handle = request.initiate_with(&tm).await.unwrap();
 
         let resp = handle.join().await.unwrap();
         assert_eq!(expected_upload_id.deref(), resp.upload_id.unwrap().deref());
@@ -336,7 +336,7 @@ mod test {
             .bucket("test-bucket")
             .key("test-key")
             .body(stream);
-        let handle = request.send_with(&tm).await.unwrap();
+        let handle = request.initiate_with(&tm).await.unwrap();
         let resp = handle.join().await.unwrap();
         assert_eq!(resp.upload_id(), None);
         assert_eq!(expected_e_tag.deref(), resp.e_tag().unwrap());
@@ -397,7 +397,7 @@ mod test {
             .bucket("test-bucket")
             .key("test-key")
             .body(stream);
-        let handle = request.send_with(&tm).await.unwrap();
+        let handle = request.initiate_with(&tm).await.unwrap();
         wait_till_create_mpu.wait();
         let abort = handle.abort().await.unwrap();
         assert_eq!(abort.upload_id().unwrap(), expected_upload_id.deref());

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -161,14 +161,14 @@ async fn try_start_mpu_upload(
         mpu.upload_id
     );
     let upload_id = mpu.upload_id.clone().expect("upload_id is present");
-
     let mut mpu_data = MultipartUploadData {
         upload_part_tasks: Default::default(),
         read_body_tasks: Default::default(),
         response: Some(mpu),
         upload_id: upload_id.clone(),
     };
-    distribute_work(&mut mpu_data, ctx, stream, part_size, upload_id)?;
+
+    distribute_work(&mut mpu_data, ctx, stream, part_size)?;
     Ok(UploadType::MultipartUpload(mpu_data))
 }
 

--- a/aws-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/builders.rs
@@ -911,7 +911,7 @@ impl UploadFluentBuilder {
 
 impl crate::operation::upload::input::UploadInputBuilder {
     /// Initiate an upload transfer for a single object with this input using the given client.
-    pub async fn send_with(
+    pub async fn initiate_with(
         self,
         client: &crate::Client,
     ) -> Result<UploadHandle, crate::error::Error> {

--- a/aws-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/builders.rs
@@ -911,7 +911,7 @@ impl UploadFluentBuilder {
 
 impl crate::operation::upload::input::UploadInputBuilder {
     /// Initiate an upload transfer for a single object with this input using the given client.
-    pub async fn initiate_with(
+    pub fn initiate_with(
         self,
         client: &crate::Client,
     ) -> Result<UploadHandle, crate::error::Error> {

--- a/aws-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/builders.rs
@@ -29,10 +29,10 @@ impl UploadFluentBuilder {
         bucket = self.inner.bucket.as_deref().unwrap_or_default(),
         key = self.inner.key.as_deref().unwrap_or_default(),
     ))]
-    // TODO: Make it consistent with download by renaming it to initiate and making it synchronous
-    pub async fn send(self) -> Result<UploadHandle, crate::error::Error> {
+
+    pub fn initiate(self) -> Result<UploadHandle, crate::error::Error> {
         let input = self.inner.build()?;
-        crate::operation::upload::Upload::orchestrate(self.handle, input).await
+        crate::operation::upload::Upload::orchestrate(self.handle, input)
     }
 
     /// <p>The canned ACL to apply to the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL">Canned ACL</a> in the <i>Amazon S3 User Guide</i>.</p>
@@ -917,6 +917,6 @@ impl crate::operation::upload::input::UploadInputBuilder {
     ) -> Result<UploadHandle, crate::error::Error> {
         let mut fluent_builder = client.upload();
         fluent_builder.inner = self;
-        fluent_builder.send().await
+        fluent_builder.initiate()
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/context.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 pub(crate) struct UploadContext {
     /// reference to client handle used to do actual work
     pub(crate) handle: Arc<crate::client::Handle>,
-    /// the multipart upload ID
-    pub(crate) upload_id: Option<String>,
+    // /// the multipart upload ID
+    // pub(crate) upload_id: Option<String>,
     /// the original request (NOTE: the body will have been taken for processing, only the other fields remain)
     pub(crate) request: Arc<UploadInput>,
 }
@@ -29,13 +29,13 @@ impl UploadContext {
         self.request.deref()
     }
 
-    /// Set the upload ID if the transfer will be done using a multipart upload
-    pub(crate) fn set_upload_id(&mut self, upload_id: String) {
-        self.upload_id = Some(upload_id)
-    }
-
-    /// Check if this transfer is using multipart upload
-    pub(crate) fn is_multipart_upload(&self) -> bool {
-        self.upload_id.is_some()
-    }
+    // /// Set the upload ID if the transfer will be done using a multipart upload
+    // pub(crate) fn set_upload_id(&mut self, upload_id: String) {
+    //     self.upload_id = Some(upload_id)
+    // }
+    //
+    // /// Check if this transfer is using multipart upload
+    // pub(crate) fn is_multipart_upload(&self) -> bool {
+    //     self.upload_id.is_some()
+    // }
 }

--- a/aws-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/context.rs
@@ -12,8 +12,6 @@ use std::sync::Arc;
 pub(crate) struct UploadContext {
     /// reference to client handle used to do actual work
     pub(crate) handle: Arc<crate::client::Handle>,
-    // /// the multipart upload ID
-    // pub(crate) upload_id: Option<String>,
     /// the original request (NOTE: the body will have been taken for processing, only the other fields remain)
     pub(crate) request: Arc<UploadInput>,
 }
@@ -29,13 +27,4 @@ impl UploadContext {
         self.request.deref()
     }
 
-    // /// Set the upload ID if the transfer will be done using a multipart upload
-    // pub(crate) fn set_upload_id(&mut self, upload_id: String) {
-    //     self.upload_id = Some(upload_id)
-    // }
-    //
-    // /// Check if this transfer is using multipart upload
-    // pub(crate) fn is_multipart_upload(&self) -> bool {
-    //     self.upload_id.is_some()
-    // }
 }

--- a/aws-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/context.rs
@@ -26,5 +26,4 @@ impl UploadContext {
     pub(crate) fn request(&self) -> &UploadInput {
         self.request.deref()
     }
-
 }

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -15,7 +15,6 @@ use tokio::task::{self, JoinHandle};
 use tracing::Instrument;
 
 #[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
 pub(crate) enum UploadType {
     MultipartUpload(MultipartUploadContext),
     PutObject(JoinHandle<Result<UploadOutput, crate::error::Error>>),
@@ -24,6 +23,7 @@ pub(crate) enum UploadType {
 // TODO: waahm7 better naming?
 #[derive(Debug)]
 pub(crate) struct MultipartUploadContext {
+    // TODO: docs
     pub(crate) upload_part_tasks:
         Arc<Mutex<task::JoinSet<Result<CompletedPart, crate::error::Error>>>>,
     pub(crate) read_body_tasks: task::JoinSet<Result<(), crate::error::Error>>,

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -16,13 +16,12 @@ use tracing::Instrument;
 
 #[derive(Debug)]
 pub(crate) enum UploadType {
-    MultipartUpload(MultipartUploadContext),
+    MultipartUpload(MultipartUploadData),
     PutObject(JoinHandle<Result<UploadOutput, crate::error::Error>>),
 }
 
-// TODO: waahm7 better naming?
 #[derive(Debug)]
-pub(crate) struct MultipartUploadContext {
+pub(crate) struct MultipartUploadData {
     // TODO: docs
     pub(crate) upload_part_tasks:
         Arc<Mutex<task::JoinSet<Result<CompletedPart, crate::error::Error>>>>,
@@ -97,7 +96,7 @@ impl UploadHandle {
 /// Abort the upload and cancel any in-progress part uploads.
 async fn abort_multipart_upload(
     ctx: UploadContext,
-    mut mpu_ctx: MultipartUploadContext,
+    mut mpu_ctx: MultipartUploadData,
 ) -> Result<AbortedUpload, crate::error::Error> {
     // cancel in-progress read_body tasks
     mpu_ctx.read_body_tasks.abort_all();

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -73,7 +73,7 @@ impl UploadHandle {
         // TODO: We won't send completeMPU until customers join the future. This can create a
         // bottleneck where we have many uploads not making the completeMPU call, waiting for the join
         // to happen, and then everyone tries to do completeMPU at the same time. We should investigate doing
-        // this without waiting for join to happen. 
+        // this without waiting for join to happen.
         complete_upload(self).await
     }
 

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -15,7 +15,7 @@ use tokio::{sync::Mutex, task};
 use tower::{service_fn, Service, ServiceBuilder, ServiceExt};
 use tracing::Instrument;
 
-use super::handle::UploadType;
+use super::MultipartUploadContext;
 
 /// Request/input type for our "upload_part" service.
 #[derive(Debug, Clone)]
@@ -97,7 +97,7 @@ pub(super) fn upload_part_service(
 /// * stream - the body input stream
 /// * part_size - the part_size for each part
 pub(super) fn distribute_work(
-    upload_type: &mut UploadType,
+    mpu_ctx: &mut MultipartUploadContext,
     ctx: UploadContext,
     stream: InputStream,
     part_size: u64,
@@ -109,52 +109,43 @@ pub(super) fn distribute_work(
             .part_size(part_size.try_into().expect("valid part size"))
             .build(),
     );
-    match upload_type {
-        UploadType::PutObject { .. } => {
-            unreachable!("distribute_work must not be called for PutObject.")
-        }
-        UploadType::MultipartUpload {
-            upload_part_tasks,
-            read_body_tasks,
-            response: _,
-        } => {
-            // group all spawned tasks together
-            let parent_span_for_all_tasks = tracing::debug_span!(
-                parent: None, "upload-tasks", // TODO: for upload_objects, parent should be upload-objects-tasks
-                bucket = ctx.request.bucket().unwrap_or_default(),
-                key = ctx.request.key().unwrap_or_default(),
-            );
-            parent_span_for_all_tasks.follows_from(tracing::Span::current());
+    // group all spawned tasks together
+    let parent_span_for_all_tasks = tracing::debug_span!(
+        parent: None, "upload-tasks", // TODO: for upload_objects, parent should be upload-objects-tasks
+        bucket = ctx.request.bucket().unwrap_or_default(),
+        key = ctx.request.key().unwrap_or_default(),
+    );
+    parent_span_for_all_tasks.follows_from(tracing::Span::current());
 
-            // it looks nice to group all read-workers under single span
-            let parent_span_for_read_tasks = tracing::debug_span!(
-                parent: parent_span_for_all_tasks.clone(),
-                "upload-read-tasks"
-            );
+    // it looks nice to group all read-workers under single span
+    let parent_span_for_read_tasks = tracing::debug_span!(
+        parent: parent_span_for_all_tasks.clone(),
+        "upload-read-tasks"
+    );
 
-            // it looks nice to group all upload tasks together under single span
-            let parent_span_for_upload_tasks = tracing::debug_span!(
-                parent: parent_span_for_all_tasks,
-                "upload-net-tasks"
-            );
+    // it looks nice to group all upload tasks together under single span
+    let parent_span_for_upload_tasks = tracing::debug_span!(
+        parent: parent_span_for_all_tasks,
+        "upload-net-tasks"
+    );
 
-            let svc = upload_part_service(&ctx);
-            let n_workers = ctx.handle.num_workers();
-            for _ in 0..n_workers {
-                let worker = read_body(
-                    part_reader.clone(),
-                    ctx.clone(),
-                    upload_id.clone(),
-                    svc.clone(),
-                    upload_part_tasks.clone(),
-                    parent_span_for_upload_tasks.clone(),
-                );
-                read_body_tasks.spawn(worker.instrument(parent_span_for_read_tasks.clone()));
-            }
-            tracing::trace!("work distributed for uploading parts");
-            Ok(())
-        }
+    let svc = upload_part_service(&ctx);
+    let n_workers = ctx.handle.num_workers();
+    for _ in 0..n_workers {
+        let worker = read_body(
+            part_reader.clone(),
+            ctx.clone(),
+            upload_id.clone(),
+            svc.clone(),
+            mpu_ctx.upload_part_tasks.clone(),
+            parent_span_for_upload_tasks.clone(),
+        );
+        mpu_ctx
+            .read_body_tasks
+            .spawn(worker.instrument(parent_span_for_read_tasks.clone()));
     }
+    tracing::trace!("work distributed for uploading parts");
+    Ok(())
 }
 
 /// Worker function that pulls part data from the `part_reader` and spawns tasks to upload each part until the reader

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -15,7 +15,7 @@ use tokio::{sync::Mutex, task};
 use tower::{service_fn, Service, ServiceBuilder, ServiceExt};
 use tracing::Instrument;
 
-use super::MultipartUploadContext;
+use super::MultipartUploadData;
 
 /// Request/input type for our "upload_part" service.
 #[derive(Debug, Clone)]
@@ -97,7 +97,7 @@ pub(super) fn upload_part_service(
 /// * stream - the body input stream
 /// * part_size - the part_size for each part
 pub(super) fn distribute_work(
-    mpu_ctx: &mut MultipartUploadContext,
+    mpu_data: &mut MultipartUploadData,
     ctx: UploadContext,
     stream: InputStream,
     part_size: u64,
@@ -137,10 +137,10 @@ pub(super) fn distribute_work(
             ctx.clone(),
             upload_id.clone(),
             svc.clone(),
-            mpu_ctx.upload_part_tasks.clone(),
+            mpu_data.upload_part_tasks.clone(),
             parent_span_for_upload_tasks.clone(),
         );
-        mpu_ctx
+        mpu_data
             .read_body_tasks
             .spawn(worker.instrument(parent_span_for_read_tasks.clone()));
     }

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -101,7 +101,6 @@ pub(super) fn distribute_work(
     ctx: UploadContext,
     stream: InputStream,
     part_size: u64,
-    upload_id: String,
 ) -> Result<(), error::Error> {
     let part_reader = Arc::new(
         PartReaderBuilder::new()
@@ -135,7 +134,7 @@ pub(super) fn distribute_work(
         let worker = read_body(
             part_reader.clone(),
             ctx.clone(),
-            upload_id.clone(),
+            mpu_data.upload_id.clone(),
             svc.clone(),
             mpu_data.upload_part_tasks.clone(),
             parent_span_for_upload_tasks.clone(),

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -253,8 +253,7 @@ async fn upload_single_obj(
         .build()
         .expect("valid input");
 
-    let mut handle =
-        crate::operation::upload::Upload::orchestrate(ctx.handle.clone(), input).await?;
+    let handle = crate::operation::upload::Upload::orchestrate(ctx.handle.clone(), input)?;
 
     // The cancellation process would work fine without this if statement.
     // It's here so we can save a single upload operation that would otherwise

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -322,27 +322,19 @@ fn handle_failed_upload(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Barrier};
-
-    use aws_sdk_s3::operation::{
-        abort_multipart_upload::AbortMultipartUploadOutput,
-        create_multipart_upload::CreateMultipartUploadOutput, put_object::PutObjectOutput,
-        upload_part::UploadPartOutput,
-    };
+    use aws_sdk_s3::operation::put_object::PutObjectOutput;
     use aws_smithy_mocks_experimental::{mock, RuleMode};
     use bytes::Bytes;
     use test_common::mock_client_with_stubbed_http_client;
 
     use crate::{
         client::Handle,
-        config::MIN_MULTIPART_PART_SIZE_BYTES,
         io::InputStream,
         operation::upload_objects::{
             worker::{upload_single_obj, UploadObjectJob},
             UploadObjectsContext, UploadObjectsInputBuilder,
         },
         runtime::scheduler::Scheduler,
-        types::PartSize,
         DEFAULT_CONCURRENCY,
     };
 
@@ -732,92 +724,6 @@ mod tests {
         };
 
         ctx.state.cancel_tx.send(true).unwrap();
-
-        let err = upload_single_obj(&ctx, job).await.unwrap_err();
-
-        assert_eq!(&crate::error::ErrorKind::OperationCancelled, err.kind());
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_cancel_single_upload_via_multipart_upload() {
-        let bucket = "test-bucket";
-        let key = "test-key";
-        let upload_id: String = "test-upload-id".to_owned();
-
-        let wait_till_create_mpu = Arc::new(Barrier::new(2));
-        let (resume_upload_single_obj_tx, resume_upload_single_obj_rx) =
-            tokio::sync::watch::channel(());
-        let resume_upload_single_obj_tx = Arc::new(resume_upload_single_obj_tx);
-
-        let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
-            let wait_till_create_mpu = wait_till_create_mpu.clone();
-            let upload_id = upload_id.clone();
-            move || {
-                // This ensures that a cancellation signal won't be sent until `create_multipart_upload`.
-                wait_till_create_mpu.wait();
-
-                // This increases the reliability of the test, ensuring that the cancellation signal has been sent
-                // and that `upload_single_obj` can now resume.
-                while !resume_upload_single_obj_rx.has_changed().unwrap() {
-                    std::thread::sleep(std::time::Duration::from_millis(100));
-                }
-
-                CreateMultipartUploadOutput::builder()
-                    .upload_id(upload_id.clone())
-                    .build()
-            }
-        });
-        let upload_part = mock!(aws_sdk_s3::Client::upload_part)
-            .then_output(|| UploadPartOutput::builder().build());
-        let abort_mpu = mock!(aws_sdk_s3::Client::abort_multipart_upload)
-            .match_requests({
-                let upload_id = upload_id.clone();
-                move |input| {
-                    input.upload_id.as_ref() == Some(&upload_id)
-                        && input.bucket() == Some(bucket)
-                        && input.key() == Some(key)
-                }
-            })
-            .then_output(|| AbortMultipartUploadOutput::builder().build());
-        let s3_client = mock_client_with_stubbed_http_client!(
-            aws_sdk_s3,
-            RuleMode::MatchAny,
-            &[create_mpu, upload_part, abort_mpu]
-        );
-        let config = crate::Config::builder()
-            .set_multipart_threshold(PartSize::Target(MIN_MULTIPART_PART_SIZE_BYTES))
-            .client(s3_client)
-            .build();
-
-        let scheduler = Scheduler::new(DEFAULT_CONCURRENCY);
-
-        let handle = std::sync::Arc::new(Handle { config, scheduler });
-        let input = UploadObjectsInputBuilder::default()
-            .source("doesnotmatter")
-            .bucket(bucket)
-            .build()
-            .unwrap();
-
-        // specify the size of the contents so it triggers multipart upload
-        let contents = vec![0; MIN_MULTIPART_PART_SIZE_BYTES as usize];
-        let ctx = UploadObjectsContext::new(handle, input);
-        let job = UploadObjectJob {
-            object: InputStream::from(Bytes::copy_from_slice(contents.as_slice())),
-            key: key.to_owned(),
-        };
-
-        tokio::task::spawn({
-            let ctx = ctx.clone();
-            let resume_upload_single_obj_tx = resume_upload_single_obj_tx.clone();
-            async move {
-                wait_till_create_mpu.wait();
-                // The upload operation has reached a point where a `CreateMultipartUploadOutput` is being prepared,
-                // which means that cancellation can now be triggered.
-                ctx.state.cancel_tx.send(true).unwrap();
-                // Tell `upload_single_obj` that it can now proceed.
-                resume_upload_single_obj_tx.send(()).unwrap();
-            }
-        });
 
         let err = upload_single_obj(&ctx, job).await.unwrap_err();
 

--- a/aws-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_test.rs
@@ -141,8 +141,7 @@ async fn test_many_uploads_no_deadlock() {
             .bucket("test-bucket")
             .key(format!("many-async-uploads-{}.txt", i))
             .body(InputStream::from_part_stream(stream))
-            .send()
-            .await
+            .initiate()
             .unwrap();
 
         transfers.push((handle, tx));


### PR DESCRIPTION
*Description of changes:*
This PR is just a refactor of the Upload APIs and doesn't make any functional changes.

- This is a follow-up to https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/73 to return the handle ASAP for the UploadObject API as well. This approach will make it easier to implement features like reading the first part to determine PutObject vs MPU.
- `upload_handle.abort()` now takes ownership of the handle instead of a reference. It makes more sense to take ownership so that customers can't call `join` or do other things with the handle after aborting, as it won't be valid.
- I have added a TODO to make the completeMPU call asynchronous as well, instead of waiting for users to call `join`. From testing, completeMPU can be an expensive call for large objects.
- `upload_id` was an Option because it won't be available for PutObject. I have moved it to the `MultipartUploadData` struct, and it will be non-optional wherever MPU is involved.
- Move `test_cancel_single_upload_via_multipart_upload` test to upload_tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
