### PR TITLE
Validate field mappings between Transfer Manager input/output and S3 input/output types

### DIFF
--- a/aws-sdk-s3-transfer-manager/src/operation/download/chunk_meta.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/chunk_meta.rs
@@ -131,43 +131,43 @@ impl From<GetObjectOutput> for ChunkMetadata {
         Self {
             _request_id: value.request_id().map(|s| s.to_string()),
             _extended_request_id: value.extended_request_id().map(|s| s.to_string()),
-            delete_marker: value.delete_marker,
             accept_ranges: value.accept_ranges,
-            expiration: value.expiration,
-            restore: value.restore,
-            last_modified: value.last_modified,
-            content_length: value.content_length,
-            e_tag: value.e_tag,
+            bucket_key_enabled: value.bucket_key_enabled,
+            cache_control: value.cache_control,
             checksum_crc32: value.checksum_crc32,
             checksum_crc32_c: value.checksum_crc32_c,
             checksum_crc64_nvme: value.checksum_crc64_nvme,
             checksum_sha1: value.checksum_sha1,
             checksum_sha256: value.checksum_sha256,
             checksum_type: value.checksum_type,
-            missing_meta: value.missing_meta,
-            version_id: value.version_id,
-            cache_control: value.cache_control,
             content_disposition: value.content_disposition,
             content_encoding: value.content_encoding,
             content_language: value.content_language,
+            content_length: value.content_length,
             content_range: value.content_range,
             content_type: value.content_type,
-            website_redirect_location: value.website_redirect_location,
-            server_side_encryption: value.server_side_encryption,
+            delete_marker: value.delete_marker,
+            e_tag: value.e_tag,
+            expiration: value.expiration,
+            expires_string: value.expires_string,
+            last_modified: value.last_modified,
             metadata: value.metadata,
+            missing_meta: value.missing_meta,
+            object_lock_legal_hold_status: value.object_lock_legal_hold_status,
+            object_lock_mode: value.object_lock_mode,
+            object_lock_retain_until_date: value.object_lock_retain_until_date,
+            parts_count: value.parts_count,
+            replication_status: value.replication_status,
+            request_charged: value.request_charged,
+            restore: value.restore,
+            server_side_encryption: value.server_side_encryption,
             sse_customer_algorithm: value.sse_customer_algorithm,
             sse_customer_key_md5: value.sse_customer_key_md5,
             ssekms_key_id: value.ssekms_key_id,
-            bucket_key_enabled: value.bucket_key_enabled,
             storage_class: value.storage_class,
-            request_charged: value.request_charged,
-            replication_status: value.replication_status,
-            parts_count: value.parts_count,
             tag_count: value.tag_count,
-            object_lock_mode: value.object_lock_mode,
-            object_lock_retain_until_date: value.object_lock_retain_until_date,
-            object_lock_legal_hold_status: value.object_lock_legal_hold_status,
-            expires_string: value.expires_string,
+            version_id: value.version_id,
+            website_redirect_location: value.website_redirect_location,
         }
     }
 }
@@ -232,5 +232,145 @@ impl ::std::fmt::Debug for ChunkMetadata {
         formatter.field("_extended_request_id", &self._extended_request_id);
         formatter.field("_request_id", &self._request_id);
         formatter.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_s3::operation::get_object::GetObjectOutput;
+    use aws_sdk_s3::types::{
+        ChecksumType, ObjectLockLegalHoldStatus, ObjectLockMode, ReplicationStatus, RequestCharged,
+        ServerSideEncryption, StorageClass,
+    };
+    use aws_smithy_types::DateTime;
+
+    #[test]
+    fn test_from_get_object_output() {
+        let get_object_output = GetObjectOutput::builder()
+            .accept_ranges("bytes=0-999")
+            .bucket_key_enabled(true)
+            .cache_control("no-cache")
+            .checksum_crc32("AAAAAA==")
+            .checksum_type(ChecksumType::FullObject)
+            .content_disposition("attachment")
+            .content_encoding("gzip")
+            .content_language("en")
+            .content_length(1024)
+            .content_range("bytes 0-1023/1024")
+            .content_type("application/octet-stream")
+            .delete_marker(false)
+            .e_tag("test-etag")
+            .expiration("test-expiration")
+            .expires_string("test-expires")
+            .last_modified(aws_smithy_types::DateTime::from_secs(1234567890))
+            .missing_meta(0)
+            .object_lock_legal_hold_status(ObjectLockLegalHoldStatus::On)
+            .object_lock_mode(ObjectLockMode::Governance)
+            .object_lock_retain_until_date(aws_smithy_types::DateTime::from_secs(1234567890))
+            .parts_count(1)
+            .replication_status(ReplicationStatus::Complete)
+            .request_charged(RequestCharged::Requester)
+            .restore("test-restore")
+            .server_side_encryption(ServerSideEncryption::Aes256)
+            .sse_customer_algorithm("AES256")
+            .sse_customer_key_md5("test-md5")
+            .ssekms_key_id("test-kms-key")
+            .storage_class(StorageClass::Standard)
+            .tag_count(2)
+            .version_id("test-version")
+            .website_redirect_location("https://example.com")
+            .build();
+
+        let chunk_metadata = ChunkMetadata::from(get_object_output);
+
+        // Repeat expected values because `get_object_output` has been consumed above
+        assert_eq!(
+            Some("bytes=0-999".to_string()),
+            chunk_metadata.accept_ranges
+        );
+        assert_eq!(Some(true), chunk_metadata.bucket_key_enabled);
+        assert_eq!(Some("no-cache".to_string()), chunk_metadata.cache_control);
+        assert_eq!(Some("AAAAAA==".to_string()), chunk_metadata.checksum_crc32);
+        assert_eq!(None, chunk_metadata.checksum_crc32_c);
+        assert_eq!(None, chunk_metadata.checksum_crc64_nvme);
+        assert_eq!(None, chunk_metadata.checksum_sha1);
+        assert_eq!(None, chunk_metadata.checksum_sha256);
+        assert_eq!(Some(ChecksumType::FullObject), chunk_metadata.checksum_type);
+        assert_eq!(
+            Some("attachment".to_string()),
+            chunk_metadata.content_disposition
+        );
+        assert_eq!(Some("gzip".to_string()), chunk_metadata.content_encoding);
+        assert_eq!(Some("en".to_string()), chunk_metadata.content_language);
+        assert_eq!(Some(1024), chunk_metadata.content_length);
+        assert_eq!(
+            Some("bytes 0-1023/1024".to_string()),
+            chunk_metadata.content_range
+        );
+        assert_eq!(
+            Some("application/octet-stream".to_string()),
+            chunk_metadata.content_type
+        );
+        assert_eq!(Some(false), chunk_metadata.delete_marker);
+        assert_eq!(Some("test-etag".to_string()), chunk_metadata.e_tag);
+        assert_eq!(
+            Some("test-expiration".to_string()),
+            chunk_metadata.expiration
+        );
+        assert_eq!(
+            Some("test-expires".to_string()),
+            chunk_metadata.expires_string
+        );
+        assert_eq!(
+            Some(DateTime::from_secs(1234567890)),
+            chunk_metadata.last_modified
+        );
+        assert_eq!(Some(0), chunk_metadata.missing_meta);
+        assert_eq!(
+            Some(ObjectLockLegalHoldStatus::On),
+            chunk_metadata.object_lock_legal_hold_status
+        );
+        assert_eq!(
+            Some(ObjectLockMode::Governance),
+            chunk_metadata.object_lock_mode
+        );
+        assert_eq!(
+            Some(DateTime::from_secs(1234567890)),
+            chunk_metadata.object_lock_retain_until_date
+        );
+        assert_eq!(Some(1), chunk_metadata.parts_count);
+        assert_eq!(
+            Some(ReplicationStatus::Complete),
+            chunk_metadata.replication_status
+        );
+        assert_eq!(
+            Some(RequestCharged::Requester),
+            chunk_metadata.request_charged
+        );
+        assert_eq!(Some("test-restore".to_string()), chunk_metadata.restore);
+        assert_eq!(
+            Some(ServerSideEncryption::Aes256),
+            chunk_metadata.server_side_encryption
+        );
+        assert_eq!(
+            Some("AES256".to_string()),
+            chunk_metadata.sse_customer_algorithm
+        );
+        assert_eq!(
+            Some("test-md5".to_string()),
+            chunk_metadata.sse_customer_key_md5
+        );
+        assert_eq!(
+            Some("test-kms-key".to_string()),
+            chunk_metadata.ssekms_key_id
+        );
+        assert_eq!(Some(StorageClass::Standard), chunk_metadata.storage_class);
+        assert_eq!(Some(2), chunk_metadata.tag_count);
+        assert_eq!(Some("test-version".to_string()), chunk_metadata.version_id);
+        assert_eq!(
+            Some("https://example.com".to_string()),
+            chunk_metadata.website_redirect_location
+        );
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
@@ -225,14 +225,7 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
                 .response
                 .take()
                 .expect("response set")
-                .set_e_tag(complete_mpu_resp.e_tag.clone())
-                .set_expiration(complete_mpu_resp.expiration.clone())
-                .set_checksum_crc32(complete_mpu_resp.checksum_crc32.clone())
-                .set_checksum_crc32_c(complete_mpu_resp.checksum_crc32_c.clone())
-                .set_checksum_crc64_nvme(complete_mpu_resp.checksum_crc64_nvme.clone())
-                .set_checksum_sha1(complete_mpu_resp.checksum_sha1.clone())
-                .set_checksum_sha256(complete_mpu_resp.checksum_sha256.clone())
-                .set_version_id(complete_mpu_resp.version_id.clone());
+                .update_from_complete_mpu(&complete_mpu_resp);
 
             tracing::trace!("upload completed successfully");
 

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/input.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/input.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+pub(crate) mod convert;
+
 use crate::io::InputStream;
 use crate::types::FailedMultipartUploadPolicy;
 use aws_smithy_types::error::operation::BuildError;

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/input/convert.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/input/convert.rs
@@ -1,0 +1,530 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use super::UploadInput;
+use aws_sdk_s3::operation::{
+    abort_multipart_upload::builders::AbortMultipartUploadFluentBuilder,
+    complete_multipart_upload::builders::CompleteMultipartUploadFluentBuilder,
+    create_multipart_upload::builders::CreateMultipartUploadFluentBuilder,
+    put_object::builders::PutObjectFluentBuilder, upload_part::builders::UploadPartFluentBuilder,
+};
+use aws_sdk_s3::types::{ChecksumAlgorithm, ChecksumType};
+
+/// Copy fields from UploadInput to `PutObjectFluentBuilder`
+pub(crate) fn copy_fields_to_put_object_request(
+    upload_input: &UploadInput,
+    put_object_builder: PutObjectFluentBuilder,
+) -> PutObjectFluentBuilder {
+    let mut put_object_builder = put_object_builder
+        .set_acl(upload_input.acl.clone())
+        .set_bucket(upload_input.bucket.clone())
+        .set_bucket_key_enabled(upload_input.bucket_key_enabled)
+        .set_cache_control(upload_input.cache_control.clone())
+        .set_content_disposition(upload_input.content_disposition.clone())
+        .set_content_encoding(upload_input.content_encoding.clone())
+        .set_content_language(upload_input.content_language.clone())
+        .set_content_md5(upload_input.content_md5.clone())
+        .set_content_type(upload_input.content_type.clone())
+        .set_expected_bucket_owner(upload_input.expected_bucket_owner.clone())
+        .set_expires(upload_input.expires)
+        .set_grant_full_control(upload_input.grant_full_control.clone())
+        .set_grant_read(upload_input.grant_read.clone())
+        .set_grant_read_acp(upload_input.grant_read_acp.clone())
+        .set_grant_write_acp(upload_input.grant_write_acp.clone())
+        .set_key(upload_input.key.clone())
+        .set_metadata(upload_input.metadata.clone())
+        .set_object_lock_legal_hold_status(upload_input.object_lock_legal_hold_status.clone())
+        .set_object_lock_mode(upload_input.object_lock_mode.clone())
+        .set_object_lock_retain_until_date(upload_input.object_lock_retain_until_date)
+        .set_request_payer(upload_input.request_payer.clone())
+        .set_server_side_encryption(upload_input.server_side_encryption.clone())
+        .set_sse_customer_algorithm(upload_input.sse_customer_algorithm.clone())
+        .set_sse_customer_key(upload_input.sse_customer_key.clone())
+        .set_sse_customer_key_md5(upload_input.sse_customer_key_md5.clone())
+        .set_ssekms_encryption_context(upload_input.sse_kms_encryption_context.clone())
+        .set_ssekms_key_id(upload_input.sse_kms_key_id.clone())
+        .set_storage_class(upload_input.storage_class.clone())
+        .set_tagging(upload_input.tagging.clone())
+        .set_website_redirect_location(upload_input.website_redirect_location.clone());
+
+    if let Some(checksum_strategy) = &upload_input.checksum_strategy {
+        if let Some(value) = checksum_strategy.full_object_checksum() {
+            // We have the full-object checksum value, so set it
+            put_object_builder = match checksum_strategy.algorithm() {
+                ChecksumAlgorithm::Crc32 => put_object_builder.checksum_crc32(value),
+                ChecksumAlgorithm::Crc32C => put_object_builder.checksum_crc32_c(value),
+                ChecksumAlgorithm::Crc64Nvme => put_object_builder.checksum_crc64_nvme(value),
+                ChecksumAlgorithm::Sha1 => put_object_builder.checksum_sha1(value),
+                ChecksumAlgorithm::Sha256 => put_object_builder.checksum_sha256(value),
+                algo => unreachable!("unexpected algorithm `{algo}` for full object checksum"),
+            }
+        } else {
+            // Set checksum algorithm, which tells SDK to calculate and add checksum value
+            put_object_builder =
+                put_object_builder.checksum_algorithm(checksum_strategy.algorithm().clone())
+        }
+    }
+
+    put_object_builder
+}
+
+// Copy fields from `UploadInput` to `CreateMultipartUploadFluentBuilder`
+pub(crate) fn copy_fields_to_mpu_request(
+    upload_input: &UploadInput,
+    mpu_builder: CreateMultipartUploadFluentBuilder,
+) -> CreateMultipartUploadFluentBuilder {
+    let mut mpu_builder = mpu_builder
+        .set_acl(upload_input.acl.clone())
+        .set_bucket(upload_input.bucket.clone())
+        .set_bucket_key_enabled(upload_input.bucket_key_enabled)
+        .set_cache_control(upload_input.cache_control.clone())
+        .set_content_disposition(upload_input.content_disposition.clone())
+        .set_content_encoding(upload_input.content_encoding.clone())
+        .set_content_language(upload_input.content_language.clone())
+        .set_content_type(upload_input.content_type.clone())
+        .set_expected_bucket_owner(upload_input.expected_bucket_owner.clone())
+        .set_expires(upload_input.expires)
+        .set_grant_full_control(upload_input.grant_full_control.clone())
+        .set_grant_read(upload_input.grant_read.clone())
+        .set_grant_read_acp(upload_input.grant_read_acp.clone())
+        .set_grant_write_acp(upload_input.grant_write_acp.clone())
+        .set_key(upload_input.key.clone())
+        .set_metadata(upload_input.metadata.clone())
+        .set_object_lock_legal_hold_status(upload_input.object_lock_legal_hold_status.clone())
+        .set_object_lock_mode(upload_input.object_lock_mode.clone())
+        .set_object_lock_retain_until_date(upload_input.object_lock_retain_until_date)
+        .set_request_payer(upload_input.request_payer.clone())
+        .set_server_side_encryption(upload_input.server_side_encryption.clone())
+        .set_sse_customer_algorithm(upload_input.sse_customer_algorithm.clone())
+        .set_sse_customer_key(upload_input.sse_customer_key.clone())
+        .set_sse_customer_key_md5(upload_input.sse_customer_key_md5.clone())
+        .set_ssekms_encryption_context(upload_input.sse_kms_encryption_context.clone())
+        .set_ssekms_key_id(upload_input.sse_kms_key_id.clone())
+        .set_storage_class(upload_input.storage_class.clone())
+        .set_tagging(upload_input.tagging.clone())
+        .set_website_redirect_location(upload_input.website_redirect_location.clone());
+
+    if let Some(checksum_strategy) = &upload_input.checksum_strategy {
+        mpu_builder = mpu_builder
+            .checksum_algorithm(checksum_strategy.algorithm().clone())
+            .checksum_type(checksum_strategy.type_if_multipart().clone());
+    }
+
+    mpu_builder
+}
+
+// Copy fields from UploadInput to `UploadPartFluentBuilder`
+//
+// Takes an optional checksum value passed by user via `PartStream`.
+pub(crate) fn copy_fields_to_upload_part_request(
+    upload_input: &UploadInput,
+    upload_part_builder: UploadPartFluentBuilder,
+    checksum_value: Option<&String>,
+) -> UploadPartFluentBuilder {
+    let mut upload_part_builder = upload_part_builder
+        .set_bucket(upload_input.bucket.clone())
+        .set_expected_bucket_owner(upload_input.expected_bucket_owner.clone())
+        .set_key(upload_input.key.clone())
+        .set_request_payer(upload_input.request_payer.clone())
+        .set_sse_customer_algorithm(upload_input.sse_customer_algorithm.clone())
+        .set_sse_customer_key(upload_input.sse_customer_key.clone())
+        .set_sse_customer_key_md5(upload_input.sse_customer_key_md5.clone());
+
+    if let Some(checksum_strategy) = &upload_input.checksum_strategy {
+        // If user passed checksum value via PartStream, add it to request
+        if let Some(checksum_value) = checksum_value {
+            upload_part_builder = match checksum_strategy.algorithm() {
+                ChecksumAlgorithm::Crc32 => upload_part_builder.checksum_crc32(checksum_value),
+                ChecksumAlgorithm::Crc32C => upload_part_builder.checksum_crc32_c(checksum_value),
+                ChecksumAlgorithm::Crc64Nvme => {
+                    upload_part_builder.checksum_crc64_nvme(checksum_value)
+                }
+                ChecksumAlgorithm::Sha1 => upload_part_builder.checksum_sha1(checksum_value),
+                ChecksumAlgorithm::Sha256 => upload_part_builder.checksum_sha256(checksum_value),
+                algo => unreachable!("unexpected checksum algorithm `{algo}`"),
+            };
+        } else {
+            // Otherwise, set checksum algorithm, which tells SDK to calculate and add checksum value
+            upload_part_builder =
+                upload_part_builder.checksum_algorithm(checksum_strategy.algorithm().clone());
+        }
+    } else {
+        // Warn if user is passing a checksum value, but the upload isn't doing checksums.
+        // We can't just set a checksum header, because we don't know what algorithm to use.
+        if checksum_value.is_some() {
+            tracing::warn!("Ignoring part checksum provided during upload, because no ChecksumStrategy is specified");
+        }
+    }
+
+    upload_part_builder
+}
+
+// Copy fields from UploadInput to `CompleteMultipartUploadFluentBuilder`
+//
+// Takes a closure that produces the full object checksum via `PartStream` as a fallback,
+// which makes this function asynchronous.
+pub(crate) async fn copy_fields_to_complete_mpu_request<F, Fut>(
+    upload_input: &UploadInput,
+    complete_mpu_builder: CompleteMultipartUploadFluentBuilder,
+    part_stream_full_object_checksum: F,
+) -> CompleteMultipartUploadFluentBuilder
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Option<String>>,
+{
+    let mut complete_mpu_builder = complete_mpu_builder
+        .set_bucket(upload_input.bucket.clone())
+        .set_key(upload_input.key.clone())
+        .set_request_payer(upload_input.request_payer.clone())
+        .set_expected_bucket_owner(upload_input.expected_bucket_owner.clone())
+        .set_sse_customer_algorithm(upload_input.sse_customer_algorithm.clone())
+        .set_sse_customer_key(upload_input.sse_customer_key.clone())
+        .set_sse_customer_key_md5(upload_input.sse_customer_key_md5.clone());
+
+    if let Some(checksum_strategy) = &upload_input.checksum_strategy {
+        complete_mpu_builder =
+            complete_mpu_builder.checksum_type(checksum_strategy.type_if_multipart().clone());
+
+        // check for user-provided full-object checksum...
+        if checksum_strategy.type_if_multipart() == &ChecksumType::FullObject {
+            // it might have been passed via ChecksumStrategy or PartStream
+            let full_object_checksum = match checksum_strategy.full_object_checksum() {
+                Some(checksum) => Some(checksum.into()),
+                None => part_stream_full_object_checksum().await,
+            };
+
+            // if we got one, set the proper request field
+            if let Some(value) = full_object_checksum {
+                complete_mpu_builder = match checksum_strategy.algorithm() {
+                    ChecksumAlgorithm::Crc32 => complete_mpu_builder.checksum_crc32(value),
+                    ChecksumAlgorithm::Crc32C => complete_mpu_builder.checksum_crc32_c(value),
+                    ChecksumAlgorithm::Crc64Nvme => complete_mpu_builder.checksum_crc64_nvme(value),
+                    algo => {
+                        unreachable!("unexpected algorithm `{algo}` for full object checksum")
+                    }
+                };
+            }
+        }
+    }
+
+    complete_mpu_builder
+}
+
+// Copy fields from UploadInput to `AbortMultipartUploadFluentBuilder`
+pub(crate) fn copy_fields_to_abort_mpu_request(
+    upload_input: &UploadInput,
+    abort_mpu_builder: AbortMultipartUploadFluentBuilder,
+) -> AbortMultipartUploadFluentBuilder {
+    abort_mpu_builder
+        .set_bucket(upload_input.bucket.clone())
+        .set_key(upload_input.key.clone())
+        .set_request_payer(upload_input.request_payer.clone())
+        .set_expected_bucket_owner(upload_input.expected_bucket_owner.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operation::upload::ChecksumStrategy;
+    use aws_sdk_s3::operation::put_object::PutObjectOutput;
+    use aws_sdk_s3::operation::upload_part::UploadPartOutput;
+    use aws_sdk_s3::types::{
+        ObjectCannedAcl, ObjectLockLegalHoldStatus, ObjectLockMode, RequestPayer,
+        ServerSideEncryption, StorageClass,
+    };
+    use aws_sdk_s3::{Client, Config};
+    use aws_smithy_mocks::{mock, mock_client, RuleMode};
+    use aws_smithy_types::DateTime;
+    use std::sync::Arc;
+
+    fn upload_request_for_tests() -> UploadInput {
+        UploadInput::builder()
+            .acl(ObjectCannedAcl::PublicRead)
+            .bucket("test-bucket")
+            .bucket_key_enabled(true)
+            .cache_control("max-age=3600")
+            .checksum_strategy(ChecksumStrategy::with_crc32("0xebe6c6e6"))
+            .content_disposition("attachment; filename=test.txt")
+            .content_encoding("gzip")
+            .content_language("en-US")
+            .content_type("text/plain")
+            .expected_bucket_owner("owner123")
+            .expires(DateTime::from_secs(1234567890))
+            .grant_full_control("test-full-control")
+            .grant_read("test-read")
+            .grant_read_acp("test-read-acp")
+            .grant_write_acp("test-write-acp")
+            .key("test-key")
+            .metadata("key", "value")
+            .object_lock_legal_hold_status(ObjectLockLegalHoldStatus::On)
+            .object_lock_mode(ObjectLockMode::Governance)
+            .object_lock_retain_until_date(DateTime::from_secs(1234567890))
+            .request_payer(RequestPayer::Requester)
+            .server_side_encryption(ServerSideEncryption::Aes256)
+            .sse_customer_algorithm("AES256")
+            .sse_customer_key("test-key")
+            .sse_customer_key_md5("test-md5")
+            .sse_kms_encryption_context("test-context")
+            .sse_kms_key_id("test-kms-key")
+            .storage_class(StorageClass::StandardIa)
+            .tagging("key1=value1")
+            .website_redirect_location("https://example.com")
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_all_fields_copied_to_put_object_request() {
+        let upload_req = Arc::new(upload_request_for_tests());
+
+        // Using a mock client to verify field value copying,
+        // since `PutObjectInputBuilder` does not implement `Clone`.
+        // This prevents us from doing:
+        // `put_object_builder.as_input().clone().build().unwrap();`
+        let put_object_mock = mock!(aws_sdk_s3::Client::put_object)
+            .match_requests({
+                let upload_req = upload_req.clone();
+                move |put_object_req| {
+                    assert_eq!(upload_req.bucket(), put_object_req.bucket());
+                    assert_eq!(None, put_object_req.checksum_algorithm());
+                    assert_eq!(Some("0xebe6c6e6"), put_object_req.checksum_crc32(),);
+                    assert_eq!(None, put_object_req.checksum_crc32_c());
+                    assert_eq!(None, put_object_req.checksum_crc64_nvme(),);
+                    assert_eq!(None, put_object_req.checksum_sha1());
+                    assert_eq!(None, put_object_req.checksum_sha256(),);
+                    assert_eq!(
+                        upload_req.expected_bucket_owner(),
+                        put_object_req.expected_bucket_owner()
+                    );
+                    assert_eq!(upload_req.key(), put_object_req.key());
+                    assert_eq!(upload_req.request_payer(), put_object_req.request_payer());
+                    assert_eq!(
+                        upload_req.sse_customer_algorithm(),
+                        put_object_req.sse_customer_algorithm()
+                    );
+                    assert_eq!(
+                        upload_req.sse_customer_key(),
+                        put_object_req.sse_customer_key()
+                    );
+                    assert_eq!(
+                        upload_req.sse_customer_key_md5(),
+                        put_object_req.sse_customer_key_md5()
+                    );
+                    true
+                }
+            })
+            .then_output(|| PutObjectOutput::builder().build());
+
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&put_object_mock]);
+
+        let put_object_builder = client
+            .put_object()
+            .body(aws_sdk_s3::primitives::ByteStream::from(
+                bytes::Bytes::from("test"),
+            ))
+            .content_length(4);
+
+        let put_object_builder =
+            copy_fields_to_put_object_request(upload_req.as_ref(), put_object_builder);
+
+        let _ = put_object_builder.send().await.unwrap();
+    }
+
+    #[test]
+    fn test_all_fields_copied_to_mpu_request() {
+        let upload_req = upload_request_for_tests();
+
+        let config = aws_sdk_s3::Config::builder().build();
+        let client = aws_sdk_s3::Client::from_conf(config);
+        let mpu_builder = copy_fields_to_mpu_request(&upload_req, client.create_multipart_upload());
+        let mpu_req = mpu_builder.as_input().clone().build().unwrap();
+
+        assert_eq!(upload_req.acl(), mpu_req.acl());
+        assert_eq!(upload_req.bucket(), mpu_req.bucket());
+        assert_eq!(
+            upload_req.bucket_key_enabled(),
+            mpu_req.bucket_key_enabled()
+        );
+        assert_eq!(upload_req.cache_control(), mpu_req.cache_control());
+        assert_eq!(
+            upload_req.checksum_strategy().map(|c| c.algorithm()),
+            mpu_req.checksum_algorithm()
+        );
+        assert_eq!(
+            upload_req.content_disposition(),
+            mpu_req.content_disposition()
+        );
+        assert_eq!(upload_req.content_encoding(), mpu_req.content_encoding());
+        assert_eq!(upload_req.content_language(), mpu_req.content_language());
+        assert_eq!(upload_req.content_type(), mpu_req.content_type());
+        assert_eq!(
+            upload_req.expected_bucket_owner(),
+            mpu_req.expected_bucket_owner()
+        );
+        assert_eq!(upload_req.expires(), mpu_req.expires());
+        assert_eq!(
+            upload_req.grant_full_control(),
+            mpu_req.grant_full_control()
+        );
+        assert_eq!(upload_req.grant_read(), mpu_req.grant_read());
+        assert_eq!(upload_req.grant_read_acp(), mpu_req.grant_read_acp());
+        assert_eq!(upload_req.grant_write_acp(), mpu_req.grant_write_acp());
+        assert_eq!(upload_req.key(), mpu_req.key());
+        assert_eq!(upload_req.metadata(), mpu_req.metadata());
+        assert_eq!(
+            upload_req.object_lock_legal_hold_status(),
+            mpu_req.object_lock_legal_hold_status()
+        );
+        assert_eq!(upload_req.object_lock_mode(), mpu_req.object_lock_mode());
+        assert_eq!(
+            upload_req.object_lock_retain_until_date(),
+            mpu_req.object_lock_retain_until_date()
+        );
+        assert_eq!(upload_req.request_payer(), mpu_req.request_payer());
+        assert_eq!(
+            upload_req.sse_customer_algorithm(),
+            mpu_req.sse_customer_algorithm()
+        );
+        assert_eq!(upload_req.sse_customer_key(), mpu_req.sse_customer_key());
+        assert_eq!(
+            upload_req.sse_customer_key_md5(),
+            mpu_req.sse_customer_key_md5()
+        );
+        assert_eq!(
+            upload_req.sse_kms_encryption_context(),
+            mpu_req.ssekms_encryption_context()
+        );
+        assert_eq!(upload_req.sse_kms_key_id(), mpu_req.ssekms_key_id());
+        assert_eq!(
+            upload_req.server_side_encryption(),
+            mpu_req.server_side_encryption()
+        );
+        assert_eq!(upload_req.storage_class(), mpu_req.storage_class());
+        assert_eq!(upload_req.tagging(), mpu_req.tagging());
+        assert_eq!(
+            upload_req.website_redirect_location(),
+            mpu_req.website_redirect_location()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_all_fields_copied_to_upload_part_request() {
+        let upload_req = Arc::new(upload_request_for_tests());
+
+        // Using a mock client to verify field value copying,
+        // since `UploadPartInputBuilder` does not implement `Clone`.
+        // This prevents us from doing:
+        // `upload_part_builder.as_input().clone().build().unwrap();`
+        let upload_part_mock = mock!(aws_sdk_s3::Client::upload_part)
+            .match_requests({
+                let upload_req = upload_req.clone();
+                move |upload_part_req| {
+                    assert_eq!(upload_req.bucket(), upload_part_req.bucket());
+                    assert_eq!(
+                        Some(&aws_sdk_s3::types::ChecksumAlgorithm::Crc32),
+                        upload_part_req.checksum_algorithm()
+                    );
+                    assert_eq!(
+                        upload_req.expected_bucket_owner(),
+                        upload_part_req.expected_bucket_owner()
+                    );
+                    assert_eq!(upload_req.key(), upload_part_req.key());
+                    assert_eq!(upload_req.request_payer(), upload_part_req.request_payer());
+                    assert_eq!(
+                        upload_req.sse_customer_algorithm(),
+                        upload_part_req.sse_customer_algorithm()
+                    );
+                    assert_eq!(
+                        upload_req.sse_customer_key(),
+                        upload_part_req.sse_customer_key()
+                    );
+                    assert_eq!(
+                        upload_req.sse_customer_key_md5(),
+                        upload_part_req.sse_customer_key_md5()
+                    );
+                    true
+                }
+            })
+            .then_output(|| UploadPartOutput::builder().build());
+
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&upload_part_mock]);
+        let upload_part_builder = client.upload_part().upload_id("test-id").part_number(1);
+        let upload_part_builder =
+            copy_fields_to_upload_part_request(upload_req.as_ref(), upload_part_builder, None);
+        let _ = upload_part_builder.send().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_copy_fields_to_complete_mpu_request() {
+        let config = Config::builder().build();
+        let client = Client::from_conf(config);
+
+        let upload_req = upload_request_for_tests();
+
+        let complete_mpu_builder = copy_fields_to_complete_mpu_request(
+            &upload_req,
+            client.complete_multipart_upload(),
+            || async move { None },
+        )
+        .await;
+        let complete_mpu_req = complete_mpu_builder.as_input().clone().build().unwrap();
+
+        assert_eq!(upload_req.bucket(), complete_mpu_req.bucket());
+        assert_eq!(Some("0xebe6c6e6"), complete_mpu_req.checksum_crc32());
+        assert_eq!(None, complete_mpu_req.checksum_crc32_c());
+        assert_eq!(None, complete_mpu_req.checksum_crc64_nvme());
+        assert_eq!(None, complete_mpu_req.checksum_sha1());
+        assert_eq!(None, complete_mpu_req.checksum_sha256());
+        assert_eq!(
+            upload_req.expected_bucket_owner(),
+            complete_mpu_req.expected_bucket_owner()
+        );
+        // TODO(https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/117): Enable these assertions
+        /*
+        assert_eq!(
+            upload_req.if_match(),
+            complete_mpu_req.if_match()
+        );
+        assert_eq!(
+            upload_req.if_none_match(),
+            complete_mpu_req.if_none_match()
+        );
+        */
+        assert_eq!(upload_req.key(), complete_mpu_req.key());
+        assert_eq!(upload_req.request_payer(), complete_mpu_req.request_payer());
+        assert_eq!(
+            upload_req.sse_customer_algorithm(),
+            complete_mpu_req.sse_customer_algorithm()
+        );
+        assert_eq!(
+            upload_req.sse_customer_key(),
+            complete_mpu_req.sse_customer_key()
+        );
+        assert_eq!(
+            upload_req.sse_customer_key_md5(),
+            complete_mpu_req.sse_customer_key_md5()
+        );
+    }
+
+    #[test]
+    fn test_copy_fields_to_abort_mpu_request() {
+        let config = Config::builder().build();
+        let client = Client::from_conf(config);
+
+        let upload_req = upload_request_for_tests();
+
+        let abort_mpu_builder =
+            copy_fields_to_abort_mpu_request(&upload_req, client.abort_multipart_upload());
+        let abort_mpu_req = abort_mpu_builder.as_input().clone().build().unwrap();
+
+        assert_eq!(upload_req.bucket(), abort_mpu_req.bucket());
+        assert_eq!(
+            upload_req.expected_bucket_owner(),
+            abort_mpu_req.expected_bucket_owner()
+        );
+        assert_eq!(upload_req.key(), abort_mpu_req.key());
+        assert_eq!(upload_req.request_payer(), abort_mpu_req.request_payer());
+    }
+}


### PR DESCRIPTION
*Description of changes:*
This PR primarily focuses on refactoring and testing. At a high level, Transfer Manager defines its own input/output types and translates them into the corresponding input/output types for S3's operations. During this translation, the fields from the original types must be copied to the destination types. This PR adds unit tests to verify the correctness of these field mappings for the following conversions:
- `UploadInput` (transfer manager) -> `PutObjectInput` (s3)
- `UploadInput` (transfer manager) -> `CreateMultipartUploadInput` (s3)
- `UploadInput` (transfer manager) -> `UploadPartInput` (s3)
- `UploadInput` (transfer manager) -> `CompleteMultipartUploadInput` (s3)
- `UploadInput` (transfer manager) -> `AbortMultipartUploadInput` (s3)
- `CompleteMultipartOutput` (s3) -> `UploadOutput` (transfer manager)
- `PutObjectOutput` (s3) -> `UploadOutput` (transfer manager)
- `GetObjectOutput` (s3) -> `ChunkMetadata` (transfer manager)

For the translations corresponding to the first five bullet points above, their conversion utilities have been defined in the `src/operation/upload/input/convert.rs` module. They are implemented as free functions that mutate fluent builders for the following reasons:
- While a `impl From<&UploadInput> for PutObjectInputBuilder` was considered, later execution code calls [`.customize`](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/66f57b1f96cac3e93d32e0dca6e9e24755593139/aws-sdk-s3-transfer-manager/src/operation/upload.rs#L176-L177), which requires us to have a fluent builder.
- Some conversions (e.g., the third bullet point) need to handle an optional checksum as a fallback;  an additional argument makes a `From` implementation a bit cumbersome.

For starters, they are free functions mutating fluent builders for consistency, but this is a two-way door implementation; they can be updated in the future.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
