### PR TITLE
Trivial: tweak internal variable names related to channels

### DIFF
--- a/aws-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-s3-transfer-manager/src/operation/download/handle.rs
@@ -19,7 +19,7 @@ use super::object_meta::ObjectMetadata;
 #[non_exhaustive]
 pub struct DownloadHandle {
     /// Object metadata receiver.
-    pub(crate) object_meta_receiver: Mutex<Option<Receiver<ObjectMetadata>>>,
+    pub(crate) object_meta_rx: Mutex<Option<Receiver<ObjectMetadata>>>,
     /// Object metadata.
     pub(crate) object_meta: OnceCell<ObjectMetadata>,
 
@@ -39,12 +39,12 @@ impl DownloadHandle {
         let meta = self
             .object_meta
             .get_or_try_init(|| async {
-                let mut object_meta_receiver = self.object_meta_receiver.lock().await;
-                let object_meta_receiver = object_meta_receiver
+                let mut object_meta_rx = self.object_meta_rx.lock().await;
+                let object_meta_rx = object_meta_rx
                     .take()
-                    .ok_or("meta_receiver is already taken")
+                    .ok_or("object_meta_rx is already taken")
                     .map_err(error::from_kind(ErrorKind::ObjectNotDiscoverable))?;
-                object_meta_receiver
+                object_meta_rx
                     .await
                     .map_err(error::from_kind(ErrorKind::ObjectNotDiscoverable))
             })


### PR DESCRIPTION
- rename `comp_tx/rx` -> `chunk_tx/rx`
    - When searching the code to figure out how chunks flowed through channels, it really confused me that this was named `comp_` 
- rename `object_meta_receiver` -> `object_meta_rx`
    - Makes it consistent with other receiver variables

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
