### PR TITLE
Let user provide checksums via PartStream

### DIFF
--- a/aws-s3-transfer-manager/src/io/adapters.rs
+++ b/aws-s3-transfer-manager/src/io/adapters.rs
@@ -118,7 +118,7 @@ where
                             let data: Bytes = inner_buf.into();
                             let part_number = *this.next_part;
                             *this.next_part += 1;
-                            let part = PartData { part_number, data };
+                            let part = PartData::new(part_number, data);
                             return Poll::Ready(Some(Ok(part)));
                         } else if n == 0 {
                             // EOF

--- a/aws-s3-transfer-manager/src/io/part_reader.rs
+++ b/aws-s3-transfer-manager/src/io/part_reader.rs
@@ -86,6 +86,13 @@ impl PartReader {
             Inner::Dyn(part_stream) => part_stream.next_part(&self.stream_cx).await,
         }
     }
+
+    pub(crate) async fn full_object_checksum(&self) -> Option<String> {
+        match &self.inner {
+            Inner::Dyn(part_stream) => part_stream.full_object_checksum().await,
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -265,6 +272,12 @@ impl DynPartReader {
             Some(result) => result.map(Some).map_err(|err| err.into()),
             None => Ok(None),
         }
+    }
+
+    // this is only async because it locks a Tokio Mutex
+    async fn full_object_checksum(&self) -> Option<String> {
+        let stream = self.inner.lock().await;
+        stream.full_object_checksum()
     }
 }
 

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -188,18 +188,16 @@ impl PartData {
         }
     }
 
-    /// Create a new part, with a precalculated checksum
+    /// Set this part's checksum, if you've calculated it yourself
     /// (base64 encoding of the big-endian checksum value for this part's data
     /// using the algorithm specified in the [ChecksumStrategy](crate::operation::upload::ChecksumStrategy)).
-    pub fn with_checksum(
-        part_number: u64,
-        data: impl Into<Bytes>,
-        checksum: impl Into<String>,
-    ) -> Self {
-        Self {
-            checksum: Some(checksum.into()),
-            ..Self::new(part_number, data)
-        }
+    ///
+    /// If you don't set this, the Transfer Manager will calculate one
+    /// automatically, unless you've explicitly disabled checksum calculation
+    /// (see [ChecksumStrategy](crate::operation::upload::ChecksumStrategy)).
+    pub fn with_checksum(mut self, checksum: impl Into<String>) -> Self {
+        self.checksum = Some(checksum.into());
+        self
     }
 }
 
@@ -225,8 +223,8 @@ pub trait PartStream {
     /// Returns the bounds on the total size of the stream
     fn size_hint(&self) -> crate::io::SizeHint;
 
-    /// Return the full object checksum, if you calculated it yourself while streaming.
-    /// S3 can validate this against the checksum it calculates server side.
+    /// If you calculated the full object checksum while streaming, return it.
+    /// This will be sent to S3 for validation against the checksum it calculated server side.
     ///
     /// If None is returned (the default implementation), S3 will not do this additional validation.
     ///

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -189,6 +189,8 @@ impl PartData {
     }
 
     /// Create a new part, with a precalculated checksum
+    /// (base64 encoding of the big-endian checksum value for this part's data
+    /// using the algorithm specified in the [ChecksumStrategy](crate::operation::upload::ChecksumStrategy)).
     pub fn with_checksum(
         part_number: u64,
         data: impl Into<Bytes>,
@@ -223,16 +225,19 @@ pub trait PartStream {
     /// Returns the bounds on the total size of the stream
     fn size_hint(&self) -> crate::io::SizeHint;
 
-    /// Return the full object checksum value, if you calculated it yourself while streaming.
-    /// S3 can validate this against the checksum value it calculates server side.
+    /// Return the full object checksum, if you calculated it yourself while streaming.
+    /// S3 can validate this against the checksum it calculates server side.
     ///
     /// If None is returned (the default implementation), S3 will not do this additional validation.
     ///
     /// This function is called once, after [`PartStream::poll_part()`] yields the final part,
-    /// if you used a [ChecksumStrategy](crate::operation::upload::ChecksumStrategy) with
+    /// if and only if you used a [ChecksumStrategy](crate::operation::upload::ChecksumStrategy) with
     /// [ChecksumType::FullObject](aws_sdk_s3::types::ChecksumType) and didn't set its
     /// [full_object_checksum](crate::operation::upload::ChecksumStrategy::full_object_checksum)
     /// value up front.
+    ///
+    /// Return the base64 encoding of the big-endian checksum value of the full object's data,
+    /// using the algorithm specified in the [ChecksumStrategy](crate::operation::upload::ChecksumStrategy)).
     fn full_object_checksum(&self) -> Option<String> {
         None
     }

--- a/aws-s3-transfer-manager/src/io/stream.rs
+++ b/aws-s3-transfer-manager/src/io/stream.rs
@@ -171,6 +171,7 @@ pub struct PartData {
     // 1-indexed
     pub(crate) part_number: u64,
     pub(crate) data: Bytes,
+    pub(crate) checksum: Option<String>,
 }
 
 impl PartData {
@@ -183,6 +184,19 @@ impl PartData {
         Self {
             part_number,
             data: data.into(),
+            checksum: None,
+        }
+    }
+
+    /// Create a new part, with a precalculated checksum
+    pub fn with_checksum(
+        part_number: u64,
+        data: impl Into<Bytes>,
+        checksum: impl Into<String>,
+    ) -> Self {
+        Self {
+            checksum: Some(checksum.into()),
+            ..Self::new(part_number, data)
         }
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.md
+++ b/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.md
@@ -6,9 +6,18 @@ For more information, see <https://docs.aws.amazon.com/AmazonS3/latest/userguide
 You can set a specific [`ChecksumStrategy`], if you wish to choose the
 checksum algorithm or already know the checksum value.
 
-`CRC64NVME` checksums are calculated by default (if no strategy is set and the underlying
+The Transfer Manager will calculate `CRC64NVME` checksums by default (if no strategy is set and the underlying
 S3 client is configured with the default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenSupported`]).
 
 To disable checksum calculation, do not set a [`ChecksumStrategy`] and make sure the underlying S3 client is
 configured with the non-default [`aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired`].
-If you do this, S3 will still calculate and store a `CRC64NVME` full object checksum for the object.
+S3 will still calculate and store a `CRC64NVME` full object checksum for the object server side.
+
+If you want to provide checksum values yourself, there are several options.
+You may provide the value up front via [`ChecksumStrategy::full_object_checksum`].
+If you are streaming data with a [PartStream](crate::io::PartStream),
+you may also provide a checksum with each [part](crate::io::PartData::with_checksum),
+and may provide the [full object checksum](crate::io::PartStream::full_object_checksum)
+when streaming is complete.
+
+Checksum strings are the base64 encoding of the big endian checksum value.

--- a/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/checksum_strategy.rs
@@ -15,7 +15,8 @@ pub struct ChecksumStrategy {
 }
 
 impl ChecksumStrategy {
-    /// Use a precalculated `CRC64NVME` full object checksum value.
+    /// Use a precalculated `CRC64NVME` full object checksum
+    /// (base64 encoding of the big-endian checksum value).
     pub fn with_crc64_nvme(value: impl Into<String>) -> Self {
         Self {
             algorithm: ChecksumAlgorithm::Crc64Nvme,
@@ -24,7 +25,8 @@ impl ChecksumStrategy {
         }
     }
 
-    /// Use a precalculated `CRC32` full object checksum value.
+    /// Use a precalculated `CRC32` full object checksum
+    /// (base64 encoding of the big-endian checksum value).
     pub fn with_crc32(value: impl Into<String>) -> Self {
         Self {
             algorithm: ChecksumAlgorithm::Crc32,
@@ -33,7 +35,8 @@ impl ChecksumStrategy {
         }
     }
 
-    /// Use a precalculated `CRC32C` full object checksum value.
+    /// Use a precalculated `CRC32C` full object checksum
+    /// (base64 encoding of the big-endian checksum value).
     pub fn with_crc32_c(value: impl Into<String>) -> Self {
         Self {
             algorithm: ChecksumAlgorithm::Crc32C,

--- a/aws-s3-transfer-manager/tests/upload_checksum_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_checksum_test.rs
@@ -193,11 +193,11 @@ impl PartStream for TestStream {
         let part = this.parts.get(part_index).map(|b| {
             let part_number = *this.next_part_num;
             *this.next_part_num += 1;
-            let part_data = if let Some(checksum) = &this.part_checksums[part_index] {
-                PartData::with_checksum(part_number, b.clone(), checksum)
-            } else {
-                PartData::new(part_number, b.clone())
-            };
+            let mut part_data = PartData::new(part_number, b.clone());
+            if let Some(checksum) = &this.part_checksums[part_index] {
+                part_data = part_data.with_checksum(checksum);
+            }
+
             Ok(part_data)
         });
         Poll::Ready(part)


### PR DESCRIPTION
**Issue #:**
- https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/3

Give users the ability to provide their own checksum values **as** they stream their data (the previous PR just let users provide the full checksum value up front)

**Description of changes:**
- Users may provide a checksum value with each part
- Users may provide a full object checksum value after streaming is complete

**Possible future issues:**
Currently, `PartStream` is always sent as a multipart upload. In this PR, the user can provide part checksums, and final checksum and that's exactly how multipart upload works.

BUT In the future, we may want to optimize a small stream into a single PutObject. This would add some ambiguities:
- if user is doing SHA, we can't use their part checksums, because we have to send it as a single PutObject
- if user is doing CRC, and provided part checksums but no full object checksum, then we'll never send those user-provided-part-checksums to S3

In both these cases, the Transfer Manager **could** do some local validation as it combines parts into a single PutObject, validating the user-provided checksums at the part boundaries. But it bends the promise we made to the user, that we'd send their checksums all the way to S3 for validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
