### PR TITLE
use default HTTPS client from SDK crate and cleanup http-02 usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+vNext
+======
+
+* Use the default HTTPS client from SDK crate which is now based on `aws-lc`.
+
 v0.1.1
 ======
 

--- a/aws-sdk-s3-transfer-manager/Cargo.toml
+++ b/aws-sdk-s3-transfer-manager/Cargo.toml
@@ -16,14 +16,13 @@ keywords = ["AWS", "Amazon", "S3", "high-performance", "transfer-manager"]
 [dependencies]
 async-channel = "2.3.1"
 async-trait = "0.1.83"
-aws-config = { version = "1.5.15", features = ["behavior-version-latest"] }
-aws-sdk-s3 = { version = "1.76.0", features = ["behavior-version-latest"] }
-aws-smithy-async = "1.2.4"
-aws-smithy-experimental = { version = "0.1.5", features = ["crypto-aws-lc"] }
-aws-smithy-runtime-api = "1.7.3"
-aws-runtime = "1.5.4"
-aws-smithy-types = "1.2.13"
-aws-types = "1.3.4"
+aws-config = { version = "1.6.0", features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1.79.0", features = ["behavior-version-latest"] }
+aws-smithy-async = "1.2.5"
+aws-smithy-runtime-api = "1.7.4"
+aws-runtime = "1.5.6"
+aws-smithy-types = "1.3.0"
+aws-types = "1.3.6"
 blocking = "1.6.1"
 bytes = "1"
 bytes-utils = "0.1.4"
@@ -37,13 +36,14 @@ walkdir = "2"
 tokio-util = "0.7.13"
 
 [dev-dependencies]
-aws-sdk-s3 = { version = "1.76.0", features = ["behavior-version-latest", "test-util"] }
-aws-smithy-checksums = "0.62.0"
-aws-smithy-mocks-experimental = "0.2.1"
-aws-smithy-runtime = { version = "1.7.7", features = ["client", "connector-hyper-0-14-x", "test-util", "wire-mock"] }
+aws-sdk-s3 = { version = "1.79.0", features = ["behavior-version-latest", "test-util"] }
+aws-smithy-checksums = "0.63.1"
+aws-smithy-mocks-experimental = "0.2.3"
+aws-smithy-runtime = { version = "1.8.0", features = ["client", "test-util"] }
+aws-smithy-http-client = { version = "1.0.0", features = ["test-util", "wire-mock"] }
 clap = { version = "4.5.7", default-features = false, features = ["derive", "std", "help"] }
 console-subscriber = "0.4.0"
-http-02x = { package = "http", version = "0.2.9" }
+http = "1"
 http-body-1x = { package = "http-body", version = "1" }
 fastrand = "2.1.1"
 futures-test = "0.3.30"

--- a/aws-sdk-s3-transfer-manager/src/config/loader.rs
+++ b/aws-sdk-s3-transfer-manager/src/config/loader.rs
@@ -9,9 +9,8 @@ use aws_runtime::user_agent::{ApiMetadata, AwsUserAgent, FrameworkMetadata};
 use aws_sdk_s3::config::{Intercept, IntoShared};
 use aws_types::os_shim_internal::Env;
 
-use crate::config::Builder;
-use crate::types::ConcurrencyMode;
-use crate::{http, types::PartSize, Config};
+use crate::config::{Builder, Config};
+use crate::types::{ConcurrencyMode, PartSize};
 
 #[derive(Debug)]
 struct S3TransferManagerInterceptor {
@@ -103,10 +102,7 @@ impl ConfigLoader {
     /// If fields have been overridden during builder construction, the override values will be
     /// used. Otherwise, the default values for each field will be provided.
     pub async fn load(self) -> Config {
-        let shared_config = aws_config::defaults(BehaviorVersion::latest())
-            .http_client(http::default_client())
-            .load()
-            .await;
+        let shared_config = aws_config::defaults(BehaviorVersion::latest()).load().await;
 
         let mut sdk_client_builder = aws_sdk_s3::config::Builder::from(&shared_config);
 

--- a/aws-sdk-s3-transfer-manager/src/http.rs
+++ b/aws-sdk-s3-transfer-manager/src/http.rs
@@ -2,14 +2,5 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-use aws_smithy_experimental::hyper_1_0::{CryptoMode, HyperClientBuilder};
-use aws_smithy_runtime_api::client::http::SharedHttpClient;
 
 pub(crate) mod header;
-
-/// The default HTTP client used by a transfer manager when not explicitly configured.
-pub(crate) fn default_client() -> SharedHttpClient {
-    HyperClientBuilder::new()
-        .crypto_mode(CryptoMode::AwsLc)
-        .build_https()
-}

--- a/aws-sdk-s3-transfer-manager/test-common/Cargo.toml
+++ b/aws-sdk-s3-transfer-manager/test-common/Cargo.toml
@@ -7,7 +7,8 @@ publish = false
 
 [dependencies]
 aws-smithy-mocks-experimental = "0.2.1"
-http-02x = { package = "http", version = "0.2.9" }
+aws-smithy-http-client = { version = "1.0.0", features = ["test-util"] }
+http = "1"
 tempfile = "3.12.0"
 bytes = "1.9.0"
 aws-sdk-s3-transfer-manager = { path = "../../aws-sdk-s3-transfer-manager", version = "0.1.0" }

--- a/aws-sdk-s3-transfer-manager/test-common/src/lib.rs
+++ b/aws-sdk-s3-transfer-manager/test-common/src/lib.rs
@@ -81,11 +81,9 @@ macro_rules! mock_client_with_stubbed_http_client {
             client
                 .config()
                 .to_builder()
-                .http_client(
-                    aws_smithy_runtime::client::http::test_util::infallible_client_fn(|_req| {
-                        http_02x::Response::builder().status(200).body("").unwrap()
-                    }),
-                )
+                .http_client(aws_smithy_http_client::test_util::infallible_client_fn(
+                    |_req| http::Response::builder().status(200).body("").unwrap(),
+                ))
                 .build(),
         )
     }};


### PR DESCRIPTION
**Description of changes:**

Stop overriding the HTTP client and use the default from the SDK crate which as of [latest release](https://github.com/awslabs/aws-sdk-rust/discussions/1257) is the same as what we were setting. Also cleaned up internal usage of legacy http-02 crate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
