### PR TITLE
Improve Scheduling Algorithm for Different BucketTypes and TransferDirection

### DIFF
--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency.rs
@@ -13,4 +13,4 @@ mod layer;
 mod service;
 
 pub(crate) use self::layer::ConcurrencyLimitLayer;
-pub(crate) use self::service::ProvidePayloadSize;
+pub(crate) use self::service::ProvideNetworkPermitContext;

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -76,7 +76,8 @@ impl<T: Clone> Clone for ConcurrencyLimit<T> {
 mod tests {
 
     use crate::metrics::unit::ByteUnit;
-    use crate::runtime::scheduler::{RequestType, Scheduler};
+    use crate::operation::BucketType;
+    use crate::runtime::scheduler::{Scheduler, TransferDirection};
     use crate::types::TargetThroughput;
     use crate::{middleware::limit::concurrency::ConcurrencyLimitLayer, types::ConcurrencyMode};
     use aws_smithy_runtime::test_util::capture_test_logs::show_test_logs;
@@ -92,7 +93,8 @@ mod tests {
         fn network_permit_context(&self) -> super::NetworkPermitContext {
             super::NetworkPermitContext {
                 payload_size_estimate: self.0.len() as u64,
-                request_type: RequestType::S3Download,
+                bucket_type: BucketType::Standard,
+                direction: TransferDirection::Download,
             }
         }
     }
@@ -174,7 +176,8 @@ mod tests {
         fn network_permit_context(&self) -> super::NetworkPermitContext {
             super::NetworkPermitContext {
                 payload_size_estimate: self.0,
-                request_type: RequestType::S3Download,
+                bucket_type: BucketType::Standard,
+                direction: TransferDirection::Download,
             }
         }
     }

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -76,8 +76,8 @@ impl<T: Clone> Clone for ConcurrencyLimit<T> {
 mod tests {
 
     use crate::metrics::unit::ByteUnit;
-    use crate::types::BucketType;
     use crate::runtime::scheduler::{Scheduler, TransferDirection};
+    use crate::types::BucketType;
     use crate::types::TargetThroughput;
     use crate::{middleware::limit::concurrency::ConcurrencyLimitLayer, types::ConcurrencyMode};
     use aws_smithy_runtime::test_util::capture_test_logs::show_test_logs;

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -76,7 +76,7 @@ impl<T: Clone> Clone for ConcurrencyLimit<T> {
 mod tests {
 
     use crate::metrics::unit::ByteUnit;
-    use crate::operation::BucketType;
+    use crate::types::BucketType;
     use crate::runtime::scheduler::{Scheduler, TransferDirection};
     use crate::types::TargetThroughput;
     use crate::{middleware::limit::concurrency::ConcurrencyLimitLayer, types::ConcurrencyMode};

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -26,9 +26,9 @@ impl<T> ConcurrencyLimit<T> {
     }
 }
 
-/// Provide the request/response payload size estimate
+/// Provide the request network permit context 
 pub(crate) trait ProvideNetworkPermitContext {
-    /// Payload size estimate in bytes
+    /// `NetworkPermitContext` for the request 
     fn network_permit_context(&self) -> NetworkPermitContext;
 }
 

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -9,7 +9,7 @@ use tower::Service;
 
 use super::future::ResponseFuture;
 use crate::error;
-use crate::runtime::scheduler::{PermitType, Scheduler};
+use crate::runtime::scheduler::{NetworkPermitContext, PermitType, Scheduler};
 
 /// Enforces a limit on the concurrent requests an underlying service receives
 /// using the given [`Scheduler`].
@@ -27,16 +27,16 @@ impl<T> ConcurrencyLimit<T> {
 }
 
 /// Provide the request/response payload size estimate
-pub(crate) trait ProvidePayloadSize {
+pub(crate) trait ProvideNetworkPermitContext {
     /// Payload size estimate in bytes
-    fn payload_size_estimate(&self) -> u64;
+    fn network_permit_context(&self) -> NetworkPermitContext;
 }
 
 impl<S, Request> Service<Request> for ConcurrencyLimit<S>
 where
     S: Service<Request> + Clone,
     S::Error: From<error::Error>,
-    Request: ProvidePayloadSize,
+    Request: ProvideNetworkPermitContext,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -57,7 +57,7 @@ where
     fn call(&mut self, req: Request) -> Self::Future {
         // NOTE: We assume this is a dataplane request as that is the only place
         // we make use of tower is for upload/download. If this changes this logic needs updated.
-        let ptype = PermitType::Network(req.payload_size_estimate());
+        let ptype = PermitType::Network(req.network_permit_context());
         let permit_fut = self.scheduler.acquire_permit(ptype);
         ResponseFuture::new(self.inner.clone(), req, permit_fut, self.scheduler.clone())
     }
@@ -76,21 +76,24 @@ impl<T: Clone> Clone for ConcurrencyLimit<T> {
 mod tests {
 
     use crate::metrics::unit::ByteUnit;
-    use crate::runtime::scheduler::Scheduler;
+    use crate::runtime::scheduler::{RequestType, Scheduler};
     use crate::types::TargetThroughput;
     use crate::{middleware::limit::concurrency::ConcurrencyLimitLayer, types::ConcurrencyMode};
     use aws_smithy_runtime::test_util::capture_test_logs::show_test_logs;
     use tokio_test::{assert_pending, assert_ready_ok, task};
     use tower_test::{assert_request_eq, mock};
 
-    use super::ProvidePayloadSize;
+    use super::ProvideNetworkPermitContext;
 
     #[derive(Debug)]
     struct TestInput(&'static str);
 
-    impl ProvidePayloadSize for TestInput {
-        fn payload_size_estimate(&self) -> u64 {
-            self.0.len() as u64
+    impl ProvideNetworkPermitContext for TestInput {
+        fn network_permit_context(&self) -> super::NetworkPermitContext {
+            super::NetworkPermitContext {
+                payload_size_estimate: self.0.len() as u64,
+                request_type: RequestType::S3Download,
+            }
         }
     }
 
@@ -167,9 +170,12 @@ mod tests {
     #[derive(Debug)]
     struct MockPayload(u64);
 
-    impl ProvidePayloadSize for MockPayload {
-        fn payload_size_estimate(&self) -> u64 {
-            self.0
+    impl ProvideNetworkPermitContext for MockPayload {
+        fn network_permit_context(&self) -> super::NetworkPermitContext {
+            super::NetworkPermitContext {
+                payload_size_estimate: self.0,
+                request_type: RequestType::S3Download,
+            }
         }
     }
 

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -26,9 +26,9 @@ impl<T> ConcurrencyLimit<T> {
     }
 }
 
-/// Provide the request network permit context 
+/// Provide the [`NetworkPermitContext`] for the request
 pub(crate) trait ProvideNetworkPermitContext {
-    /// `NetworkPermitContext` for the request 
+    /// [`NetworkPermitContext`] for the request 
     fn network_permit_context(&self) -> NetworkPermitContext;
 }
 

--- a/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
+++ b/aws-s3-transfer-manager/src/middleware/limit/concurrency/service.rs
@@ -28,7 +28,7 @@ impl<T> ConcurrencyLimit<T> {
 
 /// Provide the [`NetworkPermitContext`] for the request
 pub(crate) trait ProvideNetworkPermitContext {
-    /// [`NetworkPermitContext`] for the request 
+    /// [`NetworkPermitContext`] for the request
     fn network_permit_context(&self) -> NetworkPermitContext;
 }
 

--- a/aws-s3-transfer-manager/src/operation.rs
+++ b/aws-s3-transfer-manager/src/operation.rs
@@ -67,11 +67,3 @@ pub(crate) fn validate_target_is_dir(metadata: &Metadata, path: &Path) -> Result
         )))
     }
 }
-
-/// Type of the bucket for the transfer
-#[derive(Debug, Clone, PartialEq)]
-#[non_exhaustive]
-pub(crate) enum BucketType {
-    Standard,
-    Express,
-}

--- a/aws-s3-transfer-manager/src/operation.rs
+++ b/aws-s3-transfer-manager/src/operation.rs
@@ -67,3 +67,11 @@ pub(crate) fn validate_target_is_dir(metadata: &Metadata, path: &Path) -> Result
         )))
     }
 }
+
+/// Type of the bucket for the transfer
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub(crate) enum BucketType {
+    Standard,
+    Express,
+}

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -73,7 +73,7 @@ impl Download {
             todo!("single part download not implemented")
         }
 
-        let bucket_type = BucketType::from_bucket(input.bucket().unwrap_or(""));
+        let bucket_type = BucketType::from_bucket_name(input.bucket().unwrap_or(""));
         let ctx = DownloadContext::new(handle, bucket_type);
         let concurrency = ctx.handle.num_workers();
         let (chunk_tx, chunk_rx) = mpsc::channel(concurrency);

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -73,12 +73,7 @@ impl Download {
             todo!("single part download not implemented")
         }
 
-        let bucket_type = if input.bucket().unwrap_or("").ends_with("--x-s3") {
-            BucketType::Express
-        } else {
-            BucketType::Standard
-        };
-
+        let bucket_type = BucketType::from_bucket(input.bucket().unwrap_or(""));
         let ctx = DownloadContext::new(handle, bucket_type);
         let concurrency = ctx.handle.num_workers();
         let (chunk_tx, chunk_rx) = mpsc::channel(concurrency);

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -36,6 +36,7 @@ use crate::io::AggregatedBytes;
 use crate::runtime::scheduler::{
     NetworkPermitContext, OwnedWorkPermit, PermitType, TransferDirection,
 };
+use crate::types::BucketType;
 use aws_smithy_types::byte_stream::ByteStream;
 use discovery::discover_obj;
 use service::distribute_work;
@@ -44,7 +45,7 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, watch, Mutex, OnceCell};
 use tokio::task::{self, JoinSet};
 
-use super::{BucketType, CancelNotificationReceiver, CancelNotificationSender, TransferContext};
+use super::{CancelNotificationReceiver, CancelNotificationSender, TransferContext};
 
 /// Operation struct for single object download
 #[derive(Clone, Default, Debug)]
@@ -283,8 +284,8 @@ impl DownloadContext {
         self.state.current_seq.load(Ordering::SeqCst)
     }
 
-    /// Returns the type of bucket
+    /// Returns the type of bucket targeted by this operation
     fn bucket_type(&self) -> BucketType {
-        self.state.bucket_type.clone()
+        self.state.bucket_type
     }
 }

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -73,7 +73,8 @@ impl Download {
             todo!("single part download not implemented")
         }
 
-        let bucket_type = BucketType::from_bucket_name(input.bucket().expect("bucket is available"));
+        let bucket_type =
+            BucketType::from_bucket_name(input.bucket().expect("bucket is available"));
         let ctx = DownloadContext::new(handle, bucket_type);
         let concurrency = ctx.handle.num_workers();
         let (chunk_tx, chunk_rx) = mpsc::channel(concurrency);

--- a/aws-s3-transfer-manager/src/operation/download.rs
+++ b/aws-s3-transfer-manager/src/operation/download.rs
@@ -73,7 +73,7 @@ impl Download {
             todo!("single part download not implemented")
         }
 
-        let bucket_type = BucketType::from_bucket_name(input.bucket().unwrap_or(""));
+        let bucket_type = BucketType::from_bucket_name(input.bucket().expect("bucket is available"));
         let ctx = DownloadContext::new(handle, bucket_type);
         let concurrency = ctx.handle.num_workers();
         let (chunk_tx, chunk_rx) = mpsc::channel(concurrency);

--- a/aws-s3-transfer-manager/src/operation/download/discovery.rs
+++ b/aws-s3-transfer-manager/src/operation/download/discovery.rs
@@ -231,6 +231,7 @@ mod tests {
     fn strategy_from_range(range: Option<&str>) -> ObjectDiscoveryStrategy {
         let input = DownloadInput::builder()
             .bucket("test-bucket")
+            .key("test-key")
             .set_range(range.map(|r| r.to_string()))
             .build()
             .unwrap();

--- a/aws-s3-transfer-manager/src/operation/download/discovery.rs
+++ b/aws-s3-transfer-manager/src/operation/download/discovery.rs
@@ -216,7 +216,7 @@ mod tests {
     };
     use crate::operation::download::DownloadContext;
     use crate::operation::download::DownloadInput;
-    use crate::operation::BucketType;
+    use crate::types::BucketType;
     use crate::types::PartSize;
     use aws_sdk_s3::operation::get_object::{GetObjectError, GetObjectOutput};
     use aws_sdk_s3::operation::head_object::HeadObjectOutput;

--- a/aws-s3-transfer-manager/src/operation/download/discovery.rs
+++ b/aws-s3-transfer-manager/src/operation/download/discovery.rs
@@ -230,6 +230,7 @@ mod tests {
 
     fn strategy_from_range(range: Option<&str>) -> ObjectDiscoveryStrategy {
         let input = DownloadInput::builder()
+            .bucket("test-bucket")
             .set_range(range.map(|r| r.to_string()))
             .build()
             .unwrap();

--- a/aws-s3-transfer-manager/src/operation/download/discovery.rs
+++ b/aws-s3-transfer-manager/src/operation/download/discovery.rs
@@ -216,7 +216,7 @@ mod tests {
     };
     use crate::operation::download::DownloadContext;
     use crate::operation::download::DownloadInput;
-    use crate::runtime::scheduler::RequestType;
+    use crate::operation::BucketType;
     use crate::types::PartSize;
     use aws_sdk_s3::operation::get_object::{GetObjectError, GetObjectOutput};
     use aws_sdk_s3::operation::head_object::HeadObjectOutput;
@@ -281,7 +281,10 @@ mod tests {
         });
         let client = mock_client_with_stubbed_http_client!(aws_sdk_s3, &[&head_obj_rule]);
 
-        let ctx = DownloadContext::new(test_handle(client, 5 * ByteUnit::Mebibyte.as_bytes_u64()),  RequestType::S3Download);
+        let ctx = DownloadContext::new(
+            test_handle(client, 5 * ByteUnit::Mebibyte.as_bytes_u64()),
+            BucketType::Standard,
+        );
 
         let input = DownloadInput::builder()
             .bucket("test-bucket")
@@ -310,7 +313,7 @@ mod tests {
             });
         let client = mock_client_with_stubbed_http_client!(aws_sdk_s3, &[&get_obj_rule]);
 
-        let ctx = DownloadContext::new(test_handle(client, target_part_size),  RequestType::S3Download);
+        let ctx = DownloadContext::new(test_handle(client, target_part_size), BucketType::Standard);
 
         let request = DownloadInput::builder()
             .bucket("test-bucket")
@@ -347,7 +350,7 @@ mod tests {
             });
         let client = mock_client_with_stubbed_http_client!(aws_sdk_s3, &[&get_obj_rule]);
 
-        let ctx = DownloadContext::new(test_handle(client, target_part_size),  RequestType::S3Download);
+        let ctx = DownloadContext::new(test_handle(client, target_part_size), BucketType::Standard);
 
         let request = DownloadInput::builder()
             .bucket("test-bucket")
@@ -382,7 +385,7 @@ mod tests {
             });
         let client = mock_client_with_stubbed_http_client!(aws_sdk_s3, &[&get_obj_rule]);
 
-        let ctx = DownloadContext::new(test_handle(client, target_part_size),  RequestType::S3Download);
+        let ctx = DownloadContext::new(test_handle(client, target_part_size), BucketType::Standard);
 
         let request = DownloadInput::builder()
             .bucket("test-bucket")
@@ -420,7 +423,7 @@ mod tests {
             });
         let client = mock_client_with_stubbed_http_client!(aws_sdk_s3, &[&get_obj_rule]);
 
-        let ctx = DownloadContext::new(test_handle(client, target_part_size),  RequestType::S3Download);
+        let ctx = DownloadContext::new(test_handle(client, target_part_size), BucketType::Standard);
 
         let request = DownloadInput::builder()
             .bucket("test-bucket")
@@ -457,7 +460,7 @@ mod tests {
             &[&get_range_rule, &get_first_part_rule]
         );
 
-        let ctx = DownloadContext::new(test_handle(client, target_part_size),  RequestType::S3Download);
+        let ctx = DownloadContext::new(test_handle(client, target_part_size), BucketType::Standard);
 
         let request = DownloadInput::builder()
             .bucket("test-bucket")

--- a/aws-s3-transfer-manager/src/operation/download/discovery.rs
+++ b/aws-s3-transfer-manager/src/operation/download/discovery.rs
@@ -216,6 +216,7 @@ mod tests {
     };
     use crate::operation::download::DownloadContext;
     use crate::operation::download::DownloadInput;
+    use crate::runtime::scheduler::RequestType;
     use crate::types::PartSize;
     use aws_sdk_s3::operation::get_object::{GetObjectError, GetObjectOutput};
     use aws_sdk_s3::operation::head_object::HeadObjectOutput;
@@ -280,7 +281,7 @@ mod tests {
         });
         let client = mock_client_with_stubbed_http_client!(aws_sdk_s3, &[&head_obj_rule]);
 
-        let ctx = DownloadContext::new(test_handle(client, 5 * ByteUnit::Mebibyte.as_bytes_u64()));
+        let ctx = DownloadContext::new(test_handle(client, 5 * ByteUnit::Mebibyte.as_bytes_u64()),  RequestType::S3Download);
 
         let input = DownloadInput::builder()
             .bucket("test-bucket")
@@ -309,7 +310,7 @@ mod tests {
             });
         let client = mock_client_with_stubbed_http_client!(aws_sdk_s3, &[&get_obj_rule]);
 
-        let ctx = DownloadContext::new(test_handle(client, target_part_size));
+        let ctx = DownloadContext::new(test_handle(client, target_part_size),  RequestType::S3Download);
 
         let request = DownloadInput::builder()
             .bucket("test-bucket")
@@ -346,7 +347,7 @@ mod tests {
             });
         let client = mock_client_with_stubbed_http_client!(aws_sdk_s3, &[&get_obj_rule]);
 
-        let ctx = DownloadContext::new(test_handle(client, target_part_size));
+        let ctx = DownloadContext::new(test_handle(client, target_part_size),  RequestType::S3Download);
 
         let request = DownloadInput::builder()
             .bucket("test-bucket")
@@ -381,7 +382,7 @@ mod tests {
             });
         let client = mock_client_with_stubbed_http_client!(aws_sdk_s3, &[&get_obj_rule]);
 
-        let ctx = DownloadContext::new(test_handle(client, target_part_size));
+        let ctx = DownloadContext::new(test_handle(client, target_part_size),  RequestType::S3Download);
 
         let request = DownloadInput::builder()
             .bucket("test-bucket")
@@ -419,7 +420,7 @@ mod tests {
             });
         let client = mock_client_with_stubbed_http_client!(aws_sdk_s3, &[&get_obj_rule]);
 
-        let ctx = DownloadContext::new(test_handle(client, target_part_size));
+        let ctx = DownloadContext::new(test_handle(client, target_part_size),  RequestType::S3Download);
 
         let request = DownloadInput::builder()
             .bucket("test-bucket")
@@ -456,7 +457,7 @@ mod tests {
             &[&get_range_rule, &get_first_part_rule]
         );
 
-        let ctx = DownloadContext::new(test_handle(client, target_part_size));
+        let ctx = DownloadContext::new(test_handle(client, target_part_size),  RequestType::S3Download);
 
         let request = DownloadInput::builder()
             .bucket("test-bucket")

--- a/aws-s3-transfer-manager/src/operation/download/input.rs
+++ b/aws-s3-transfer-manager/src/operation/download/input.rs
@@ -6,6 +6,7 @@
 use std::fmt;
 
 use aws_sdk_s3::operation::get_object::builders::GetObjectInputBuilder;
+use aws_smithy_types::error::operation::BuildError;
 
 /// Input type for downloading a single object
 #[allow(missing_docs)] // documentation missing in model
@@ -817,6 +818,10 @@ impl DownloadInputBuilder {
     }
     /// Consumes the builder and constructs a [`DownloadInput`].
     pub fn build(self) -> Result<DownloadInput, ::aws_smithy_types::error::operation::BuildError> {
+        if self.bucket.is_none() {
+            return Err(BuildError::missing_field("bucket", "A bucket is required"));
+        }
+
         Result::Ok(DownloadInput {
             bucket: self.bucket,
             if_match: self.if_match,

--- a/aws-s3-transfer-manager/src/operation/download/input.rs
+++ b/aws-s3-transfer-manager/src/operation/download/input.rs
@@ -822,6 +822,10 @@ impl DownloadInputBuilder {
             return Err(BuildError::missing_field("bucket", "A bucket is required"));
         }
 
+        if self.key.is_none() {
+            return Err(BuildError::missing_field("key", "A key is required"));
+        }
+
         Result::Ok(DownloadInput {
             bucket: self.bucket,
             if_match: self.if_match,

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -22,6 +22,7 @@ use tower::{service_fn, Service, ServiceBuilder, ServiceExt};
 use tracing::Instrument;
 
 use super::body::ChunkOutput;
+use super::TransferDirection;
 use super::{DownloadInput, DownloadInputBuilder};
 
 /// Request/input type for our "chunk" service.
@@ -45,7 +46,8 @@ impl ProvideNetworkPermitContext for DownloadChunkRequest {
 
         NetworkPermitContext {
             payload_size_estimate: payload_estimate,
-            request_type: self.ctx.request_type(),
+            bucket_type: self.ctx.bucket_type(),
+            direction: TransferDirection::Download,
         }
     }
 }

--- a/aws-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-s3-transfer-manager/src/operation/download/service.rs
@@ -7,9 +7,10 @@ use crate::error::ErrorKind;
 use crate::http::header;
 use crate::io::AggregatedBytes;
 use crate::middleware::limit::concurrency::ConcurrencyLimitLayer;
-use crate::middleware::limit::concurrency::ProvidePayloadSize;
+use crate::middleware::limit::concurrency::ProvideNetworkPermitContext;
 use crate::middleware::retry;
 use crate::operation::download::DownloadContext;
+use crate::runtime::scheduler::NetworkPermitContext;
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::byte_stream::ByteStream;
 use std::cmp;
@@ -32,15 +33,20 @@ pub(super) struct DownloadChunkRequest {
     pub(super) start_seq: u64,
 }
 
-impl ProvidePayloadSize for DownloadChunkRequest {
-    fn payload_size_estimate(&self) -> u64 {
+impl ProvideNetworkPermitContext for DownloadChunkRequest {
+    fn network_permit_context(&self) -> NetworkPermitContext {
         // we can't know the actual size by calling next_seq() as that would modify the
         // state. Instead we give an estimate based on the current sequence.
         let seq = self.ctx.current_seq();
         let remaining = self.remaining.clone();
         let part_size = self.ctx.handle.download_part_size_bytes();
         let range = next_range(seq, remaining, part_size, self.start_seq);
-        range.end() - range.start() + 1
+        let payload_estimate = range.end() - range.start() + 1;
+
+        NetworkPermitContext {
+            payload_size_estimate: payload_estimate,
+            request_type: self.ctx.request_type(),
+        }
     }
 }
 

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -228,7 +228,7 @@ async fn try_start_mpu_upload(
 }
 
 fn new_context(handle: Arc<crate::client::Handle>, req: UploadInput) -> UploadContext {
-    let request_type = if req.bucket().unwrap_or("").starts_with("--x-s3") {
+    let request_type = if req.bucket().unwrap_or("").ends_with("--x-s3") {
         RequestType::S3ExpressUpload
     } else {
         RequestType::S3Upload

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -111,7 +111,6 @@ async fn put_object(
         error::invalid_input(format!("content_length:{} is invalid.", content_length))
     })?;
 
-    // waahm7: fix
     let _permit = ctx
         .handle
         .scheduler

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -229,15 +229,10 @@ async fn try_start_mpu_upload(
 }
 
 fn new_context(handle: Arc<crate::client::Handle>, req: UploadInput) -> UploadContext {
-    let bucket_type = if req.bucket().unwrap_or("").ends_with("--x-s3") {
-        BucketType::Express
-    } else {
-        BucketType::Standard
-    };
     UploadContext {
         handle,
+        bucket_type: BucketType::from_bucket(req.bucket().unwrap_or("")),
         request: Arc::new(req),
-        bucket_type,
     }
 }
 

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -231,7 +231,7 @@ async fn try_start_mpu_upload(
 fn new_context(handle: Arc<crate::client::Handle>, req: UploadInput) -> UploadContext {
     UploadContext {
         handle,
-        bucket_type: BucketType::from_bucket_name(req.bucket().unwrap_or("")),
+        bucket_type: BucketType::from_bucket_name(req.bucket().expect("bucket is availabe")),
         request: Arc::new(req),
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -231,7 +231,7 @@ async fn try_start_mpu_upload(
 fn new_context(handle: Arc<crate::client::Handle>, req: UploadInput) -> UploadContext {
     UploadContext {
         handle,
-        bucket_type: BucketType::from_bucket(req.bucket().unwrap_or("")),
+        bucket_type: BucketType::from_bucket_name(req.bucket().unwrap_or("")),
         request: Arc::new(req),
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-s3-transfer-manager/src/operation/upload.rs
@@ -19,6 +19,7 @@ use crate::error;
 use crate::io::part_reader::Builder as PartReaderBuilder;
 use crate::io::InputStream;
 use crate::runtime::scheduler::{NetworkPermitContext, PermitType, TransferDirection};
+use crate::types::BucketType;
 use context::UploadContext;
 pub use handle::UploadHandle;
 use handle::{MultipartUploadData, UploadType};
@@ -31,8 +32,6 @@ use tracing::Instrument;
 
 use std::cmp;
 use std::sync::Arc;
-
-use super::BucketType;
 
 /// Maximum number of parts that a single S3 multipart upload supports
 const MAX_PARTS: u64 = 10_000;

--- a/aws-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/context.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::operation::upload::UploadInput;
+use crate::runtime::scheduler::RequestType;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -14,6 +15,8 @@ pub(crate) struct UploadContext {
     pub(crate) handle: Arc<crate::client::Handle>,
     /// the original request (NOTE: the body will have been taken for processing, only the other fields remain)
     pub(crate) request: Arc<UploadInput>,
+
+    pub(crate) request_type: RequestType,
 }
 
 impl UploadContext {
@@ -25,5 +28,10 @@ impl UploadContext {
     /// The original request (sans the body as it will have been taken for processing)
     pub(crate) fn request(&self) -> &UploadInput {
         self.request.deref()
+    }
+
+    /// The original request (sans the body as it will have been taken for processing)
+    pub(crate) fn request_type(&self) -> RequestType {
+        self.request_type.clone()
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/context.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::operation::upload::UploadInput;
-use crate::runtime::scheduler::RequestType;
+use crate::operation::BucketType;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -16,7 +16,8 @@ pub(crate) struct UploadContext {
     /// the original request (NOTE: the body will have been taken for processing, only the other fields remain)
     pub(crate) request: Arc<UploadInput>,
 
-    pub(crate) request_type: RequestType,
+    /// 
+    pub(crate) bucket_type: BucketType,
 }
 
 impl UploadContext {
@@ -31,7 +32,7 @@ impl UploadContext {
     }
 
     /// The original request (sans the body as it will have been taken for processing)
-    pub(crate) fn request_type(&self) -> RequestType {
-        self.request_type.clone()
+    pub(crate) fn bucket_type(&self) -> BucketType {
+        self.bucket_type.clone()
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/context.rs
@@ -16,7 +16,7 @@ pub(crate) struct UploadContext {
     /// the original request (NOTE: the body will have been taken for processing, only the other fields remain)
     pub(crate) request: Arc<UploadInput>,
 
-    /// Type of S3 bucket
+    /// Type of S3 bucket targeted by this operation
     pub(crate) bucket_type: BucketType,
 }
 

--- a/aws-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/context.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::operation::upload::UploadInput;
-use crate::operation::BucketType;
+use crate::types::BucketType;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -31,8 +31,8 @@ impl UploadContext {
         self.request.deref()
     }
 
-    /// Type of S3 bucket
+    /// Type of S3 bucket targeted by this operation
     pub(crate) fn bucket_type(&self) -> BucketType {
-        self.bucket_type.clone()
+        self.bucket_type
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/context.rs
@@ -16,7 +16,7 @@ pub(crate) struct UploadContext {
     /// the original request (NOTE: the body will have been taken for processing, only the other fields remain)
     pub(crate) request: Arc<UploadInput>,
 
-    /// 
+    /// Type of S3 bucket
     pub(crate) bucket_type: BucketType,
 }
 
@@ -31,7 +31,7 @@ impl UploadContext {
         self.request.deref()
     }
 
-    /// The original request (sans the body as it will have been taken for processing)
+    /// Type of S3 bucket
     pub(crate) fn bucket_type(&self) -> BucketType {
         self.bucket_type.clone()
     }

--- a/aws-s3-transfer-manager/src/operation/upload/input.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/input.rs
@@ -1282,6 +1282,10 @@ impl UploadInputBuilder {
             return Err(BuildError::missing_field("bucket", "A bucket is required"));
         }
 
+        if self.key.is_none() {
+            return Err(BuildError::missing_field("key", "A key is required"));
+        }
+
         Ok(UploadInput {
             body: self.body.unwrap_or_default(),
             acl: self.acl,

--- a/aws-s3-transfer-manager/src/operation/upload/input.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/input.rs
@@ -5,6 +5,7 @@
 
 use crate::io::InputStream;
 use crate::types::FailedMultipartUploadPolicy;
+use aws_smithy_types::error::operation::BuildError;
 
 use std::fmt::Debug;
 use std::mem;
@@ -1277,6 +1278,10 @@ impl UploadInputBuilder {
 
     /// Consumes the builder and constructs a [`UploadInput`]
     pub fn build(self) -> Result<UploadInput, ::aws_smithy_types::error::operation::BuildError> {
+        if self.bucket.is_none() {
+            return Err(BuildError::missing_field("bucket", "A bucket is required"));
+        }
+
         Ok(UploadInput {
             body: self.body.unwrap_or_default(),
             acl: self.acl,

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -256,7 +256,13 @@ mod tests {
                     config: Config::builder().client(s3_client).build(),
                     scheduler: Scheduler::new(ConcurrencyMode::Explicit(1)),
                 }),
-                request: Arc::new(UploadInput::builder().bucket(bucket_name).key("test-key").build().unwrap()),
+                request: Arc::new(
+                    UploadInput::builder()
+                        .bucket(bucket_name)
+                        .key("test-key")
+                        .build()
+                        .unwrap(),
+                ),
                 bucket_type: BucketType::from_bucket_name(bucket_name),
             },
             part_data: PartData::new(1, Bytes::default()),

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -250,7 +250,6 @@ mod tests {
 
     fn _mock_upload_part_request_with_bucket_name(
         bucket_name: &str,
-        bucket_type: BucketType,
     ) -> UploadPartRequest {
         let s3_client = mock_client_with_stubbed_http_client!(aws_sdk_s3, []);
         UploadPartRequest {
@@ -260,7 +259,7 @@ mod tests {
                     scheduler: Scheduler::new(ConcurrencyMode::Explicit(1)),
                 }),
                 request: Arc::new(UploadInput::builder().bucket(bucket_name).build().unwrap()),
-                bucket_type,
+                bucket_type: BucketType::from_bucket(bucket_name),
             },
             part_data: PartData::new(1, Bytes::default()),
             upload_id: "test-id".to_string(),
@@ -273,11 +272,11 @@ mod tests {
 
         // Test S3 Express bucket
         let express_req =
-            _mock_upload_part_request_with_bucket_name("test--x-s3", BucketType::Express);
+            _mock_upload_part_request_with_bucket_name("test--x-s3");
         assert!(policy.clone_request(&express_req).is_none());
 
         // Test regular bucket
-        let regular_req = _mock_upload_part_request_with_bucket_name("test", BucketType::Standard);
+        let regular_req = _mock_upload_part_request_with_bucket_name("test");
         assert!(policy.clone_request(&regular_req).is_some());
     }
 }

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use super::{BucketType, MultipartUploadData, TransferDirection};
+use super::{MultipartUploadData, TransferDirection};
 use crate::{
     error,
     io::{part_reader::PartReader, PartData},
@@ -10,6 +10,7 @@ use crate::{
     },
     operation::upload::UploadContext,
     runtime::scheduler::NetworkPermitContext,
+    types::BucketType,
 };
 use aws_sdk_s3::{
     primitives::ByteStream,

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -257,7 +257,7 @@ mod tests {
                     scheduler: Scheduler::new(ConcurrencyMode::Explicit(1)),
                 }),
                 request: Arc::new(UploadInput::builder().bucket(bucket_name).build().unwrap()),
-                bucket_type: BucketType::from_bucket(bucket_name),
+                bucket_type: BucketType::from_bucket_name(bucket_name),
             },
             part_data: PartData::new(1, Bytes::default()),
             upload_id: "test-id".to_string(),

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -256,7 +256,7 @@ mod tests {
                     config: Config::builder().client(s3_client).build(),
                     scheduler: Scheduler::new(ConcurrencyMode::Explicit(1)),
                 }),
-                request: Arc::new(UploadInput::builder().bucket(bucket_name).build().unwrap()),
+                request: Arc::new(UploadInput::builder().bucket(bucket_name).key("test-key").build().unwrap()),
                 bucket_type: BucketType::from_bucket_name(bucket_name),
             },
             part_data: PartData::new(1, Bytes::default()),

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -1,14 +1,15 @@
 use std::sync::Arc;
 
-use super::MultipartUploadData;
+use super::{MultipartUploadData, RequestType};
 use crate::{
     error,
     io::{part_reader::PartReader, PartData},
     middleware::{
         hedge,
-        limit::concurrency::{ConcurrencyLimitLayer, ProvidePayloadSize},
+        limit::concurrency::{ConcurrencyLimitLayer, ProvideNetworkPermitContext},
     },
     operation::upload::UploadContext,
+    runtime::scheduler::NetworkPermitContext,
 };
 use aws_sdk_s3::{
     primitives::ByteStream,
@@ -38,9 +39,12 @@ pub(super) struct UploadPartRequest {
     pub(super) upload_id: String,
 }
 
-impl ProvidePayloadSize for UploadPartRequest {
-    fn payload_size_estimate(&self) -> u64 {
-        self.part_data.data.len() as u64
+impl ProvideNetworkPermitContext for UploadPartRequest {
+    fn network_permit_context(&self) -> NetworkPermitContext {
+        NetworkPermitContext {
+            payload_size_estimate: self.part_data.data.len() as u64,
+            request_type: self.ctx.request_type(),
+        }
     }
 }
 
@@ -49,10 +53,10 @@ pub(crate) struct UploadHedgePolicy;
 
 impl Policy<UploadPartRequest> for UploadHedgePolicy {
     fn clone_request(&self, req: &UploadPartRequest) -> Option<UploadPartRequest> {
-        if req.ctx.request.bucket().unwrap_or("").ends_with("--x-s3") {
-            None
-        } else {
+        if req.ctx.request_type() == RequestType::S3Upload {
             Some(req.clone())
+        } else {
+            None
         }
     }
     fn can_retry(&self, _req: &UploadPartRequest) -> bool {
@@ -234,7 +238,7 @@ pub(super) async fn read_body(
 mod tests {
     use super::*;
     use crate::client::Handle;
-    use crate::operation::upload::UploadInput;
+    use crate::operation::upload::{RequestType, UploadInput};
     use crate::runtime::scheduler::Scheduler;
     use crate::types::ConcurrencyMode;
     use crate::Config;
@@ -250,6 +254,7 @@ mod tests {
                     scheduler: Scheduler::new(ConcurrencyMode::Explicit(1)),
                 }),
                 request: Arc::new(UploadInput::builder().bucket(bucket_name).build().unwrap()),
+                request_type: RequestType::S3Upload,
             },
             part_data: PartData::new(1, Bytes::default()),
             upload_id: "test-id".to_string(),

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -248,9 +248,7 @@ mod tests {
     use bytes::Bytes;
     use test_common::mock_client_with_stubbed_http_client;
 
-    fn _mock_upload_part_request_with_bucket_name(
-        bucket_name: &str,
-    ) -> UploadPartRequest {
+    fn _mock_upload_part_request_with_bucket_name(bucket_name: &str) -> UploadPartRequest {
         let s3_client = mock_client_with_stubbed_http_client!(aws_sdk_s3, []);
         UploadPartRequest {
             ctx: UploadContext {
@@ -271,8 +269,7 @@ mod tests {
         let policy = UploadHedgePolicy;
 
         // Test S3 Express bucket
-        let express_req =
-            _mock_upload_part_request_with_bucket_name("test--x-s3");
+        let express_req = _mock_upload_part_request_with_bucket_name("test--x-s3");
         assert!(policy.clone_request(&express_req).is_none());
 
         // Test regular bucket

--- a/aws-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-s3-transfer-manager/src/operation/upload/service.rs
@@ -245,7 +245,10 @@ mod tests {
     use bytes::Bytes;
     use test_common::mock_client_with_stubbed_http_client;
 
-    fn _mock_upload_part_request_with_bucket_name(bucket_name: &str) -> UploadPartRequest {
+    fn _mock_upload_part_request_with_bucket_name(
+        bucket_name: &str,
+        request_type: RequestType,
+    ) -> UploadPartRequest {
         let s3_client = mock_client_with_stubbed_http_client!(aws_sdk_s3, []);
         UploadPartRequest {
             ctx: UploadContext {
@@ -254,7 +257,7 @@ mod tests {
                     scheduler: Scheduler::new(ConcurrencyMode::Explicit(1)),
                 }),
                 request: Arc::new(UploadInput::builder().bucket(bucket_name).build().unwrap()),
-                request_type: RequestType::S3Upload,
+                request_type,
             },
             part_data: PartData::new(1, Bytes::default()),
             upload_id: "test-id".to_string(),
@@ -266,11 +269,12 @@ mod tests {
         let policy = UploadHedgePolicy;
 
         // Test S3 Express bucket
-        let express_req = _mock_upload_part_request_with_bucket_name("test--x-s3");
+        let express_req =
+            _mock_upload_part_request_with_bucket_name("test--x-s3", RequestType::S3ExpressUpload);
         assert!(policy.clone_request(&express_req).is_none());
 
         // Test regular bucket
-        let regular_req = _mock_upload_part_request_with_bucket_name("test");
+        let regular_req = _mock_upload_part_request_with_bucket_name("test", RequestType::S3Upload);
         assert!(policy.clone_request(&regular_req).is_some());
     }
 }

--- a/aws-s3-transfer-manager/src/runtime/scheduler.rs
+++ b/aws-s3-transfer-manager/src/runtime/scheduler.rs
@@ -10,8 +10,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::error;
-use crate::operation::BucketType;
 use crate::runtime::token_bucket::{OwnedToken, TokenBucket};
+use crate::types::BucketType;
 use crate::types::ConcurrencyMode;
 
 // TODO - measure actual throughput and track high water mark
@@ -167,8 +167,8 @@ impl SchedulerMetrics {
 mod tests {
     use super::{PermitType, Scheduler};
     use crate::{
-        operation::BucketType,
         runtime::scheduler::{NetworkPermitContext, TransferDirection},
+        types::BucketType,
         types::ConcurrencyMode,
     };
 

--- a/aws-s3-transfer-manager/src/runtime/scheduler.rs
+++ b/aws-s3-transfer-manager/src/runtime/scheduler.rs
@@ -80,7 +80,7 @@ pub(crate) struct NetworkPermitContext {
 /// The type of work to be done
 #[derive(Debug, Clone)]
 pub(crate) enum PermitType {
-    /// A network request to transmit or receive to or from an API with the given payload size estimate
+    /// A network request to transmit or receive data from an API.
     Network(NetworkPermitContext),
 }
 

--- a/aws-s3-transfer-manager/src/runtime/scheduler.rs
+++ b/aws-s3-transfer-manager/src/runtime/scheduler.rs
@@ -59,12 +59,14 @@ impl Scheduler {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+/// Direction of the transfer
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum TransferDirection {
     Upload,
     Download,
 }
 
+/// Context needed to determine number of tokens needed for Network Permit.
 #[derive(Debug, Clone)]
 pub(crate) struct NetworkPermitContext {
     pub(crate) payload_size_estimate: u64,

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -43,6 +43,7 @@ const S3_EXPRESS_P50_REQUEST_LATENCY: Duration = Duration::from_millis(4);
 ///
 /// Source: S3 team and S3 docs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-design-patterns.html#optimizing-performance-parallelization
 /// > Make one concurrent request for each 85-90 MB/s of desired network throughput
+///
 /// This is internal implementation detail and subject to change in future.
 ///
 /// Applies to: ConcurrencyMode::TargetThroughput

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -108,7 +108,7 @@ impl PermitType {
     /// The token cost for the permit type in Mbps
     fn token_cost_megabit_per_sec(&self) -> u32 {
         let cost = match self {
-            PermitType::Network(network_ctx) => tokens_for_network_context(network_ctx),
+            PermitType::Network(network_context) => tokens_for_network_context(network_context),
         };
         cost.try_into().unwrap()
     }

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -12,8 +12,8 @@ use tokio_util::sync::PollSemaphore;
 
 use crate::error;
 use crate::metrics::{unit::ByteUnit, Throughput};
-use crate::operation::BucketType;
 use crate::runtime::scheduler::PermitType;
+use crate::types::BucketType;
 use crate::types::ConcurrencyMode;
 
 use super::scheduler::{NetworkPermitContext, TransferDirection};
@@ -291,9 +291,9 @@ mod tests {
     use std::time::Duration;
 
     use crate::metrics::unit::ByteUnit;
-    use crate::operation::BucketType;
     use crate::runtime::scheduler::{NetworkPermitContext, TransferDirection};
     use crate::runtime::token_bucket::{estimated_throughput, tokens_for_payload};
+    use crate::types::BucketType;
     use crate::{
         metrics::Throughput,
         runtime::token_bucket::{token_bucket_size, MIN_BUCKET_TOKENS},

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -46,7 +46,7 @@ const S3_EXPRESS_MAX_PER_REQUEST_DOWNLOAD_THROUGHPUT: Throughput =
     Throughput::new_bytes_per_sec(150 * 1000 * 1000);
 
 const S3_EXPRESS_MAX_PER_REQUEST_UPLOAD_THROUGHPUT: Throughput =
-    Throughput::new_bytes_per_sec(90 * 1000 * 1000);
+    Throughput::new_bytes_per_sec(125 * 1000 * 1000);
 
 /// Minimum concurrent requests at full throughput we want to support
 ///

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -108,7 +108,7 @@ impl PermitType {
     /// The token cost for the permit type in Mbps
     fn token_cost_megabit_per_sec(&self) -> u32 {
         let cost = match self {
-            PermitType::Network(payload_size) => tokens_for_payload(payload_size),
+            PermitType::Network(network_ctx) => tokens_for_network_context(network_ctx),
         };
         cost.try_into().unwrap()
     }
@@ -257,8 +257,8 @@ fn token_bucket_size(throughput: Throughput) -> u64 {
     cmp::max(MIN_BUCKET_TOKENS, megabit_per_sec)
 }
 
-/// Tokens for payload size
-fn tokens_for_payload(network_context: &NetworkPermitContext) -> u64 {
+/// Tokens for network context 
+fn tokens_for_network_context(network_context: &NetworkPermitContext) -> u64 {
     let estimated_mbps = estimated_throughput(
         network_context.payload_size_estimate,
         network_context.p50_request_latency(),
@@ -292,7 +292,7 @@ mod tests {
 
     use crate::metrics::unit::ByteUnit;
     use crate::runtime::scheduler::{NetworkPermitContext, TransferDirection};
-    use crate::runtime::token_bucket::{estimated_throughput, tokens_for_payload};
+    use crate::runtime::token_bucket::{estimated_throughput, tokens_for_network_context};
     use crate::types::BucketType;
     use crate::{
         metrics::Throughput,
@@ -341,7 +341,7 @@ mod tests {
     fn test_tokens_for_payload() {
         assert_eq!(
             5,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: 1024,
                 bucket_type: BucketType::Standard,
                 direction: TransferDirection::Download,
@@ -349,7 +349,7 @@ mod tests {
         );
         assert_eq!(
             27,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: 100 * 1024,
                 bucket_type: BucketType::Standard,
                 direction: TransferDirection::Download,
@@ -357,7 +357,7 @@ mod tests {
         );
         assert_eq!(
             267,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: MEGABYTE,
                 bucket_type: BucketType::Standard,
                 direction: TransferDirection::Download,
@@ -365,7 +365,7 @@ mod tests {
         );
         assert_eq!(
             720,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: 5 * MEGABYTE,
                 bucket_type: BucketType::Standard,
                 direction: TransferDirection::Download,
@@ -373,7 +373,7 @@ mod tests {
         );
         assert_eq!(
             720,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: 8 * MEGABYTE,
                 bucket_type: BucketType::Standard,
                 direction: TransferDirection::Download,
@@ -381,7 +381,7 @@ mod tests {
         );
         assert_eq!(
             720,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: 1000 * MEGABYTE,
                 bucket_type: BucketType::Standard,
                 direction: TransferDirection::Download,
@@ -389,7 +389,7 @@ mod tests {
         );
         assert_eq!(
             27,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: 100 * 1024,
                 bucket_type: BucketType::Standard,
                 direction: TransferDirection::Upload,
@@ -397,7 +397,7 @@ mod tests {
         );
         assert_eq!(
             160,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: MEGABYTE,
                 bucket_type: BucketType::Standard,
                 direction: TransferDirection::Upload,
@@ -405,7 +405,7 @@ mod tests {
         );
         assert_eq!(
             205,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: 100 * 1024,
                 bucket_type: BucketType::Express,
                 direction: TransferDirection::Download,
@@ -413,7 +413,7 @@ mod tests {
         );
         assert_eq!(
             1200,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: MEGABYTE,
                 bucket_type: BucketType::Express,
                 direction: TransferDirection::Download,
@@ -421,7 +421,7 @@ mod tests {
         );
         assert_eq!(
             205,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: 100 * 1024,
                 bucket_type: BucketType::Express,
                 direction: TransferDirection::Upload,
@@ -429,7 +429,7 @@ mod tests {
         );
         assert_eq!(
             880,
-            tokens_for_payload(&NetworkPermitContext {
+            tokens_for_network_context(&NetworkPermitContext {
                 payload_size_estimate: MEGABYTE,
                 bucket_type: BucketType::Express,
                 direction: TransferDirection::Upload,

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -92,7 +92,7 @@ const MIN_CONCURRENT_REQUESTS: u64 = 8;
 ///
 /// Source: None, reasonable default
 /// Applies to: ConcurrencyMode::TargetThroughput
-const MIN_BUCKET_TOKENS: u64 = (S3_MAX_PER_REQUEST_DOWNLOAD_THROUGHPUT.bytes_transferred()
+const MIN_BUCKET_TOKENS: u64 = (S3_EXPRESS_MAX_PER_REQUEST_DOWNLOAD_THROUGHPUT.bytes_transferred()
     / 1_000_000)
     * 8
     * MIN_CONCURRENT_REQUESTS;

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -257,7 +257,7 @@ fn token_bucket_size(throughput: Throughput) -> u64 {
     cmp::max(MIN_BUCKET_TOKENS, megabit_per_sec)
 }
 
-/// Tokens for network context 
+/// Tokens for network context
 fn tokens_for_network_context(network_context: &NetworkPermitContext) -> u64 {
     let estimated_mbps = estimated_throughput(
         network_context.payload_size_estimate,

--- a/aws-s3-transfer-manager/src/runtime/token_bucket.rs
+++ b/aws-s3-transfer-manager/src/runtime/token_bucket.rs
@@ -386,5 +386,53 @@ mod tests {
                 direction: TransferDirection::Download,
             })
         );
+        assert_eq!(
+            27,
+            tokens_for_payload(&NetworkPermitContext {
+                payload_size_estimate: 100 * 1024,
+                bucket_type: BucketType::Standard,
+                direction: TransferDirection::Upload,
+            })
+        );
+        assert_eq!(
+            160,
+            tokens_for_payload(&NetworkPermitContext {
+                payload_size_estimate: MEGABYTE,
+                bucket_type: BucketType::Standard,
+                direction: TransferDirection::Upload,
+            })
+        );
+        assert_eq!(
+            205,
+            tokens_for_payload(&NetworkPermitContext {
+                payload_size_estimate: 100 * 1024,
+                bucket_type: BucketType::Express,
+                direction: TransferDirection::Download,
+            })
+        );
+        assert_eq!(
+            1200,
+            tokens_for_payload(&NetworkPermitContext {
+                payload_size_estimate: MEGABYTE,
+                bucket_type: BucketType::Express,
+                direction: TransferDirection::Download,
+            })
+        );
+        assert_eq!(
+            205,
+            tokens_for_payload(&NetworkPermitContext {
+                payload_size_estimate: 100 * 1024,
+                bucket_type: BucketType::Express,
+                direction: TransferDirection::Upload,
+            })
+        );
+        assert_eq!(
+            880,
+            tokens_for_payload(&NetworkPermitContext {
+                payload_size_estimate: MEGABYTE,
+                bucket_type: BucketType::Express,
+                direction: TransferDirection::Upload,
+            })
+        );
     }
 }

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -331,7 +331,7 @@ pub(crate) enum BucketType {
 }
 
 impl BucketType {
-    pub(crate) fn from_bucket(bucket_name: &str) -> Self {
+    pub(crate) fn from_bucket_name(bucket_name: &str) -> Self {
         if bucket_name.ends_with("--x-s3") {
             BucketType::Express
         } else {

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -321,3 +321,11 @@ impl FailedUpload {
         &self.error
     }
 }
+
+/// Type of the bucket for the transfer
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
+pub(crate) enum BucketType {
+    Standard,
+    Express,
+}

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -332,10 +332,10 @@ pub(crate) enum BucketType {
 
 impl BucketType {
     pub(crate) fn from_bucket(bucket_name: &str) -> Self {
-        if bucket_name.ends_with("--x-s3") { 
-             BucketType::Express
+        if bucket_name.ends_with("--x-s3") {
+            BucketType::Express
         } else {
-             BucketType::Standard
+            BucketType::Standard
         }
     }
 }

--- a/aws-s3-transfer-manager/src/types.rs
+++ b/aws-s3-transfer-manager/src/types.rs
@@ -329,3 +329,13 @@ pub(crate) enum BucketType {
     Standard,
     Express,
 }
+
+impl BucketType {
+    pub(crate) fn from_bucket(bucket_name: &str) -> Self {
+        if bucket_name.ends_with("--x-s3") { 
+             BucketType::Express
+        } else {
+             BucketType::Standard
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
After #95, we saw a regression for the upload workloads. After discussions with the S3 team and running a bunch of experiments, this PR tunes the algorithm to have different numbers based on BucketType (Standard vs Express) and TransferDirection (Upload vs Download). This change fixes the performance regression for S3Standard Upload use-cases and uses lower number of connections for S3Express. 
Upload max throughput before my changes on c7gn.16xlarge with 200 target_throughput and S3Standard:
```
Running `target/release/s3-benchrunner-rust sdk-rust-tm ../../workloads/upload-max-throughput.run.json waqar-s3 us-west-2 200`
  Run:1 Secs:67.922668 Gb/s:63.233195
  Run:2 Secs:70.939868 Gb/s:60.543773
  Run:3 Secs:72.816502 Gb/s:58.983434
  Run:4 Secs:71.702563 Gb/s:59.899774
  Run:5 Secs:69.736383 Gb/s:61.588616
  Run:6 Secs:71.151194 Gb/s:60.363953
  Run:7 Secs:69.929214 Gb/s:61.418784
  Run:8 Secs:69.079735 Gb/s:62.174056
  Run:9 Secs:69.595188 Gb/s:61.713567

```
After my changes:
```
Running `target/release/s3-benchrunner-rust sdk-rust-tm ../../workloads/upload-max-throughput.run.json waqar-s3 us-west-
  2 200`
Run:1 Secs:27.046535 Gb/s:158.799171
Run:2 Secs:26.326644 Gb/s:163.141463
Run:3 Secs:26.788453 Gb/s:160.329050
Run:4 Secs:28.541450 Gb/s:150.481746
Run:5 Secs:28.787644 Gb/s:149.194817
Run:6 Secs:27.378442 Gb/s:156.874059
Run:7 Secs:25.345130 Gb/s:169.459275
Run:8 Secs:28.504043 Gb/s:150.679229
Run:9 Secs:25.211700 Gb/s:170.356118
Run:10 Secs:27.980239 Gb/s:153.500021
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
