### PR TITLE
Set x-amz-checksum-type on CompleteMultipartUpload

### DIFF
--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -213,8 +213,12 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
                 .set_sse_customer_key(handle.ctx.request.sse_customer_key.clone())
                 .set_sse_customer_key_md5(handle.ctx.request.sse_customer_key_md5.clone());
 
-            // check for user-provided full-object checksum...
             if let Some(checksum_strategy) = &handle.ctx.request.checksum_strategy {
+                // The Transfer Manager SEP recommends setting checksum-type on both
+                // CompleteMultipartUpload AND CreateMultipartUpload.
+                req = req.checksum_type(checksum_strategy.type_if_multipart().clone());
+
+                // check for user-provided full-object checksum...
                 if checksum_strategy.type_if_multipart() == &ChecksumType::FullObject {
                     // it might have been passed via ChecksumStrategy or PartStream
                     let full_object_checksum = match checksum_strategy.full_object_checksum() {

--- a/aws-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/handle.rs
@@ -214,8 +214,6 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
                 .set_sse_customer_key_md5(handle.ctx.request.sse_customer_key_md5.clone());
 
             if let Some(checksum_strategy) = &handle.ctx.request.checksum_strategy {
-                // The Transfer Manager SEP recommends setting checksum-type on both
-                // CompleteMultipartUpload AND CreateMultipartUpload.
                 req = req.checksum_type(checksum_strategy.type_if_multipart().clone());
 
                 // check for user-provided full-object checksum...

--- a/aws-s3-transfer-manager/tests/upload_checksum_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_checksum_test.rs
@@ -346,6 +346,11 @@ fn mock_s3_client_for_multipart_upload(
                     // if it was passed via ChecksumStrategy, or via PartStream.
                     let input_checksum_field = get_checksum_value!(input);
                     if let Some(request_strategy) = &request_strategy {
+                        assert_eq!(
+                            input.checksum_type(),
+                            Some(request_strategy.type_if_multipart())
+                        );
+
                         if let Some((field_algorithm, field_value)) = &input_checksum_field {
                             assert_eq!(field_algorithm, request_strategy.algorithm());
                             assert_eq!(field_value, &multipart_checksum);
@@ -359,6 +364,7 @@ fn mock_s3_client_for_multipart_upload(
                         }
                     } else {
                         assert!(input_checksum_field.is_none());
+                        assert!(input.checksum_type.is_none());
                     }
 
                     // The multipart_upload struct should include info about each part


### PR DESCRIPTION
**Issue:**
Multipart upload is failing when a full object checksum is provided by the user

**Description of Changes:**

Both CreateMultipartUpload AND CompleteMultipartUpload have `x-amz-checksum-type` fields. Set that field the same in both requests.

Previously we only set it in CreateMultipartUpload, which works when you're letting S3 calculate the full-object checksum value, but doesn't work when you provide the full-object checksum value yourself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
