### PR TITLE
Validate ranged GET requests

### DIFF
--- a/aws-sdk-s3-transfer-manager/external-types.toml
+++ b/aws-sdk-s3-transfer-manager/external-types.toml
@@ -1,12 +1,14 @@
 allowed_external_types = [
     "aws_sdk_s3::*",
-    "aws_types::sdk_config::SdkConfig",
     "aws_smithy_runtime_api::*",
     "aws_smithy_types::*",
-    "tokio::runtime::task::error::JoinError",
-    "tokio::io::async_read::AsyncRead",
-    "bytes::bytes::Bytes",
-    "bytes::buf::buf_impl::Buf",
     "aws_types::request_id::RequestId",
-    "aws_types::request_id::RequestIdExt",
+    "bytes::buf::buf_impl::Buf",
+    "bytes::bytes::Bytes",
+    "tokio::io::async_read::AsyncRead",
+    "tokio::runtime::task::error::JoinError",
+
+    # TODO(create an issue in cargo-check-external-types): false positives since `RetryPolicy` is `pub(crate)`
+    "futures_util::future::ready::Ready",
+    "tower::retry::policy::Policy",
 ]

--- a/aws-sdk-s3-transfer-manager/src/error.rs
+++ b/aws-sdk-s3-transfer-manager/src/error.rs
@@ -37,7 +37,7 @@ pub enum ErrorKind {
     ObjectNotDiscoverable,
 
     /// Failed to upload or download a chunk of an object
-    ChunkFailed,
+    ChunkFailed(ChunkFailed),
 
     /// Resource not found (e.g. bucket, key, multipart upload ID not found)
     NotFound,
@@ -48,6 +48,39 @@ pub enum ErrorKind {
     /// The operation is being canceled because the user explicitly called `.abort` on the handle,
     /// or a child operation failed with the abort policy.
     OperationCancelled,
+}
+
+/// Stores information about failed chunk
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChunkFailed {
+    /// The ID of the chunk that failed.
+    /// For downloads, this is the sequence number of the chunk,
+    /// and for uploads, it is the upload ID.
+    id: ChunkId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ChunkId {
+    Download(u64),
+    Upload(String),
+}
+
+impl ChunkFailed {
+    /// The sequence number of the chunk for download operation
+    pub fn download_seq(&self) -> Option<u64> {
+        match self.id {
+            ChunkId::Download(seq) => Some(seq),
+            _ => None,
+        }
+    }
+
+    /// The upload ID of the chunk for upload operation
+    pub fn upload_id(&self) -> Option<&str> {
+        match &self.id {
+            ChunkId::Upload(id) => Some(id),
+            _ => None,
+        }
+    }
 }
 
 impl Error {
@@ -76,7 +109,9 @@ impl fmt::Display for Error {
             ErrorKind::IOError => write!(f, "I/O error"),
             ErrorKind::RuntimeError => write!(f, "runtime error"),
             ErrorKind::ObjectNotDiscoverable => write!(f, "object discovery failed"),
-            ErrorKind::ChunkFailed => write!(f, "failed to process chunk"),
+            ErrorKind::ChunkFailed(chunk_failed) => {
+                write!(f, "failed to process chunk {:?}", chunk_failed.id)
+            }
             ErrorKind::NotFound => write!(f, "resource not found"),
             ErrorKind::ChildOperationFailed => write!(f, "child operation failed"),
             ErrorKind::OperationCancelled => write!(f, "operation cancelled"),
@@ -135,6 +170,13 @@ where
     E: Into<BoxError>,
 {
     Error::new(ErrorKind::ObjectNotDiscoverable, err)
+}
+
+pub(crate) fn chunk_failed<E>(id: ChunkId, err: E) -> Error
+where
+    E: Into<BoxError>,
+{
+    Error::new(ErrorKind::ChunkFailed(ChunkFailed { id }), err)
 }
 
 pub(crate) fn from_kind<E>(kind: ErrorKind) -> impl FnOnce(E) -> Error

--- a/aws-sdk-s3-transfer-manager/src/error.rs
+++ b/aws-sdk-s3-transfer-manager/src/error.rs
@@ -66,16 +66,17 @@ pub(crate) enum ChunkId {
 }
 
 impl ChunkFailed {
-    /// The sequence number of the chunk for download operation
-    pub fn download_seq(&self) -> Option<u64> {
+    // The sequence number of the chunk for download operation
+    pub(crate) fn download_seq(&self) -> Option<u64> {
         match self.id {
             ChunkId::Download(seq) => Some(seq),
             _ => None,
         }
     }
 
-    /// The upload ID of the chunk for upload operation
-    pub fn upload_id(&self) -> Option<&str> {
+    #[allow(dead_code)]
+    // The upload ID of the chunk for upload operation
+    pub(crate) fn upload_id(&self) -> Option<&str> {
         match &self.id {
             ChunkId::Upload(id) => Some(id),
             _ => None,

--- a/aws-sdk-s3-transfer-manager/src/io/aggregated_bytes.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/aggregated_bytes.rs
@@ -9,8 +9,6 @@ use aws_sdk_s3::primitives::ByteStream;
 use bytes::{Buf, Bytes};
 use bytes_utils::SegmentedBuf;
 
-use crate::error::ErrorKind;
-
 /// Non-contiguous Binary Data Storage
 ///
 /// When data is read from the network, it is read in a sequence of chunks that are not in
@@ -45,14 +43,14 @@ impl AggregatedBytes {
     }
 
     /// Make this buffer from a ByteStream
-    pub(crate) async fn from_byte_stream(value: ByteStream) -> Result<Self, crate::error::Error> {
+    pub(crate) async fn from_byte_stream(
+        value: ByteStream,
+    ) -> Result<Self, aws_smithy_types::byte_stream::error::Error> {
         let mut value = value;
         let mut output = SegmentedBuf::new();
         while let Some(buf) = value.next().await {
-            match buf {
-                Ok(buf) => output.push(buf),
-                Err(err) => return Err(crate::error::from_kind(ErrorKind::ChunkFailed)(err)),
-            };
+            let buf = buf?;
+            output.push(buf);
         }
         Ok(AggregatedBytes(output))
     }

--- a/aws-sdk-s3-transfer-manager/src/middleware.rs
+++ b/aws-sdk-s3-transfer-manager/src/middleware.rs
@@ -5,4 +5,3 @@
 
 pub(crate) mod hedge;
 pub(crate) mod limit;
-pub(crate) mod retry;

--- a/aws-sdk-s3-transfer-manager/src/operation/download.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download.rs
@@ -29,6 +29,9 @@ pub use chunk_meta::ChunkMetadata;
 mod object_meta;
 pub use object_meta::ObjectMetadata;
 
+mod retry;
+pub(crate) use retry::RetryPolicy;
+
 mod service;
 
 use crate::error;

--- a/aws-sdk-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/service.rs
@@ -40,7 +40,7 @@ impl ProvideNetworkPermitContext for DownloadChunkRequest {
     fn network_permit_context(&self) -> NetworkPermitContext {
         // we can't know the actual size by calling next_seq() as that would modify the
         // state. Instead we give an estimate based on the current sequence.
-        let seq = self.ctx.current_seq();
+        let seq = self.current_seq;
         let remaining = self.remaining.clone();
         let part_size = self.ctx.handle.download_part_size_bytes();
         let range = next_range(seq, remaining, part_size, self.start_seq);

--- a/aws-sdk-s3-transfer-manager/src/operation/download/service.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/service.rs
@@ -4,13 +4,14 @@
  */
 
 use crate::error;
+use crate::error::ChunkId;
 use crate::error::ErrorKind;
 use crate::http::header;
 use crate::io::AggregatedBytes;
 use crate::middleware::limit::concurrency::ConcurrencyLimitLayer;
 use crate::middleware::limit::concurrency::ProvideNetworkPermitContext;
-use crate::middleware::retry;
 use crate::operation::download::DownloadContext;
+use crate::operation::download::RetryPolicy;
 use crate::runtime::scheduler::NetworkPermitContext;
 use aws_smithy_types::body::SdkBody;
 use aws_smithy_types::byte_stream::ByteStream;
@@ -33,14 +34,17 @@ pub(super) struct DownloadChunkRequest {
     pub(super) remaining: RangeInclusive<u64>,
     pub(super) input: DownloadInputBuilder,
     pub(super) start_seq: u64,
-    pub(super) current_seq: u64,
+    // Initially set to `None`.
+    // It will be assigned the sequence when `download_chunk_handler` is invoked through retries
+    // to ensure the handler operates on the previously assigned number.
+    pub(super) seq: Option<u64>,
 }
 
 impl ProvideNetworkPermitContext for DownloadChunkRequest {
     fn network_permit_context(&self) -> NetworkPermitContext {
         // we can't know the actual size by calling next_seq() as that would modify the
         // state. Instead we give an estimate based on the current sequence.
-        let seq = self.current_seq;
+        let seq = self.ctx.current_seq();
         let remaining = self.remaining.clone();
         let part_size = self.ctx.handle.download_part_size_bytes();
         let range = next_range(seq, remaining, part_size, self.start_seq);
@@ -82,21 +86,26 @@ fn next_chunk(
 async fn download_chunk_handler(
     request: DownloadChunkRequest,
 ) -> Result<ChunkOutput, error::Error> {
-    let current_seq = request.current_seq;
+    // `seq` should be assigned at this point, i.e., after the handler begins execution.
+    // Assigning `seq` at the time of `tokio::spawn` could cause issues, as spawn order is not guaranteed.
+    // This could result in later `seq`s being processed before earlier ones, leading to inefficient memory usage.
+    // Related: https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/60
+    let seq: u64 = request.seq.unwrap_or_else(|| request.ctx.next_seq());
+
     // the rest of the work is in its own fn, so we can log `seq` in the tracing span
-    download_specific_chunk(request)
-        .instrument(tracing::debug_span!("download-chunk", current_seq))
+    download_specific_chunk(request, seq)
+        .instrument(tracing::debug_span!("download-chunk", seq))
         .await
 }
 
 async fn download_specific_chunk(
     request: DownloadChunkRequest,
+    seq: u64,
 ) -> Result<ChunkOutput, error::Error> {
     let ctx = request.ctx;
     let part_size = ctx.handle.download_part_size_bytes();
-    let current_seq = request.current_seq;
     let input = next_chunk(
-        current_seq,
+        seq,
         request.remaining,
         part_size,
         request.start_seq,
@@ -108,24 +117,27 @@ async fn download_specific_chunk(
     let mut cancel_rx = ctx.state.cancel_rx.clone();
     tokio::select! {
         _ = cancel_rx.changed() => {
-            tracing::debug!("Received cancellating signal, exiting and not downloading chunk#{current_seq}");
+            tracing::debug!("Received cancellating signal, exiting and not downloading chunk#{seq}");
             Err(error::operation_cancelled())
         },
         resp = op.send() => {
             match resp {
-                Err(err) => Err(error::from_kind(error::ErrorKind::ChunkFailed)(err)),
+                Err(err) => Err(error::chunk_failed(ChunkId::Download(seq), err)),
                 Ok(mut resp) => {
-                    validate_content_range(&requested_byte_range, resp.content_range())?;
+                    validate_content_range(seq, &requested_byte_range, resp.content_range())?;
                     let body = mem::replace(&mut resp.body, ByteStream::new(SdkBody::taken()));
                     let body = AggregatedBytes::from_byte_stream(body)
                         .instrument(tracing::debug_span!(
                             "collect-body-from-download-chunk",
-                            current_seq
+                            seq
                         ))
-                        .await?;
+                        .await
+                        .map_err(|err| {
+                           error::chunk_failed(ChunkId::Download(seq), err)
+                        })?;
 
                     Ok(ChunkOutput {
-                        seq: current_seq,
+                        seq,
                         data: body,
                         metadata: resp.into(),
                     })
@@ -146,7 +158,7 @@ pub(super) fn chunk_service(
 
     ServiceBuilder::new()
         .layer(concurrency_limit)
-        .retry(retry::RetryPolicy::default())
+        .retry(RetryPolicy::default())
         .service(svc)
 }
 
@@ -177,23 +189,19 @@ pub(super) fn distribute_work(
     let size = *remaining.end() - *remaining.start() + 1;
     let num_parts = size.div_ceil(part_size);
     for _ in 0..num_parts {
+        let req = DownloadChunkRequest {
+            ctx: ctx.clone(),
+            remaining: remaining.clone(),
+            input: input.clone(),
+            start_seq,
+            seq: None,
+        };
+
         let svc = svc.clone();
-        let ctx = ctx.clone();
-        let remaining = remaining.clone();
-        let input = input.clone();
         let chunk_tx = chunk_tx.clone();
         let cancel_tx = ctx.state.cancel_tx.clone();
 
         let task = async move {
-            let current_seq = ctx.next_seq();
-            let req = DownloadChunkRequest {
-                ctx,
-                remaining,
-                input,
-                start_seq,
-                current_seq,
-            };
-
             let resp = svc.oneshot(req).await;
             // If any chunk fails, send cancel notification, to kill any other in-flight chunks
             if let Err(err) = &resp {
@@ -236,6 +244,7 @@ pub(super) fn distribute_work(
 /// Handles both "1024-2047" and "bytes=1024-2047" formats for the requested content range.
 /// The response_content_range is of the form Some("bytes 1024-2047/4096").
 fn validate_content_range(
+    seq: u64,
     requested_content_range: &str,
     response_content_range: Option<&str>,
 ) -> Result<(), error::Error> {
@@ -250,8 +259,7 @@ fn validate_content_range(
     {
         Ok(())
     } else {
-        Err(crate::error::Error::new(
-            crate::error::ErrorKind::ChunkFailed,
+        Err(crate::error::chunk_failed(ChunkId::Download(seq),
             format!(
                 "Content range in response must match the requested range: requested range {}, content-range in response {:?}",
                 requested_content_range,
@@ -265,21 +273,33 @@ fn validate_content_range(
 mod tests {
     use super::*;
 
+    const DUMMY_SEQ: u64 = 1;
+
     #[test]
     fn test_validate_content_range_success() {
-        assert!(validate_content_range("1024-2047", Some("bytes 1024-2047/4096")).is_ok());
-        assert!(validate_content_range("bytes=1024-2047", Some("bytes 1024-2047/4096")).is_ok());
+        assert!(
+            validate_content_range(DUMMY_SEQ, "1024-2047", Some("bytes 1024-2047/4096")).is_ok()
+        );
+        assert!(
+            validate_content_range(DUMMY_SEQ, "bytes=1024-2047", Some("bytes 1024-2047/4096"))
+                .is_ok()
+        );
     }
 
     #[test]
     fn test_validate_content_range_mismatch() {
-        assert!(validate_content_range("1024-2047", Some("bytes 2048-3071/4096")).is_err());
-        assert!(validate_content_range("bytes=1024-2047", Some("bytes 2048-3071/4096")).is_err());
+        assert!(
+            validate_content_range(DUMMY_SEQ, "1024-2047", Some("bytes 2048-3071/4096")).is_err()
+        );
+        assert!(
+            validate_content_range(DUMMY_SEQ, "bytes=1024-2047", Some("bytes 2048-3071/4096"))
+                .is_err()
+        );
     }
 
     #[test]
     fn test_validate_content_range_none_response() {
-        assert!(validate_content_range("1024-2047", None).is_err());
-        assert!(validate_content_range("bytes=1024-2047", None).is_err());
+        assert!(validate_content_range(DUMMY_SEQ, "1024-2047", None).is_err());
+        assert!(validate_content_range(DUMMY_SEQ, "bytes=1024-2047", None).is_err());
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use crate::error::ChunkId;
 use crate::io::part_reader::PartReader;
 use crate::operation::upload::context::UploadContext;
 use crate::operation::upload::{UploadOutput, UploadOutputBuilder};
@@ -193,8 +194,8 @@ async fn complete_upload(handle: UploadHandle) -> Result<UploadOutput, crate::er
             tracing::trace!("completing multipart upload");
 
             if number_of_upload_requests != all_parts.len() {
-                return Err(crate::error::Error::new(
-                    crate::error::ErrorKind::ChunkFailed,
+                return Err(crate::error::chunk_failed(
+                    ChunkId::Upload(mpu_data.upload_id),
                     format!(
                         "The total number of UploadPart requests must match the expected number of parts: request count {}, number of parts {}",
                         number_of_upload_requests,

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/service.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/service.rs
@@ -226,8 +226,8 @@ pub(super) async fn read_body(
         if part_reader.part_size() != part_data.data.remaining()
             && part_data.is_last() == Some(false)
         {
-            return Err(error::Error::new(
-                error::ErrorKind::ChunkFailed,
+            return Err(error::chunk_failed(
+                error::ChunkId::Upload(upload_id),
                 format!(
                     "upload part size mismatch for non-last part {}: configured part size {}, got data size {}",
                     part_data.part_number,

--- a/aws-sdk-s3-transfer-manager/tests/download_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/download_test.rs
@@ -252,7 +252,7 @@ async fn test_retry_failed_chunk() {
                 .header("Content-Length", format!("{}", data.len() - part_size))
                 .header(
                     "Content-Range",
-                    format!("bytes {}-{}/{}", part_size, data.len(), data.len()),
+                    format!("bytes {}-{}/{}", part_size, data.len() - 1, data.len()),
                 )
                 .body(SdkBody::from_body_1_x(FailingBody::new(
                     data.slice(part_size..),
@@ -269,7 +269,7 @@ async fn test_retry_failed_chunk() {
                 .header("Content-Length", format!("{}", data.len() - part_size))
                 .header(
                     "Content-Range",
-                    format!("bytes {}-{}/{}", part_size, data.len(), data.len()),
+                    format!("bytes {}-{}/{}", part_size, data.len() - 1, data.len()),
                 )
                 .body(SdkBody::from(data.slice(part_size..)))
                 .unwrap(),
@@ -361,7 +361,7 @@ async fn test_retry_max_attempts() {
                 .header("Content-Length", format!("{}", part_size))
                 .header(
                     "Content-Range",
-                    format!("bytes {}-{}/{}", part_size, data.len(), data.len()),
+                    format!("bytes {}-{}/{}", part_size, data.len() - 1, data.len()),
                 )
                 .body(SdkBody::from_body_1_x(FailingBody::new(
                     data.slice(part_size..),


### PR DESCRIPTION
*Description of changes:*
This PR adds the following validation to ranged GetObject requests:
- The total number of ranged GET requests must match the expected number of parts ([code change](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/697c35ff3683f70fa3b53cd7967e8d4ad8aaffa7/aws-sdk-s3-transfer-manager/src/operation/download/service.rs#L217-L226))
- ContentRange of a GetObject request and the response should match ([code change](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/697c35ff3683f70fa3b53cd7967e8d4ad8aaffa7/aws-sdk-s3-transfer-manager/src/operation/download/service.rs#L115))

The PR did NOT add the following validation:
- The content range of the response should align with the starting offset of the destination to which the Transfer Manager writes the part.

since the Transfer Manager returns a [Body](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/main/aws-sdk-s3-transfer-manager/src/operation/download/body.rs#L19-L23), and it's up to a user to yield and write bytes to the destination.

Finally, as part of this PR, we have fixed a bug exposed by the second bullet above. Specifically, [test_retry_failed_chunk](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/main/aws-sdk-s3-transfer-manager/tests/download_test.rs#L228) and [test_retry_max_attempts](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/main/aws-sdk-s3-transfer-manager/tests/download_test.rs#L350) failed the validation (good tests!) because [download_chunk_handler](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/66f57b1f96cac3e93d32e0dca6e9e24755593139/aws-sdk-s3-transfer-manager/src/operation/download/service.rs#L80), a tower handler for downloads, was internally incrementing a sequence number it is responsible for. This caused the sequence number to be bumped incorrectly during [a tower retry](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/66f57b1f96cac3e93d32e0dca6e9e24755593139/aws-sdk-s3-transfer-manager/src/operation/download/service.rs#L146). During retries, the handler should continue using the same sequence number rather than incrementing it. This is ensured by setting the sequence number within the `RetryPolicy::retry` method. 

### Tests
- CI
- Manually ran examples in `cp.rs` with ranged GET to ensure the validation was not triggered for successful cases

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.