### PR TITLE
add objects api e2e test

### DIFF
--- a/aws-s3-transfer-manager/src/io/path_body.rs
+++ b/aws-s3-transfer-manager/src/io/path_body.rs
@@ -99,7 +99,7 @@ impl PathBodyBuilder {
                 let metadata = self.metadata.unwrap_or(fs::metadata(path.clone())?);
                 let file_size = metadata.len();
 
-                if offset >= file_size {
+                if offset > file_size {
                     return Err(ErrorKind::OffsetGreaterThanFileSize.into());
                 }
 

--- a/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -108,7 +108,10 @@ pub(super) async fn list_directory_contents(
                                         );
                                         Ok(UploadObjectJob::new(object_key.into_owned(), object))
                                     }
-                                    Err(e) => Err(e.into()),
+                                    Err(e) => {
+                                         tracing::error!("failed to prepare to upload {relative_filename}: {}", DisplayErrorContext(&e));
+                                        Err(e.into())
+                                    },
                                 }
                             }
                             Err(walkdir_error) => {

--- a/aws-s3-transfer-manager/test-common/src/lib.rs
+++ b/aws-s3-transfer-manager/test-common/src/lib.rs
@@ -38,6 +38,7 @@ pub fn create_test_dir(
     }
 
     // Set the directories in `inaccessible_dir_relative_paths` to be inaccessible
+    // which will in turn render the files within those directories inaccessible
     for dir_relative_path in inaccessible_dir_relative_paths {
         let dir_path = temp_dir.path().join(*dir_relative_path);
         make_directory_inaccessible(&dir_path);

--- a/aws-s3-transfer-manager/test-common/src/lib.rs
+++ b/aws-s3-transfer-manager/test-common/src/lib.rs
@@ -57,18 +57,7 @@ fn make_directory_inaccessible(dir_path: &std::path::Path) {
 
 #[cfg(target_family = "windows")]
 fn make_directory_inaccessible(dir_path: &std::path::Path) {
-    use std::os::windows::fs::PermissionsExt;
-    let mut permissions = std::fs::metadata(dir_path).unwrap().permissions();
-
-    // On Windows, we can deny access by making the directory read-only
-    // and removing all other attributes
-    const FILE_ATTRIBUTE_READONLY: u32 = 0x1;
-    permissions.set_readonly(true);
-    permissions.set_mode(FILE_ATTRIBUTE_READONLY);
-
-    std::fs::set_permissions(dir_path, permissions).unwrap();
-
-    // Note: This provides limited inaccessibility on Windows compared to Unix
+    panic!("make_directory_inaccessible is not implemented for Windows");
 }
 
 /// A macro to generate a mock S3 client with the underlying HTTP client stubbed out

--- a/aws-s3-transfer-manager/test-common/src/lib.rs
+++ b/aws-s3-transfer-manager/test-common/src/lib.rs
@@ -71,7 +71,6 @@ fn make_directory_inaccessible(dir_path: &std::path::Path) {
     // Note: This provides limited inaccessibility on Windows compared to Unix
 }
 
-
 /// A macro to generate a mock S3 client with the underlying HTTP client stubbed out
 ///
 /// This macro wraps [`mock_client`](aws_smithy_mocks_experimental::mock_client) to work around the issue

--- a/aws-s3-transfer-manager/test-common/src/lib.rs
+++ b/aws-s3-transfer-manager/test-common/src/lib.rs
@@ -56,7 +56,7 @@ fn make_directory_inaccessible(dir_path: &std::path::Path) {
 }
 
 #[cfg(target_family = "windows")]
-fn make_directory_inaccessible(dir_path: &std::path::Path) {
+fn make_directory_inaccessible(_dir_path: &std::path::Path) {
     panic!("make_directory_inaccessible is not implemented for Windows");
 }
 

--- a/aws-s3-transfer-manager/test-common/src/lib.rs
+++ b/aws-s3-transfer-manager/test-common/src/lib.rs
@@ -14,7 +14,6 @@ use uuid::Uuid;
 /// For testing purposes, certain directories (and all files within them) can be made
 /// inaccessible by providing `inaccessible_dir_relative_paths`, which should be relative
 /// to `recursion_root`.
-#[cfg(target_family = "unix")]
 pub fn create_test_dir(
     recursion_root: Option<&str>,
     files: Vec<(&str, usize)>,
@@ -35,20 +34,43 @@ pub fn create_test_dir(
 
         // Create the file with the specified size
         let mut file = std::fs::File::create(&full_path).unwrap();
-        std::io::Write::write_all(&mut file, &vec![0; size]).unwrap(); // Writing `size` byte
+        std::io::Write::write_all(&mut file, &vec![0; size]).unwrap(); // Writing `size` bytes
     }
 
-    // Set the directories in `inaccessible_dir_relative_paths` to be inaccessible,
-    // which will in turn render the files within those directories inaccessible
+    // Set the directories in `inaccessible_dir_relative_paths` to be inaccessible
     for dir_relative_path in inaccessible_dir_relative_paths {
         let dir_path = temp_dir.path().join(*dir_relative_path);
-        let mut permissions = std::fs::metadata(&dir_path).unwrap().permissions();
-        std::os::unix::fs::PermissionsExt::set_mode(&mut permissions, 0o000); // No permissions for anyone
-        std::fs::set_permissions(dir_path, permissions).unwrap();
+        make_directory_inaccessible(&dir_path);
     }
 
     temp_dir
 }
+
+// Platform-specific helper function to make directories inaccessible
+#[cfg(target_family = "unix")]
+fn make_directory_inaccessible(dir_path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = std::fs::metadata(dir_path).unwrap().permissions();
+    permissions.set_mode(0o000); // No permissions for anyone
+    std::fs::set_permissions(dir_path, permissions).unwrap();
+}
+
+#[cfg(target_family = "windows")]
+fn make_directory_inaccessible(dir_path: &std::path::Path) {
+    use std::os::windows::fs::PermissionsExt;
+    let mut permissions = std::fs::metadata(dir_path).unwrap().permissions();
+
+    // On Windows, we can deny access by making the directory read-only
+    // and removing all other attributes
+    const FILE_ATTRIBUTE_READONLY: u32 = 0x1;
+    permissions.set_readonly(true);
+    permissions.set_mode(FILE_ATTRIBUTE_READONLY);
+
+    std::fs::set_permissions(dir_path, permissions).unwrap();
+
+    // Note: This provides limited inaccessibility on Windows compared to Unix
+}
+
 
 /// A macro to generate a mock S3 client with the underlying HTTP client stubbed out
 ///

--- a/aws-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -431,7 +431,6 @@ async fn test_object_download_range_failures() {
 }
 
 #[tokio::test]
-#[cfg(target_family = "unix")]
 async fn test_objects_transfer() {
     let (tm, _) = test_tm().await;
     let (bucket_name, _) = get_bucket_names();

--- a/aws-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -443,10 +443,12 @@ async fn test_objects_transfer() {
 
     let temp_dir = create_test_dir(Some("e2e_downloads"), vec![], &[]);
 
+    // Download all pre-existing objects except the ones with `aes256-c` suffix
+    // The objects details can be found https://github.com/awslabs/aws-c-s3/tree/main/tests/test_helper
     let download_handle = tm
         .download_objects()
         .bucket(bucket_name.as_str())
-        .key_prefix("pre-")
+        .key_prefix("pre-existing")
         .set_filter(Some(DownloadFilter::from(sse_c_filter)))
         .destination(temp_dir.path())
         .send()

--- a/aws-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -431,6 +431,7 @@ async fn test_object_download_range_failures() {
 }
 
 #[tokio::test]
+#[cfg(target_family = "unix")]
 async fn test_objects_transfer() {
     let (tm, _) = test_tm().await;
     let (bucket_name, _) = get_bucket_names();

--- a/aws-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -11,7 +11,6 @@ use aws_s3_transfer_manager::io::{InputStream, PartData, PartStream, SizeHint, S
 use aws_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_s3_transfer_manager::operation::upload::ChecksumStrategy;
 use aws_sdk_s3::types::ChecksumMode;
-use std::fs;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::Poll;

--- a/aws-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -1,4 +1,4 @@
-// #![cfg(e2e_test)]
+#![cfg(e2e_test)]
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -15,7 +15,6 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::Poll;
 use std::time::Duration;
-use aws_smithy_runtime::test_util::capture_test_logs::show_test_logs;
 use test_common::{create_test_dir, drain, global_uuid_str};
 
 use aws_s3_transfer_manager::types::{DownloadFilter, PartSize};
@@ -434,7 +433,6 @@ async fn test_object_download_range_failures() {
 async fn test_objects_transfer() {
     let (tm, _) = test_tm().await;
     let (bucket_name, _) = get_bucket_names();
-    let _logs = show_test_logs();
 
     // SSE-C objects require the key to download, skipping it.
     fn sse_c_filter(obj: &aws_sdk_s3::types::Object) -> bool {


### PR DESCRIPTION
*Issue #, if available:*
- Added e2e tests for objects API 
- Uncovers a bug where upload failed for empty object
```
2025-02-28T00:13:54.179657Z DEBUG download-objects-tasks{bucket="aws-s3-transfer-manager-rs-test-bucket" destination="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="pre-"}: aws_s3_transfer_manager::operation::download_objects::worker: worker finished downloading key Some("pre-existing-1MB")
2025-02-28T00:13:54.179726Z TRACE download-objects-tasks{bucket="aws-s3-transfer-manager-rs-test-bucket" destination="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="pre-"}: aws_s3_transfer_manager::operation::download_objects::worker: req channel closed, worker finished
2025-02-28T00:13:54.388360Z DEBUG download-objects-tasks{bucket="aws-s3-transfer-manager-rs-test-bucket" destination="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="pre-"}: aws_s3_transfer_manager::operation::download_objects::worker: worker finished downloading key Some("pre-existing-1MB-@")
2025-02-28T00:13:54.388392Z TRACE download-objects-tasks{bucket="aws-s3-transfer-manager-rs-test-bucket" destination="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="pre-"}: aws_s3_transfer_manager::operation::download_objects::worker: req channel closed, worker finished
2025-02-28T00:13:54.797637Z DEBUG download-objects-tasks{bucket="aws-s3-transfer-manager-rs-test-bucket" destination="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="pre-"}: aws_s3_transfer_manager::operation::download_objects::worker: worker finished downloading key Some("pre-existing-10MB")
2025-02-28T00:13:54.797687Z TRACE download-objects-tasks{bucket="aws-s3-transfer-manager-rs-test-bucket" destination="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="pre-"}: aws_s3_transfer_manager::operation::download_objects::worker: req channel closed, worker finished
2025-02-28T00:13:55.404790Z DEBUG download-objects-tasks{bucket="aws-s3-transfer-manager-rs-test-bucket" destination="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="pre-"}: aws_s3_transfer_manager::operation::download_objects::worker: worker finished downloading key Some("pre-existing-10MB-kms")
2025-02-28T00:13:55.404821Z TRACE download-objects-tasks{bucket="aws-s3-transfer-manager-rs-test-bucket" destination="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="pre-"}: aws_s3_transfer_manager::operation::download_objects::worker: req channel closed, worker finished
2025-02-28T00:13:56.439397Z DEBUG download-objects-tasks{bucket="aws-s3-transfer-manager-rs-test-bucket" destination="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="pre-"}: aws_s3_transfer_manager::operation::download_objects::worker: worker finished downloading key Some("pre-existing-10MB-aes256")
2025-02-28T00:13:56.439430Z TRACE download-objects-tasks{bucket="aws-s3-transfer-manager-rs-test-bucket" destination="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="pre-"}: aws_s3_transfer_manager::operation::download_objects::worker: req channel closed, worker finished
2025-02-28T00:13:56.440660Z DEBUG aws_s3_transfer_manager::operation::upload_objects::worker: skipping object due to filter: "/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl"
2025-02-28T00:13:56.440698Z DEBUG aws_s3_transfer_manager::operation::upload_objects::worker: preparing to upload pre-existing-1MB with object key upload/2149915a-af5a-4614-8124-7b166fb187a5/test/pre-existing-1MB...
2025-02-28T00:13:56.440761Z TRACE aws_s3_transfer_manager::operation::upload: upload request content size hint (1048576) less than min part size threshold (16777216); sending as single PutObject request
2025-02-28T00:13:56.440801Z DEBUG aws_s3_transfer_manager::operation::upload_objects::worker: preparing to upload pre-existing-10MB-kms with object key upload/2149915a-af5a-4614-8124-7b166fb187a5/test/pre-existing-10MB-kms...
2025-02-28T00:13:56.440830Z TRACE aws_s3_transfer_manager::operation::upload: upload request content size hint (10485760) less than min part size threshold (16777216); sending as single PutObject request
2025-02-28T00:13:56.441972Z DEBUG aws_s3_transfer_manager::operation::upload_objects::worker: preparing to upload pre-existing-async-error-xml with object key upload/2149915a-af5a-4614-8124-7b166fb187a5/test/pre-existing-async-error-xml...
2025-02-28T00:13:56.442633Z TRACE aws_s3_transfer_manager::operation::upload: upload request content size hint (278) less than min part size threshold (16777216); sending as single PutObject request
2025-02-28T00:13:56.442718Z DEBUG aws_s3_transfer_manager::operation::upload_objects::worker: preparing to upload pre-existing-10MB with object key upload/2149915a-af5a-4614-8124-7b166fb187a5/test/pre-existing-10MB...
2025-02-28T00:13:56.442741Z TRACE aws_s3_transfer_manager::operation::upload: upload request content size hint (10485760) less than min part size threshold (16777216); sending as single PutObject request
2025-02-28T00:13:56.443421Z DEBUG initiate-upload-objects{bucket="aws-s3-transfer-manager-rs-test-bucket" source="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="upload/2149915a-af5a-4614-8124-7b166fb187a5/test"}:object-uploader{worker=8}: aws_s3_transfer_manager::operation::upload_objects::worker: worker received an error from the `list_directory` task: I/O error
2025-02-28T00:13:56.443478Z ERROR initiate-upload-objects{bucket="aws-s3-transfer-manager-rs-test-bucket" source="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="upload/2149915a-af5a-4614-8124-7b166fb187a5/test"}:object-uploader{worker=9}: aws_s3_transfer_manager::operation::upload_objects::worker: received cancellation signal, exiting and ignoring any future work
2025-02-28T00:13:56.443494Z ERROR initiate-upload-objects{bucket="aws-s3-transfer-manager-rs-test-bucket" source="/var/folders/kq/w7cg5c8j6n590dg9x_55p4sc0000gq/T/e2e_downloadss6clMl" key_prefix="upload/2149915a-af5a-4614-8124-7b166fb187a5/test"}:object-uploader{worker=3}: aws_s3_transfer_manager::operation::upload_objects::worker: received cancellation signal, exiting and ignoring any future work
2
```

*Description of changes:*
- Fix the bug where when the file is empty the offset is 0, will triggers the `OffsetGreaterThanFileSize` error, which should just result in a 0 length of path_body
- Add tests to download all the `pre-existing` files, (skip the `aes256-c`, as the SSE-C will require a client level key to download), and then upload all the downloaded objects.
- `pre-existing` files detail can be found https://github.com/awslabs/aws-c-s3/tree/main/tests/test_helper

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
