### PR TITLE
Checksums for Upload

### DIFF
--- a/aws-s3-transfer-manager/Cargo.toml
+++ b/aws-s3-transfer-manager/Cargo.toml
@@ -11,14 +11,14 @@ publish = false
 [dependencies]
 async-channel = "2.3.1"
 async-trait = "0.1.83"
-aws-config = { version = "1.5.11", features = ["behavior-version-latest"] }
-aws-sdk-s3 = { version = "1.66.0", features = ["behavior-version-latest"] }
-aws-smithy-async = "1.2.2"
-aws-smithy-experimental = { version = "0.1.3", features = ["crypto-aws-lc"] }
+aws-config = { version = "1.5.15", features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1.71.0", features = ["behavior-version-latest"] }
+aws-smithy-async = "1.2.4"
+aws-smithy-experimental = { version = "0.1.5", features = ["crypto-aws-lc"] }
 aws-smithy-runtime-api = "1.7.3"
-aws-runtime = "1.5.1"
-aws-smithy-types = "1.2.10"
-aws-types = "1.3.3"
+aws-runtime = "1.5.4"
+aws-smithy-types = "1.2.12"
+aws-types = "1.3.4"
 blocking = "1.6.1"
 bytes = "1"
 bytes-utils = "0.1.4"
@@ -31,15 +31,17 @@ tracing = "0.1"
 walkdir = "2"
 
 [dev-dependencies]
-aws-sdk-s3 = { version = "1.66.0", features = ["behavior-version-latest", "test-util"] }
+aws-sdk-s3 = { version = "1.71.0", features = ["behavior-version-latest", "test-util"] }
+aws-smithy-checksums = "0.62.0"
 aws-smithy-mocks-experimental = "0.2.1"
-aws-smithy-runtime = { version = "1.7.5", features = ["client", "connector-hyper-0-14-x", "test-util", "wire-mock"] }
+aws-smithy-runtime = { version = "1.7.7", features = ["client", "connector-hyper-0-14-x", "test-util", "wire-mock"] }
 clap = { version = "4.5.7", default-features = false, features = ["derive", "std", "help"] }
 console-subscriber = "0.4.0"
 http-02x = { package = "http", version = "0.2.9" }
 http-body-1x = { package = "http-body", version = "1" }
 fastrand = "2.1.1"
 futures-test = "0.3.30"
+md5 = "0.7.0"
 tempfile = "3.12.0"
 test-common = { path = "./test-common", version = "0.1.0" }
 tokio-test = "0.4.4"

--- a/aws-s3-transfer-manager/src/metrics.rs
+++ b/aws-s3-transfer-manager/src/metrics.rs
@@ -284,7 +284,7 @@ pub struct ThroughputDisplayContext<'a> {
     pub unit: unit::ByteUnit,
 }
 
-impl<'a> fmt::Display for ThroughputDisplayContext<'a> {
+impl fmt::Display for ThroughputDisplayContext<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(precision) = f.precision() {
             write!(

--- a/aws-s3-transfer-manager/src/metrics.rs
+++ b/aws-s3-transfer-manager/src/metrics.rs
@@ -53,6 +53,11 @@ pub mod unit {
 
         /// The number of bits represented by this unit
         pub const fn as_bits_u64(&self) -> u64 {
+            self.as_bits_usize() as u64
+        }
+
+        /// The number of bits represented by this unit
+        pub const fn as_bits_usize(&self) -> usize {
             match self {
                 ByteUnit::Byte => 8,
                 ByteUnit::Kilobit => 1_000,
@@ -66,7 +71,12 @@ pub mod unit {
 
         /// The number of bytes represented by this unit
         pub const fn as_bytes_u64(&self) -> u64 {
-            self.as_bits_u64() >> 3
+            self.as_bytes_usize() as u64
+        }
+
+        /// The number of bytes represented by this unit
+        pub const fn as_bytes_usize(&self) -> usize {
+            self.as_bits_usize() >> 3
         }
 
         pub(crate) const fn as_str(&self) -> &'static str {

--- a/aws-s3-transfer-manager/src/operation/download/chunk_meta.rs
+++ b/aws-s3-transfer-manager/src/operation/download/chunk_meta.rs
@@ -41,10 +41,14 @@ pub struct ChunkMetadata {
     pub checksum_crc32: Option<String>,
     /// <p>The base64-encoded, 32-bit CRC-32C checksum of the object. This will only be present if it was uploaded with the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub checksum_crc32_c: Option<String>,
+    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub checksum_crc64_nvme: Option<String>,
     /// <p>The base64-encoded, 160-bit SHA-1 digest of the object. This will only be present if it was uploaded with the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub checksum_sha1: Option<String>,
     /// <p>The base64-encoded, 256-bit SHA-256 digest of the object. This will only be present if it was uploaded with the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub checksum_sha256: Option<String>,
+    /// <p>The checksum type, which determines how part-level checksums are combined to create an object-level checksum for multipart objects. You can use this header response to verify that the checksum type that is received is the same checksum type that was specified in the <code>CreateMultipartUpload</code> request. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub checksum_type: Option<aws_sdk_s3::types::ChecksumType>,
     /// <p>This is set to the number of metadata entries not returned in the headers that are prefixed with <code>x-amz-meta-</code>. This can happen if you create metadata using an API like SOAP that supports more flexible metadata than the REST API. For example, using SOAP, you can create metadata whose values are not legal HTTP headers.</p><note>
     /// <p>This functionality is not supported for directory buckets.</p>
     /// </note>
@@ -136,8 +140,10 @@ impl From<GetObjectOutput> for ChunkMetadata {
             e_tag: value.e_tag,
             checksum_crc32: value.checksum_crc32,
             checksum_crc32_c: value.checksum_crc32_c,
+            checksum_crc64_nvme: value.checksum_crc64_nvme,
             checksum_sha1: value.checksum_sha1,
             checksum_sha256: value.checksum_sha256,
+            checksum_type: value.checksum_type,
             missing_meta: value.missing_meta,
             version_id: value.version_id,
             cache_control: value.cache_control,
@@ -189,8 +195,10 @@ impl ::std::fmt::Debug for ChunkMetadata {
         formatter.field("e_tag", &self.e_tag);
         formatter.field("checksum_crc32", &self.checksum_crc32);
         formatter.field("checksum_crc32_c", &self.checksum_crc32_c);
+        formatter.field("checksum_crc64_nvme", &self.checksum_crc64_nvme);
         formatter.field("checksum_sha1", &self.checksum_sha1);
         formatter.field("checksum_sha256", &self.checksum_sha256);
+        formatter.field("checksum_type", &self.checksum_type);
         formatter.field("missing_meta", &self.missing_meta);
         formatter.field("version_id", &self.version_id);
         formatter.field("cache_control", &self.cache_control);

--- a/aws-s3-transfer-manager/src/operation/download/chunk_meta.rs
+++ b/aws-s3-transfer-manager/src/operation/download/chunk_meta.rs
@@ -41,7 +41,7 @@ pub struct ChunkMetadata {
     pub checksum_crc32: Option<String>,
     /// <p>The base64-encoded, 32-bit CRC-32C checksum of the object. This will only be present if it was uploaded with the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub checksum_crc32_c: Option<String>,
-    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    /// <p>The Base64 encoded, 64-bit CRC64NVME checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
     pub checksum_crc64_nvme: Option<String>,
     /// <p>The base64-encoded, 160-bit SHA-1 digest of the object. This will only be present if it was uploaded with the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub checksum_sha1: Option<String>,

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -159,7 +159,7 @@ async fn put_object(
                 aws_sdk_s3::types::ChecksumAlgorithm::Crc32 => req.checksum_crc32(value),
                 aws_sdk_s3::types::ChecksumAlgorithm::Crc32C => req.checksum_crc32_c(value),
                 aws_sdk_s3::types::ChecksumAlgorithm::Crc64Nvme => req.checksum_crc64_nvme(value),
-                algo => panic!("unexpected algorithm `{algo}` for full object checksum"),
+                algo => unreachable!("unexpected algorithm `{algo}` for full object checksum"),
             };
         } else {
             // Set checksum algorithm, which tells SDK to calculate and add checksum value
@@ -276,6 +276,7 @@ async fn start_mpu(ctx: &UploadContext) -> Result<UploadOutputBuilder, crate::er
 #[cfg(test)]
 mod test {
     use crate::io::InputStream;
+    use crate::metrics::unit::ByteUnit;
     use crate::operation::upload::UploadInput;
     use crate::types::{ConcurrencySetting, PartSize};
     use aws_sdk_s3::operation::abort_multipart_upload::AbortMultipartUploadOutput;
@@ -377,7 +378,7 @@ mod test {
 
         let tm_config = crate::Config::builder()
             .concurrency(ConcurrencySetting::Explicit(1))
-            .set_multipart_threshold(PartSize::Target(10 * 1024 * 1024))
+            .set_multipart_threshold(PartSize::Target(10 * ByteUnit::Mebibyte.as_bytes_u64()))
             .client(client)
             .build();
         let tm = crate::Client::new(tm_config);
@@ -437,7 +438,7 @@ mod test {
         let tm_config = crate::Config::builder()
             .concurrency(ConcurrencySetting::Explicit(1))
             .set_multipart_threshold(PartSize::Target(10))
-            .set_target_part_size(PartSize::Target(5 * 1024 * 1024))
+            .set_target_part_size(PartSize::Target(5 * ByteUnit::Mebibyte.as_bytes_u64()))
             .client(client)
             .build();
 

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -56,8 +56,9 @@ impl Upload {
                     .client()
                     .config()
                     .request_checksum_calculation()
-                    .unwrap_or(&aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported)
-                    .eq(&aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported)
+                    .cloned()
+                    .unwrap_or_default()
+                    == aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported
                 {
                     input.checksum_strategy = Some(ChecksumStrategy::default());
                 }

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -5,12 +5,15 @@
 
 /// Operation builders
 pub mod builders;
+mod checksum_strategy;
 mod input;
 mod output;
 
 mod context;
 mod handle;
 mod service;
+
+pub use checksum_strategy::ChecksumStrategy;
 
 use crate::error;
 use crate::io::InputStream;
@@ -40,6 +43,27 @@ impl Upload {
         handle: Arc<crate::client::Handle>,
         mut input: crate::operation::upload::UploadInput,
     ) -> Result<UploadHandle, error::Error> {
+        match &input.checksum_strategy {
+            // User set the checksum strategy: validate it
+            Some(checksum_strategy) => checksum_strategy.validate()?,
+
+            None => {
+                // User didn't explicitly set checksum strategy.
+                // If SDK is configured to send checksums: use default checksum strategy.
+                // Else: continue with no checksums
+                if handle
+                    .config
+                    .client()
+                    .config()
+                    .request_checksum_calculation()
+                    .unwrap()
+                    .eq(&aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported)
+                {
+                    input.checksum_strategy = Some(ChecksumStrategy::default());
+                }
+            }
+        }
+
         let stream = input.take_body();
         let ctx = new_context(handle.clone(), input);
         Ok(UploadHandle::new(
@@ -91,7 +115,7 @@ async fn put_object(
     // FIXME - This affects performance in cases with a lot of small files workloads. We need a way to schedule
     // more work for a lot of small files.
     let _permit = ctx.handle.scheduler.acquire_permit().await?;
-    let resp = ctx
+    let mut req = ctx
         .client()
         .put_object()
         .set_acl(ctx.request.acl.clone())
@@ -125,8 +149,24 @@ async fn put_object(
         .set_object_lock_mode(ctx.request.object_lock_mode.clone())
         .set_object_lock_retain_until_date(ctx.request.object_lock_retain_until_date)
         .set_object_lock_legal_hold_status(ctx.request.object_lock_legal_hold_status.clone())
-        .set_expected_bucket_owner(ctx.request.expected_bucket_owner.clone())
-        .set_checksum_algorithm(ctx.request.checksum_algorithm.clone())
+        .set_expected_bucket_owner(ctx.request.expected_bucket_owner.clone());
+
+    if let Some(checksum_strategy) = &ctx.request.checksum_strategy {
+        if let Some(value) = &checksum_strategy.full_object_checksum {
+            // We have the full-object checksum value, so set it
+            req = match &checksum_strategy.algorithm {
+                aws_sdk_s3::types::ChecksumAlgorithm::Crc32 => req.checksum_crc32(value),
+                aws_sdk_s3::types::ChecksumAlgorithm::Crc32C => req.checksum_crc32_c(value),
+                aws_sdk_s3::types::ChecksumAlgorithm::Crc64Nvme => req.checksum_crc64_nvme(value),
+                algo => panic!("unexpected algorithm `{algo}` for full object checksum"),
+            };
+        } else {
+            // Set checksum algorithm, which tells SDK to calculate and add checksum value
+            req = req.checksum_algorithm(checksum_strategy.algorithm.clone());
+        }
+    }
+
+    let resp = req
         .customize()
         .disable_payload_signing()
         .send()
@@ -186,7 +226,7 @@ async fn start_mpu(ctx: &UploadContext) -> Result<UploadOutputBuilder, crate::er
     let req = ctx.request();
     let client = ctx.client();
 
-    let resp = client
+    let mut req = client
         .create_multipart_upload()
         .set_acl(req.acl.clone())
         .set_bucket(req.bucket.clone())
@@ -216,8 +256,15 @@ async fn start_mpu(ctx: &UploadContext) -> Result<UploadOutputBuilder, crate::er
         .set_object_lock_mode(req.object_lock_mode.clone())
         .set_object_lock_retain_until_date(req.object_lock_retain_until_date)
         .set_object_lock_legal_hold_status(req.object_lock_legal_hold_status.clone())
-        .set_expected_bucket_owner(req.expected_bucket_owner.clone())
-        .set_checksum_algorithm(req.checksum_algorithm.clone())
+        .set_expected_bucket_owner(req.expected_bucket_owner.clone());
+
+    if let Some(checksum_strategy) = &ctx.request.checksum_strategy {
+        req = req
+            .checksum_algorithm(checksum_strategy.algorithm.clone())
+            .checksum_type(checksum_strategy.type_if_multipart.clone());
+    }
+
+    let resp = req
         .send()
         .instrument(tracing::debug_span!("send-create-multipart-upload"))
         .await?;

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -56,7 +56,7 @@ impl Upload {
                     .client()
                     .config()
                     .request_checksum_calculation()
-                    .unwrap()
+                    .unwrap_or(&aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported)
                     .eq(&aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported)
                 {
                     input.checksum_strategy = Some(ChecksumStrategy::default());

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -13,7 +13,7 @@ mod context;
 mod handle;
 mod service;
 
-pub use checksum_strategy::ChecksumStrategy;
+pub use checksum_strategy::{ChecksumStrategy, ChecksumStrategyBuilder};
 
 use crate::error;
 use crate::io::InputStream;

--- a/aws-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/builders.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::types::FailedMultipartUploadPolicy;
 
-use super::{UploadHandle, UploadInputBuilder};
+use super::{ChecksumStrategy, UploadHandle, UploadInputBuilder};
 
 /// Fluent builder for constructing a single object upload transfer
 #[derive(Debug)]
@@ -232,123 +232,55 @@ impl UploadFluentBuilder {
     pub fn get_content_type(&self) -> Option<&str> {
         self.inner.get_content_type()
     }
-    /// <p>Indicates the algorithm used to create the checksum for the object when you use the SDK. This header will not provide any additional functionality if you don't use the SDK. When you send this header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i> </code> or <code>x-amz-trailer</code> header sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>.</p>
-    /// <p>For the <code>x-amz-checksum-<i>algorithm</i> </code> header, replace <code> <i>algorithm</i> </code> with the supported algorithm from the following list:</p>
-    /// <ul>
-    /// <li>
-    /// <p>CRC32</p></li>
-    /// <li>
-    /// <p>CRC32C</p></li>
-    /// <li>
-    /// <p>SHA1</p></li>
-    /// <li>
-    /// <p>SHA256</p></li>
-    /// </ul>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    /// <p>If the individual checksum value you provide through <code>x-amz-checksum-<i>algorithm</i> </code> doesn't match the checksum algorithm you set through <code>x-amz-sdk-checksum-algorithm</code>, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code> parameter and uses the checksum algorithm that matches the provided value in <code>x-amz-checksum-<i>algorithm</i> </code>.</p><note>
-    /// <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>
-    /// </note>
-    pub fn checksum_algorithm(mut self, input: aws_sdk_s3::types::ChecksumAlgorithm) -> Self {
-        self.inner = self.inner.checksum_algorithm(input);
+
+    /// Strategy for calculating checksum values during upload.
+    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
+    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
+    ///
+    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
+    /// checksum algorithm or already know the checksum value.
+    ///
+    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
+    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
+    ///
+    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
+    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    pub fn checksum_strategy(mut self, input: ChecksumStrategy) -> Self {
+        self.inner = self.inner.checksum_strategy(input);
         self
     }
-    /// <p>Indicates the algorithm used to create the checksum for the object when you use the SDK. This header will not provide any additional functionality if you don't use the SDK. When you send this header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i> </code> or <code>x-amz-trailer</code> header sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>.</p>
-    /// <p>For the <code>x-amz-checksum-<i>algorithm</i> </code> header, replace <code> <i>algorithm</i> </code> with the supported algorithm from the following list:</p>
-    /// <ul>
-    /// <li>
-    /// <p>CRC32</p></li>
-    /// <li>
-    /// <p>CRC32C</p></li>
-    /// <li>
-    /// <p>SHA1</p></li>
-    /// <li>
-    /// <p>SHA256</p></li>
-    /// </ul>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    /// <p>If the individual checksum value you provide through <code>x-amz-checksum-<i>algorithm</i> </code> doesn't match the checksum algorithm you set through <code>x-amz-sdk-checksum-algorithm</code>, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code> parameter and uses the checksum algorithm that matches the provided value in <code>x-amz-checksum-<i>algorithm</i> </code>.</p><note>
-    /// <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>
-    /// </note>
-    pub fn set_checksum_algorithm(
-        mut self,
-        input: Option<aws_sdk_s3::types::ChecksumAlgorithm>,
-    ) -> Self {
-        self.inner = self.inner.set_checksum_algorithm(input);
+
+    /// Strategy for calculating checksum values during upload.
+    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
+    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
+    ///
+    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
+    /// checksum algorithm or already know the checksum value.
+    ///
+    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
+    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
+    ///
+    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
+    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    pub fn set_checksum_strategy(mut self, input: Option<ChecksumStrategy>) -> Self {
+        self.inner = self.inner.set_checksum_strategy(input);
         self
     }
-    /// <p>Indicates the algorithm used to create the checksum for the object when you use the SDK. This header will not provide any additional functionality if you don't use the SDK. When you send this header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i> </code> or <code>x-amz-trailer</code> header sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>.</p>
-    /// <p>For the <code>x-amz-checksum-<i>algorithm</i> </code> header, replace <code> <i>algorithm</i> </code> with the supported algorithm from the following list:</p>
-    /// <ul>
-    /// <li>
-    /// <p>CRC32</p></li>
-    /// <li>
-    /// <p>CRC32C</p></li>
-    /// <li>
-    /// <p>SHA1</p></li>
-    /// <li>
-    /// <p>SHA256</p></li>
-    /// </ul>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    /// <p>If the individual checksum value you provide through <code>x-amz-checksum-<i>algorithm</i> </code> doesn't match the checksum algorithm you set through <code>x-amz-sdk-checksum-algorithm</code>, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code> parameter and uses the checksum algorithm that matches the provided value in <code>x-amz-checksum-<i>algorithm</i> </code>.</p><note>
-    /// <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>
-    /// </note>
-    pub fn get_checksum_algorithm(&self) -> &Option<aws_sdk_s3::types::ChecksumAlgorithm> {
-        self.inner.get_checksum_algorithm()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32 checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_crc32(mut self, input: impl Into<String>) -> Self {
-        self.inner = self.inner.checksum_crc32(input);
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32 checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn set_checksum_crc32(mut self, input: Option<String>) -> Self {
-        self.inner = self.inner.set_checksum_crc32(input);
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32 checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn get_checksum_crc32(&self) -> Option<&str> {
-        self.inner.get_checksum_crc32()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32C checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_crc32_c(mut self, input: impl Into<String>) -> Self {
-        self.inner = self.inner.checksum_crc32_c(input);
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32C checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn set_checksum_crc32_c(mut self, input: Option<String>) -> Self {
-        self.inner = self.inner.set_checksum_crc32_c(input);
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32C checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn get_checksum_crc32_c(&self) -> Option<&str> {
-        self.inner.get_checksum_crc32_c()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 160-bit SHA-1 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_sha1(mut self, input: impl Into<String>) -> Self {
-        self.inner = self.inner.checksum_sha1(input);
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 160-bit SHA-1 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn set_checksum_sha1(mut self, input: Option<String>) -> Self {
-        self.inner = self.inner.set_checksum_sha1(input);
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 160-bit SHA-1 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn get_checksum_sha1(&self) -> Option<&str> {
-        self.inner.get_checksum_sha1()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 256-bit SHA-256 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_sha256(mut self, input: impl Into<String>) -> Self {
-        self.inner = self.inner.checksum_sha256(input);
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 256-bit SHA-256 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn set_checksum_sha256(mut self, input: Option<String>) -> Self {
-        self.inner = self.inner.set_checksum_sha256(input);
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 256-bit SHA-256 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn get_checksum_sha256(&self) -> Option<&str> {
-        self.inner.get_checksum_sha256()
+
+    /// Strategy for calculating checksum values during upload.
+    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
+    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
+    ///
+    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
+    /// checksum algorithm or already know the checksum value.
+    ///
+    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
+    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
+    ///
+    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
+    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    pub fn get_checksum_strategy(&self) -> Option<&ChecksumStrategy> {
+        self.inner.get_checksum_strategy()
     }
     /// <p>The date and time at which the object is no longer cacheable. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc7234#section-5.3">https://www.rfc-editor.org/rfc/rfc7234#section-5.3</a>.</p>
     pub fn expires(mut self, input: ::aws_smithy_types::DateTime) -> Self {

--- a/aws-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/builders.rs
@@ -233,52 +233,19 @@ impl UploadFluentBuilder {
         self.inner.get_content_type()
     }
 
-    /// Strategy for calculating checksum values during upload.
-    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
-    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
-    ///
-    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
-    /// checksum algorithm or already know the checksum value.
-    ///
-    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
-    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
-    ///
-    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
-    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    #[doc = std::include_str!("checksum_strategy.md")]
     pub fn checksum_strategy(mut self, input: ChecksumStrategy) -> Self {
         self.inner = self.inner.checksum_strategy(input);
         self
     }
 
-    /// Strategy for calculating checksum values during upload.
-    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
-    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
-    ///
-    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
-    /// checksum algorithm or already know the checksum value.
-    ///
-    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
-    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
-    ///
-    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
-    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    #[doc = std::include_str!("checksum_strategy.md")]
     pub fn set_checksum_strategy(mut self, input: Option<ChecksumStrategy>) -> Self {
         self.inner = self.inner.set_checksum_strategy(input);
         self
     }
 
-    /// Strategy for calculating checksum values during upload.
-    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
-    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
-    ///
-    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
-    /// checksum algorithm or already know the checksum value.
-    ///
-    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
-    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
-    ///
-    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
-    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    #[doc = std::include_str!("checksum_strategy.md")]
     pub fn get_checksum_strategy(&self) -> Option<&ChecksumStrategy> {
         self.inner.get_checksum_strategy()
     }

--- a/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.md
+++ b/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.md
@@ -1,0 +1,14 @@
+Strategy for calculating checksum values during upload.
+
+Checksum values can be sent to S3, to verify the integrity of uploaded data.
+For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
+
+You can set a specific [`ChecksumStrategy`], if you wish to choose the
+checksum algorithm or already know the checksum value.
+
+`CRC64NVME` checksums are calculated by default (if no strategy is set and the underlying
+S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
+
+To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
+configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+If you do this, S3 will still calculate and store a `CRC64NVME` full object checksum for the object.

--- a/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
@@ -1,0 +1,283 @@
+use aws_sdk_s3::types::{ChecksumAlgorithm, ChecksumType};
+
+use crate::error;
+
+/// Strategy for calculating checksum values during upload.
+/// These values are sent to S3 and used to verify the integrity of the uploaded data.
+/// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
+///
+/// You can set a specific [`ChecksumStrategy`], if you wish to choose the
+/// checksum algorithm or already know the checksum value.
+///
+/// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
+/// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
+///
+/// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
+/// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+/// If you do this, S3 will still calculate a `CRC64NVME` full object checksum for the object.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct ChecksumStrategy {
+    /// The checksum algorithm to use.
+    pub algorithm: ChecksumAlgorithm,
+
+    /// The checksum type to use IF the upload is multipart.
+    ///
+    /// Note that if the upload is NOT multipart (e.g. object size is below the multipart threshold),
+    /// the object's checksum type will always be [`ChecksumType::FullObject`], regardless of this setting.
+    pub type_if_multipart: ChecksumType,
+
+    /// The precalculated full object checksum value.
+    ///
+    /// If specified, this value will be sent to S3 as the full object checksum value.
+    /// In the case of a multipart upload, the transfer manager still calculates
+    /// checksums for individual parts, but this value will always be sent as the full object checksum value.
+    ///
+    /// If not specified, the transfer manager will calculate the checksum value.
+    ///
+    /// You may not specify this when `type_if_multipart` is [`ChecksumType::Composite`].
+    pub full_object_checksum: Option<String>,
+}
+
+impl ChecksumStrategy {
+    /// Use a precalculated `CRC64NVME` full object checksum value.
+    pub fn with_crc64_nvme(value: impl Into<String>) -> Self {
+        Self {
+            algorithm: ChecksumAlgorithm::Crc64Nvme,
+            type_if_multipart: ChecksumType::FullObject,
+            full_object_checksum: Some(value.into()),
+        }
+    }
+
+    /// Use a precalculated `CRC32` full object checksum value.
+    pub fn with_crc32(value: impl Into<String>) -> Self {
+        Self {
+            algorithm: ChecksumAlgorithm::Crc32,
+            type_if_multipart: ChecksumType::FullObject,
+            full_object_checksum: Some(value.into()),
+        }
+    }
+
+    /// Use a precalculated `CRC32C` full object checksum value.
+    pub fn with_crc32_c(value: impl Into<String>) -> Self {
+        Self {
+            algorithm: ChecksumAlgorithm::Crc32C,
+            type_if_multipart: ChecksumType::FullObject,
+            full_object_checksum: Some(value.into()),
+        }
+    }
+
+    /// The transfer manager calculates a `CRC64NVME` full object checksum while uploading.
+    /// This is the default strategy.
+    pub fn with_calculated_crc64_nvme() -> Self {
+        Self {
+            algorithm: ChecksumAlgorithm::Crc64Nvme,
+            type_if_multipart: ChecksumType::FullObject,
+            full_object_checksum: None,
+        }
+    }
+
+    /// The transfer manager calculates a `CRC32` full object checksum while uploading.
+    pub fn with_calculated_crc32() -> Self {
+        Self {
+            algorithm: ChecksumAlgorithm::Crc32,
+            type_if_multipart: ChecksumType::FullObject,
+            full_object_checksum: None,
+        }
+    }
+
+    /// The transfer manager calculates a `CRC32C` full object checksum while uploading.
+    pub fn with_calculated_crc32_c() -> Self {
+        Self {
+            algorithm: ChecksumAlgorithm::Crc32C,
+            type_if_multipart: ChecksumType::FullObject,
+            full_object_checksum: None,
+        }
+    }
+
+    /// The transfer manager calculates `CRC32` checksums while uploading.
+    /// If the upload is multipart, the object will have a composite checksum,
+    /// otherwise it will have a full object checksum.
+    pub fn with_calculated_crc32_composite_if_multipart() -> Self {
+        Self {
+            algorithm: ChecksumAlgorithm::Crc32,
+            type_if_multipart: ChecksumType::Composite,
+            full_object_checksum: None,
+        }
+    }
+
+    /// The transfer manager calculates `CRC32C` checksums while uploading.
+    /// If the upload is multipart, the object will have a composite checksum,
+    /// otherwise it will have a full object checksum.
+    pub fn with_calculated_crc32_c_composite_if_multipart() -> Self {
+        Self {
+            algorithm: ChecksumAlgorithm::Crc32C,
+            type_if_multipart: ChecksumType::Composite,
+            full_object_checksum: None,
+        }
+    }
+
+    /// The transfer manager calculates `SHA1` checksums while uploading.
+    /// If the upload is multipart, the object will have a composite checksum,
+    /// otherwise it will have a full object checksum.
+    pub fn with_calculated_sha1_composite_if_multipart() -> Self {
+        Self {
+            algorithm: ChecksumAlgorithm::Sha1,
+            type_if_multipart: ChecksumType::Composite,
+            full_object_checksum: None,
+        }
+    }
+
+    /// The transfer manager calculates `SHA256` checksums while uploading.
+    /// If the upload is multipart, the object will have a composite checksum,
+    /// otherwise it will have a full object checksum.
+    pub fn with_calculated_sha256_composite_if_multipart() -> Self {
+        Self {
+            algorithm: ChecksumAlgorithm::Sha256,
+            type_if_multipart: ChecksumType::Composite,
+            full_object_checksum: None,
+        }
+    }
+
+    /// Create checksum strategy from parts.
+    ///
+    /// It is possible to create an invalid strategy this way,
+    /// use [`ChecksumStrategy::validate()`] to check. e.g. S3 does not allow
+    /// any `SHA` algorithm to do full object multipart uploads, and does not
+    /// allow `CRC64NVME` to do composite multipart uploads.
+    pub fn new(
+        algorithm: ChecksumAlgorithm,
+        type_if_multipart: ChecksumType,
+        full_object_checksum: Option<String>,
+    ) -> Self {
+        Self {
+            algorithm,
+            type_if_multipart,
+            full_object_checksum,
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), crate::error::Error> {
+        // Ensure multipart checksum type is something we know about
+        match self.type_if_multipart {
+            ChecksumType::Composite | ChecksumType::FullObject => (),
+            _ => {
+                return Err(error::invalid_input(format!(
+                    "Unknown multipart checksum type: {}",
+                    self.type_if_multipart
+                )));
+            }
+        }
+
+        // Ensure checksum algorithm is something we know about, and set whether it only supports one checksum type
+        let only_one_supported_multipart_checksum_type = match self.algorithm {
+            ChecksumAlgorithm::Crc64Nvme => Some(ChecksumType::FullObject),
+            ChecksumAlgorithm::Crc32 | ChecksumAlgorithm::Crc32C => None,
+            ChecksumAlgorithm::Sha1 | ChecksumAlgorithm::Sha256 => Some(ChecksumType::Composite),
+            _ => {
+                return Err(error::invalid_input(format!(
+                    "Unknown checksum algorithm: {}",
+                    self.algorithm
+                )));
+            }
+        };
+
+        // If only one multipart checksum type is supported, make sure it's being used
+        if only_one_supported_multipart_checksum_type.is_some_and(|x| x != self.type_if_multipart) {
+            return Err(error::invalid_input(format!(
+                "`{}` checksum algorithm does not support `{}` multipart checksum type",
+                self.algorithm, self.type_if_multipart
+            )));
+        }
+
+        // Ensure full object checksum value is only being provided when type is FullObject
+        if self.full_object_checksum.is_some() && self.type_if_multipart != ChecksumType::FullObject
+        {
+            return Err(error::invalid_input(
+                format!("You cannot provide the full object checksum value up front when the multipart upload type is `{}` (algorithm is `{}`)", self.type_if_multipart, self.algorithm)
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for ChecksumStrategy {
+    /// The transfer manager calculates a `CRC64NVME` full object checksum while uploading.
+    fn default() -> Self {
+        Self::with_calculated_crc64_nvme()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_algorithm_is_crc64() {
+        assert_eq!(
+            ChecksumStrategy::default().algorithm,
+            ChecksumAlgorithm::Crc64Nvme
+        );
+    }
+
+    #[test]
+    fn test_validation_ok() {
+        // All ChecksumStrategy::with_XYZ() constructors should create something valid
+        ChecksumStrategy::default().validate().unwrap();
+        ChecksumStrategy::with_crc64_nvme("06PGTl8uMFM=")
+            .validate()
+            .unwrap();
+        ChecksumStrategy::with_crc32("3fRuog==").validate().unwrap();
+        ChecksumStrategy::with_crc32_c("X9v3eA==")
+            .validate()
+            .unwrap();
+        ChecksumStrategy::with_calculated_crc64_nvme()
+            .validate()
+            .unwrap();
+        ChecksumStrategy::with_calculated_crc32()
+            .validate()
+            .unwrap();
+        ChecksumStrategy::with_calculated_crc32_c()
+            .validate()
+            .unwrap();
+        ChecksumStrategy::with_calculated_crc32_composite_if_multipart()
+            .validate()
+            .unwrap();
+        ChecksumStrategy::with_calculated_crc32_c_composite_if_multipart()
+            .validate()
+            .unwrap();
+        ChecksumStrategy::with_calculated_sha1_composite_if_multipart()
+            .validate()
+            .unwrap();
+        ChecksumStrategy::with_calculated_sha256_composite_if_multipart()
+            .validate()
+            .unwrap();
+    }
+
+    #[test]
+    fn test_validation_errors() {
+        // ChecksumStrategy::new() can create something invalid.
+        // Use that to test validate()
+
+        ChecksumStrategy::new(ChecksumAlgorithm::Crc64Nvme, ChecksumType::Composite, None)
+            .validate()
+            .expect_err("Composite checksums not allowed with CRC64NVME");
+
+        ChecksumStrategy::new(ChecksumAlgorithm::Sha1, ChecksumType::FullObject, None)
+            .validate()
+            .expect_err("FullObject checksums not allowed with SHA-1");
+
+        ChecksumStrategy::new(ChecksumAlgorithm::Sha256, ChecksumType::FullObject, None)
+            .validate()
+            .expect_err("FullObject checksums not allowed with SHA-256");
+
+        ChecksumStrategy::new(
+            ChecksumAlgorithm::Crc32,
+            ChecksumType::Composite,
+            Some("3fRuog==".to_string()),
+        )
+        .validate()
+        .expect_err("full_object_checksum values not allowed with Composite");
+    }
+}

--- a/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
@@ -2,19 +2,7 @@ use aws_sdk_s3::types::{ChecksumAlgorithm, ChecksumType};
 
 use crate::error;
 
-/// Strategy for calculating checksum values during upload.
-/// These values are sent to S3 and used to verify the integrity of the uploaded data.
-/// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
-///
-/// You can set a specific [`ChecksumStrategy`], if you wish to choose the
-/// checksum algorithm or already know the checksum value.
-///
-/// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
-/// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
-///
-/// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
-/// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
-/// If you do this, S3 will still calculate a `CRC64NVME` full object checksum for the object.
+#[doc = std::include_str!("checksum_strategy.md")]
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ChecksumStrategy {

--- a/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
@@ -1,30 +1,17 @@
 use aws_sdk_s3::types::{ChecksumAlgorithm, ChecksumType};
-
-use crate::error;
+use aws_smithy_types::error::operation::BuildError;
 
 #[doc = std::include_str!("checksum_strategy.md")]
-#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ChecksumStrategy {
     /// The checksum algorithm to use.
-    pub algorithm: ChecksumAlgorithm,
+    algorithm: ChecksumAlgorithm,
 
     /// The checksum type to use IF the upload is multipart.
-    ///
-    /// Note that if the upload is NOT multipart (e.g. object size is below the multipart threshold),
-    /// the object's checksum type will always be [`ChecksumType::FullObject`], regardless of this setting.
-    pub type_if_multipart: ChecksumType,
+    type_if_multipart: ChecksumType,
 
     /// The precalculated full object checksum value.
-    ///
-    /// If specified, this value will be sent to S3 as the full object checksum value.
-    /// In the case of a multipart upload, the transfer manager still calculates
-    /// checksums for individual parts, but this value will always be sent as the full object checksum value.
-    ///
-    /// If not specified, the transfer manager will calculate the checksum value.
-    ///
-    /// You may not specify this when `type_if_multipart` is [`ChecksumType::Composite`].
-    pub full_object_checksum: Option<String>,
+    full_object_checksum: Option<String>,
 }
 
 impl ChecksumStrategy {
@@ -127,66 +114,44 @@ impl ChecksumStrategy {
         }
     }
 
-    /// Create checksum strategy from parts.
+    /// Builder for [`ChecksumStrategy`].
     ///
-    /// It is possible to create an invalid strategy this way,
-    /// use [`ChecksumStrategy::validate()`] to check. e.g. S3 does not allow
-    /// any `SHA` algorithm to do full object multipart uploads, and does not
-    /// allow `CRC64NVME` to do composite multipart uploads.
-    pub fn new(
-        algorithm: ChecksumAlgorithm,
-        type_if_multipart: ChecksumType,
-        full_object_checksum: Option<String>,
-    ) -> Self {
-        Self {
-            algorithm,
-            type_if_multipart,
-            full_object_checksum,
+    /// Note that [`Builder::build()`] can fail if the strategy is invalid.
+    /// E.g. S3 does not allow any `SHA` algorithm to do full object multipart uploads,
+    /// and does not allow `CRC64NVME` to do composite multipart uploads.
+    /// You should prefer the `with_` constructors, which cannot fail.
+    pub fn builder() -> Builder {
+        Builder {
+            algorithm: None,
+            type_if_multipart: None,
+            full_object_checksum: None,
         }
     }
 
-    pub(crate) fn validate(&self) -> Result<(), crate::error::Error> {
-        // Ensure multipart checksum type is something we know about
-        match self.type_if_multipart {
-            ChecksumType::Composite | ChecksumType::FullObject => (),
-            _ => {
-                return Err(error::invalid_input(format!(
-                    "Unknown multipart checksum type: {}",
-                    self.type_if_multipart
-                )));
-            }
-        }
+    /// The checksum algorithm to use.
+    pub fn algorithm(&self) -> &ChecksumAlgorithm {
+        &self.algorithm
+    }
 
-        // Ensure checksum algorithm is something we know about, and set whether it only supports one checksum type
-        let only_one_supported_multipart_checksum_type = match self.algorithm {
-            ChecksumAlgorithm::Crc64Nvme => Some(ChecksumType::FullObject),
-            ChecksumAlgorithm::Crc32 | ChecksumAlgorithm::Crc32C => None,
-            ChecksumAlgorithm::Sha1 | ChecksumAlgorithm::Sha256 => Some(ChecksumType::Composite),
-            _ => {
-                return Err(error::invalid_input(format!(
-                    "Unknown checksum algorithm: {}",
-                    self.algorithm
-                )));
-            }
-        };
+    /// The checksum type to use IF the upload is multipart.
+    ///
+    /// Note that if the upload is NOT multipart (e.g. object size is below the multipart threshold),
+    /// the object's checksum type will always be [`ChecksumType::FullObject`], regardless of this setting.
+    pub fn type_if_multipart(&self) -> &ChecksumType {
+        &self.type_if_multipart
+    }
 
-        // If only one multipart checksum type is supported, make sure it's being used
-        if only_one_supported_multipart_checksum_type.is_some_and(|x| x != self.type_if_multipart) {
-            return Err(error::invalid_input(format!(
-                "`{}` checksum algorithm does not support `{}` multipart checksum type",
-                self.algorithm, self.type_if_multipart
-            )));
-        }
-
-        // Ensure full object checksum value is only being provided when type is FullObject
-        if self.full_object_checksum.is_some() && self.type_if_multipart != ChecksumType::FullObject
-        {
-            return Err(error::invalid_input(
-                format!("You cannot provide the full object checksum value up front when the multipart upload type is `{}` (algorithm is `{}`)", self.type_if_multipart, self.algorithm)
-            ));
-        }
-
-        Ok(())
+    /// The precalculated full object checksum value.
+    ///
+    /// If specified, this value will be sent to S3 as the full object checksum value.
+    /// In the case of a multipart upload, the transfer manager still calculates
+    /// checksums for individual parts, but this value will always be sent as the full object checksum value.
+    ///
+    /// If not specified, the transfer manager will calculate the checksum value.
+    ///
+    /// You may not specify this when [type_if_multipart](`Self::type_if_multipart`) is [`ChecksumType::Composite`].
+    pub fn full_object_checksum(&self) -> Option<&str> {
+        self.full_object_checksum.as_deref()
     }
 }
 
@@ -194,6 +159,109 @@ impl Default for ChecksumStrategy {
     /// The transfer manager calculates a `CRC64NVME` full object checksum while uploading.
     fn default() -> Self {
         Self::with_calculated_crc64_nvme()
+    }
+}
+
+/// Builder for [`ChecksumStrategy`].
+#[derive(Debug)]
+pub struct Builder {
+    algorithm: Option<ChecksumAlgorithm>,
+    type_if_multipart: Option<ChecksumType>,
+    full_object_checksum: Option<String>,
+}
+
+impl Builder {
+    /// The checksum algorithm to use.
+    pub fn algorithm(mut self, input: ChecksumAlgorithm) -> Self {
+        self.algorithm = Some(input);
+        self
+    }
+
+    /// The checksum type to use IF the upload is multipart.
+    ///
+    /// Note that if the upload is NOT multipart (e.g. object size is below the multipart threshold),
+    /// the object's checksum type will always be [`ChecksumType::FullObject`], regardless of this setting.
+    pub fn type_if_multipart(mut self, input: ChecksumType) -> Self {
+        self.type_if_multipart = Some(input);
+        self
+    }
+
+    /// The precalculated full object checksum value.
+    ///
+    /// If specified, this value will be sent to S3 as the full object checksum value.
+    /// In the case of a multipart upload, the transfer manager still calculates
+    /// checksums for individual parts, but this value will always be sent as the full object checksum value.
+    ///
+    /// If not specified, the transfer manager will calculate the checksum value.
+    ///
+    /// You may not specify this when [type_if_multipart](`Self::type_if_multipart`) is [`ChecksumType::Composite`].
+    pub fn full_object_checksum(mut self, input: impl Into<String>) -> Self {
+        self.full_object_checksum = Some(input.into());
+        self
+    }
+
+    /// TODO: docs
+    pub fn build(self) -> Result<ChecksumStrategy, BuildError> {
+        let algorithm = self.algorithm.ok_or_else(|| {
+            BuildError::missing_field("algorithm", "Checksum algorithm is required")
+        })?;
+
+        // Ensure checksum algorithm is something we know about
+        match algorithm {
+            ChecksumAlgorithm::Crc64Nvme
+            | ChecksumAlgorithm::Crc32
+            | ChecksumAlgorithm::Crc32C
+            | ChecksumAlgorithm::Sha1
+            | ChecksumAlgorithm::Sha256 => (),
+            _ => {
+                return Err(BuildError::invalid_field(
+                    "algorithm",
+                    format!("Unknown checksum algorithm: {}", algorithm),
+                ));
+            }
+        }
+
+        // If multipart checksum type not specified, default to FullObject, unless a SHA algorithm is being used
+        let type_if_multipart = match self.type_if_multipart {
+            Some(type_if_multipart) => type_if_multipart,
+            None => match &algorithm {
+                &ChecksumAlgorithm::Sha1 | &ChecksumAlgorithm::Sha256 => ChecksumType::Composite,
+                _ => ChecksumType::FullObject,
+            },
+        };
+
+        // Validate multipart checksum type
+        match (&type_if_multipart, &algorithm) {
+            // Check for illegal combinations...
+            (&ChecksumType::Composite, &ChecksumAlgorithm::Crc64Nvme)
+            | (&ChecksumType::FullObject, &ChecksumAlgorithm::Sha1)
+            | (&ChecksumType::FullObject, &ChecksumAlgorithm::Sha256) => {
+                return Err(BuildError::invalid_field("type_if_multipart", format!(
+                    "`{algorithm}` checksum algorithm does not support `{type_if_multipart}` multipart checksum type"
+                )));
+            }
+            // Anything else is legal...
+            (&ChecksumType::Composite, _) | (&ChecksumType::FullObject, _) => (),
+            // Unless we don't even recognize the ChecksumType
+            (_, _) => {
+                return Err(BuildError::invalid_field(
+                    "type_if_multipart",
+                    format!("Unknown multipart checksum type: {}", type_if_multipart),
+                ));
+            }
+        };
+
+        if self.full_object_checksum.is_some() && &type_if_multipart != &ChecksumType::FullObject {
+            return Err(BuildError::invalid_field("full_object_checksum",
+                format!("You cannot provide the full object checksum value up front when the multipart checksum type is `{type_if_multipart}` (algorithm is `{algorithm}`)")
+            ));
+        }
+
+        Ok(ChecksumStrategy {
+            algorithm,
+            type_if_multipart,
+            full_object_checksum: self.full_object_checksum,
+        })
     }
 }
 
@@ -210,62 +278,113 @@ mod tests {
     }
 
     #[test]
-    fn test_validation_ok() {
+    fn test_with_xyz_constructors() {
         // All ChecksumStrategy::with_XYZ() constructors should create something valid
-        ChecksumStrategy::default().validate().unwrap();
-        ChecksumStrategy::with_crc64_nvme("06PGTl8uMFM=")
-            .validate()
-            .unwrap();
-        ChecksumStrategy::with_crc32("3fRuog==").validate().unwrap();
-        ChecksumStrategy::with_crc32_c("X9v3eA==")
-            .validate()
-            .unwrap();
-        ChecksumStrategy::with_calculated_crc64_nvme()
-            .validate()
-            .unwrap();
-        ChecksumStrategy::with_calculated_crc32()
-            .validate()
-            .unwrap();
-        ChecksumStrategy::with_calculated_crc32_c()
-            .validate()
-            .unwrap();
-        ChecksumStrategy::with_calculated_crc32_composite_if_multipart()
-            .validate()
-            .unwrap();
-        ChecksumStrategy::with_calculated_crc32_c_composite_if_multipart()
-            .validate()
-            .unwrap();
-        ChecksumStrategy::with_calculated_sha1_composite_if_multipart()
-            .validate()
-            .unwrap();
-        ChecksumStrategy::with_calculated_sha256_composite_if_multipart()
-            .validate()
-            .unwrap();
+        let strategy = ChecksumStrategy::default();
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Crc64Nvme);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::FullObject);
+        assert_eq!(strategy.full_object_checksum(), None);
+
+        let strategy = ChecksumStrategy::with_crc64_nvme("06PGTl8uMFM=");
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Crc64Nvme);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::FullObject);
+        assert_eq!(strategy.full_object_checksum(), Some("06PGTl8uMFM="));
+
+        let strategy = ChecksumStrategy::with_crc32("3fRuog==");
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Crc32);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::FullObject);
+        assert_eq!(strategy.full_object_checksum(), Some("3fRuog=="));
+
+        let strategy = ChecksumStrategy::with_crc32_c("X9v3eA==");
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Crc32C);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::FullObject);
+        assert_eq!(strategy.full_object_checksum(), Some("X9v3eA=="));
+
+        let strategy = ChecksumStrategy::with_calculated_crc64_nvme();
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Crc64Nvme);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::FullObject);
+        assert_eq!(strategy.full_object_checksum(), None);
+
+        let strategy = ChecksumStrategy::with_calculated_crc32();
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Crc32);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::FullObject);
+        assert_eq!(strategy.full_object_checksum(), None);
+
+        let strategy = ChecksumStrategy::with_calculated_crc32_c();
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Crc32C);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::FullObject);
+        assert_eq!(strategy.full_object_checksum(), None);
+
+        let strategy = ChecksumStrategy::with_calculated_crc32_composite_if_multipart();
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Crc32);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::Composite);
+        assert_eq!(strategy.full_object_checksum(), None);
+
+        let strategy = ChecksumStrategy::with_calculated_crc32_c_composite_if_multipart();
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Crc32C);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::Composite);
+        assert_eq!(strategy.full_object_checksum(), None);
+
+        let strategy = ChecksumStrategy::with_calculated_sha1_composite_if_multipart();
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Sha1);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::Composite);
+        assert_eq!(strategy.full_object_checksum(), None);
+
+        let strategy = ChecksumStrategy::with_calculated_sha256_composite_if_multipart();
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Sha256);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::Composite);
+        assert_eq!(strategy.full_object_checksum(), None);
     }
 
     #[test]
-    fn test_validation_errors() {
-        // ChecksumStrategy::new() can create something invalid.
-        // Use that to test validate()
+    fn test_builder() {
+        // Assert that values passed to builder carry through
+        let strategy = ChecksumStrategy::builder()
+            .algorithm(ChecksumAlgorithm::Crc32C) // non-default value
+            .type_if_multipart(ChecksumType::Composite) // non-default value
+            .build()
+            .unwrap();
+        assert_eq!(strategy.algorithm(), &ChecksumAlgorithm::Crc32C);
+        assert_eq!(strategy.type_if_multipart(), &ChecksumType::Composite);
+        assert_eq!(strategy.full_object_checksum(), None);
 
-        ChecksumStrategy::new(ChecksumAlgorithm::Crc64Nvme, ChecksumType::Composite, None)
-            .validate()
+        let strategy = ChecksumStrategy::builder()
+            .algorithm(ChecksumAlgorithm::Crc32)
+            .full_object_checksum("3fRuog==")
+            .build()
+            .unwrap();
+        assert_eq!(strategy.full_object_checksum(), Some("3fRuog=="));
+    }
+
+    #[test]
+    fn test_builder_validation() {
+        ChecksumStrategy::builder()
+            .build()
+            .expect_err("Builder requires algorithm");
+
+        ChecksumStrategy::builder()
+            .algorithm(ChecksumAlgorithm::Crc64Nvme)
+            .type_if_multipart(ChecksumType::Composite)
+            .build()
             .expect_err("Composite checksums not allowed with CRC64NVME");
 
-        ChecksumStrategy::new(ChecksumAlgorithm::Sha1, ChecksumType::FullObject, None)
-            .validate()
+        ChecksumStrategy::builder()
+            .algorithm(ChecksumAlgorithm::Sha1)
+            .type_if_multipart(ChecksumType::FullObject)
+            .build()
             .expect_err("FullObject checksums not allowed with SHA-1");
 
-        ChecksumStrategy::new(ChecksumAlgorithm::Sha256, ChecksumType::FullObject, None)
-            .validate()
+        ChecksumStrategy::builder()
+            .algorithm(ChecksumAlgorithm::Sha256)
+            .type_if_multipart(ChecksumType::FullObject)
+            .build()
             .expect_err("FullObject checksums not allowed with SHA-256");
 
-        ChecksumStrategy::new(
-            ChecksumAlgorithm::Crc32,
-            ChecksumType::Composite,
-            Some("3fRuog==".to_string()),
-        )
-        .validate()
-        .expect_err("full_object_checksum values not allowed with Composite");
+        ChecksumStrategy::builder()
+            .algorithm(ChecksumAlgorithm::Crc32)
+            .type_if_multipart(ChecksumType::Composite)
+            .full_object_checksum("3fRuog==")
+            .build()
+            .expect_err("full_object_checksum values not allowed with Composite");
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
@@ -114,14 +114,9 @@ impl ChecksumStrategy {
         }
     }
 
-    /// Builder for [`ChecksumStrategy`].
-    ///
-    /// Note that [`Builder::build()`] can fail if the strategy is invalid.
-    /// E.g. S3 does not allow any `SHA` algorithm to do full object multipart uploads,
-    /// and does not allow `CRC64NVME` to do composite multipart uploads.
-    /// You should prefer the `with_` constructors, which cannot fail.
-    pub fn builder() -> Builder {
-        Builder {
+    #[doc = std::include_str!("checksum_strategy_builder.md")]
+    pub fn builder() -> ChecksumStrategyBuilder {
+        ChecksumStrategyBuilder {
             algorithm: None,
             type_if_multipart: None,
             full_object_checksum: None,
@@ -162,15 +157,15 @@ impl Default for ChecksumStrategy {
     }
 }
 
-/// Builder for [`ChecksumStrategy`].
+#[doc = std::include_str!("checksum_strategy_builder.md")]
 #[derive(Debug)]
-pub struct Builder {
+pub struct ChecksumStrategyBuilder {
     algorithm: Option<ChecksumAlgorithm>,
     type_if_multipart: Option<ChecksumType>,
     full_object_checksum: Option<String>,
 }
 
-impl Builder {
+impl ChecksumStrategyBuilder {
     /// The checksum algorithm to use.
     pub fn algorithm(mut self, input: ChecksumAlgorithm) -> Self {
         self.algorithm = Some(input);
@@ -200,7 +195,11 @@ impl Builder {
         self
     }
 
-    /// TODO: docs
+    /// Returns a [`ChecksumStrategy`] from this builder, or an error if the strategy is illegal
+    /// (e.g. S3 does not allow any `SHA` algorithm to use [`ChecksumType::FullObject`] in multipart uploads).
+    ///
+    /// The `ChecksumStrategy::with_` constructors are recommended over the builder,
+    /// because they cannot fail.
     pub fn build(self) -> Result<ChecksumStrategy, BuildError> {
         let algorithm = self.algorithm.ok_or_else(|| {
             BuildError::missing_field("algorithm", "Checksum algorithm is required")
@@ -360,7 +359,7 @@ mod tests {
     fn test_builder_validation() {
         ChecksumStrategy::builder()
             .build()
-            .expect_err("Builder requires algorithm");
+            .expect_err("ChecksumStrategyBuilder requires algorithm");
 
         ChecksumStrategy::builder()
             .algorithm(ChecksumAlgorithm::Crc64Nvme)

--- a/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
@@ -251,7 +251,7 @@ impl Builder {
             }
         };
 
-        if self.full_object_checksum.is_some() && &type_if_multipart != &ChecksumType::FullObject {
+        if self.full_object_checksum.is_some() && type_if_multipart != ChecksumType::FullObject {
             return Err(BuildError::invalid_field("full_object_checksum",
                 format!("You cannot provide the full object checksum value up front when the multipart checksum type is `{type_if_multipart}` (algorithm is `{algorithm}`)")
             ));

--- a/aws-s3-transfer-manager/src/operation/upload/checksum_strategy_builder.md
+++ b/aws-s3-transfer-manager/src/operation/upload/checksum_strategy_builder.md
@@ -1,0 +1,8 @@
+Builder for [`ChecksumStrategy`].
+
+You should prefer to use the `ChecksumStrategy::with_` constructors, instead of the builder.
+The builder lets you construct a [`ChecksumStrategy`] from its constituent parts, but its `build()`
+function can fail because some combinations are illegal. For example,
+S3 does not allow any `SHA` algorithm to use [`ChecksumType::FullObject`] in multipart uploads,
+and does not allow `CRC64NVME` to do composite multipart uploads.
+The `with_` constructors cannot fail.

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -214,9 +214,9 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
             if let Some(checksum_strategy) = &handle.ctx.request.checksum_strategy {
                 // TODO(aws-s3-transfer-manager-rs#3): allow user to pass full-object checksum value via callback on PartStream
 
-                if let Some(value) = &checksum_strategy.full_object_checksum {
+                if let Some(value) = checksum_strategy.full_object_checksum() {
                     // We have the full-object checksum value, so set it
-                    req = match &checksum_strategy.algorithm {
+                    req = match checksum_strategy.algorithm() {
                         aws_sdk_s3::types::ChecksumAlgorithm::Crc32 => req.checksum_crc32(value),
                         aws_sdk_s3::types::ChecksumAlgorithm::Crc32C => req.checksum_crc32_c(value),
                         aws_sdk_s3::types::ChecksumAlgorithm::Crc64Nvme => {

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -222,7 +222,9 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
                         aws_sdk_s3::types::ChecksumAlgorithm::Crc64Nvme => {
                             req.checksum_crc64_nvme(value)
                         }
-                        algo => panic!("unexpected algorithm `{algo}` for full object checksum"),
+                        algo => {
+                            unreachable!("unexpected algorithm `{algo}` for full object checksum")
+                        }
                     };
                 }
             }

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -193,7 +193,7 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
             all_parts.sort_by_key(|p| p.part_number.expect("part number set"));
 
             // complete the multipart upload
-            let complete_mpu_resp = handle
+            let mut req = handle
                 .ctx
                 .client()
                 .complete_multipart_upload()
@@ -205,16 +205,29 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
                         .set_parts(Some(all_parts))
                         .build(),
                 )
-                // TODO(aws-sdk-rust#1159) - implement checksums
-                // .set_checksum_crc32()
-                // .set_checksum_crc32_c()
-                // .set_checksum_sha1()
-                // .set_checksum_sha256()
                 .set_request_payer(handle.ctx.request.request_payer.clone())
                 .set_expected_bucket_owner(handle.ctx.request.expected_bucket_owner.clone())
                 .set_sse_customer_algorithm(handle.ctx.request.sse_customer_algorithm.clone())
                 .set_sse_customer_key(handle.ctx.request.sse_customer_key.clone())
-                .set_sse_customer_key_md5(handle.ctx.request.sse_customer_key_md5.clone())
+                .set_sse_customer_key_md5(handle.ctx.request.sse_customer_key_md5.clone());
+
+            if let Some(checksum_strategy) = &handle.ctx.request.checksum_strategy {
+                // TODO(aws-s3-transfer-manager-rs#3): allow user to pass full-object checksum value via callback on PartStream
+
+                if let Some(value) = &checksum_strategy.full_object_checksum {
+                    // We have the full-object checksum value, so set it
+                    req = match &checksum_strategy.algorithm {
+                        aws_sdk_s3::types::ChecksumAlgorithm::Crc32 => req.checksum_crc32(value),
+                        aws_sdk_s3::types::ChecksumAlgorithm::Crc32C => req.checksum_crc32_c(value),
+                        aws_sdk_s3::types::ChecksumAlgorithm::Crc64Nvme => {
+                            req.checksum_crc64_nvme(value)
+                        }
+                        algo => panic!("unexpected algorithm `{algo}` for full object checksum"),
+                    };
+                }
+            }
+
+            let complete_mpu_resp = req
                 .send()
                 .instrument(tracing::debug_span!("send-complete-multipart-upload"))
                 .await?;
@@ -226,6 +239,11 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
                 .expect("response set")
                 .set_e_tag(complete_mpu_resp.e_tag.clone())
                 .set_expiration(complete_mpu_resp.expiration.clone())
+                .set_checksum_crc32(complete_mpu_resp.checksum_crc32.clone())
+                .set_checksum_crc32_c(complete_mpu_resp.checksum_crc32_c.clone())
+                .set_checksum_crc64_nvme(complete_mpu_resp.checksum_crc64_nvme.clone())
+                .set_checksum_sha1(complete_mpu_resp.checksum_sha1.clone())
+                .set_checksum_sha256(complete_mpu_resp.checksum_sha256.clone())
                 .set_version_id(complete_mpu_resp.version_id.clone());
 
             tracing::trace!("upload completed successfully");

--- a/aws-s3-transfer-manager/src/operation/upload/input.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/input.rs
@@ -9,6 +9,8 @@ use crate::types::FailedMultipartUploadPolicy;
 use std::fmt::Debug;
 use std::mem;
 
+use super::ChecksumStrategy;
+
 /// Request type for uploading a single object
 #[non_exhaustive]
 pub struct UploadInput {
@@ -50,31 +52,19 @@ pub struct UploadInput {
     pub content_md5: Option<String>,
     /// <p>A standard MIME type describing the format of the contents. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-content-type">https://www.rfc-editor.org/rfc/rfc9110.html#name-content-type</a>.</p>
     pub content_type: Option<String>,
-    /// <p>Indicates the algorithm used to create the checksum for the object when you use the SDK. This header will not provide any additional functionality if you don't use the SDK. When you send this header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i> </code> or <code>x-amz-trailer</code> header sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>.</p>
-    /// <p>For the <code>x-amz-checksum-<i>algorithm</i> </code> header, replace <code> <i>algorithm</i> </code> with the supported algorithm from the following list:</p>
-    /// <ul>
-    /// <li>
-    /// <p>CRC32</p></li>
-    /// <li>
-    /// <p>CRC32C</p></li>
-    /// <li>
-    /// <p>SHA1</p></li>
-    /// <li>
-    /// <p>SHA256</p></li>
-    /// </ul>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    /// <p>If the individual checksum value you provide through <code>x-amz-checksum-<i>algorithm</i> </code> doesn't match the checksum algorithm you set through <code>x-amz-sdk-checksum-algorithm</code>, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code> parameter and uses the checksum algorithm that matches the provided value in <code>x-amz-checksum-<i>algorithm</i> </code>.</p><note>
-    /// <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>
-    /// </note>
-    pub checksum_algorithm: Option<aws_sdk_s3::types::ChecksumAlgorithm>,
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32 checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub checksum_crc32: Option<String>,
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32C checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub checksum_crc32_c: Option<String>,
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 160-bit SHA-1 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub checksum_sha1: Option<String>,
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 256-bit SHA-256 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub checksum_sha256: Option<String>,
+    /// Strategy for calculating checksum values during upload.
+    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
+    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
+    ///
+    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
+    /// checksum algorithm or already know the checksum value.
+    ///
+    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
+    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
+    ///
+    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
+    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    pub checksum_strategy: Option<ChecksumStrategy>,
     /// <p>The date and time at which the object is no longer cacheable. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc7234#section-5.3">https://www.rfc-editor.org/rfc/rfc7234#section-5.3</a>.</p>
     pub expires: Option<::aws_smithy_types::DateTime>,
     /// <p>Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.</p><note>
@@ -260,40 +250,20 @@ impl UploadInput {
     pub fn content_type(&self) -> Option<&str> {
         self.content_type.as_deref()
     }
-    /// <p>Indicates the algorithm used to create the checksum for the object when you use the SDK. This header will not provide any additional functionality if you don't use the SDK. When you send this header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i> </code> or <code>x-amz-trailer</code> header sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>.</p>
-    /// <p>For the <code>x-amz-checksum-<i>algorithm</i> </code> header, replace <code> <i>algorithm</i> </code> with the supported algorithm from the following list:</p>
-    /// <ul>
-    /// <li>
-    /// <p>CRC32</p></li>
-    /// <li>
-    /// <p>CRC32C</p></li>
-    /// <li>
-    /// <p>SHA1</p></li>
-    /// <li>
-    /// <p>SHA256</p></li>
-    /// </ul>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    /// <p>If the individual checksum value you provide through <code>x-amz-checksum-<i>algorithm</i> </code> doesn't match the checksum algorithm you set through <code>x-amz-sdk-checksum-algorithm</code>, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code> parameter and uses the checksum algorithm that matches the provided value in <code>x-amz-checksum-<i>algorithm</i> </code>.</p><note>
-    /// <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>
-    /// </note>
-    pub fn checksum_algorithm(&self) -> Option<&aws_sdk_s3::types::ChecksumAlgorithm> {
-        self.checksum_algorithm.as_ref()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32 checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_crc32(&self) -> Option<&str> {
-        self.checksum_crc32.as_deref()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32C checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_crc32_c(&self) -> Option<&str> {
-        self.checksum_crc32_c.as_deref()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 160-bit SHA-1 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_sha1(&self) -> Option<&str> {
-        self.checksum_sha1.as_deref()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 256-bit SHA-256 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_sha256(&self) -> Option<&str> {
-        self.checksum_sha256.as_deref()
+    /// Strategy for calculating checksum values during upload.
+    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
+    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
+    ///
+    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
+    /// checksum algorithm or already know the checksum value.
+    ///
+    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
+    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
+    ///
+    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
+    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    pub fn checksum_strategy(&self) -> Option<&ChecksumStrategy> {
+        self.checksum_strategy.as_ref()
     }
     /// <p>The date and time at which the object is no longer cacheable. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc7234#section-5.3">https://www.rfc-editor.org/rfc/rfc7234#section-5.3</a>.</p>
     pub fn expires(&self) -> Option<&::aws_smithy_types::DateTime> {
@@ -472,11 +442,7 @@ impl Debug for UploadInput {
         formatter.field("content_length", &self.content_length);
         formatter.field("content_md5", &self.content_md5);
         formatter.field("content_type", &self.content_type);
-        formatter.field("checksum_algorithm", &self.checksum_algorithm);
-        formatter.field("checksum_crc32", &self.checksum_crc32);
-        formatter.field("checksum_crc32_c", &self.checksum_crc32_c);
-        formatter.field("checksum_sha1", &self.checksum_sha1);
-        formatter.field("checksum_sha256", &self.checksum_sha256);
+        formatter.field("checksum_strategy", &self.checksum_strategy);
         formatter.field("expires", &self.expires);
         formatter.field("grant_full_control", &self.grant_full_control);
         formatter.field("grant_read", &self.grant_read);
@@ -533,11 +499,7 @@ pub struct UploadInputBuilder {
     pub(crate) content_length: Option<i64>,
     pub(crate) content_md5: Option<String>,
     pub(crate) content_type: Option<String>,
-    pub(crate) checksum_algorithm: Option<aws_sdk_s3::types::ChecksumAlgorithm>,
-    pub(crate) checksum_crc32: Option<String>,
-    pub(crate) checksum_crc32_c: Option<String>,
-    pub(crate) checksum_sha1: Option<String>,
-    pub(crate) checksum_sha256: Option<String>,
+    pub(crate) checksum_strategy: Option<ChecksumStrategy>,
     pub(crate) expires: Option<::aws_smithy_types::DateTime>,
     pub(crate) grant_full_control: Option<String>,
     pub(crate) grant_read: Option<String>,
@@ -761,123 +723,52 @@ impl UploadInputBuilder {
     pub fn get_content_type(&self) -> Option<&str> {
         self.content_type.as_deref()
     }
-    /// <p>Indicates the algorithm used to create the checksum for the object when you use the SDK. This header will not provide any additional functionality if you don't use the SDK. When you send this header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i> </code> or <code>x-amz-trailer</code> header sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>.</p>
-    /// <p>For the <code>x-amz-checksum-<i>algorithm</i> </code> header, replace <code> <i>algorithm</i> </code> with the supported algorithm from the following list:</p>
-    /// <ul>
-    /// <li>
-    /// <p>CRC32</p></li>
-    /// <li>
-    /// <p>CRC32C</p></li>
-    /// <li>
-    /// <p>SHA1</p></li>
-    /// <li>
-    /// <p>SHA256</p></li>
-    /// </ul>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    /// <p>If the individual checksum value you provide through <code>x-amz-checksum-<i>algorithm</i> </code> doesn't match the checksum algorithm you set through <code>x-amz-sdk-checksum-algorithm</code>, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code> parameter and uses the checksum algorithm that matches the provided value in <code>x-amz-checksum-<i>algorithm</i> </code>.</p><note>
-    /// <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>
-    /// </note>
-    pub fn checksum_algorithm(mut self, input: aws_sdk_s3::types::ChecksumAlgorithm) -> Self {
-        self.checksum_algorithm = Some(input);
+    /// Strategy for calculating checksum values during upload.
+    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
+    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
+    ///
+    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
+    /// checksum algorithm or already know the checksum value.
+    ///
+    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
+    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
+    ///
+    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
+    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    pub fn checksum_strategy(mut self, input: ChecksumStrategy) -> Self {
+        self.checksum_strategy = Some(input);
         self
     }
-    /// <p>Indicates the algorithm used to create the checksum for the object when you use the SDK. This header will not provide any additional functionality if you don't use the SDK. When you send this header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i> </code> or <code>x-amz-trailer</code> header sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>.</p>
-    /// <p>For the <code>x-amz-checksum-<i>algorithm</i> </code> header, replace <code> <i>algorithm</i> </code> with the supported algorithm from the following list:</p>
-    /// <ul>
-    /// <li>
-    /// <p>CRC32</p></li>
-    /// <li>
-    /// <p>CRC32C</p></li>
-    /// <li>
-    /// <p>SHA1</p></li>
-    /// <li>
-    /// <p>SHA256</p></li>
-    /// </ul>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    /// <p>If the individual checksum value you provide through <code>x-amz-checksum-<i>algorithm</i> </code> doesn't match the checksum algorithm you set through <code>x-amz-sdk-checksum-algorithm</code>, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code> parameter and uses the checksum algorithm that matches the provided value in <code>x-amz-checksum-<i>algorithm</i> </code>.</p><note>
-    /// <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>
-    /// </note>
-    pub fn set_checksum_algorithm(
-        mut self,
-        input: Option<aws_sdk_s3::types::ChecksumAlgorithm>,
-    ) -> Self {
-        self.checksum_algorithm = input;
+    /// Strategy for calculating checksum values during upload.
+    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
+    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
+    ///
+    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
+    /// checksum algorithm or already know the checksum value.
+    ///
+    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
+    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
+    ///
+    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
+    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    pub fn set_checksum_strategy(mut self, input: Option<ChecksumStrategy>) -> Self {
+        self.checksum_strategy = input;
         self
     }
-    /// <p>Indicates the algorithm used to create the checksum for the object when you use the SDK. This header will not provide any additional functionality if you don't use the SDK. When you send this header, there must be a corresponding <code>x-amz-checksum-<i>algorithm</i> </code> or <code>x-amz-trailer</code> header sent. Otherwise, Amazon S3 fails the request with the HTTP status code <code>400 Bad Request</code>.</p>
-    /// <p>For the <code>x-amz-checksum-<i>algorithm</i> </code> header, replace <code> <i>algorithm</i> </code> with the supported algorithm from the following list:</p>
-    /// <ul>
-    /// <li>
-    /// <p>CRC32</p></li>
-    /// <li>
-    /// <p>CRC32C</p></li>
-    /// <li>
-    /// <p>SHA1</p></li>
-    /// <li>
-    /// <p>SHA256</p></li>
-    /// </ul>
-    /// <p>For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    /// <p>If the individual checksum value you provide through <code>x-amz-checksum-<i>algorithm</i> </code> doesn't match the checksum algorithm you set through <code>x-amz-sdk-checksum-algorithm</code>, Amazon S3 ignores any provided <code>ChecksumAlgorithm</code> parameter and uses the checksum algorithm that matches the provided value in <code>x-amz-checksum-<i>algorithm</i> </code>.</p><note>
-    /// <p>For directory buckets, when you use Amazon Web Services SDKs, <code>CRC32</code> is the default checksum algorithm that's used for performance.</p>
-    /// </note>
-    pub fn get_checksum_algorithm(&self) -> &Option<aws_sdk_s3::types::ChecksumAlgorithm> {
-        &self.checksum_algorithm
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32 checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_crc32(mut self, input: impl Into<String>) -> Self {
-        self.checksum_crc32 = Some(input.into());
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32 checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn set_checksum_crc32(mut self, input: Option<String>) -> Self {
-        self.checksum_crc32 = input;
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32 checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn get_checksum_crc32(&self) -> Option<&str> {
-        self.checksum_crc32.as_deref()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32C checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_crc32_c(mut self, input: impl Into<String>) -> Self {
-        self.checksum_crc32_c = Some(input.into());
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32C checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn set_checksum_crc32_c(mut self, input: Option<String>) -> Self {
-        self.checksum_crc32_c = input;
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 32-bit CRC32C checksum of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn get_checksum_crc32_c(&self) -> Option<&str> {
-        self.checksum_crc32_c.as_deref()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 160-bit SHA-1 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_sha1(mut self, input: impl Into<String>) -> Self {
-        self.checksum_sha1 = Some(input.into());
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 160-bit SHA-1 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn set_checksum_sha1(mut self, input: Option<String>) -> Self {
-        self.checksum_sha1 = input;
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 160-bit SHA-1 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn get_checksum_sha1(&self) -> Option<&str> {
-        self.checksum_sha1.as_deref()
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 256-bit SHA-256 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn checksum_sha256(mut self, input: impl Into<String>) -> Self {
-        self.checksum_sha256 = Some(input.into());
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 256-bit SHA-256 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn set_checksum_sha256(mut self, input: Option<String>) -> Self {
-        self.checksum_sha256 = input;
-        self
-    }
-    /// <p>This header can be used as a data integrity check to verify that the data received is the same data that was originally sent. This header specifies the base64-encoded, 256-bit SHA-256 digest of the object. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
-    pub fn get_checksum_sha256(&self) -> Option<&str> {
-        self.checksum_sha256.as_deref()
+    /// Strategy for calculating checksum values during upload.
+    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
+    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
+    ///
+    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
+    /// checksum algorithm or already know the checksum value.
+    ///
+    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
+    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
+    ///
+    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
+    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    pub fn get_checksum_strategy(&self) -> Option<&ChecksumStrategy> {
+        self.checksum_strategy.as_ref()
     }
     /// <p>The date and time at which the object is no longer cacheable. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc7234#section-5.3">https://www.rfc-editor.org/rfc/rfc7234#section-5.3</a>.</p>
     pub fn expires(mut self, input: ::aws_smithy_types::DateTime) -> Self {
@@ -1452,11 +1343,7 @@ impl UploadInputBuilder {
             content_length: self.content_length,
             content_md5: self.content_md5,
             content_type: self.content_type,
-            checksum_algorithm: self.checksum_algorithm,
-            checksum_crc32: self.checksum_crc32,
-            checksum_crc32_c: self.checksum_crc32_c,
-            checksum_sha1: self.checksum_sha1,
-            checksum_sha256: self.checksum_sha256,
+            checksum_strategy: self.checksum_strategy,
             expires: self.expires,
             grant_full_control: self.grant_full_control,
             grant_read: self.grant_read,
@@ -1497,11 +1384,7 @@ impl Debug for UploadInputBuilder {
         formatter.field("content_length", &self.content_length);
         formatter.field("content_md5", &self.content_md5);
         formatter.field("content_type", &self.content_type);
-        formatter.field("checksum_algorithm", &self.checksum_algorithm);
-        formatter.field("checksum_crc32", &self.checksum_crc32);
-        formatter.field("checksum_crc32_c", &self.checksum_crc32_c);
-        formatter.field("checksum_sha1", &self.checksum_sha1);
-        formatter.field("checksum_sha256", &self.checksum_sha256);
+        formatter.field("checksum_strategy", &self.checksum_strategy);
         formatter.field("expires", &self.expires);
         formatter.field("grant_full_control", &self.grant_full_control);
         formatter.field("grant_read", &self.grant_read);

--- a/aws-s3-transfer-manager/src/operation/upload/input.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/input.rs
@@ -52,18 +52,7 @@ pub struct UploadInput {
     pub content_md5: Option<String>,
     /// <p>A standard MIME type describing the format of the contents. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#name-content-type">https://www.rfc-editor.org/rfc/rfc9110.html#name-content-type</a>.</p>
     pub content_type: Option<String>,
-    /// Strategy for calculating checksum values during upload.
-    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
-    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
-    ///
-    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
-    /// checksum algorithm or already know the checksum value.
-    ///
-    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
-    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
-    ///
-    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
-    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    #[doc = std::include_str!("checksum_strategy.md")]
     pub checksum_strategy: Option<ChecksumStrategy>,
     /// <p>The date and time at which the object is no longer cacheable. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc7234#section-5.3">https://www.rfc-editor.org/rfc/rfc7234#section-5.3</a>.</p>
     pub expires: Option<::aws_smithy_types::DateTime>,
@@ -250,18 +239,7 @@ impl UploadInput {
     pub fn content_type(&self) -> Option<&str> {
         self.content_type.as_deref()
     }
-    /// Strategy for calculating checksum values during upload.
-    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
-    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
-    ///
-    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
-    /// checksum algorithm or already know the checksum value.
-    ///
-    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
-    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
-    ///
-    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
-    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    #[doc = std::include_str!("checksum_strategy.md")]
     pub fn checksum_strategy(&self) -> Option<&ChecksumStrategy> {
         self.checksum_strategy.as_ref()
     }
@@ -723,50 +701,17 @@ impl UploadInputBuilder {
     pub fn get_content_type(&self) -> Option<&str> {
         self.content_type.as_deref()
     }
-    /// Strategy for calculating checksum values during upload.
-    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
-    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
-    ///
-    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
-    /// checksum algorithm or already know the checksum value.
-    ///
-    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
-    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
-    ///
-    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
-    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    #[doc = std::include_str!("checksum_strategy.md")]
     pub fn checksum_strategy(mut self, input: ChecksumStrategy) -> Self {
         self.checksum_strategy = Some(input);
         self
     }
-    /// Strategy for calculating checksum values during upload.
-    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
-    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
-    ///
-    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
-    /// checksum algorithm or already know the checksum value.
-    ///
-    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
-    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
-    ///
-    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
-    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    #[doc = std::include_str!("checksum_strategy.md")]
     pub fn set_checksum_strategy(mut self, input: Option<ChecksumStrategy>) -> Self {
         self.checksum_strategy = input;
         self
     }
-    /// Strategy for calculating checksum values during upload.
-    /// These values are sent to S3 and used to verify the integrity of the uploaded data.
-    /// For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html>.
-    ///
-    /// You can set a specific [`ChecksumStrategy`], if you wish to choose the
-    /// checksum algorithm or already know the checksum value.
-    ///
-    /// <code>CRC64NVME</code> checksums are calculated by default (if no strategy is set and the underlying
-    /// S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
-    ///
-    /// To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
-    /// configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
+    #[doc = std::include_str!("checksum_strategy.md")]
     pub fn get_checksum_strategy(&self) -> Option<&ChecksumStrategy> {
         self.checksum_strategy.as_ref()
     }

--- a/aws-s3-transfer-manager/src/operation/upload/output.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/output.rs
@@ -28,11 +28,17 @@ pub struct UploadOutput {
     /// <p>The base64-encoded, 32-bit CRC32C checksum of the object. This will only be present if it was uploaded with the object. When you use an API operation on an object that was uploaded using multipart uploads, this value may not be a direct checksum value of the full object. Instead, it's a calculation based on the checksum values of each individual part. For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub checksum_crc32_c: Option<String>,
 
+    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. This header is present if the object was uploaded with the <code>CRC64NVME</code> checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, <code>CRC64NVME</code>, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub checksum_crc64_nvme: Option<String>,
+
     /// <p>The base64-encoded, 160-bit SHA-1 digest of the object. This will only be present if it was uploaded with the object. When you use the API operation on an object that was uploaded using multipart uploads, this value may not be a direct checksum value of the full object. Instead, it's a calculation based on the checksum values of each individual part. For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub checksum_sha1: Option<String>,
 
     /// <p>The base64-encoded, 256-bit SHA-256 digest of the object. This will only be present if it was uploaded with the object. When you use an API operation on an object that was uploaded using multipart uploads, this value may not be a direct checksum value of the full object. Instead, it's a calculation based on the checksum values of each individual part. For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub checksum_sha256: Option<String>,
+
+    /// <p>This header specifies the checksum type of the object, which determines how part-level checksums are combined to create an object-level checksum for multipart objects. For <code>PutObject</code> uploads, the checksum type is always <code>FULL_OBJECT</code>. You can use this header as a data integrity check to verify that the checksum type that is received is the same checksum that was specified. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub checksum_type: Option<aws_sdk_s3::types::ChecksumType>,
 
     /// <p>The server-side encryption algorithm used when you store this object in Amazon S3 (for example, <code>AES256</code>, <code>aws:kms</code>, <code>aws:kms:dsse</code>).</p><note>
     /// <p>For directory buckets, only server-side encryption with Amazon S3 managed keys (SSE-S3) (<code>AES256</code>) is supported.</p>
@@ -101,6 +107,10 @@ impl UploadOutput {
     pub fn checksum_crc32_c(&self) -> Option<&str> {
         self.checksum_crc32_c.as_deref()
     }
+    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. This header is present if the object was uploaded with the <code>CRC64NVME</code> checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, <code>CRC64NVME</code>, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub fn checksum_crc64_nvme(&self) -> Option<&str> {
+        self.checksum_crc64_nvme.as_deref()
+    }
     /// <p>The base64-encoded, 160-bit SHA-1 digest of the object. This will only be present if it was uploaded with the object. When you use the API operation on an object that was uploaded using multipart uploads, this value may not be a direct checksum value of the full object. Instead, it's a calculation based on the checksum values of each individual part. For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn checksum_sha1(&self) -> Option<&str> {
         self.checksum_sha1.as_deref()
@@ -108,6 +118,10 @@ impl UploadOutput {
     /// <p>The base64-encoded, 256-bit SHA-256 digest of the object. This will only be present if it was uploaded with the object. When you use an API operation on an object that was uploaded using multipart uploads, this value may not be a direct checksum value of the full object. Instead, it's a calculation based on the checksum values of each individual part. For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn checksum_sha256(&self) -> Option<&str> {
         self.checksum_sha256.as_deref()
+    }
+    /// <p>This header specifies the checksum type of the object, which determines how part-level checksums are combined to create an object-level checksum for multipart objects. For <code>PutObject</code> uploads, the checksum type is always <code>FULL_OBJECT</code>. You can use this header as a data integrity check to verify that the checksum type that is received is the same checksum that was specified. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub fn checksum_type(&self) -> Option<&aws_sdk_s3::types::ChecksumType> {
+        self.checksum_type.as_ref()
     }
     /// <p>The server-side encryption algorithm used when you store this object in Amazon S3 (for example, <code>AES256</code>, <code>aws:kms</code>, <code>aws:kms:dsse</code>).</p><note>
     /// <p>For directory buckets, only server-side encryption with Amazon S3 managed keys (SSE-S3) (<code>AES256</code>) is supported.</p>
@@ -173,8 +187,10 @@ impl Debug for UploadOutput {
         formatter.field("e_tag", &self.e_tag);
         formatter.field("checksum_crc32", &self.checksum_crc32);
         formatter.field("checksum_crc32_c", &self.checksum_crc32_c);
+        formatter.field("checksum_crc64_nvme", &self.checksum_crc64_nvme);
         formatter.field("checksum_sha1", &self.checksum_sha1);
         formatter.field("checksum_sha256", &self.checksum_sha256);
+        formatter.field("checksum_type", &self.checksum_type);
         formatter.field("server_side_encryption", &self.server_side_encryption);
         formatter.field("version_id", &self.version_id);
         formatter.field("sse_customer_algorithm", &self.sse_customer_algorithm);
@@ -199,8 +215,10 @@ pub struct UploadOutputBuilder {
     pub(crate) e_tag: Option<String>,
     pub(crate) checksum_crc32: Option<String>,
     pub(crate) checksum_crc32_c: Option<String>,
+    pub(crate) checksum_crc64_nvme: Option<String>,
     pub(crate) checksum_sha1: Option<String>,
     pub(crate) checksum_sha256: Option<String>,
+    pub(crate) checksum_type: Option<aws_sdk_s3::types::ChecksumType>,
     pub(crate) server_side_encryption: Option<aws_sdk_s3::types::ServerSideEncryption>,
     pub(crate) version_id: Option<String>,
     pub(crate) sse_customer_algorithm: Option<String>,
@@ -281,6 +299,20 @@ impl UploadOutputBuilder {
     pub fn get_checksum_crc32_c(&self) -> Option<&str> {
         self.checksum_crc32_c.as_deref()
     }
+    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. This header is present if the object was uploaded with the <code>CRC64NVME</code> checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, <code>CRC64NVME</code>, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub fn checksum_crc64_nvme(mut self, input: impl Into<String>) -> Self {
+        self.checksum_crc64_nvme = Some(input.into());
+        self
+    }
+    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. This header is present if the object was uploaded with the <code>CRC64NVME</code> checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, <code>CRC64NVME</code>, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub fn set_checksum_crc64_nvme(mut self, input: Option<String>) -> Self {
+        self.checksum_crc64_nvme = input;
+        self
+    }
+    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. This header is present if the object was uploaded with the <code>CRC64NVME</code> checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, <code>CRC64NVME</code>, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub fn get_checksum_crc64_nvme(&self) -> Option<&str> {
+        self.checksum_crc64_nvme.as_deref()
+    }
     /// <p>The base64-encoded, 160-bit SHA-1 digest of the object. This will only be present if it was uploaded with the object. When you use the API operation on an object that was uploaded using multipart uploads, this value may not be a direct checksum value of the full object. Instead, it's a calculation based on the checksum values of each individual part. For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn checksum_sha1(mut self, input: impl Into<String>) -> Self {
         self.checksum_sha1 = Some(input.into());
@@ -308,6 +340,20 @@ impl UploadOutputBuilder {
     /// <p>The base64-encoded, 256-bit SHA-256 digest of the object. This will only be present if it was uploaded with the object. When you use an API operation on an object that was uploaded using multipart uploads, this value may not be a direct checksum value of the full object. Instead, it's a calculation based on the checksum values of each individual part. For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn get_checksum_sha256(&self) -> Option<&str> {
         self.checksum_sha256.as_deref()
+    }
+    /// <p>This header specifies the checksum type of the object, which determines how part-level checksums are combined to create an object-level checksum for multipart objects. For <code>PutObject</code> uploads, the checksum type is always <code>FULL_OBJECT</code>. You can use this header as a data integrity check to verify that the checksum type that is received is the same checksum that was specified. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub fn checksum_type(mut self, input: aws_sdk_s3::types::ChecksumType) -> Self {
+        self.checksum_type = Some(input);
+        self
+    }
+    /// <p>This header specifies the checksum type of the object, which determines how part-level checksums are combined to create an object-level checksum for multipart objects. For <code>PutObject</code> uploads, the checksum type is always <code>FULL_OBJECT</code>. You can use this header as a data integrity check to verify that the checksum type that is received is the same checksum that was specified. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub fn set_checksum_type(mut self, input: Option<aws_sdk_s3::types::ChecksumType>) -> Self {
+        self.checksum_type = input;
+        self
+    }
+    /// <p>This header specifies the checksum type of the object, which determines how part-level checksums are combined to create an object-level checksum for multipart objects. For <code>PutObject</code> uploads, the checksum type is always <code>FULL_OBJECT</code>. You can use this header as a data integrity check to verify that the checksum type that is received is the same checksum that was specified. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    pub fn get_checksum_type(&self) -> &Option<aws_sdk_s3::types::ChecksumType> {
+        &self.checksum_type
     }
     /// <p>The server-side encryption algorithm used when you store this object in Amazon S3 (for example, <code>AES256</code>, <code>aws:kms</code>, <code>aws:kms:dsse</code>).</p><note>
     /// <p>For directory buckets, only server-side encryption with Amazon S3 managed keys (SSE-S3) (<code>AES256</code>) is supported.</p>
@@ -501,8 +547,10 @@ impl UploadOutputBuilder {
             e_tag: self.e_tag,
             checksum_crc32: self.checksum_crc32,
             checksum_crc32_c: self.checksum_crc32_c,
+            checksum_crc64_nvme: self.checksum_crc64_nvme,
             checksum_sha1: self.checksum_sha1,
             checksum_sha256: self.checksum_sha256,
+            checksum_type: self.checksum_type,
             server_side_encryption: self.server_side_encryption,
             version_id: self.version_id,
             sse_customer_algorithm: self.sse_customer_algorithm,
@@ -527,12 +575,14 @@ impl From<PutObjectOutput> for UploadOutputBuilder {
             sse_kms_encryption_context: value.ssekms_encryption_context,
             bucket_key_enabled: value.bucket_key_enabled,
             request_charged: value.request_charged,
-            checksum_sha256: value.checksum_sha256,
             expiration: value.expiration,
             e_tag: value.e_tag,
             checksum_crc32: value.checksum_crc32,
             checksum_crc32_c: value.checksum_crc32_c,
+            checksum_crc64_nvme: value.checksum_crc64_nvme,
             checksum_sha1: value.checksum_sha1,
+            checksum_sha256: value.checksum_sha256,
+            checksum_type: value.checksum_type,
             version_id: value.version_id,
         }
     }
@@ -545,8 +595,10 @@ impl Debug for UploadOutputBuilder {
         formatter.field("e_tag", &self.e_tag);
         formatter.field("checksum_crc32", &self.checksum_crc32);
         formatter.field("checksum_crc32_c", &self.checksum_crc32_c);
+        formatter.field("checksum_crc64_nvme", &self.checksum_crc64_nvme);
         formatter.field("checksum_sha1", &self.checksum_sha1);
         formatter.field("checksum_sha256", &self.checksum_sha256);
+        formatter.field("checksum_type", &self.checksum_type);
         formatter.field("server_side_encryption", &self.server_side_encryption);
         formatter.field("version_id", &self.version_id);
         formatter.field("sse_customer_algorithm", &self.sse_customer_algorithm);
@@ -574,13 +626,15 @@ impl From<CreateMultipartUploadOutput> for UploadOutputBuilder {
             sse_kms_encryption_context: value.ssekms_encryption_context,
             bucket_key_enabled: value.bucket_key_enabled,
             request_charged: value.request_charged,
-            // remaining fields not available from CreateMultipartUploadOutput
-            checksum_sha256: None,
+            checksum_type: value.checksum_type,
+            // remaining fields will be set later, from CompleteMultipartUploadOutput
             expiration: None,
             e_tag: None,
             checksum_crc32: None,
             checksum_crc32_c: None,
+            checksum_crc64_nvme: None,
             checksum_sha1: None,
+            checksum_sha256: None,
             version_id: None,
             // TODO(aws-sdk-rust#1159): abort_rule_id and abort_date seem unique to CreateMultipartUploadOutput
         }

--- a/aws-s3-transfer-manager/src/operation/upload/output.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/output.rs
@@ -28,7 +28,7 @@ pub struct UploadOutput {
     /// <p>The base64-encoded, 32-bit CRC32C checksum of the object. This will only be present if it was uploaded with the object. When you use an API operation on an object that was uploaded using multipart uploads, this value may not be a direct checksum value of the full object. Instead, it's a calculation based on the checksum values of each individual part. For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub checksum_crc32_c: Option<String>,
 
-    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. This header is present if the object was uploaded with the <code>CRC64NVME</code> checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, <code>CRC64NVME</code>, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    /// <p>The Base64 encoded, 64-bit CRC64NVME checksum of the object. This header is present if the object was uploaded with the CRC64NVME checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, CRC64NVME, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
     pub checksum_crc64_nvme: Option<String>,
 
     /// <p>The base64-encoded, 160-bit SHA-1 digest of the object. This will only be present if it was uploaded with the object. When you use the API operation on an object that was uploaded using multipart uploads, this value may not be a direct checksum value of the full object. Instead, it's a calculation based on the checksum values of each individual part. For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html#large-object-checksums"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>
@@ -107,7 +107,7 @@ impl UploadOutput {
     pub fn checksum_crc32_c(&self) -> Option<&str> {
         self.checksum_crc32_c.as_deref()
     }
-    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. This header is present if the object was uploaded with the <code>CRC64NVME</code> checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, <code>CRC64NVME</code>, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    /// <p>The Base64 encoded, 64-bit CRC64NVME checksum of the object. This header is present if the object was uploaded with the CRC64NVME checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, CRC64NVME, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
     pub fn checksum_crc64_nvme(&self) -> Option<&str> {
         self.checksum_crc64_nvme.as_deref()
     }
@@ -299,17 +299,17 @@ impl UploadOutputBuilder {
     pub fn get_checksum_crc32_c(&self) -> Option<&str> {
         self.checksum_crc32_c.as_deref()
     }
-    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. This header is present if the object was uploaded with the <code>CRC64NVME</code> checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, <code>CRC64NVME</code>, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    /// <p>The Base64 encoded, 64-bit CRC64NVME checksum of the object. This header is present if the object was uploaded with the CRC64NVME checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, CRC64NVME, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
     pub fn checksum_crc64_nvme(mut self, input: impl Into<String>) -> Self {
         self.checksum_crc64_nvme = Some(input.into());
         self
     }
-    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. This header is present if the object was uploaded with the <code>CRC64NVME</code> checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, <code>CRC64NVME</code>, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    /// <p>The Base64 encoded, 64-bit CRC64NVME checksum of the object. This header is present if the object was uploaded with the CRC64NVME checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, CRC64NVME, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
     pub fn set_checksum_crc64_nvme(mut self, input: Option<String>) -> Self {
         self.checksum_crc64_nvme = input;
         self
     }
-    /// <p>The Base64 encoded, 64-bit <code>CRC64NVME</code> checksum of the object. This header is present if the object was uploaded with the <code>CRC64NVME</code> checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, <code>CRC64NVME</code>, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
+    /// <p>The Base64 encoded, 64-bit CRC64NVME checksum of the object. This header is present if the object was uploaded with the CRC64NVME checksum algorithm, or if it was uploaded without a checksum (and Amazon S3 added the default checksum, CRC64NVME, to the uploaded object). For more information about how checksums are calculated with multipart uploads, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html">Checking object integrity in the Amazon S3 User Guide</a>.</p>
     pub fn get_checksum_crc64_nvme(&self) -> Option<&str> {
         self.checksum_crc64_nvme.as_deref()
     }

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -50,7 +50,7 @@ async fn upload_part_handler(request: UploadPartRequest) -> Result<CompletedPart
         // TODO(aws-s3-transfer-manager-rs#3): allow user to pass per-part checksum values via PartStream
 
         // Set checksum algorithm, which tells SDK to calculate and add checksum value
-        req = req.checksum_algorithm(checksum_strategy.algorithm.clone());
+        req = req.checksum_algorithm(checksum_strategy.algorithm().clone());
     }
 
     let resp = req

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -31,8 +31,7 @@ async fn upload_part_handler(request: UploadPartRequest) -> Result<CompletedPart
     let part_data = request.part_data;
     let part_number = part_data.part_number as i32;
 
-    // TODO(aws-sdk-rust#1159): set checksum fields if applicable
-    let resp = ctx
+    let mut req = ctx
         .client()
         .upload_part()
         .set_bucket(ctx.request.bucket.clone())
@@ -45,7 +44,16 @@ async fn upload_part_handler(request: UploadPartRequest) -> Result<CompletedPart
         .set_sse_customer_key(ctx.request.sse_customer_key.clone())
         .set_sse_customer_key_md5(ctx.request.sse_customer_key_md5.clone())
         .set_request_payer(ctx.request.request_payer.clone())
-        .set_expected_bucket_owner(ctx.request.expected_bucket_owner.clone())
+        .set_expected_bucket_owner(ctx.request.expected_bucket_owner.clone());
+
+    if let Some(checksum_strategy) = &ctx.request.checksum_strategy {
+        // TODO(aws-s3-transfer-manager-rs#3): allow user to pass per-part checksum values via PartStream
+
+        // Set checksum algorithm, which tells SDK to calculate and add checksum value
+        req = req.checksum_algorithm(checksum_strategy.algorithm.clone());
+    }
+
+    let resp = req
         .customize()
         .disable_payload_signing()
         .send()
@@ -58,6 +66,7 @@ async fn upload_part_handler(request: UploadPartRequest) -> Result<CompletedPart
         .set_e_tag(resp.e_tag.clone())
         .set_checksum_crc32(resp.checksum_crc32.clone())
         .set_checksum_crc32_c(resp.checksum_crc32_c.clone())
+        .set_checksum_crc64_nvme(resp.checksum_crc64_nvme.clone())
         .set_checksum_sha1(resp.checksum_sha1.clone())
         .set_checksum_sha256(resp.checksum_sha256.clone())
         .build();

--- a/aws-s3-transfer-manager/tests/download_test.rs
+++ b/aws-s3-transfer-manager/tests/download_test.rs
@@ -6,6 +6,7 @@
 use aws_config::Region;
 use aws_s3_transfer_manager::{
     error::{BoxError, Error},
+    metrics::unit::ByteUnit,
     operation::download::DownloadHandle,
     types::{ConcurrencySetting, PartSize},
 };
@@ -23,8 +24,6 @@ use bytes::{BufMut, Bytes, BytesMut};
 /// NOTE: these tests are somewhat brittle as they assume particular paths through the codebase.
 /// As an example we generally assume object discovery goes through `GetObject` with a ranged get
 /// for the first part.
-
-const MEBIBYTE: usize = 1024 * 1024;
 
 fn rand_data(size: usize) -> Bytes {
     iter::repeat_with(fastrand::alphanumeric)
@@ -130,8 +129,8 @@ fn test_tm(http_client: StaticReplayClient, part_size: usize) -> aws_s3_transfer
 /// Test the object ranges are expected and we get all the data
 #[tokio::test]
 async fn test_download_ranges() {
-    let data = rand_data(12 * MEBIBYTE);
-    let part_size = 5 * MEBIBYTE;
+    let data = rand_data(12 * ByteUnit::Mebibyte.as_bytes_usize());
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
 
     let (tm, http_client) = simple_test_tm(&data, part_size);
 
@@ -162,8 +161,8 @@ async fn test_download_ranges() {
 /// Test body not consumed which should not prevent the handle from being dropped
 #[tokio::test]
 async fn test_body_not_consumed() {
-    let data = rand_data(12 * MEBIBYTE);
-    let part_size = 5 * MEBIBYTE;
+    let data = rand_data(12 * ByteUnit::Mebibyte.as_bytes_usize());
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
 
     let (tm, _) = simple_test_tm(&data, part_size);
 
@@ -179,8 +178,8 @@ async fn test_body_not_consumed() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_abort_download() {
-    let data = rand_data(25 * MEBIBYTE);
-    let part_size = MEBIBYTE;
+    let data = rand_data(25 * ByteUnit::Mebibyte.as_bytes_usize());
+    let part_size = ByteUnit::Mebibyte.as_bytes_usize();
 
     let (tm, http_client) = simple_test_tm(&data, part_size);
 
@@ -244,9 +243,9 @@ impl http_body_1x::Body for FailingBody {
 /// Test chunk/part failure is retried
 #[tokio::test]
 async fn test_retry_failed_chunk() {
-    let data = rand_data(12 * MEBIBYTE);
-    let part_size = 8 * MEBIBYTE;
-    let frame_size = 16 * 1024;
+    let data = rand_data(12 * ByteUnit::Mebibyte.as_bytes_usize());
+    let part_size = 8 * ByteUnit::Mebibyte.as_bytes_usize();
+    let frame_size = 16 * ByteUnit::Kibibyte.as_bytes_usize();
     let fail_after_byte = frame_size * 4;
 
     let http_client = StaticReplayClient::new(vec![
@@ -322,8 +321,8 @@ const ERROR_RESPONSE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 /// Test non retryable SdkError
 #[tokio::test]
 async fn test_non_retryable_error() {
-    let data = rand_data(20 * MEBIBYTE);
-    let part_size = 8 * MEBIBYTE;
+    let data = rand_data(20 * ByteUnit::Mebibyte.as_bytes_usize());
+    let part_size = 8 * ByteUnit::Mebibyte.as_bytes_usize();
 
     let http_client = StaticReplayClient::new(vec![
         ReplayEvent::new(
@@ -366,8 +365,8 @@ async fn test_non_retryable_error() {
 /// Test max attempts exhausted reading a stream
 #[tokio::test]
 async fn test_retry_max_attempts() {
-    let data = rand_data(12 * MEBIBYTE);
-    let part_size = 8 * MEBIBYTE;
+    let data = rand_data(12 * ByteUnit::Mebibyte.as_bytes_usize());
+    let part_size = 8 * ByteUnit::Mebibyte.as_bytes_usize();
     let frame_size = 16 * 1024;
     let fail_after_byte = frame_size * 4;
 
@@ -425,8 +424,8 @@ async fn test_retry_max_attempts() {
 /// Test the if_match header was added correctly based on the response from server.
 #[tokio::test]
 async fn test_download_if_match() {
-    let data = rand_data(12 * MEBIBYTE);
-    let part_size = 5 * MEBIBYTE;
+    let data = rand_data(12 * ByteUnit::Mebibyte.as_bytes_usize());
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
 
     let (tm, http_client) = simple_test_tm(&data, part_size);
 
@@ -460,8 +459,8 @@ const OBJECT_MODIFIED_RESPONSE: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 /// Test that if the object modified during download.
 #[tokio::test]
 async fn test_download_object_modified() {
-    let data = rand_data(12 * MEBIBYTE);
-    let part_size = 5 * MEBIBYTE;
+    let data = rand_data(12 * ByteUnit::Mebibyte.as_bytes_usize());
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
 
     // Create a static replay client (http connector) to mock the S3 response when object modified during download.
     //

--- a/aws-s3-transfer-manager/tests/download_test.rs
+++ b/aws-s3-transfer-manager/tests/download_test.rs
@@ -21,9 +21,9 @@ use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClien
 use aws_smithy_types::body::SdkBody;
 use bytes::{BufMut, Bytes, BytesMut};
 
-/// NOTE: these tests are somewhat brittle as they assume particular paths through the codebase.
-/// As an example we generally assume object discovery goes through `GetObject` with a ranged get
-/// for the first part.
+// NOTE: these tests are somewhat brittle as they assume particular paths through the codebase.
+// As an example we generally assume object discovery goes through `GetObject` with a ranged get
+// for the first part.
 
 fn rand_data(size: usize) -> Bytes {
     iter::repeat_with(fastrand::alphanumeric)

--- a/aws-s3-transfer-manager/tests/upload_checksum_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_checksum_test.rs
@@ -138,7 +138,7 @@ pin_project! {
 impl TestStream {
     pub fn new(parts: Vec<Bytes>) -> Self {
         TestStream {
-            parts: parts,
+            parts,
             next_part_num: 1,
         }
     }
@@ -347,8 +347,8 @@ fn mock_s3_client_for_put_object(
     let mut mock_client_rules: Vec<Rule> = Vec::new();
 
     // Pre-calculate stuff for later
-    let checksum_value = calculate_checksum(&response_algorithm, &expected_body);
-    let etag = calculate_etag(&expected_body);
+    let checksum_value = calculate_checksum(&response_algorithm, expected_body);
+    let etag = calculate_etag(expected_body);
 
     // PutObject
     mock_client_rules.push(
@@ -477,7 +477,7 @@ async fn upload_helper(
         s3_client
             .config()
             .to_builder()
-            .request_checksum_calculation(sdk_checksum_calculation.clone())
+            .request_checksum_calculation(sdk_checksum_calculation)
             .build(),
     );
 

--- a/aws-s3-transfer-manager/tests/upload_checksum_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_checksum_test.rs
@@ -7,6 +7,7 @@ use std::{str::FromStr, task::Poll};
 
 use aws_s3_transfer_manager::{
     io::{InputStream, PartData, PartStream, SizeHint},
+    metrics::unit::ByteUnit,
     operation::upload::{ChecksumStrategy, UploadOutput},
     types::{ConcurrencySetting, PartSize},
 };
@@ -24,8 +25,7 @@ use bytes::Bytes;
 use pin_project_lite::pin_project;
 use test_common::mock_client_with_stubbed_http_client;
 
-const MEBIBYTE: usize = 1024 * 1024;
-const PART_SIZE: usize = 5 * MEBIBYTE;
+const PART_SIZE: usize = 5 * ByteUnit::Mebibyte.as_bytes_usize();
 
 fn calculate_checksum(algorithm: &ChecksumAlgorithm, data: &[u8]) -> String {
     let smithy_algorithm =

--- a/aws-s3-transfer-manager/tests/upload_checksum_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_checksum_test.rs
@@ -1,0 +1,829 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::{str::FromStr, task::Poll};
+
+use aws_s3_transfer_manager::{
+    io::{InputStream, PartData, PartStream, SizeHint},
+    operation::upload::{ChecksumStrategy, UploadOutput},
+    types::{ConcurrencySetting, PartSize},
+};
+use aws_sdk_s3::{
+    operation::{
+        complete_multipart_upload::CompleteMultipartUploadOutput,
+        create_multipart_upload::CreateMultipartUploadOutput, put_object::PutObjectOutput,
+        upload_part::UploadPartOutput,
+    },
+    types::{ChecksumAlgorithm, ChecksumType},
+};
+use aws_smithy_mocks_experimental::{mock, Rule, RuleMode};
+use aws_smithy_runtime::test_util::capture_test_logs::capture_test_logs;
+use bytes::Bytes;
+use pin_project_lite::pin_project;
+use test_common::mock_client_with_stubbed_http_client;
+
+const MEBIBYTE: usize = 1024 * 1024;
+const PART_SIZE: usize = 5 * MEBIBYTE;
+
+fn calculate_checksum(algorithm: &ChecksumAlgorithm, data: &[u8]) -> String {
+    let smithy_algorithm =
+        aws_smithy_checksums::ChecksumAlgorithm::from_str(algorithm.as_str()).unwrap();
+    let mut http_checksum = smithy_algorithm.into_impl();
+    http_checksum.update(data);
+    http_checksum.header_value().to_str().unwrap().to_string()
+}
+
+fn calculate_full_object_checksum(algorithm: &ChecksumAlgorithm, parts: &Vec<Bytes>) -> String {
+    // S3 doesn't allow SHA algorithms to do full-object checksums with multipart upload
+    assert_ne!(algorithm, &ChecksumAlgorithm::Sha1);
+    assert_ne!(algorithm, &ChecksumAlgorithm::Sha256);
+
+    let smithy_algorithm =
+        aws_smithy_checksums::ChecksumAlgorithm::from_str(algorithm.as_str()).unwrap();
+    let mut http_checksum = smithy_algorithm.into_impl();
+    for part in parts {
+        http_checksum.update(part.as_ref());
+    }
+    http_checksum.header_value().to_str().unwrap().to_string()
+}
+
+fn calculate_composite_checksum(algorithm: &ChecksumAlgorithm, parts: &Vec<Bytes>) -> String {
+    // S3 doesn't allow CRC64NVME to do composite checksums
+    assert_ne!(algorithm, &ChecksumAlgorithm::Crc64Nvme);
+
+    let mut concatenated_part_checksums = String::new();
+    for part in parts {
+        let checksum = calculate_checksum(algorithm, part.as_ref());
+        concatenated_part_checksums.push_str(&checksum);
+    }
+
+    let composite_checksum = calculate_checksum(algorithm, concatenated_part_checksums.as_bytes());
+    let count = parts.len();
+    format!("{composite_checksum}-{count}")
+}
+
+/// Calculate final Composite or FullObject checksum for multipart upload
+fn calculate_multipart_checksum(
+    algorithm: &ChecksumAlgorithm,
+    checksum_type: &ChecksumType,
+    parts: &Vec<Bytes>,
+) -> String {
+    match checksum_type {
+        ChecksumType::Composite => calculate_composite_checksum(algorithm, parts),
+        ChecksumType::FullObject => calculate_full_object_checksum(algorithm, parts),
+        _ => panic!("unrecognized checksum type"),
+    }
+}
+
+/// Calculate ETag as it appears in S3 headers, with the extra quotes and everything
+fn calculate_etag(data: &[u8]) -> String {
+    let digest = md5::compute(data);
+    format!("\"{digest:x}\"")
+}
+
+/// Get checksum algorithm and value from types like PutObjectInput,
+/// that have a field per algorithm (checksum_crc32, checksum_crc64_nvme, etc)
+/// Returns Optional<(ChecksumAlgorithm, String)>
+#[macro_export]
+macro_rules! get_checksum_value {
+    ($shape:expr) => {{
+        let algorithms_and_optional_values = [
+            (ChecksumAlgorithm::Crc32, $shape.checksum_crc32()),
+            (ChecksumAlgorithm::Crc32C, $shape.checksum_crc32_c()),
+            (ChecksumAlgorithm::Crc64Nvme, $shape.checksum_crc64_nvme()),
+            (ChecksumAlgorithm::Sha1, $shape.checksum_sha1()),
+            (ChecksumAlgorithm::Sha256, $shape.checksum_sha256()),
+        ];
+
+        let mut found: Option<(ChecksumAlgorithm, String)> = None;
+        for (algorithm, optional_value) in algorithms_and_optional_values {
+            if let Some(value) = optional_value {
+                if found.is_some() {
+                    panic!("Multiple checksums are set, but only one is allowed.")
+                }
+                found = Some((algorithm, value.to_string()));
+            }
+        }
+
+        found
+    }};
+}
+
+/// Set checksum value on types like PutObjectFluentBuilder,
+/// that have a field per algorithm (checksum_crc32, checksum_crc64_nvme, etc).
+#[macro_export]
+macro_rules! set_checksum_value {
+    ($builder:expr, $algorithm:expr, $value:expr) => {
+        match $algorithm {
+            ChecksumAlgorithm::Crc32 => $builder.checksum_crc32($value),
+            ChecksumAlgorithm::Crc32C => $builder.checksum_crc32_c($value),
+            ChecksumAlgorithm::Crc64Nvme => $builder.checksum_crc64_nvme($value),
+            ChecksumAlgorithm::Sha1 => $builder.checksum_sha1($value),
+            ChecksumAlgorithm::Sha256 => $builder.checksum_sha256($value),
+            _ => panic!("unknown algorithm"),
+        }
+    };
+}
+
+pin_project! {
+    #[derive(Debug)]
+    struct TestStream {
+        pub parts: Vec<Bytes>,
+        next_part_num: u64,
+    }
+}
+
+impl TestStream {
+    pub fn new(parts: Vec<Bytes>) -> Self {
+        TestStream {
+            parts: parts,
+            next_part_num: 1,
+        }
+    }
+}
+
+impl PartStream for TestStream {
+    fn poll_part(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        _stream_cx: &aws_s3_transfer_manager::io::StreamContext,
+    ) -> Poll<Option<std::io::Result<PartData>>> {
+        let this = self.project();
+        let part_index = *this.next_part_num as usize - 1;
+        let part = this.parts.get(part_index).map(|b| {
+            let part_number = *this.next_part_num;
+            *this.next_part_num += 1;
+            Ok(PartData::new(part_number, b.clone()))
+        });
+        Poll::Ready(part)
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::exact(self.parts.iter().map(|b| b.len() as u64).sum())
+    }
+}
+
+fn mock_s3_client_for_multipart_upload(
+    request_strategy: Option<ChecksumStrategy>,
+    response_algorithm: ChecksumAlgorithm,
+    response_checksum_type: ChecksumType,
+    expected_parts: &Vec<Bytes>,
+) -> aws_sdk_s3::Client {
+    let mut mock_client_rules: Vec<Rule> = Vec::new();
+
+    // Pre-calculate stuff for later
+    let upload_id = "test-upload-id".to_string();
+    let part_checksums: Vec<String> = expected_parts
+        .iter()
+        .map(|part| calculate_checksum(&response_algorithm, part))
+        .collect();
+
+    let part_etags: Vec<String> = expected_parts
+        .iter()
+        .map(|part| calculate_etag(part))
+        .collect();
+
+    let multipart_checksum =
+        calculate_multipart_checksum(&response_algorithm, &response_checksum_type, expected_parts);
+
+    // CreateMultipartUpload
+    mock_client_rules.push(
+        mock!(aws_sdk_s3::Client::create_multipart_upload)
+            .match_requests({
+                let request_strategy = request_strategy.clone();
+                move |input| {
+                    // checksum algorithm and type should only be specified if a strategy is being used
+                    assert_eq!(
+                        input.checksum_algorithm(),
+                        request_strategy.as_ref().map(|s| &s.algorithm)
+                    );
+                    assert_eq!(
+                        input.checksum_type(),
+                        request_strategy.as_ref().map(|s| &s.type_if_multipart)
+                    );
+                    true
+                }
+            })
+            .then_output({
+                let upload_id = upload_id.clone();
+                let response_algorithm = response_algorithm.clone();
+                let response_checksum_type = response_checksum_type.clone();
+                move || {
+                    CreateMultipartUploadOutput::builder()
+                        .upload_id(&upload_id)
+                        .checksum_algorithm(response_algorithm.clone())
+                        .checksum_type(response_checksum_type.clone())
+                        .build()
+                }
+            }),
+    );
+
+    // N UploadPart rules
+    for part_i in 0..expected_parts.len() {
+        mock_client_rules.push(
+            mock!(aws_sdk_s3::Client::upload_part)
+                .match_requests({
+                    let upload_id = upload_id.clone();
+                    let request_strategy = request_strategy.clone();
+                    let part_checksum = part_checksums[part_i].clone();
+                    let part_number = part_i as i32 + 1;
+                    move |input| {
+                        assert_eq!(input.upload_id(), Some(upload_id.as_str()));
+                        assert_eq!(input.part_number(), Some(part_number));
+
+                        if let Some(request_strategy) = &request_strategy {
+                            // Transfer Manager is doing checksums.
+                            // If it doesn't know the part's actual checksum value, it should set the algorithm.
+                            if let Some((field_algorithm, field_value)) = get_checksum_value!(input)
+                            {
+                                assert_eq!(field_algorithm, request_strategy.algorithm);
+                                assert_eq!(field_value, part_checksum);
+                                // doesn't matter if algorithm is set too, but if it is, it should be correct
+                                if let Some(input_algorithm) = input.checksum_algorithm() {
+                                    assert_eq!(input_algorithm, &request_strategy.algorithm);
+                                }
+                            } else {
+                                assert_eq!(
+                                    input.checksum_algorithm(),
+                                    Some(&request_strategy.algorithm)
+                                );
+                            }
+                        } else {
+                            // Transfer Manager is not doing checksums
+                            assert_eq!(input.checksum_algorithm(), None);
+                            assert!(get_checksum_value!(input).is_none());
+                        }
+                        true
+                    }
+                })
+                .then_output({
+                    let response_algorithm = response_algorithm.clone();
+                    let part_checksum = part_checksums[part_i].clone();
+                    let part_etag = part_etags[part_i].clone();
+                    move || {
+                        let mut resp = UploadPartOutput::builder().e_tag(&part_etag);
+                        // As of 2025, S3 always sends checksums in UploadPart responses
+                        resp = set_checksum_value!(resp, response_algorithm, &part_checksum);
+                        resp.build()
+                    }
+                }),
+        );
+    }
+
+    // CompleteMultipartUpload
+    mock_client_rules.push(
+        mock!(aws_sdk_s3::Client::complete_multipart_upload)
+            .match_requests({
+                let upload_id = upload_id.clone();
+                let request_strategy = request_strategy.clone();
+                let response_algorithm = response_algorithm.clone();
+                let part_checksums = part_checksums.clone();
+                let part_etags = part_etags.clone();
+                move |input| {
+                    assert_eq!(input.upload_id(), Some(upload_id.as_str()));
+
+                    // If strategy provided full-object checksum, that value should be on the CompleteMultipartUpload
+                    let input_checksum_field = get_checksum_value!(input);
+                    match &request_strategy {
+                        None => assert!(input_checksum_field.is_none()),
+
+                        Some(request_strategy) => match &request_strategy.full_object_checksum {
+                            None => assert!(input_checksum_field.is_none()),
+
+                            Some(full_object_checksum) => {
+                                let (field_algorithm, field_value) = input_checksum_field.unwrap();
+                                assert_eq!(field_algorithm, request_strategy.algorithm);
+                                assert_eq!(&field_value, full_object_checksum);
+                            }
+                        },
+                    }
+
+                    // The multipart_upload struct should include info about each part
+                    let input_parts = input.multipart_upload().unwrap().parts();
+                    assert_eq!(input_parts.len(), part_checksums.len());
+                    for input_part in input_parts {
+                        let part_i =
+                            usize::try_from(input_part.part_number().unwrap() - 1).unwrap();
+                        assert_eq!(input_part.e_tag(), Some(part_etags[part_i].as_str()));
+
+                        // As of 2025, S3 always sends a checksum in UploadPart responses,
+                        // ensure these checksums are reported in CompleteMultipartUpload.
+                        // (Technically, it would be OK to omit the part checksums in a few situations,
+                        // they only seem to be required for composite checksums,
+                        // but it never hurts to include them, so do it for simplicity's sake)
+                        let (input_part_algorithm, input_part_checksum) =
+                            get_checksum_value!(input_part).unwrap();
+                        assert_eq!(input_part_checksum, part_checksums[part_i]);
+                        assert_eq!(input_part_algorithm, response_algorithm);
+                    }
+
+                    true
+                }
+            })
+            .then_output({
+                let response_algorithm = response_algorithm.clone();
+                let response_checksum_type = response_checksum_type.clone();
+                let multipart_checksum = multipart_checksum.clone();
+                move || {
+                    // As of 2025, S3 always sends a checksum in CompleteMultipartUpload response
+                    let mut req = CompleteMultipartUploadOutput::builder()
+                        .checksum_type(response_checksum_type.clone());
+                    req = set_checksum_value!(req, &response_algorithm, &multipart_checksum);
+                    req.build()
+                }
+            }),
+    );
+
+    mock_client_with_stubbed_http_client!(aws_sdk_s3, RuleMode::Sequential, &mock_client_rules)
+}
+
+fn mock_s3_client_for_put_object(
+    request_strategy: Option<ChecksumStrategy>,
+    response_algorithm: ChecksumAlgorithm,
+    expected_body: &Bytes,
+) -> aws_sdk_s3::Client {
+    let mut mock_client_rules: Vec<Rule> = Vec::new();
+
+    // Pre-calculate stuff for later
+    let checksum_value = calculate_checksum(&response_algorithm, &expected_body);
+    let etag = calculate_etag(&expected_body);
+
+    // PutObject
+    mock_client_rules.push(
+        mock!(aws_sdk_s3::Client::put_object)
+            .match_requests({
+                let request_strategy = request_strategy.clone();
+                move |input| {
+                    if let Some(request_strategy) = &request_strategy {
+                        // Transfer Manager is doing checksums.
+                        if let Some(provided_checksum) = &request_strategy.full_object_checksum {
+                            // Full-object checksum provided up front. Assert it was used
+                            let (input_checksum_algorithm, input_checksum_value) =
+                                get_checksum_value!(input).unwrap();
+                            assert_eq!(input_checksum_algorithm, request_strategy.algorithm);
+                            assert_eq!(&input_checksum_value, provided_checksum);
+                        } else {
+                            // Transfer Manager should set algorithm, so SDK will calculate actual checksum value
+                            assert_eq!(
+                                input.checksum_algorithm(),
+                                Some(&request_strategy.algorithm)
+                            );
+                        }
+                    } else {
+                        // Transfer Manager is not doing checksums
+                        assert!(get_checksum_value!(input).is_none());
+                        assert_eq!(input.checksum_algorithm(), None);
+                    }
+
+                    true
+                }
+            })
+            .then_output({
+                let response_algorithm = response_algorithm.clone();
+                let checksum_value = checksum_value.clone();
+                let etag = etag.clone();
+                move || {
+                    // As of 2025, S3 always sends checksums in PutObject responses
+                    let mut resp = PutObjectOutput::builder()
+                        .e_tag(&etag)
+                        .checksum_type(ChecksumType::FullObject);
+                    resp = set_checksum_value!(resp, response_algorithm, &checksum_value);
+
+                    resp.build()
+                }
+            }),
+    );
+
+    mock_client_with_stubbed_http_client!(aws_sdk_s3, RuleMode::Sequential, &mock_client_rules)
+}
+
+async fn test_mpu(
+    user_checksum_strategy: Option<ChecksumStrategy>,
+    parts: Vec<Bytes>,
+) -> UploadOutput {
+    upload_helper(
+        user_checksum_strategy,
+        parts,
+        true,
+        aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported,
+    )
+    .await
+}
+
+async fn test_put_object(
+    user_checksum_strategy: Option<ChecksumStrategy>,
+    body: Bytes,
+) -> UploadOutput {
+    upload_helper(
+        user_checksum_strategy,
+        vec![body],
+        false,
+        aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported,
+    )
+    .await
+}
+
+async fn upload_helper(
+    user_checksum_strategy: Option<ChecksumStrategy>,
+    parts: Vec<Bytes>,
+    send_as_multipart: bool,
+    sdk_checksum_calculation: aws_sdk_s3::config::RequestChecksumCalculation,
+) -> UploadOutput {
+    let (_guard, _rx) = capture_test_logs();
+
+    // This is the ChecksumStrategy we expect the Transfer Manager to use while sending requests
+    let request_checksum_strategy = user_checksum_strategy.clone().or(
+        // If user didn't set a strategy, Transfer Manager should fall back to default strategy,
+        // unless user also disabled checksums via SDK's config.
+        if sdk_checksum_calculation == aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported
+        {
+            Some(ChecksumStrategy::default())
+        } else {
+            None
+        },
+    );
+
+    // Determine which kind of checksums will be in the response.
+    // As of 2025, S3 always provides checksums in response, even if request had none.
+    let (response_checksum_algorithm, response_checksum_type) = match &request_checksum_strategy {
+        None => (ChecksumAlgorithm::Crc64Nvme, ChecksumType::FullObject),
+        Some(request_checksum_strategy) => (
+            request_checksum_strategy.algorithm.clone(),
+            request_checksum_strategy.type_if_multipart.clone(),
+        ),
+    };
+
+    // Create mock aws_sdk_s3::Client
+    let s3_client = if send_as_multipart {
+        mock_s3_client_for_multipart_upload(
+            request_checksum_strategy.clone(),
+            response_checksum_algorithm.clone(),
+            response_checksum_type.clone(),
+            &parts,
+        )
+    } else {
+        assert_eq!(parts.len(), 1);
+        mock_s3_client_for_put_object(
+            request_checksum_strategy.clone(),
+            response_checksum_algorithm.clone(),
+            &parts[0],
+        )
+    };
+
+    // Adjust client's SDK config to use specific RequestChecksumCalculation
+    let s3_client = aws_sdk_s3::Client::from_conf(
+        s3_client
+            .config()
+            .to_builder()
+            .request_checksum_calculation(sdk_checksum_calculation.clone())
+            .build(),
+    );
+
+    let body_stream: InputStream = if send_as_multipart {
+        InputStream::from_part_stream(TestStream::new(parts.clone()))
+    } else {
+        parts[0].clone().into()
+    };
+
+    let tm_config = aws_s3_transfer_manager::Config::builder()
+        .client(s3_client)
+        .part_size(PartSize::Target(PART_SIZE as u64))
+        .multipart_threshold(PartSize::Target(PART_SIZE as u64))
+        .concurrency(ConcurrencySetting::Explicit(1)) // guarantee parts sent in order
+        .build();
+    let tm = aws_s3_transfer_manager::Client::new(tm_config);
+
+    // Do upload
+    let upload_handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .set_checksum_strategy(user_checksum_strategy.clone())
+        .body(body_stream)
+        .initiate()
+        .unwrap();
+    let upload_output = upload_handle.join().await.unwrap();
+
+    // As of 2025, S3 always sends a checksum in the response.
+    // Assert that checksum type and value fields are set.
+    // Don't check exact contents though, leave that up to individual tests.
+    assert!(upload_output.checksum_type().is_some());
+    assert!(get_checksum_value!(upload_output).is_some());
+
+    upload_output
+}
+
+//
+// Multipart Upload Tests
+//
+
+#[tokio::test]
+async fn test_mpu_provided_full_object_crc32() {
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let full_object_checksum = calculate_full_object_checksum(&ChecksumAlgorithm::Crc32, &parts);
+    let strategy = ChecksumStrategy::with_crc32(&full_object_checksum);
+    let output = test_mpu(Some(strategy), parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert_eq!(output.checksum_crc32(), Some(full_object_checksum.as_ref()));
+}
+
+#[tokio::test]
+async fn test_mpu_provided_full_object_crc32_c() {
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let full_object_checksum = calculate_full_object_checksum(&ChecksumAlgorithm::Crc32C, &parts);
+    let strategy = ChecksumStrategy::with_crc32_c(&full_object_checksum);
+    let output = test_mpu(Some(strategy), parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert_eq!(
+        output.checksum_crc32_c(),
+        Some(full_object_checksum.as_ref())
+    );
+}
+
+#[tokio::test]
+async fn test_mpu_provided_full_object_crc64_nvme() {
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let full_object_checksum =
+        calculate_full_object_checksum(&ChecksumAlgorithm::Crc64Nvme, &parts);
+    let strategy = ChecksumStrategy::with_crc64_nvme(&full_object_checksum);
+    let output = test_mpu(Some(strategy), parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert_eq!(
+        output.checksum_crc64_nvme(),
+        Some(full_object_checksum.as_ref())
+    );
+}
+
+// NOTE: SHA algorithms not currently allowed to provide full-object checksums,
+// because it would prevent Transfer Manager from doing multipart upload.
+
+#[tokio::test]
+async fn test_mpu_calculated_full_object_crc32() {
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let strategy = ChecksumStrategy::with_calculated_crc32();
+    let output = test_mpu(Some(strategy), parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc32().is_some());
+}
+
+#[tokio::test]
+async fn test_mpu_calculated_full_object_crc32_c() {
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let strategy = ChecksumStrategy::with_calculated_crc32_c();
+    let output = test_mpu(Some(strategy), parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc32_c().is_some());
+}
+
+#[tokio::test]
+async fn test_mpu_calculated_full_object_crc64_nvme() {
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let strategy = ChecksumStrategy::with_calculated_crc64_nvme();
+    let output = test_mpu(Some(strategy), parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc64_nvme().is_some());
+}
+
+// NOTE: SHA full-object MPU checksums not supported by S3
+
+#[tokio::test]
+async fn test_mpu_calculated_composite_crc32() {
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let strategy = ChecksumStrategy::with_calculated_crc32_composite_if_multipart();
+    let output = test_mpu(Some(strategy), parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::Composite));
+    assert!(output.checksum_crc32().is_some());
+}
+
+#[tokio::test]
+async fn test_mpu_calculated_composite_crc32_c() {
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let strategy = ChecksumStrategy::with_calculated_crc32_c_composite_if_multipart();
+    let output = test_mpu(Some(strategy), parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::Composite));
+    assert!(output.checksum_crc32_c().is_some());
+}
+
+// NOTE: CRC64NVME composite checksums not supported by S3
+
+#[tokio::test]
+async fn test_mpu_calculated_composite_sha1() {
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let strategy = ChecksumStrategy::with_calculated_sha1_composite_if_multipart();
+    let output = test_mpu(Some(strategy), parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::Composite));
+    assert!(output.checksum_sha1().is_some());
+}
+
+#[tokio::test]
+async fn test_mpu_calculated_composite_sha256() {
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let strategy = ChecksumStrategy::with_calculated_sha256_composite_if_multipart();
+    let output = test_mpu(Some(strategy), parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::Composite));
+    assert!(output.checksum_sha256().is_some());
+}
+#[tokio::test]
+async fn test_mpu_default_strategy() {
+    // Test where user didn't set a strategy, but SDK is calculating checksums wherever possible (its default behavior).
+    // Transfer Manager should end up using the default checksum strategy (full-object CRC64NVME).
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let strategy: Option<ChecksumStrategy> = None;
+    let output = test_mpu(strategy, parts).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc64_nvme().is_some());
+}
+
+#[tokio::test]
+async fn test_mpu_no_strategy() {
+    // Test where user didn't set a strategy AND disabled checksums via SDK's config.
+    // Transfer Manager should not send any checksum data. But it will still receive checksums because,
+    // as of 2025, S3 always sends them in responses (defaulting to full-object CRC64NVME).
+    let parts = vec![
+        Bytes::from(vec![b'a'; PART_SIZE]),
+        Bytes::from("abcdefghijklm".as_bytes()),
+    ];
+    let strategy: Option<ChecksumStrategy> = None;
+    let send_as_multipart = true;
+    let sdk_checksum_calculation = aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired;
+    let output = upload_helper(strategy, parts, send_as_multipart, sdk_checksum_calculation).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc64_nvme().is_some());
+}
+
+//
+// PutObject Upload Tests
+//
+
+#[tokio::test]
+async fn test_put_object_provided_full_object_crc32() {
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let full_object_checksum = calculate_checksum(&ChecksumAlgorithm::Crc32, &body);
+    let strategy = ChecksumStrategy::with_crc32(&full_object_checksum);
+    let output = test_put_object(Some(strategy), body).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert_eq!(output.checksum_crc32(), Some(full_object_checksum.as_ref()));
+}
+
+#[tokio::test]
+async fn test_put_object_provided_full_object_crc32_c() {
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let full_object_checksum = calculate_checksum(&ChecksumAlgorithm::Crc32C, &body);
+    let strategy = ChecksumStrategy::with_crc32_c(&full_object_checksum);
+    let output = test_put_object(Some(strategy), body).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert_eq!(
+        output.checksum_crc32_c(),
+        Some(full_object_checksum.as_ref())
+    );
+}
+
+#[tokio::test]
+async fn test_put_object_provided_full_object_crc64_nvme() {
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let full_object_checksum = calculate_checksum(&ChecksumAlgorithm::Crc64Nvme, &body);
+    let strategy = ChecksumStrategy::with_crc64_nvme(&full_object_checksum);
+    let output = test_put_object(Some(strategy), body).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert_eq!(
+        output.checksum_crc64_nvme(),
+        Some(full_object_checksum.as_ref())
+    );
+}
+
+// NOTE: SHA algorithms not currently allowed to provide full-object checksums,
+// because it would prevent Transfer Manager from doing multipart upload.
+
+#[tokio::test]
+async fn test_put_object_calculated_full_object_crc32() {
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let strategy = ChecksumStrategy::with_calculated_crc32();
+    let output = test_put_object(Some(strategy), body).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc32().is_some());
+}
+
+#[tokio::test]
+async fn test_put_object_calculated_full_object_crc32_c() {
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let strategy = ChecksumStrategy::with_calculated_crc32_c();
+    let output = test_put_object(Some(strategy), body).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc32_c().is_some());
+}
+
+#[tokio::test]
+async fn test_put_object_calculated_full_object_crc64_nvme() {
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let strategy = ChecksumStrategy::with_calculated_crc64_nvme();
+    let output = test_put_object(Some(strategy), body).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc64_nvme().is_some());
+}
+
+#[tokio::test]
+async fn test_put_object_calculated_crc32_composite_if_multipart() {
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let strategy = ChecksumStrategy::with_calculated_crc32_composite_if_multipart();
+    let output = test_put_object(Some(strategy), body).await;
+    // NOTE: since it wasn't multipart, the checksum isn't composite
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc32().is_some());
+}
+
+#[tokio::test]
+async fn test_put_object_calculated_crc32_c_composite_if_multipart() {
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let strategy = ChecksumStrategy::with_calculated_crc32_c_composite_if_multipart();
+    let output = test_put_object(Some(strategy), body).await;
+    // NOTE: since it wasn't multipart, the checksum isn't composite
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc32_c().is_some());
+}
+
+// NOTE: CRC64NVME composite checksums not supported by S3
+
+#[tokio::test]
+async fn test_put_object_calculated_sha1_composite_if_multipart() {
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let strategy = ChecksumStrategy::with_calculated_sha1_composite_if_multipart();
+    let output = test_put_object(Some(strategy), body).await;
+    // NOTE: since it wasn't multipart, the checksum isn't composite
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_sha1().is_some());
+}
+
+#[tokio::test]
+async fn test_put_object_calculated_sha256_composite_if_multipart() {
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let strategy = ChecksumStrategy::with_calculated_sha256_composite_if_multipart();
+    let output = test_put_object(Some(strategy), body).await;
+    // NOTE: since it wasn't multipart, the checksum isn't composite
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_sha256().is_some());
+}
+#[tokio::test]
+async fn test_put_object_default_strategy() {
+    // Test where user didn't set a strategy, but SDK is calculating checksums wherever possible (its default behavior).
+    // Transfer Manager should end up using the default checksum strategy (full-object CRC64NVME).
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let strategy: Option<ChecksumStrategy> = None;
+    let output = test_put_object(strategy, body).await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc64_nvme().is_some());
+}
+
+#[tokio::test]
+async fn test_put_object_no_strategy() {
+    // Test where user didn't set a strategy AND disabled checksums via SDK's config.
+    // Transfer Manager should not send any checksum data. But it will still receive checksums because,
+    // as of 2025, S3 always sends them in responses (defaulting to full-object CRC64NVME).
+    let body = Bytes::from("abcdefghijklm".as_bytes());
+    let strategy: Option<ChecksumStrategy> = None;
+    let send_as_multipart = false;
+    let sdk_checksum_calculation = aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired;
+    let output = upload_helper(
+        strategy,
+        vec![body],
+        send_as_multipart,
+        sdk_checksum_calculation,
+    )
+    .await;
+    assert_eq!(output.checksum_type(), Some(&ChecksumType::FullObject));
+    assert!(output.checksum_crc64_nvme().is_some());
+}


### PR DESCRIPTION
**Issue #:**
https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/3

Users should have control over checksums during upload. They should be able to choose the checksum algorithm, and multipart checksum type. If the user already has a checksum, they should be able to provide it and have that value sent to S3, to ensure verify data integrity from absolute beginning to absolute end.

**Challenges:**

1) It's easy for users to misconfigure checksum settings. S3 models checksums with 7 distinct input fields (checksum_crc32, checksum_crc32_c, checksum_crc64_nvme, checksum_sha1, checksum_sha256, checksum_type, checksum_algorithm). Certain combinations of fields don't work together (e.g. not all algorithms can be used with all multipart-checksum-types, it's invalid to set multiple checksum values, etc).

    We should make it impossible to misconfigure, or at least make it hard to misconfigure and quickly detect a misconfiguration.

2) The "Composite" multipart checksum type makes things complicated. If we let users provide a composite checksum up front, the Transfer Manager would **HAVE TO** do a multipart upload (3+ HTTP requests). It wouldn't be able to optimize a small upload into 1 PutObject HTTP request, because PutObject can only provide full object checksums.

    And it's not clear anyone *wants* to use composite checksums. In the past, multipart uploads had to use composite checksums, or have no checksum whatsoever. But as of Re:Invent 2024 (see [announcement](https://aws.amazon.com/blogs/aws/introducing-default-data-integrity-protections-for-new-objects-in-amazon-s3/)) S3 supports full object checksums on multipart uploads (for CRC algorithms, but not SHA algorithms). All AWS SDKs will (soon) default to sending CRC full object checksums. S3 now defaults to assigning full object CRC64NVME checksums to all objects if the client didn't already do it. So full object checksums are now the default, and much simpler to use and understand. Should we even support uploading with composite checksums and all their complexity in this brand new codebase?

    But there are still some valid use cases for uploading with composite checksums. First, if the user needs to use a SHA algorithm (S3 currently only allows CRC algorithms to do full object checksums). Second, if the user really actually cares about the checksums on their individual parts (S3 does not currently store a checksum on individual parts if the upload uses a full object checksum in the end).

    So... we should probably still support composite checksums. But maybe don't bend over too far to support complicated use cases (e.g. letting user provide composite checksums up front). But also, keep the door open to supporting it in the future, if someone needs it bad enough to justify all the complexity.

**Description of changes:**

1) `ChecksumStrategy` is new struct, which serves as an optional field on `UploadInput`. This is easier to use than the 7 distinct fields mentioned above. It has many constructors to help users create a valid configuration. There's also a `ChecksumStrategyBuilder` that lets someone set the individual fields, if that's easier for their code to deal with. Its `build()` function checks for all possible misconfiguration.

2) Let users provide a full object checksum up front, but NOT provide composite checksum up front (see challenge 2 above on why that would be hard). We could still support it in the future, but probably nobody wants this. Also, we WILL support providing checksums *per part* in the future, regardless of the multipart checksum type, and that is very likely good enough for someone that needs to use composite checksums and wants to provide the values themselves.

**Planned Future Work:**
1) Let users provide a full object checksum AFTER streaming the body.
2) Let users provide a checksum for each part as it's streamed (this will work with both full object and composite checksums)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
