### PR TITLE
Fix bumping up part_size based on Content-Length

### DIFF
--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -195,7 +195,7 @@ async fn try_start_mpu_upload(
 ) -> Result<UploadType, crate::error::Error> {
     let part_size = cmp::max(
         ctx.handle.upload_part_size_bytes(),
-        content_length / MAX_PARTS,
+        content_length.div_ceil(MAX_PARTS),
     );
     tracing::trace!("upload request using multipart upload with part size: {part_size} bytes");
 

--- a/aws-s3-transfer-manager/tests/upload_checksum_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_checksum_test.rs
@@ -20,7 +20,6 @@ use aws_sdk_s3::{
     types::{ChecksumAlgorithm, ChecksumType},
 };
 use aws_smithy_mocks_experimental::{mock, Rule, RuleMode};
-use aws_smithy_runtime::test_util::capture_test_logs::capture_test_logs;
 use bytes::Bytes;
 use pin_project_lite::pin_project;
 use test_common::mock_client_with_stubbed_http_client;

--- a/aws-s3-transfer-manager/tests/upload_checksum_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_checksum_test.rs
@@ -521,8 +521,6 @@ impl TestConfig {
 }
 
 async fn run_test(config: TestConfig) -> UploadOutput {
-    let (_guard, _rx) = capture_test_logs();
-
     // This is the ChecksumStrategy we expect the Transfer Manager to use while sending requests
     let request_checksum_strategy = config.user_checksum_strategy.clone().or(
         // If user didn't set a strategy, Transfer Manager should fall back to default strategy,

--- a/aws-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_test.rs
@@ -204,7 +204,7 @@ async fn test_large_upload_part_size_bump() {
     // actual object is empty, but we will bump the part_size based on size_hint
     drop(tx);
     handle.join().await.unwrap();
-
+    // part_size must be bumped using size_hint.div_ceil(MAX_PARTS) to fit the MAX_PARTS limit.
     let expected_part_size = 10737419;
     let logs: String = logs_rx.contents();
 

--- a/aws-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-s3-transfer-manager/tests/upload_test.rs
@@ -201,7 +201,7 @@ async fn test_large_upload_part_size_bump() {
         .initiate()
         .unwrap();
 
-    // actual object is empty but we should have bumped the part_size from size_hint
+    // actual object is empty, but we will bump the part_size based on size_hint
     drop(tx);
     handle.join().await.unwrap();
 


### PR DESCRIPTION
*Issue #, if available:*
#62 

*Description of changes:*
- There was a bug that we were doing normal divide and not ceil divide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
