### PR TITLE
Replace concurrency knob

### DIFF
--- a/aws-s3-transfer-manager/Cargo.toml
+++ b/aws-s3-transfer-manager/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1.42.0", features = ["rt-multi-thread", "io-util", "sync", 
 tower = { version = "0.5.2", features = ["limit", "retry", "util", "hedge", "buffer"] }
 tracing = "0.1"
 walkdir = "2"
+tokio-util = "0.7.13"
 
 [dev-dependencies]
 aws-sdk-s3 = { version = "1.66.0", features = ["behavior-version-latest", "test-util"] }

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -311,8 +311,7 @@ async fn main() -> Result<(), BoxError> {
             .init();
     }
 
-    // tracing::debug!("using concurrency mode: {:?}", args.concurrency.mode());
-    println!("using concurrency mode: {:?}", args.concurrency.mode());
+    tracing::debug!("using concurrency mode: {:?}", args.concurrency.mode());
 
     use TransferUri::*;
     let result = match (&args.source, &args.dest) {

--- a/aws-s3-transfer-manager/examples/cp.rs
+++ b/aws-s3-transfer-manager/examples/cp.rs
@@ -11,7 +11,7 @@ use aws_s3_transfer_manager::io::InputStream;
 use aws_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_s3_transfer_manager::metrics::Throughput;
 use aws_s3_transfer_manager::operation::download::Body;
-use aws_s3_transfer_manager::types::{ConcurrencyMode, PartSize};
+use aws_s3_transfer_manager::types::{ConcurrencyMode, PartSize, TargetThroughput};
 use aws_sdk_s3::error::DisplayErrorContext;
 use bytes::Buf;
 use clap::{CommandFactory, Parser};
@@ -80,9 +80,9 @@ impl ConcurrencyModeArg {
 
         match (self.target_throughput_gbps, self.concurrency) {
             (None, Some(concurrency)) => ConcurrencyMode::Explicit(concurrency),
-            (Some(gbps), None) => ConcurrencyMode::TargetThroughput(Throughput::new_bytes_per_sec(
-                ByteUnit::Gigabit.as_bytes_u64() * gbps,
-            )),
+            (Some(gbps), None) => {
+                ConcurrencyMode::TargetThroughput(TargetThroughput::new_gigabits_per_sec(gbps))
+            }
             _ => ConcurrencyMode::Auto,
         }
     }

--- a/aws-s3-transfer-manager/src/config.rs
+++ b/aws-s3-transfer-manager/src/config.rs
@@ -6,7 +6,7 @@
 use aws_runtime::user_agent::FrameworkMetadata;
 
 use crate::metrics::unit::ByteUnit;
-use crate::types::{ConcurrencySetting, PartSize};
+use crate::types::{PartSize, TargetThroughput};
 use std::cmp;
 
 pub(crate) mod loader;
@@ -19,7 +19,7 @@ pub(crate) const MIN_MULTIPART_PART_SIZE_BYTES: u64 = 5 * ByteUnit::Mebibyte.as_
 pub struct Config {
     multipart_threshold: PartSize,
     target_part_size: PartSize,
-    concurrency: ConcurrencySetting,
+    target_throughput: TargetThroughput,
     framework_metadata: Option<FrameworkMetadata>,
     client: aws_sdk_s3::client::Client,
 }
@@ -40,10 +40,10 @@ impl Config {
         &self.target_part_size
     }
 
-    /// Returns the concurrency setting to use for transfer operations.
-    /// This is the maximum number of in-flight requests allowed across _all_ operations.
-    pub fn concurrency(&self) -> &ConcurrencySetting {
-        &self.concurrency
+    /// Returns the target throughput setting to use for transfer operations.
+    /// This is the target throughput of concurrent in-flight requests across _all_ operations.
+    pub fn target_throughput(&self) -> &TargetThroughput {
+        &self.target_throughput
     }
 
     /// Returns the framework metadata setting when using transfer manager.
@@ -63,7 +63,7 @@ impl Config {
 pub struct Builder {
     multipart_threshold_part_size: PartSize,
     target_part_size: PartSize,
-    concurrency: ConcurrencySetting,
+    target_throughput: TargetThroughput,
     framework_metadata: Option<FrameworkMetadata>,
     client: Option<aws_sdk_s3::Client>,
 }
@@ -123,12 +123,12 @@ impl Builder {
         self
     }
 
-    /// Set the concurrency level this component is allowed to use.
+    /// Set the target throughput this client should aim for.
     ///
-    /// This sets the maximum number of concurrent in-flight requests across _all_ operations.
-    /// Default is [ConcurrencySetting::Auto].
-    pub fn concurrency(mut self, concurrency: ConcurrencySetting) -> Self {
-        self.concurrency = concurrency;
+    /// This sets the target throughput of concurrent in-flight requests across _all_ operations.
+    /// Default is [TargetThroughput::Auto].
+    pub fn target_throughput(mut self, target_throughput: TargetThroughput) -> Self {
+        self.target_throughput = target_throughput;
         self
     }
 
@@ -156,7 +156,7 @@ impl Builder {
         Config {
             multipart_threshold: self.multipart_threshold_part_size,
             target_part_size: self.target_part_size,
-            concurrency: self.concurrency,
+            target_throughput: self.target_throughput,
             framework_metadata: self.framework_metadata,
             client: self.client.expect("client set"),
         }

--- a/aws-s3-transfer-manager/src/config/loader.rs
+++ b/aws-s3-transfer-manager/src/config/loader.rs
@@ -10,7 +10,7 @@ use aws_sdk_s3::config::{Intercept, IntoShared};
 use aws_types::os_shim_internal::Env;
 
 use crate::config::Builder;
-use crate::types::TargetThroughput;
+use crate::types::ConcurrencyMode;
 use crate::{http, types::PartSize, Config};
 
 #[derive(Debug)]
@@ -79,12 +79,12 @@ impl ConfigLoader {
         self
     }
 
-    /// Set the target throughput this client should aim for.
+    /// Set the concurrency mode this client should use.
     ///
-    /// This sets the target throughput of concurrent in-flight requests across _all_ operations.
-    /// Default is [TargetThroughput::Auto].
-    pub fn target_throughput(mut self, target_throughput: TargetThroughput) -> Self {
-        self.builder = self.builder.target_throughput(target_throughput);
+    /// This sets the mode used for concurrent in-flight requests across _all_ operations.
+    /// Default is [ConcurrencyMode::Auto].
+    pub fn concurrency(mut self, mode: ConcurrencyMode) -> Self {
+        self.builder = self.builder.concurrency(mode);
         self
     }
 

--- a/aws-s3-transfer-manager/src/metrics.rs
+++ b/aws-s3-transfer-manager/src/metrics.rs
@@ -165,7 +165,7 @@ pub struct Throughput {
 
 impl Throughput {
     /// Create a new throughput measurement with the given bytes read and time elapsed
-    pub fn new(bytes_transferred: u64, elapsed: Duration) -> Throughput {
+    pub const fn new(bytes_transferred: u64, elapsed: Duration) -> Throughput {
         Throughput {
             bytes_transferred,
             elapsed,
@@ -185,7 +185,7 @@ impl Throughput {
     ///     Throughput::new_bytes_per_sec(bytes_transferred)
     /// );
     /// ```
-    pub fn new_bytes_per_sec(bytes_transferred: u64) -> Throughput {
+    pub const fn new_bytes_per_sec(bytes_transferred: u64) -> Throughput {
         Self::new(bytes_transferred, Duration::from_secs(1))
     }
 
@@ -200,7 +200,7 @@ impl Throughput {
     }
 
     /// Total bytes transferred
-    pub fn bytes_transferred(&self) -> u64 {
+    pub const fn bytes_transferred(&self) -> u64 {
         self.bytes_transferred
     }
 

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency.rs
@@ -13,3 +13,4 @@ mod layer;
 mod service;
 
 pub(crate) use self::layer::ConcurrencyLimitLayer;
+pub(crate) use self::service::ProvidePayloadSize;

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/future.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/future.rs
@@ -61,8 +61,8 @@ where
 
 impl<S, Request> Future for ResponseFuture<S, Request>
 where
-    // FIXME - figure out error
-    S: Service<Request, Error = error::Error>,
+    S: Service<Request>,
+    S::Error: From<error::Error>,
 {
     type Output = Result<S::Response, S::Error>;
 
@@ -78,7 +78,7 @@ where
                             let fut = this.inner.call(req);
                             this.state.set(State::Called { fut, _permit });
                         }
-                        Err(err) => return Poll::Ready(Err(err)),
+                        Err(err) => return Poll::Ready(Err(err.into())),
                     }
                 }
                 StateProj::Called { fut, .. } => {

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -3,14 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use futures_util::ready;
-use std::future::Future;
-use std::mem;
-use std::pin::pin;
 use tower::Service;
 
 use super::future::ResponseFuture;
-use crate::runtime::scheduler::{AcquirePermitFuture, OwnedWorkPermit, Scheduler};
+use crate::runtime::scheduler::{PermitType, Scheduler};
 
 /// Enforces a limit on the concurrent requests an underlying service receives
 /// using the given [`Scheduler`].
@@ -18,72 +14,46 @@ use crate::runtime::scheduler::{AcquirePermitFuture, OwnedWorkPermit, Scheduler}
 pub(crate) struct ConcurrencyLimit<T> {
     inner: T,
     scheduler: Scheduler,
-    state: State,
 }
 
 impl<T> ConcurrencyLimit<T> {
     /// Create a new concurrency limiter
     pub(crate) fn new(inner: T, scheduler: Scheduler) -> Self {
-        ConcurrencyLimit {
-            inner,
-            scheduler,
-            state: State::Idle,
-        }
+        ConcurrencyLimit { inner, scheduler }
     }
 }
 
-#[derive(Debug)]
-enum State {
-    /// Permit acquired and ready
-    Ready(OwnedWorkPermit),
-    /// Waiting on a permit
-    PendingAcquire(AcquirePermitFuture),
-    /// No permit acquired or pending
-    Idle,
+/// Provide the request/response payload size estimate
+pub(crate) trait ProvidePayloadSize {
+    /// Payload size in bytes
+    fn payload_size(&self) -> u64;
 }
 
 impl<S, Request> Service<Request> for ConcurrencyLimit<S>
 where
-    S: Service<Request>,
+    S: Service<Request> + Clone,
+    Request: ProvidePayloadSize,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = ResponseFuture<S::Future>;
+    type Future = ResponseFuture<S, Request>;
 
     fn poll_ready(
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
-        loop {
-            match &mut self.state {
-                State::Ready(_) => break,
-                State::PendingAcquire(permit_fut) => {
-                    let permit_fut = pin!(permit_fut);
-                    let permit =
-                        ready!(permit_fut.poll(cx)).expect("permit acquisition never fails");
-                    self.state = State::Ready(permit);
-                }
-                State::Idle => {
-                    // we loop to ensure we poll this at least once to ensure we are woken up when ready
-                    let permit_fut = self.scheduler.acquire_permit();
-                    self.state = State::PendingAcquire(permit_fut);
-                }
-            }
-        }
         // Once we have a permit we still need to make sure the inner service is ready
+        // We can't estimate payload size without the request so we
+        // move scheduling/concurrency limiting to `call()`
         self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, req: Request) -> Self::Future {
-        // extract our permit and reset the state
-        let permit = match mem::replace(&mut self.state, State::Idle) {
-            State::Ready(permit) => permit,
-            _ => panic!("poll_ready must be called first!"),
-        };
-
-        let fut = self.inner.call(req);
-
-        ResponseFuture::new(fut, permit)
+        // NOTE: We assume this is a dataplane request as that is the only place
+        // we make use of tower is for upload/download. If this changes this logic needs updated.
+        let ptype = PermitType::DataPlane(req.payload_size());
+        let permit_fut = self.scheduler.acquire_permit(ptype);
+        ResponseFuture::new(self.inner.clone(), req, permit_fut)
     }
 }
 
@@ -92,147 +62,146 @@ impl<T: Clone> Clone for ConcurrencyLimit<T> {
         Self {
             inner: self.inner.clone(),
             scheduler: self.scheduler.clone(),
-            state: State::Idle,
         }
     }
 }
 
-#[cfg(test)]
-mod tests {
-
-    use crate::middleware::limit::concurrency::ConcurrencyLimitLayer;
-    use crate::runtime::scheduler::Scheduler;
-    use tokio_test::{assert_pending, assert_ready_ok};
-    use tower_test::{assert_request_eq, mock};
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_service_limit() {
-        let scheduler = Scheduler::new(2);
-        let limit = ConcurrencyLimitLayer::new(scheduler);
-        let (mut service, mut handle) = mock::spawn_layer(limit);
-
-        assert_ready_ok!(service.poll_ready());
-        let r1 = service.call("req 1");
-
-        assert_ready_ok!(service.poll_ready());
-        let r2 = service.call("req 2");
-
-        assert_pending!(service.poll_ready());
-
-        assert!(!service.is_woken());
-
-        // pass requests through
-        assert_request_eq!(handle, "req 1").send_response("foo");
-        assert_request_eq!(handle, "req 2").send_response("bar");
-
-        // no more requests
-        assert_pending!(handle.poll_request());
-        assert_eq!(r1.await.unwrap(), "foo");
-
-        assert!(service.is_woken());
-
-        // more requests can make it through
-        assert_ready_ok!(service.poll_ready());
-        let r3 = service.call("req 3");
-
-        assert_pending!(service.poll_ready());
-
-        assert_eq!(r2.await.unwrap(), "bar");
-
-        assert_request_eq!(handle, "req 3").send_response("baz");
-        assert_eq!(r3.await.unwrap(), "baz");
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_clone() {
-        let scheduler = Scheduler::new(1);
-        let limit = ConcurrencyLimitLayer::new(scheduler);
-        let (mut s1, mut handle) = mock::spawn_layer(limit);
-
-        assert_ready_ok!(s1.poll_ready());
-
-        // s2 should share underlying scheduler
-        let mut s2 = s1.clone();
-        assert_pending!(s2.poll_ready());
-
-        let r1 = s1.call("req 1");
-        assert_request_eq!(handle, "req 1").send_response("foo");
-
-        // s2 can't get capacity until the future is dropped/consumed
-        assert_pending!(s2.poll_ready());
-        r1.await.unwrap();
-        assert_ready_ok!(s2.poll_ready());
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_service_drop_frees_capacity() {
-        let scheduler = Scheduler::new(1);
-        let limit = ConcurrencyLimitLayer::new(scheduler);
-        let (mut s1, mut _handle) = mock::spawn_layer::<(), (), _>(limit);
-
-        assert_ready_ok!(s1.poll_ready());
-
-        // s2 should share underlying scheduler
-        let mut s2 = s1.clone();
-        assert_pending!(s2.poll_ready());
-
-        drop(s1);
-        assert!(s2.is_woken());
-        assert_ready_ok!(s2.poll_ready());
-    }
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_drop_resp_future_frees_capacity() {
-        let scheduler = Scheduler::new(1);
-        let limit = ConcurrencyLimitLayer::new(scheduler);
-        let (mut s1, mut _handle) = mock::spawn_layer::<_, (), _>(limit);
-        let mut s2 = s1.clone();
-
-        assert_ready_ok!(s1.poll_ready());
-        let r1 = s1.call("req 1");
-
-        assert_pending!(s2.poll_ready());
-        drop(r1);
-        assert_ready_ok!(s2.poll_ready());
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_service_error_frees_capacity() {
-        let scheduler = Scheduler::new(1);
-        let limit = ConcurrencyLimitLayer::new(scheduler);
-        let (mut s1, mut handle) = mock::spawn_layer::<_, (), _>(limit);
-        let mut s2 = s1.clone();
-
-        // reserve capacity on s1
-        assert_ready_ok!(s1.poll_ready());
-        assert_pending!(s2.poll_ready());
-
-        let r1 = s1.call("req 1");
-
-        assert_request_eq!(handle, "req 1").send_error("blerg");
-        r1.await.unwrap_err();
-
-        assert_ready_ok!(s2.poll_ready());
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn test_multiple_waiting() {
-        let scheduler = Scheduler::new(1);
-        let limit = ConcurrencyLimitLayer::new(scheduler);
-        let (mut s1, mut _handle) = mock::spawn_layer::<(), (), _>(limit);
-        let mut s2 = s1.clone();
-        let mut s3 = s1.clone();
-
-        // reserve capacity on s1
-        assert_ready_ok!(s1.poll_ready());
-        assert_pending!(s2.poll_ready());
-        assert_pending!(s3.poll_ready());
-
-        drop(s1);
-
-        assert!(s2.is_woken());
-        assert!(!s3.is_woken());
-
-        drop(s2);
-        assert!(s3.is_woken());
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//
+//     use crate::middleware::limit::concurrency::ConcurrencyLimitLayer;
+//     use crate::runtime::scheduler::Scheduler;
+//     use tokio_test::{assert_pending, assert_ready_ok};
+//     use tower_test::{assert_request_eq, mock};
+//
+//     #[tokio::test(flavor = "current_thread")]
+//     async fn test_service_limit() {
+//         let scheduler = Scheduler::new(2);
+//         let limit = ConcurrencyLimitLayer::new(scheduler);
+//         let (mut service, mut handle) = mock::spawn_layer(limit);
+//
+//         assert_ready_ok!(service.poll_ready());
+//         let r1 = service.call("req 1");
+//
+//         assert_ready_ok!(service.poll_ready());
+//         let r2 = service.call("req 2");
+//
+//         assert_pending!(service.poll_ready());
+//
+//         assert!(!service.is_woken());
+//
+//         // pass requests through
+//         assert_request_eq!(handle, "req 1").send_response("foo");
+//         assert_request_eq!(handle, "req 2").send_response("bar");
+//
+//         // no more requests
+//         assert_pending!(handle.poll_request());
+//         assert_eq!(r1.await.unwrap(), "foo");
+//
+//         assert!(service.is_woken());
+//
+//         // more requests can make it through
+//         assert_ready_ok!(service.poll_ready());
+//         let r3 = service.call("req 3");
+//
+//         assert_pending!(service.poll_ready());
+//
+//         assert_eq!(r2.await.unwrap(), "bar");
+//
+//         assert_request_eq!(handle, "req 3").send_response("baz");
+//         assert_eq!(r3.await.unwrap(), "baz");
+//     }
+//
+//     #[tokio::test(flavor = "current_thread")]
+//     async fn test_clone() {
+//         let scheduler = Scheduler::new(1);
+//         let limit = ConcurrencyLimitLayer::new(scheduler);
+//         let (mut s1, mut handle) = mock::spawn_layer(limit);
+//
+//         assert_ready_ok!(s1.poll_ready());
+//
+//         // s2 should share underlying scheduler
+//         let mut s2 = s1.clone();
+//         assert_pending!(s2.poll_ready());
+//
+//         let r1 = s1.call("req 1");
+//         assert_request_eq!(handle, "req 1").send_response("foo");
+//
+//         // s2 can't get capacity until the future is dropped/consumed
+//         assert_pending!(s2.poll_ready());
+//         r1.await.unwrap();
+//         assert_ready_ok!(s2.poll_ready());
+//     }
+//
+//     #[tokio::test(flavor = "current_thread")]
+//     async fn test_service_drop_frees_capacity() {
+//         let scheduler = Scheduler::new(1);
+//         let limit = ConcurrencyLimitLayer::new(scheduler);
+//         let (mut s1, mut _handle) = mock::spawn_layer::<(), (), _>(limit);
+//
+//         assert_ready_ok!(s1.poll_ready());
+//
+//         // s2 should share underlying scheduler
+//         let mut s2 = s1.clone();
+//         assert_pending!(s2.poll_ready());
+//
+//         drop(s1);
+//         assert!(s2.is_woken());
+//         assert_ready_ok!(s2.poll_ready());
+//     }
+//     #[tokio::test(flavor = "current_thread")]
+//     async fn test_drop_resp_future_frees_capacity() {
+//         let scheduler = Scheduler::new(1);
+//         let limit = ConcurrencyLimitLayer::new(scheduler);
+//         let (mut s1, mut _handle) = mock::spawn_layer::<_, (), _>(limit);
+//         let mut s2 = s1.clone();
+//
+//         assert_ready_ok!(s1.poll_ready());
+//         let r1 = s1.call("req 1");
+//
+//         assert_pending!(s2.poll_ready());
+//         drop(r1);
+//         assert_ready_ok!(s2.poll_ready());
+//     }
+//
+//     #[tokio::test(flavor = "current_thread")]
+//     async fn test_service_error_frees_capacity() {
+//         let scheduler = Scheduler::new(1);
+//         let limit = ConcurrencyLimitLayer::new(scheduler);
+//         let (mut s1, mut handle) = mock::spawn_layer::<_, (), _>(limit);
+//         let mut s2 = s1.clone();
+//
+//         // reserve capacity on s1
+//         assert_ready_ok!(s1.poll_ready());
+//         assert_pending!(s2.poll_ready());
+//
+//         let r1 = s1.call("req 1");
+//
+//         assert_request_eq!(handle, "req 1").send_error("blerg");
+//         r1.await.unwrap_err();
+//
+//         assert_ready_ok!(s2.poll_ready());
+//     }
+//
+//     #[tokio::test(flavor = "current_thread")]
+//     async fn test_multiple_waiting() {
+//         let scheduler = Scheduler::new(1);
+//         let limit = ConcurrencyLimitLayer::new(scheduler);
+//         let (mut s1, mut _handle) = mock::spawn_layer::<(), (), _>(limit);
+//         let mut s2 = s1.clone();
+//         let mut s3 = s1.clone();
+//
+//         // reserve capacity on s1
+//         assert_ready_ok!(s1.poll_ready());
+//         assert_pending!(s2.poll_ready());
+//         assert_pending!(s3.poll_ready());
+//
+//         drop(s1);
+//
+//         assert!(s2.is_woken());
+//         assert!(!s3.is_woken());
+//
+//         drop(s2);
+//         assert!(s3.is_woken());
+//     }
+// }

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -6,6 +6,7 @@
 use tower::Service;
 
 use super::future::ResponseFuture;
+use crate::error;
 use crate::runtime::scheduler::{PermitType, Scheduler};
 
 /// Enforces a limit on the concurrent requests an underlying service receives
@@ -32,6 +33,7 @@ pub(crate) trait ProvidePayloadSize {
 impl<S, Request> Service<Request> for ConcurrencyLimit<S>
 where
     S: Service<Request> + Clone,
+    S::Error: From<error::Error>,
     Request: ProvidePayloadSize,
 {
     type Response = S::Response;
@@ -66,142 +68,183 @@ impl<T: Clone> Clone for ConcurrencyLimit<T> {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//
-//     use crate::middleware::limit::concurrency::ConcurrencyLimitLayer;
-//     use crate::runtime::scheduler::Scheduler;
-//     use tokio_test::{assert_pending, assert_ready_ok};
-//     use tower_test::{assert_request_eq, mock};
-//
-//     #[tokio::test(flavor = "current_thread")]
-//     async fn test_service_limit() {
-//         let scheduler = Scheduler::new(2);
-//         let limit = ConcurrencyLimitLayer::new(scheduler);
-//         let (mut service, mut handle) = mock::spawn_layer(limit);
-//
-//         assert_ready_ok!(service.poll_ready());
-//         let r1 = service.call("req 1");
-//
-//         assert_ready_ok!(service.poll_ready());
-//         let r2 = service.call("req 2");
-//
-//         assert_pending!(service.poll_ready());
-//
-//         assert!(!service.is_woken());
-//
-//         // pass requests through
-//         assert_request_eq!(handle, "req 1").send_response("foo");
-//         assert_request_eq!(handle, "req 2").send_response("bar");
-//
-//         // no more requests
-//         assert_pending!(handle.poll_request());
-//         assert_eq!(r1.await.unwrap(), "foo");
-//
-//         assert!(service.is_woken());
-//
-//         // more requests can make it through
-//         assert_ready_ok!(service.poll_ready());
-//         let r3 = service.call("req 3");
-//
-//         assert_pending!(service.poll_ready());
-//
-//         assert_eq!(r2.await.unwrap(), "bar");
-//
-//         assert_request_eq!(handle, "req 3").send_response("baz");
-//         assert_eq!(r3.await.unwrap(), "baz");
-//     }
-//
-//     #[tokio::test(flavor = "current_thread")]
-//     async fn test_clone() {
-//         let scheduler = Scheduler::new(1);
-//         let limit = ConcurrencyLimitLayer::new(scheduler);
-//         let (mut s1, mut handle) = mock::spawn_layer(limit);
-//
-//         assert_ready_ok!(s1.poll_ready());
-//
-//         // s2 should share underlying scheduler
-//         let mut s2 = s1.clone();
-//         assert_pending!(s2.poll_ready());
-//
-//         let r1 = s1.call("req 1");
-//         assert_request_eq!(handle, "req 1").send_response("foo");
-//
-//         // s2 can't get capacity until the future is dropped/consumed
-//         assert_pending!(s2.poll_ready());
-//         r1.await.unwrap();
-//         assert_ready_ok!(s2.poll_ready());
-//     }
-//
-//     #[tokio::test(flavor = "current_thread")]
-//     async fn test_service_drop_frees_capacity() {
-//         let scheduler = Scheduler::new(1);
-//         let limit = ConcurrencyLimitLayer::new(scheduler);
-//         let (mut s1, mut _handle) = mock::spawn_layer::<(), (), _>(limit);
-//
-//         assert_ready_ok!(s1.poll_ready());
-//
-//         // s2 should share underlying scheduler
-//         let mut s2 = s1.clone();
-//         assert_pending!(s2.poll_ready());
-//
-//         drop(s1);
-//         assert!(s2.is_woken());
-//         assert_ready_ok!(s2.poll_ready());
-//     }
-//     #[tokio::test(flavor = "current_thread")]
-//     async fn test_drop_resp_future_frees_capacity() {
-//         let scheduler = Scheduler::new(1);
-//         let limit = ConcurrencyLimitLayer::new(scheduler);
-//         let (mut s1, mut _handle) = mock::spawn_layer::<_, (), _>(limit);
-//         let mut s2 = s1.clone();
-//
-//         assert_ready_ok!(s1.poll_ready());
-//         let r1 = s1.call("req 1");
-//
-//         assert_pending!(s2.poll_ready());
-//         drop(r1);
-//         assert_ready_ok!(s2.poll_ready());
-//     }
-//
-//     #[tokio::test(flavor = "current_thread")]
-//     async fn test_service_error_frees_capacity() {
-//         let scheduler = Scheduler::new(1);
-//         let limit = ConcurrencyLimitLayer::new(scheduler);
-//         let (mut s1, mut handle) = mock::spawn_layer::<_, (), _>(limit);
-//         let mut s2 = s1.clone();
-//
-//         // reserve capacity on s1
-//         assert_ready_ok!(s1.poll_ready());
-//         assert_pending!(s2.poll_ready());
-//
-//         let r1 = s1.call("req 1");
-//
-//         assert_request_eq!(handle, "req 1").send_error("blerg");
-//         r1.await.unwrap_err();
-//
-//         assert_ready_ok!(s2.poll_ready());
-//     }
-//
-//     #[tokio::test(flavor = "current_thread")]
-//     async fn test_multiple_waiting() {
-//         let scheduler = Scheduler::new(1);
-//         let limit = ConcurrencyLimitLayer::new(scheduler);
-//         let (mut s1, mut _handle) = mock::spawn_layer::<(), (), _>(limit);
-//         let mut s2 = s1.clone();
-//         let mut s3 = s1.clone();
-//
-//         // reserve capacity on s1
-//         assert_ready_ok!(s1.poll_ready());
-//         assert_pending!(s2.poll_ready());
-//         assert_pending!(s3.poll_ready());
-//
-//         drop(s1);
-//
-//         assert!(s2.is_woken());
-//         assert!(!s3.is_woken());
-//
-//         drop(s2);
-//         assert!(s3.is_woken());
-//     }
-// }
+#[cfg(test)]
+mod tests {
+
+    use crate::runtime::scheduler::Scheduler;
+    use crate::{middleware::limit::concurrency::ConcurrencyLimitLayer, types::ConcurrencyMode};
+    use tokio_test::{assert_pending, assert_ready_ok, task};
+    use tower_test::{assert_request_eq, mock};
+
+    use super::ProvidePayloadSize;
+
+    #[derive(Debug)]
+    struct TestInput(&'static str);
+
+    impl ProvidePayloadSize for TestInput {
+        fn payload_size(&self) -> u64 {
+            self.0.len() as u64
+        }
+    }
+
+    impl PartialEq<&'static str> for TestInput {
+        fn eq(&self, other: &&'static str) -> bool {
+            self.0 == *other
+        }
+    }
+
+    // #[tokio::test(flavor = "current_thread")]
+    // async fn test_service_limit() {
+    //     let scheduler = Scheduler::new(ConcurrencyMode::Explicit(2));
+    //     let limit = ConcurrencyLimitLayer::new(scheduler);
+    //     let (mut service, mut handle) = mock::spawn_layer(limit);
+    //
+    //     // println!("first call");
+    //     // assert_ready_ok!(service.poll_ready());
+    //     // let r1 = service.call(TestInput("req 1"));
+    //     //
+    //     // println!("second call");
+    //     // assert_ready_ok!(service.poll_ready());
+    //     // let r2 = service.call(TestInput("req 2"));
+    //     //
+    //     // println!("third call");
+    //     // assert_ready_ok!(service.poll_ready());
+    //     // let r3 = service.call(TestInput("req 3"));
+    //
+    //     // assert_pending!(service.poll_ready());
+    //     // assert!(!service.is_woken());
+    //     let mut t1 = task::spawn(async {
+    //         // assert_ready_ok!(service.poll_ready());
+    //         let c = service.call(TestInput("req 1"));
+    //         c.await.unwrap();
+    //     });
+    //
+    //
+    //     // let mut t1 = task::spawn(r1);
+    //     // let mut t2 = task::spawn(r2);
+    //     // let mut t3 = task::spawn(r3);
+    //     println!("poll t1");
+    //     assert_pending!(t1.poll());
+    //
+    //
+    //     println!("pass requests through");
+    //     //
+    //     // // pass requests through
+    //     assert_request_eq!(handle, "req 1").send_response("foo");
+    //     // assert_request_eq!(handle, "req 2").send_response("bar");
+    //     //
+    //     println!("no more requests");
+    //     // // no more requests
+    //     // assert_pending!(handle.poll_request());
+    //     // assert_eq!(r1.await.unwrap(), "foo");
+    //     //
+    //     // assert!(service.is_woken());
+    //     //
+    //     // println!("check no more requests through");
+    //     // // more requests can make it through
+    //     // assert_ready_ok!(service.poll_ready());
+    //     // let r3 = service.call(TestInput("req 3"));
+    //     //
+    //     // // assert_pending!(service.poll_ready());
+    //     //
+    //     // println!("check r2");
+    //     // assert_eq!(r2.await.unwrap(), "bar");
+    //     //
+    //     // println!("check r3");
+    //     // assert_request_eq!(handle, "req 3").send_response("baz");
+    //     // assert_eq!(r3.await.unwrap(), "baz");
+    // }
+    //
+    // #[tokio::test(flavor = "current_thread")]
+    // async fn test_clone() {
+    //     let scheduler = Scheduler::new(1);
+    //     let limit = ConcurrencyLimitLayer::new(scheduler);
+    //     let (mut s1, mut handle) = mock::spawn_layer(limit);
+    //
+    //     assert_ready_ok!(s1.poll_ready());
+    //
+    //     // s2 should share underlying scheduler
+    //     let mut s2 = s1.clone();
+    //     assert_pending!(s2.poll_ready());
+    //
+    //     let r1 = s1.call("req 1");
+    //     assert_request_eq!(handle, "req 1").send_response("foo");
+    //
+    //     // s2 can't get capacity until the future is dropped/consumed
+    //     assert_pending!(s2.poll_ready());
+    //     r1.await.unwrap();
+    //     assert_ready_ok!(s2.poll_ready());
+    // }
+    //
+    // #[tokio::test(flavor = "current_thread")]
+    // async fn test_service_drop_frees_capacity() {
+    //     let scheduler = Scheduler::new(1);
+    //     let limit = ConcurrencyLimitLayer::new(scheduler);
+    //     let (mut s1, mut _handle) = mock::spawn_layer::<(), (), _>(limit);
+    //
+    //     assert_ready_ok!(s1.poll_ready());
+    //
+    //     // s2 should share underlying scheduler
+    //     let mut s2 = s1.clone();
+    //     assert_pending!(s2.poll_ready());
+    //
+    //     drop(s1);
+    //     assert!(s2.is_woken());
+    //     assert_ready_ok!(s2.poll_ready());
+    // }
+    // #[tokio::test(flavor = "current_thread")]
+    // async fn test_drop_resp_future_frees_capacity() {
+    //     let scheduler = Scheduler::new(1);
+    //     let limit = ConcurrencyLimitLayer::new(scheduler);
+    //     let (mut s1, mut _handle) = mock::spawn_layer::<_, (), _>(limit);
+    //     let mut s2 = s1.clone();
+    //
+    //     assert_ready_ok!(s1.poll_ready());
+    //     let r1 = s1.call("req 1");
+    //
+    //     assert_pending!(s2.poll_ready());
+    //     drop(r1);
+    //     assert_ready_ok!(s2.poll_ready());
+    // }
+    //
+    // #[tokio::test(flavor = "current_thread")]
+    // async fn test_service_error_frees_capacity() {
+    //     let scheduler = Scheduler::new(1);
+    //     let limit = ConcurrencyLimitLayer::new(scheduler);
+    //     let (mut s1, mut handle) = mock::spawn_layer::<_, (), _>(limit);
+    //     let mut s2 = s1.clone();
+    //
+    //     // reserve capacity on s1
+    //     assert_ready_ok!(s1.poll_ready());
+    //     assert_pending!(s2.poll_ready());
+    //
+    //     let r1 = s1.call("req 1");
+    //
+    //     assert_request_eq!(handle, "req 1").send_error("blerg");
+    //     r1.await.unwrap_err();
+    //
+    //     assert_ready_ok!(s2.poll_ready());
+    // }
+    //
+    // #[tokio::test(flavor = "current_thread")]
+    // async fn test_multiple_waiting() {
+    //     let scheduler = Scheduler::new(1);
+    //     let limit = ConcurrencyLimitLayer::new(scheduler);
+    //     let (mut s1, mut _handle) = mock::spawn_layer::<(), (), _>(limit);
+    //     let mut s2 = s1.clone();
+    //     let mut s3 = s1.clone();
+    //
+    //     // reserve capacity on s1
+    //     assert_ready_ok!(s1.poll_ready());
+    //     assert_pending!(s2.poll_ready());
+    //     assert_pending!(s3.poll_ready());
+    //
+    //     drop(s1);
+    //
+    //     assert!(s2.is_woken());
+    //     assert!(!s3.is_woken());
+    //
+    //     drop(s2);
+    //     assert!(s3.is_woken());
+    // }
+}

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -105,158 +105,67 @@ mod tests {
         }
     }
 
-    // #[tokio::test(flavor = "current_thread")]
-    // async fn test_service_limit() {
-    //     let scheduler = Scheduler::new(ConcurrencyMode::Explicit(2));
-    //     let limit = ConcurrencyLimitLayer::new(scheduler);
-    //     let (mut service, mut handle) = mock::spawn_layer(limit);
-    //
-    //     // println!("first call");
-    //     // assert_ready_ok!(service.poll_ready());
-    //     // let r1 = service.call(TestInput("req 1"));
-    //     //
-    //     // println!("second call");
-    //     // assert_ready_ok!(service.poll_ready());
-    //     // let r2 = service.call(TestInput("req 2"));
-    //     //
-    //     // println!("third call");
-    //     // assert_ready_ok!(service.poll_ready());
-    //     // let r3 = service.call(TestInput("req 3"));
-    //
-    //     // assert_pending!(service.poll_ready());
-    //     // assert!(!service.is_woken());
-    //     let mut t1 = task::spawn(async {
-    //         // assert_ready_ok!(service.poll_ready());
-    //         let c = service.call(TestInput("req 1"));
-    //         c.await.unwrap();
-    //     });
-    //
-    //
-    //     // let mut t1 = task::spawn(r1);
-    //     // let mut t2 = task::spawn(r2);
-    //     // let mut t3 = task::spawn(r3);
-    //     println!("poll t1");
-    //     assert_pending!(t1.poll());
-    //
-    //
-    //     println!("pass requests through");
-    //     //
-    //     // // pass requests through
-    //     assert_request_eq!(handle, "req 1").send_response("foo");
-    //     // assert_request_eq!(handle, "req 2").send_response("bar");
-    //     //
-    //     println!("no more requests");
-    //     // // no more requests
-    //     // assert_pending!(handle.poll_request());
-    //     // assert_eq!(r1.await.unwrap(), "foo");
-    //     //
-    //     // assert!(service.is_woken());
-    //     //
-    //     // println!("check no more requests through");
-    //     // // more requests can make it through
-    //     // assert_ready_ok!(service.poll_ready());
-    //     // let r3 = service.call(TestInput("req 3"));
-    //     //
-    //     // // assert_pending!(service.poll_ready());
-    //     //
-    //     // println!("check r2");
-    //     // assert_eq!(r2.await.unwrap(), "bar");
-    //     //
-    //     // println!("check r3");
-    //     // assert_request_eq!(handle, "req 3").send_response("baz");
-    //     // assert_eq!(r3.await.unwrap(), "baz");
-    // }
-    //
-    // #[tokio::test(flavor = "current_thread")]
-    // async fn test_clone() {
-    //     let scheduler = Scheduler::new(1);
-    //     let limit = ConcurrencyLimitLayer::new(scheduler);
-    //     let (mut s1, mut handle) = mock::spawn_layer(limit);
-    //
-    //     assert_ready_ok!(s1.poll_ready());
-    //
-    //     // s2 should share underlying scheduler
-    //     let mut s2 = s1.clone();
-    //     assert_pending!(s2.poll_ready());
-    //
-    //     let r1 = s1.call("req 1");
-    //     assert_request_eq!(handle, "req 1").send_response("foo");
-    //
-    //     // s2 can't get capacity until the future is dropped/consumed
-    //     assert_pending!(s2.poll_ready());
-    //     r1.await.unwrap();
-    //     assert_ready_ok!(s2.poll_ready());
-    // }
-    //
-    // #[tokio::test(flavor = "current_thread")]
-    // async fn test_service_drop_frees_capacity() {
-    //     let scheduler = Scheduler::new(1);
-    //     let limit = ConcurrencyLimitLayer::new(scheduler);
-    //     let (mut s1, mut _handle) = mock::spawn_layer::<(), (), _>(limit);
-    //
-    //     assert_ready_ok!(s1.poll_ready());
-    //
-    //     // s2 should share underlying scheduler
-    //     let mut s2 = s1.clone();
-    //     assert_pending!(s2.poll_ready());
-    //
-    //     drop(s1);
-    //     assert!(s2.is_woken());
-    //     assert_ready_ok!(s2.poll_ready());
-    // }
-    // #[tokio::test(flavor = "current_thread")]
-    // async fn test_drop_resp_future_frees_capacity() {
-    //     let scheduler = Scheduler::new(1);
-    //     let limit = ConcurrencyLimitLayer::new(scheduler);
-    //     let (mut s1, mut _handle) = mock::spawn_layer::<_, (), _>(limit);
-    //     let mut s2 = s1.clone();
-    //
-    //     assert_ready_ok!(s1.poll_ready());
-    //     let r1 = s1.call("req 1");
-    //
-    //     assert_pending!(s2.poll_ready());
-    //     drop(r1);
-    //     assert_ready_ok!(s2.poll_ready());
-    // }
-    //
-    // #[tokio::test(flavor = "current_thread")]
-    // async fn test_service_error_frees_capacity() {
-    //     let scheduler = Scheduler::new(1);
-    //     let limit = ConcurrencyLimitLayer::new(scheduler);
-    //     let (mut s1, mut handle) = mock::spawn_layer::<_, (), _>(limit);
-    //     let mut s2 = s1.clone();
-    //
-    //     // reserve capacity on s1
-    //     assert_ready_ok!(s1.poll_ready());
-    //     assert_pending!(s2.poll_ready());
-    //
-    //     let r1 = s1.call("req 1");
-    //
-    //     assert_request_eq!(handle, "req 1").send_error("blerg");
-    //     r1.await.unwrap_err();
-    //
-    //     assert_ready_ok!(s2.poll_ready());
-    // }
-    //
-    // #[tokio::test(flavor = "current_thread")]
-    // async fn test_multiple_waiting() {
-    //     let scheduler = Scheduler::new(1);
-    //     let limit = ConcurrencyLimitLayer::new(scheduler);
-    //     let (mut s1, mut _handle) = mock::spawn_layer::<(), (), _>(limit);
-    //     let mut s2 = s1.clone();
-    //     let mut s3 = s1.clone();
-    //
-    //     // reserve capacity on s1
-    //     assert_ready_ok!(s1.poll_ready());
-    //     assert_pending!(s2.poll_ready());
-    //     assert_pending!(s3.poll_ready());
-    //
-    //     drop(s1);
-    //
-    //     assert!(s2.is_woken());
-    //     assert!(!s3.is_woken());
-    //
-    //     drop(s2);
-    //     assert!(s3.is_woken());
-    // }
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_service_limit() {
+        let scheduler = Scheduler::new(ConcurrencyMode::Explicit(2));
+        let limit = ConcurrencyLimitLayer::new(scheduler);
+        let (mut service, mut handle) = mock::spawn_layer(limit);
+
+        assert_ready_ok!(service.poll_ready());
+        let r1 = service.call(TestInput("req 1"));
+        assert_ready_ok!(service.poll_ready());
+        let r2 = service.call(TestInput("req 2"));
+
+        assert_ready_ok!(service.poll_ready());
+        let r3 = service.call(TestInput("req 3"));
+
+        let mut t1 = task::spawn(r1);
+        let mut t2 = task::spawn(r2);
+        let mut t3 = task::spawn(r3);
+        assert_pending!(t1.poll());
+        assert_pending!(t2.poll());
+        assert_pending!(t3.poll());
+
+        // pass requests through
+        assert_request_eq!(handle, "req 1").send_response("foo");
+        assert_request_eq!(handle, "req 2").send_response("bar");
+
+        assert_pending!(handle.poll_request());
+        assert_eq!(t1.await.unwrap(), "foo");
+        assert_eq!(t2.await.unwrap(), "bar");
+
+        // NOTE: because poll_ready() is implemented in poll() for this middleware we have to
+        // manually poll it here for it to pickup the permit and actually call the service
+        // otherwise we'd block on send_response(). This is mismatch between tower-test and
+        // how they expect a service to behave.
+        assert_pending!(t3.poll());
+        assert_request_eq!(handle, "req 3").send_response("baz");
+        assert_eq!(t3.await.unwrap(), "baz");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_clone() {
+        let scheduler = Scheduler::new(ConcurrencyMode::Explicit(1));
+        let limit = ConcurrencyLimitLayer::new(scheduler);
+        let (mut s1, mut handle) = mock::spawn_layer(limit);
+
+        assert_ready_ok!(s1.poll_ready());
+
+        // s2 should share underlying scheduler
+        let mut s2 = s1.clone();
+        assert_ready_ok!(s2.poll_ready());
+
+        let r1 = s1.call(TestInput("req 1"));
+        let r2 = s2.call(TestInput("req 2"));
+        let mut t1 = task::spawn(r1);
+        let mut t2 = task::spawn(r2);
+        assert_pending!(t1.poll());
+        assert_request_eq!(handle, "req 1").send_response("foo");
+
+        // s2 can't get capacity until the future is dropped/consumed
+        t1.await.unwrap();
+        assert_pending!(t2.poll());
+        assert_request_eq!(handle, "req 2").send_response("bar");
+        assert_eq!(t2.await.unwrap(), "bar");
+    }
 }

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -64,7 +64,7 @@ where
     fn call(&mut self, req: Request) -> Self::Future {
         // NOTE: We assume this is a dataplane request as that is the only place
         // we make use of tower is for upload/download. If this changes this logic needs updated.
-        let ptype = PermitType::DataPlane(req.payload_size());
+        let ptype = PermitType::Network(req.payload_size());
         let permit_fut = self.scheduler.acquire_permit(ptype);
         ResponseFuture::new(self.inner.clone(), req, permit_fut, self.inflight.clone())
     }

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -120,7 +120,7 @@ async fn send_discovery(
     let permit = ctx
         .handle
         .scheduler
-        .acquire_permit(PermitType::ControlPlane)
+        .acquire_permit(PermitType::Network(0))
         .await;
     let permit = match permit {
         Ok(permit) => permit,

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -33,7 +33,7 @@ mod service;
 
 use crate::error;
 use crate::io::AggregatedBytes;
-use crate::runtime::scheduler::OwnedWorkPermit;
+use crate::runtime::scheduler::{OwnedWorkPermit, PermitType};
 use aws_smithy_types::byte_stream::ByteStream;
 use discovery::discover_obj;
 use service::distribute_work;
@@ -115,8 +115,13 @@ async fn send_discovery(
         parent_span_for_tasks.follows_from(tracing::Span::current());
     }
 
+    // FIXME - move acquire permit to where it's used in discovery (where we know the payload size)
     // acquire a permit for discovery
-    let permit = ctx.handle.scheduler.acquire_permit().await;
+    let permit = ctx
+        .handle
+        .scheduler
+        .acquire_permit(PermitType::ControlPlane)
+        .await;
     let permit = match permit {
         Ok(permit) => permit,
         Err(err) => {

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -229,7 +229,8 @@ async fn start_mpu(ctx: &UploadContext) -> Result<UploadOutputBuilder, crate::er
 mod test {
     use crate::io::InputStream;
     use crate::operation::upload::UploadInput;
-    use crate::types::{ConcurrencySetting, PartSize};
+    use crate::types::PartSize;
+    use crate::types::TargetThroughput;
     use aws_sdk_s3::operation::abort_multipart_upload::AbortMultipartUploadOutput;
     use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadOutput;
     use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
@@ -291,7 +292,7 @@ mod test {
         );
 
         let tm_config = crate::Config::builder()
-            .concurrency(ConcurrencySetting::Explicit(1))
+            .target_throughput(TargetThroughput::no_concurrency())
             .set_multipart_threshold(PartSize::Target(10))
             .set_target_part_size(PartSize::Target(30))
             .client(client)
@@ -328,7 +329,7 @@ mod test {
             mock_client_with_stubbed_http_client!(aws_sdk_s3, RuleMode::Sequential, &[&put_object]);
 
         let tm_config = crate::Config::builder()
-            .concurrency(ConcurrencySetting::Explicit(1))
+            .target_throughput(TargetThroughput::no_concurrency())
             .set_multipart_threshold(PartSize::Target(10 * 1024 * 1024))
             .client(client)
             .build();
@@ -387,7 +388,7 @@ mod test {
         );
 
         let tm_config = crate::Config::builder()
-            .concurrency(ConcurrencySetting::Explicit(1))
+            .target_throughput(TargetThroughput::no_concurrency())
             .set_multipart_threshold(PartSize::Target(10))
             .set_target_part_size(PartSize::Target(5 * 1024 * 1024))
             .client(client)

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -241,6 +241,7 @@ mod test {
     use aws_sdk_s3::operation::put_object::PutObjectOutput;
     use aws_sdk_s3::operation::upload_part::UploadPartOutput;
     use aws_smithy_mocks_experimental::{mock, RuleMode};
+    use aws_smithy_runtime::test_util::capture_test_logs::show_test_logs;
     use bytes::Bytes;
     use std::ops::Deref;
     use std::sync::Arc;
@@ -249,6 +250,7 @@ mod test {
 
     #[tokio::test]
     async fn test_basic_mpu() {
+        let _logs = show_test_logs();
         let expected_upload_id = Arc::new("test-upload".to_owned());
         let body = Bytes::from_static(b"every adolescent dog goes bonkers early");
         let stream = InputStream::from(body);

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -113,7 +113,7 @@ async fn put_object(
     let _permit = ctx
         .handle
         .scheduler
-        .acquire_permit(PermitType::DataPlane(content_length as u64))
+        .acquire_permit(PermitType::Network(content_length as u64))
         .await?;
 
     let mut req = ctx

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -39,7 +39,7 @@ pub(super) struct UploadPartRequest {
 }
 
 impl ProvidePayloadSize for UploadPartRequest {
-    fn payload_size(&self) -> u64 {
+    fn payload_size_estimate(&self) -> u64 {
         self.part_data.data.len() as u64
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -335,6 +335,7 @@ mod tests {
             UploadObjectsContext, UploadObjectsInputBuilder,
         },
         runtime::scheduler::Scheduler,
+        types::ConcurrencyMode,
         DEFAULT_CONCURRENCY,
     };
 
@@ -709,7 +710,7 @@ mod tests {
             mock_client_with_stubbed_http_client!(aws_sdk_s3, RuleMode::MatchAny, &[put_object]);
         let config = crate::Config::builder().client(s3_client).build();
 
-        let scheduler = Scheduler::new(DEFAULT_CONCURRENCY);
+        let scheduler = Scheduler::new(ConcurrencyMode::Explicit(DEFAULT_CONCURRENCY));
 
         let handle = std::sync::Arc::new(Handle { config, scheduler });
         let input = UploadObjectsInputBuilder::default()

--- a/aws-s3-transfer-manager/src/runtime.rs
+++ b/aws-s3-transfer-manager/src/runtime.rs
@@ -4,3 +4,4 @@
  */
 
 pub(crate) mod scheduler;
+pub(crate) mod token_bucket;

--- a/aws-s3-transfer-manager/src/runtime/scheduler.rs
+++ b/aws-s3-transfer-manager/src/runtime/scheduler.rs
@@ -63,10 +63,8 @@ pub(crate) type PayloadEstimate = u64;
 /// The type of work to be done
 #[derive(Debug, Clone)]
 pub(crate) enum PermitType {
-    /// A network request to a control plane API with insignificant payload
-    ControlPlane,
-    /// A network request to transmit or receive to or from a data plane API with the given payload size estimate
-    DataPlane(PayloadEstimate),
+    /// A network request to transmit or receive to or from an API with the given payload size estimate
+    Network(PayloadEstimate),
 }
 
 /// An owned permit from the scheduler to perform some unit of work.
@@ -134,12 +132,12 @@ mod tests {
     async fn test_acquire_mode_explicit() {
         let scheduler = Scheduler::new(ConcurrencyMode::Explicit(1));
         let p1 = scheduler
-            .acquire_permit(PermitType::ControlPlane)
+            .acquire_permit(PermitType::Network(0))
             .await
             .unwrap();
         let scheduler2 = scheduler.clone();
         let jh = tokio::spawn(async move {
-            let _p2 = scheduler2.acquire_permit(PermitType::ControlPlane).await;
+            let _p2 = scheduler2.acquire_permit(PermitType::Network(0)).await;
         });
         assert!(!jh.is_finished());
         drop(p1);

--- a/aws-s3-transfer-manager/src/runtime/scheduler.rs
+++ b/aws-s3-transfer-manager/src/runtime/scheduler.rs
@@ -11,8 +11,8 @@ use crate::error;
 use crate::runtime::token_bucket::{OwnedToken, TokenBucket};
 use crate::types::ConcurrencyMode;
 
-// FIXME - track high water mark
-// FIXME - add statistics/telemetry
+// TODO - track high water mark
+// TODO - add statistics/telemetry
 
 /// Manages scheduling networking and I/O work
 ///

--- a/aws-s3-transfer-manager/src/runtime/scheduler.rs
+++ b/aws-s3-transfer-manager/src/runtime/scheduler.rs
@@ -33,7 +33,7 @@ impl Scheduler {
     /// Acquire a permit to perform some unit of work
     pub(crate) fn acquire_permit(&self, ptype: PermitType) -> AcquirePermitFuture {
         match self.try_acquire_permit(ptype.clone()) {
-            Ok(Some(token)) => AcquirePermitFuture::ready(Ok(token.into())),
+            Ok(Some(permit)) => AcquirePermitFuture::ready(Ok(permit)),
             Ok(None) => {
                 let inner = self
                     .token_bucket

--- a/aws-s3-transfer-manager/src/runtime/scheduler.rs
+++ b/aws-s3-transfer-manager/src/runtime/scheduler.rs
@@ -143,6 +143,4 @@ mod tests {
         drop(p1);
         jh.await.unwrap();
     }
-
-    // TODO - add additional tests (e.g. test the example from S3 documentation that we end up with the right concurrency)
 }

--- a/aws-s3-transfer-manager/src/runtime/scheduler.rs
+++ b/aws-s3-transfer-manager/src/runtime/scheduler.rs
@@ -57,6 +57,9 @@ impl Scheduler {
 
 pub(crate) type PayloadEstimate = u64;
 
+// TODO - when we support configuring throughput indepently we'll need to distinguish the permit
+// type and track it separately in the token bucket(s).
+
 /// The type of work to be done
 #[derive(Debug, Clone)]
 pub(crate) enum PermitType {

--- a/aws-s3-transfer-manager/src/runtime/scheduler.rs
+++ b/aws-s3-transfer-manager/src/runtime/scheduler.rs
@@ -145,6 +145,7 @@ impl SchedulerMetrics {
     }
 
     /// Get the current number of in-flight requests
+    #[cfg(test)]
     pub(crate) fn inflight(&self) -> usize {
         self.inflight.load(Ordering::SeqCst)
     }

--- a/aws-s3-transfer-manager/src/runtime/scheduler.rs
+++ b/aws-s3-transfer-manager/src/runtime/scheduler.rs
@@ -11,6 +11,9 @@ use std::future::Future;
 use std::sync::Arc;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
 
+// FIXME - track high water mark
+// FIXME - add statistics/telemetry
+
 /// Manages scheduling networking and I/O work
 ///
 /// Scheduler is internally reference-counted and can be freely cloned.
@@ -23,7 +26,7 @@ impl Scheduler {
     /// Create a new scheduler with the initial number of work permits.
     pub(crate) fn new(permits: usize) -> Self {
         Self {
-            // NOTE: tokio semahpore is fair, permits are given out in the order requested
+            // NOTE: tokio semaphore is fair, permits are given out in the order requested
             sem: Arc::new(Semaphore::new(permits)),
         }
     }

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -32,6 +32,7 @@ const S3_P50_REQUEST_LATENCY: Duration = Duration::from_millis(30);
 ///
 /// Source: S3 team and S3 docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-design-patterns.html#optimizing-performance-parallelization
 /// > Make one concurrent request for each 85-90 MB/s of desired network throughput
+///
 /// Applies to: ConcurrencyMode::TargetThroughput
 const S3_MAX_PER_REQUEST_THROUGHPUT: Throughput = Throughput::new_bytes_per_sec(90 * 1000 * 1000);
 
@@ -63,8 +64,7 @@ impl PermitType {
     /// The token cost for the permit type in Mbps
     fn token_cost_megabit_per_sec(&self) -> u32 {
         let cost = match *self {
-            PermitType::DataPlane(payload_size) => tokens_for_payload(payload_size),
-            _ => MIN_PAYLOAD_COST_TOKENS,
+            PermitType::Network(payload_size) => tokens_for_payload(payload_size),
         };
         cost.try_into().unwrap()
     }

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -51,7 +51,6 @@ impl PermitType {
 pub(crate) struct TokenBucket {
     // NOTE: tokio semaphore is fair, permits are given out in the order requested
     semaphore: Arc<Semaphore>,
-    max_permits: usize,
     mode: ConcurrencyMode,
 }
 
@@ -68,7 +67,6 @@ impl TokenBucket {
 
         TokenBucket {
             semaphore: Arc::new(Semaphore::new(max_permits)),
-            max_permits,
             mode,
         }
     }

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -61,7 +61,12 @@ impl TokenBucket {
             ConcurrencyMode::Auto => token_bucket_size(Throughput::new_bytes_per_sec(
                 AUTO_TARGET_THROUGHPUT_GIGABYTES_PER_SEC,
             )),
-            ConcurrencyMode::TargetThroughput(thrpt) => token_bucket_size(*thrpt),
+            ConcurrencyMode::TargetThroughput(target_throughput) => {
+                // TODO - we don't publicly allow configuring upload/download independently so we
+                // just pick one for now as they must be the same at the moment.
+                let thrpt = target_throughput.download();
+                token_bucket_size(*thrpt)
+            }
             ConcurrencyMode::Explicit(concurrency) => *concurrency,
         };
 

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -1,0 +1,251 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::task::Poll;
+use std::{cmp, sync::Arc, time::Duration};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::PollSemaphore;
+
+use crate::error;
+use crate::metrics::{unit::ByteUnit, Throughput};
+use crate::runtime::scheduler::PermitType;
+use crate::types::ConcurrencyMode;
+
+/// Default throughput target for auto mode
+const AUTO_TARGET_THROUGHPUT_GIGABYTES_PER_SEC: u64 = ByteUnit::Gigabit.as_bytes_u64() * 10;
+
+/// Estimated P50 latency for S3
+const S3_P50_REQUEST_LATENCY_MS: usize = 30;
+
+/// Estimated per/request max throughput S3 is capable of
+const S3_MAX_PER_REQUEST_THROUGHPUT_MB_PER_SEC: u64 = 90;
+
+/// Minimum concurrent requests at full throughput we want to support
+const MIN_CONCURRENT_REQUESTS: usize = 8;
+
+/// Min bucket size tokens
+const MIN_TOKENS: usize =
+    (S3_MAX_PER_REQUEST_THROUGHPUT_MB_PER_SEC as usize) * 8 * MIN_CONCURRENT_REQUESTS;
+
+/// Minimum token cost regardless of payload size
+const MIN_PAYLOAD_COST_TOKENS: usize = 5;
+
+impl PermitType {
+    fn token_cost(&self) -> u32 {
+        let cost = match *self {
+            PermitType::DataPlane(payload_size) => tokens_for_payload(payload_size),
+            _ => MIN_PAYLOAD_COST_TOKENS,
+        };
+        cost.try_into().unwrap()
+    }
+}
+
+/// Token bucket used for controlling target throughput
+///
+/// Tokens are weighted based on the permit type being acquired (e.g. based on payload size).
+#[derive(Debug, Clone)]
+pub(crate) struct TokenBucket {
+    // NOTE: tokio semaphore is fair, permits are given out in the order requested
+    semaphore: Arc<Semaphore>,
+    max_permits: usize,
+    mode: ConcurrencyMode,
+}
+
+impl TokenBucket {
+    /// Create a new token bucket using the given target throughput to set the maximum number of tokens
+    pub(crate) fn new(mode: ConcurrencyMode) -> Self {
+        let max_permits = match &mode {
+            ConcurrencyMode::Auto => token_bucket_size(Throughput::new_bytes_per_sec(
+                AUTO_TARGET_THROUGHPUT_GIGABYTES_PER_SEC,
+            )),
+            ConcurrencyMode::TargetThroughput(thrpt) => token_bucket_size(*thrpt),
+            ConcurrencyMode::Explicit(concurrency) => *concurrency,
+        };
+
+        TokenBucket {
+            semaphore: Arc::new(Semaphore::new(max_permits)),
+            max_permits,
+            mode,
+        }
+    }
+
+    /// Calculate the token cost for the given permit type (and current mode)
+    fn cost(&self, ptype: PermitType) -> u32 {
+        match self.mode {
+            // in explicit mode each acquire is weighted the same regardless of permit type
+            ConcurrencyMode::Explicit(_) => 1,
+            _ => ptype.token_cost(),
+        }
+    }
+
+    // pub(crate) async fn acquire(&self, ptype: PermitType) -> Result<OwnedToken, error::Error> {
+    //     let cost = self.cost(ptype);
+    //     let permit = self.semaphore.clone().acquire_many_owned(cost)
+    //         .await
+    //         .map_err(error::from_kind(error::ErrorKind::RuntimeError))?;
+    //
+    //     Ok(OwnedToken::new(permit))
+    // }
+
+    /// Acquire a token for the given permit type. Tokens are returned to the bucket when the
+    /// [OwnedToken] is dropped.
+    pub(crate) fn acquire(&self, ptype: PermitType) -> AcquireTokenFuture {
+        AcquireTokenFuture::new(PollSemaphore::new(self.semaphore.clone()), self.cost(ptype))
+    }
+
+    pub(crate) fn try_acquire(
+        &self,
+        ptype: PermitType,
+    ) -> Result<Option<OwnedToken>, error::Error> {
+        let cost = self.cost(ptype);
+        self.semaphore
+            .clone()
+            .try_acquire_many_owned(cost)
+            .map(|permit| Some(OwnedToken::new(permit)))
+            .map_err(error::from_kind(error::ErrorKind::RuntimeError))
+    }
+}
+
+pin_project! {
+    #[derive(Debug, Clone)]
+    pub(crate) struct AcquireTokenFuture {
+        sem: PollSemaphore,
+        tokens: u32
+    }
+}
+
+impl AcquireTokenFuture {
+    fn new(sem: PollSemaphore, tokens: u32) -> Self {
+        Self { sem, tokens }
+    }
+}
+
+impl Future for AcquireTokenFuture {
+    type Output = Result<OwnedToken, error::Error>;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = self.project();
+        match this.sem.poll_acquire_many(cx, *this.tokens) {
+            Poll::Ready(Some(permit)) => Poll::Ready(Ok(OwnedToken::new(permit))),
+            Poll::Ready(None) => todo!(),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// An owned permit from the scheduler to perform some unit of work.
+#[must_use]
+#[clippy::has_significant_drop]
+#[derive(Debug)]
+pub(crate) struct OwnedToken {
+    _inner: OwnedSemaphorePermit,
+}
+
+impl OwnedToken {
+    fn new(permit: OwnedSemaphorePermit) -> Self {
+        OwnedToken { _inner: permit }
+    }
+}
+
+/// Get the token bucket size to use for a given target throughput
+fn token_bucket_size(throughput: Throughput) -> usize {
+    let megabit_per_sec = throughput.as_unit_per_sec(ByteUnit::Megabit).max(1.0) as usize;
+    cmp::max(MIN_TOKENS, megabit_per_sec)
+}
+
+/// Tokens for payload size
+fn tokens_for_payload(payload_size: u64) -> usize {
+    let estimated_mbps = estimated_throughput(
+        payload_size,
+        S3_P50_REQUEST_LATENCY_MS,
+        Throughput::new_bytes_per_sec(S3_MAX_PER_REQUEST_THROUGHPUT_MB_PER_SEC * 1000 * 1000),
+    )
+    .as_unit_per_sec(ByteUnit::Megabit)
+    .round()
+    .max(1.0) as usize;
+
+    cmp::max(estimated_mbps, MIN_PAYLOAD_COST_TOKENS)
+}
+
+/// Estimate the throughput of a given request payload based on S3 latencies
+/// and max per/connection estimates.
+fn estimated_throughput(
+    payload_size: u64,
+    estimated_p50_latency_ms: usize,
+    estimated_max_request_throughput: Throughput,
+) -> Throughput {
+    let req_estimate = Throughput::new(
+        payload_size,
+        Duration::from_millis(estimated_p50_latency_ms as u64),
+    );
+
+    // take lower of the maximum per request estimate service is capable of or the estimate based on the payload
+    cmp::min_by(estimated_max_request_throughput, req_estimate, |x, y| {
+        x.partial_cmp(y).expect("valid order")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::metrics::unit::ByteUnit;
+    use crate::runtime::token_bucket::{estimated_throughput, tokens_for_payload};
+    use crate::{
+        metrics::Throughput,
+        runtime::token_bucket::{token_bucket_size, MIN_TOKENS},
+    };
+
+    const MEGABYTE: u64 = 1000 * 1000;
+
+    #[test]
+    fn test_estimated_throughput() {
+        let estimated_latency_ms = 1000;
+        let estimated_max_request_throughput = Throughput::new_bytes_per_sec(2 * MEGABYTE);
+        assert_eq!(
+            Throughput::new_bytes_per_sec(MEGABYTE),
+            estimated_throughput(
+                MEGABYTE,
+                estimated_latency_ms,
+                estimated_max_request_throughput
+            )
+        );
+        assert_eq!(
+            estimated_max_request_throughput,
+            estimated_throughput(
+                3 * MEGABYTE,
+                estimated_latency_ms,
+                estimated_max_request_throughput
+            )
+        );
+    }
+
+    #[test]
+    fn test_token_bucket_size() {
+        assert_eq!(
+            MIN_TOKENS,
+            token_bucket_size(Throughput::new_bytes_per_sec(1000))
+        );
+        assert_eq!(
+            10_000,
+            token_bucket_size(Throughput::new_bytes_per_sec(
+                ByteUnit::Gigabit.as_bytes_u64() * 10
+            ))
+        );
+    }
+
+    #[test]
+    fn test_tokens_for_payload() {
+        assert_eq!(5, tokens_for_payload(1024));
+        assert_eq!(27, tokens_for_payload(100 * 1024));
+        assert_eq!(267, tokens_for_payload(MEGABYTE));
+        assert_eq!(720, tokens_for_payload(5 * MEGABYTE));
+        assert_eq!(720, tokens_for_payload(8 * MEGABYTE));
+        assert_eq!(720, tokens_for_payload(1000 * MEGABYTE));
+    }
+}

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -23,6 +23,7 @@ pub enum PartSize {
 }
 
 /// The concurrency mode the client should use for executing requests.
+#[non_exhaustive]
 #[derive(Debug, Clone, Default)]
 pub enum ConcurrencyMode {
     /// Automatically configured concurrency based on the execution environment.

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -22,35 +22,20 @@ pub enum PartSize {
     Target(u64),
 }
 
-/// The target throughput the client should aim for.
-///
-/// NOTE: Target throughput is taken as a maximum. Actual throughput may be less than
-/// what is configured and is dependendent on the host, network conditions, etc.
+/// The concurrency mode the client should use for executing requests.
 #[derive(Debug, Clone, Default)]
-pub enum TargetThroughput {
-    /// Automatically configure an optimal target throughput setting based on the execution environment.
+pub enum ConcurrencyMode {
+    /// Automatically configured concurrency based on the execution environment.
     #[default]
     Auto,
 
-    /// Explicitly configured throughput setting.
-    Explicit(Throughput),
-}
-
-impl TargetThroughput {
-    /// Set a target throughput that signals one at a time concurrency.
+    /// Explicitly configured throughput setting the client should aim for.
     ///
-    /// NOTE: This is used mostly for testing purposes
-    #[doc(hidden)]
-    pub fn no_concurrency() -> TargetThroughput {
-        TargetThroughput::Explicit(Throughput::new_bytes_per_sec(0))
-    }
+    /// In this mode, concurrency is limited by attempting to hit a throughput target.
+    TargetThroughput(Throughput),
 
-    pub(crate) fn is_no_concurrency(&self) -> bool {
-        match self {
-            TargetThroughput::Explicit(throughput) => throughput.bytes_transferred() == 0,
-            _ => false,
-        }
-    }
+    /// Explicit concurrency control
+    Explicit(usize),
 }
 
 /// Policy for how to handle a failed multipart upload

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -41,8 +41,8 @@ pub enum ConcurrencyMode {
 /// Throughput target(s)
 #[derive(Debug, Clone)]
 pub struct TargetThroughput {
-    upload: Throughput,
     download: Throughput,
+    upload: Throughput,
 }
 
 impl TargetThroughput {
@@ -57,10 +57,10 @@ impl TargetThroughput {
 
     /// Create a new target throughput using the given upload and download
     /// throughputs.
-    fn new(upload_target: Throughput, download_target: Throughput) -> Self {
+    fn new(download_target: Throughput, upload_target: Throughput) -> Self {
         Self {
-            upload: upload_target,
             download: download_target,
+            upload: upload_target,
         }
     }
 

--- a/aws-s3-transfer-manager/tests/download_test.rs
+++ b/aws-s3-transfer-manager/tests/download_test.rs
@@ -7,7 +7,7 @@ use aws_config::Region;
 use aws_s3_transfer_manager::{
     error::{BoxError, Error},
     operation::download::DownloadHandle,
-    types::{PartSize, TargetThroughput},
+    types::{ConcurrencyMode, PartSize},
 };
 use pin_project_lite::pin_project;
 use std::{
@@ -121,7 +121,7 @@ fn test_tm(http_client: StaticReplayClient, part_size: usize) -> aws_s3_transfer
     let config = aws_s3_transfer_manager::Config::builder()
         .client(s3_client)
         .part_size(PartSize::Target(part_size as u64))
-        .target_throughput(TargetThroughput::no_concurrency())
+        .concurrency(ConcurrencyMode::Explicit(1))
         .build();
 
     aws_s3_transfer_manager::Client::new(config)

--- a/aws-s3-transfer-manager/tests/download_test.rs
+++ b/aws-s3-transfer-manager/tests/download_test.rs
@@ -7,7 +7,7 @@ use aws_config::Region;
 use aws_s3_transfer_manager::{
     error::{BoxError, Error},
     operation::download::DownloadHandle,
-    types::{ConcurrencySetting, PartSize},
+    types::{PartSize, TargetThroughput},
 };
 use pin_project_lite::pin_project;
 use std::{
@@ -121,7 +121,7 @@ fn test_tm(http_client: StaticReplayClient, part_size: usize) -> aws_s3_transfer
     let config = aws_s3_transfer_manager::Config::builder()
         .client(s3_client)
         .part_size(PartSize::Target(part_size as u64))
-        .concurrency(ConcurrencySetting::Explicit(1))
+        .target_throughput(TargetThroughput::no_concurrency())
         .build();
 
     aws_s3_transfer_manager::Client::new(config)

--- a/aws-s3-transfer-manager/tests/upload_checksum_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_checksum_test.rs
@@ -9,7 +9,7 @@ use aws_s3_transfer_manager::{
     io::{InputStream, PartData, PartStream, SizeHint},
     metrics::unit::ByteUnit,
     operation::upload::{ChecksumStrategy, UploadOutput},
-    types::{ConcurrencySetting, PartSize},
+    types::{ConcurrencyMode, PartSize},
 };
 use aws_sdk_s3::{
     operation::{
@@ -491,7 +491,7 @@ async fn upload_helper(
         .client(s3_client)
         .part_size(PartSize::Target(PART_SIZE as u64))
         .multipart_threshold(PartSize::Target(PART_SIZE as u64))
-        .concurrency(ConcurrencySetting::Explicit(1)) // guarantee parts sent in order
+        .concurrency(ConcurrencyMode::Explicit(1)) // guarantee parts sent in order
         .build();
     let tm = aws_s3_transfer_manager::Client::new(tm_config);
 


### PR DESCRIPTION
**Description of changes:**

Replaces/expands the existing explicit concurrency knob with a target throughput mode that calculates concurrency based on estimated throughput. 

* `ConcurrencyMode::Explicit` - weights every request the same and operates generally as it did before. 
* `ConcurrencyMode::Auto` - defaults to 10Gbps target throughput for now (i.e. `ConcurrencyMode::TargetThroughput(10 gbps)`). In the future I would like for this to be an adaptive mode, perhaps adjusting the token bucket refill rate based on measuring actual throughput. 
* `ConcurrencyMode::TargetThroughput` - estimates the throughput for the request taking the smaller of the estimated max per/connection throughput (~ 90 MB/s based on [S3 docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-design-patterns.html) and internal discussions) and the throughput estimated based on the payload size and S3 P50 latency. 

This new token bucket approach _should_ allow for more concurrency for smaller payloads and result in the optimal concurrency for large requests. In testing the # of inflight requests matched both the number you'd get from following S3's own docs linked above and my own testing in the past that showed ~138 requests would max out a 100 Gbps NIC.

**Questions**
* The `num_workers` function is used to set a few things still that really ought to come from somewhere else
    * The buffer layer in upload service
    * The channel size for the download body
    * Number of workers used for `upload_objects` and `download_objects`
* The min token cost for small payloads (i.e. control plane)?
* Should we allow configuring upload/download target throughput independently? Should they come out of different token buckets even?

**TODO**
* Buffer layer for upload was introduced as a way to make the service cloneable after we introduced the hedging layer. The buffer size is still based on the concurrency which is now dynamic in one or more concurrency modes. This should _probably_ be some arbitrarily large number since the concurrency layer is what actually limits max in-fight requests anyway?
* Remove/replace some existing unit tests
    * Unfortunately some of the existing unit tests are not as simple because `poll_ready` can't be relied on

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
