### PR TITLE
Validate UploadPart requests

### DIFF
--- a/aws-sdk-s3-transfer-manager/src/error.rs
+++ b/aws-sdk-s3-transfer-manager/src/error.rs
@@ -48,6 +48,10 @@ pub enum ErrorKind {
     /// The operation is being canceled because the user explicitly called `.abort` on the handle,
     /// or a child operation failed with the abort policy.
     OperationCancelled,
+
+    /// Request/response validation failed (e.g., the total number of UploadPart requests sent
+    /// did not match the expected number of parts)
+    ValidationFailed,
 }
 
 impl Error {
@@ -80,6 +84,7 @@ impl fmt::Display for Error {
             ErrorKind::NotFound => write!(f, "resource not found"),
             ErrorKind::ChildOperationFailed => write!(f, "child operation failed"),
             ErrorKind::OperationCancelled => write!(f, "operation cancelled"),
+            ErrorKind::ValidationFailed => write!(f, "validation failed"),
         }
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/io/adapters.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/adapters.rs
@@ -118,6 +118,8 @@ where
                             let data: Bytes = inner_buf.into();
                             let part_number = *this.next_part;
                             *this.next_part += 1;
+                            // We don't know whether this is the last part data, since determining that
+                            // would require an additional `poll_read`.
                             let part = PartData::new(part_number, data);
                             return Poll::Ready(Some(Ok(part)));
                         } else if n == 0 {

--- a/aws-sdk-s3-transfer-manager/src/io/stream.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/stream.rs
@@ -172,9 +172,18 @@ pub struct PartData {
     pub(crate) part_number: u64,
     pub(crate) data: Bytes,
     pub(crate) checksum: Option<String>,
+    pub(crate) is_last: Option<bool>,
 }
 
 impl PartData {
+    /// Check if this is the last part
+    ///
+    /// It is `Option` because it's not always possible to determine
+    /// whether the just-yielded part is the last one, e.g., streaming cases.
+    pub fn is_last(&self) -> Option<bool> {
+        self.is_last
+    }
+
     /// Create a new part
     pub fn new(part_number: u64, data: impl Into<Bytes>) -> Self {
         debug_assert!(
@@ -185,6 +194,7 @@ impl PartData {
             part_number,
             data: data.into(),
             checksum: None,
+            is_last: None,
         }
     }
 
@@ -197,6 +207,12 @@ impl PartData {
     /// (see [ChecksumStrategy](crate::operation::upload::ChecksumStrategy)).
     pub fn with_checksum(mut self, checksum: impl Into<String>) -> Self {
         self.checksum = Some(checksum.into());
+        self
+    }
+
+    /// Mark this part as the last part
+    pub fn mark_last(mut self, is_last: bool) -> Self {
+        self.is_last = Some(is_last);
         self
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
@@ -172,6 +172,7 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
             let mut all_parts = Vec::new();
             // join all the upload tasks. We can safely grab the lock since all the read_tasks are done.
             let mut tasks = mpu_data.upload_part_tasks.lock().await;
+            let number_of_upload_requests = tasks.len();
             while let Some(join_result) = tasks.join_next().await {
                 let result = join_result.expect("task completed");
                 match result {
@@ -190,6 +191,17 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
             }
 
             tracing::trace!("completing multipart upload");
+
+            if number_of_upload_requests != all_parts.len() {
+                return Err(crate::error::Error::new(
+                    crate::error::ErrorKind::ValidationFailed,
+                    format!(
+                        "The total number of UploadPart requests must match the expected number of parts: request count {}, number of parts {}",
+                        number_of_upload_requests,
+                        all_parts.len()
+                    ),
+                ));
+            }
 
             // parts must be sorted
             all_parts.sort_by_key(|p| p.part_number.expect("part number set"));

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/service.rs
@@ -222,6 +222,20 @@ pub(super) async fn read_body(
         .instrument(tracing::debug_span!("read-upload-body"))
         .await?
     {
+        // The content length of each UploadPart request matches the expected part size
+        if part_reader.part_size() != part_data.data.remaining()
+            && part_data.is_last() == Some(false)
+        {
+            return Err(error::Error::new(
+                error::ErrorKind::ValidationFailed,
+                format!(
+                    "upload part size mismatch for non-last part {}: configured part size {}, got data size {}",
+                    part_data.part_number,
+                    part_reader.part_size(),
+                    part_data.data.remaining()
+                ),
+            ));
+        }
         let req = UploadPartRequest {
             ctx: ctx.clone(),
             part_data,


### PR DESCRIPTION
*Description of changes:*
This PR adds the following validation to `UploadPart` requests:
- The total number of `UploadPart` requests must match the expected number of parts ([code change](https://github.com/awslabs/aws-s3-transfer-manager-rs/compare/ysaito/validate-upload-part-request?expand=1#diff-19c08f62e1609d29de38ce208ca94ab679812552d302b5895f15ac797b497c2aR195-R204))
- The content length of each `UploadPart` request must match the expected part size (except for the last part, which may be smaller than the target part size) ([code change](https://github.com/awslabs/aws-s3-transfer-manager-rs/compare/ysaito/validate-upload-part-request?expand=1#diff-03378f35eac44d2e7ef4657ae211c1805c0e071d52dcd8d5c8d1e93cc980aadaR225-R238))
- The part number assigned to each `UploadPart` request should align with the starting offset of the source (applicable to bytes and file-based) ([BytesPartReader](https://github.com/awslabs/aws-s3-transfer-manager-rs/compare/ysaito/validate-upload-part-request?expand=1#diff-3edc995013d58106e512d7ece68c317c9f11d1144a0c421db74e8a36f3ed55d4R156-R163),  [PathBodyPartReader](https://github.com/awslabs/aws-s3-transfer-manager-rs/compare/ysaito/validate-upload-part-request?expand=1#diff-3edc995013d58106e512d7ece68c317c9f11d1144a0c421db74e8a36f3ed55d4R235-R241))

Any validation error above will result in returning an `Err`, terminating the upload operation.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
