### PR TITLE
Fix DownloadObjects for S3Express

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 vNext
 ======
 
+* **BugFix:** Fix DownloadObjects for S3Express (#112)
 * Use the default HTTPS client from SDK crate which is now based on `aws-lc`.
 
 v0.1.1

--- a/aws-sdk-s3-transfer-manager/src/operation/download_objects/list_objects.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download_objects/list_objects.rs
@@ -104,11 +104,11 @@ impl State {
 impl ListObjectsPaginator {
     fn new(context: DownloadObjectsContext) -> Self {
         let mut prefix = context.state.input.key_prefix.to_owned();
-        let delimeter = context.state.input.delimiter().unwrap_or(DEFAULT_DELIMITER);
+        let delimiter = context.state.input.delimiter().unwrap_or(DEFAULT_DELIMITER);
         // S3Express requires that prefix must end with delimiter
         if let Some(prefix) = prefix.as_mut() {
-            if !prefix.ends_with(delimeter) {
-                prefix.push_str(delimeter);
+            if !prefix.ends_with(delimiter) {
+                prefix.push_str(delimiter);
             }
         }
         Self {
@@ -332,8 +332,8 @@ mod tests {
         let resp1 = mock!(aws_sdk_s3::Client::list_objects_v2)
             .match_requests(move |r| {
                 let prefix = r.prefix.clone().unwrap();
-                let delim = r.delimiter.clone().unwrap_or(DEFAULT_DELIMITER.to_string());
-                prefix.ends_with(&delim)
+                let delimiter = r.delimiter.clone().unwrap_or(DEFAULT_DELIMITER.to_string());
+                prefix.ends_with(&delimiter)
             })
             .then_output(|| {
                 list_resp(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Our current benchmark for S3Express download_objects is failing with the following:
```

  thread 'main' panicked at src/main.rs:49:17:
  child operation failed

  Caused by:
      0: service error
      1: unhandled error (InvalidRequest)
      2: Error { code: "InvalidRequest", message: "This bucket does not support a prefix that does not end in a delimiter. Specify a prefix path ending with a delimiter and try again.", aws_request_id: "01b629e01a000195c918446e0509a490957f08b1", s3_extend
  ed_request_id: "HT0YP" }
```
Make sure that prefix ends with delimiter for ListObjects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
