### PR TITLE
bootstrap benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,8 @@
 resolver = "2"
 members = [
     "aws-sdk-s3-transfer-manager",
-    "s3-mock-server"
+
+    # internal
+    "s3-mock-server",
+    "benches"
 ]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -2,7 +2,10 @@
 name = "benches"
 version = "0.0.0"
 edition = "2021"
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
+license = "Apache-2.0"
 publish = false
+description = "Internal benchmarks for aws-sdk-s3-transfer-manager"
 
 [[bench]]
 name = "throughput"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -17,3 +17,4 @@ aws-config = "1"
 s3-mock-server = { path = "../s3-mock-server" }
 aws-sdk-s3-transfer-manager = { path = "../aws-sdk-s3-transfer-manager" }
 bytes = "1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "benches"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[[bench]]
+name = "throughput"
+path = "throughput.rs"
+harness = false
+
+[dependencies]
+criterion = { version = "0.7", features = ["html_reports"] }
+tokio = { version = "1", features = ["full"] }
+aws-sdk-s3 = "1"
+aws-config = "1"
+s3-mock-server = { path = "../s3-mock-server" }
+aws-sdk-s3-transfer-manager = { path = "../aws-sdk-s3-transfer-manager" }
+bytes = "1"

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -1,0 +1,142 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_sdk_s3_transfer_manager::error::Error;
+use aws_sdk_s3_transfer_manager::operation::download::DownloadHandle;
+use bytes::{BufMut, Bytes, BytesMut};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use s3_mock_server::S3MockServer;
+
+/// drain/consume the body
+pub async fn drain(handle: &mut DownloadHandle) -> Result<(), Error> {
+    let body = handle.body_mut();
+    while let Some(chunk) = body.next().await {
+        match chunk {
+            Ok(_chunk) => {}
+            Err(err) => return Err(err),
+        }
+    }
+
+    Ok(())
+}
+
+fn download_throughput_benchmark(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+
+    let mut group = c.benchmark_group("download_throughput");
+
+    // Test sizes relevant for multipart downloads (5MB minimum part size)
+    let sizes = vec![
+        ("5GB", 5 * 1024 * 1024 * 1024),
+        ("10GB", 10 * 1024 * 1024 * 1024),
+    ];
+
+    for (name, size) in sizes {
+        group.throughput(Throughput::Bytes(size as u64));
+
+        // Benchmark S3 client directly
+        group.bench_with_input(BenchmarkId::new("s3_client", name), &size, |b, &size| {
+            b.iter_custom(|iters| {
+                rt.block_on(async {
+                    // Setup: Create server and upload object once
+                    let mock_server = S3MockServer::builder()
+                        .with_in_memory_store()
+                        .build()
+                        .unwrap();
+
+                    let handle = mock_server.start().await.unwrap();
+                    let client = handle.client().await;
+
+                    let data = Bytes::from(vec![0u8; size]);
+                    let _put_result = client
+                        .put_object()
+                        .bucket("test-bucket")
+                        .key("test-key")
+                        .body(data.into())
+                        .send()
+                        .await
+                        .unwrap();
+
+                    // Benchmark: Time only the downloads
+                    let start = std::time::Instant::now();
+                    for _ in 0..iters {
+                        let mut resp = client
+                            .get_object()
+                            .bucket("test-bucket")
+                            .key("test-key")
+                            .send()
+                            .await
+                            .unwrap();
+
+                        while let Some(chunk) = resp.body.next().await {
+                            let _ = chunk.unwrap();
+                        }
+                    }
+                    let elapsed = start.elapsed();
+
+                    handle.shutdown().await.unwrap();
+                    elapsed
+                })
+            });
+        });
+
+        // Benchmark Transfer Manager
+        group.bench_with_input(
+            BenchmarkId::new("transfer_manager", name),
+            &size,
+            |b, &size| {
+                b.iter_custom(|iters| {
+                    rt.block_on(async {
+                        // Setup: Create server and upload object once
+                        let mock_server = S3MockServer::builder()
+                            .with_in_memory_store()
+                            .build()
+                            .unwrap();
+
+                        let handle = mock_server.start().await.unwrap();
+                        let s3_client = handle.client().await;
+
+                        let data = Bytes::from(vec![0u8; size]);
+                        let _put_result = s3_client
+                            .put_object()
+                            .bucket("test-bucket")
+                            .key("test-key")
+                            .body(data.into())
+                            .send()
+                            .await
+                            .unwrap();
+
+                        // Create Transfer Manager
+                        let tm_config = aws_sdk_s3_transfer_manager::Config::builder()
+                            .client(s3_client)
+                            .build();
+                        let tm = aws_sdk_s3_transfer_manager::Client::new(tm_config);
+
+                        // Benchmark: Time only the downloads
+                        let start = std::time::Instant::now();
+                        for _ in 0..iters {
+                            let mut dl_handle = tm
+                                .download()
+                                .bucket("test-bucket")
+                                .key("test-key")
+                                .initiate()
+                                .expect("successful transfer initiate");
+                            drain(&mut dl_handle).await.unwrap();
+                        }
+                        let elapsed = start.elapsed();
+
+                        handle.shutdown().await.unwrap();
+                        elapsed
+                    })
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, download_throughput_benchmark);
+criterion_main!(benches);

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -2,12 +2,12 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 use aws_sdk_s3_transfer_manager::error::Error;
 use aws_sdk_s3_transfer_manager::operation::download::{Body, DownloadHandle};
 use bytes::Bytes;
 use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
 use s3_mock_server::S3MockServer;
+use std::hint::black_box;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
@@ -100,7 +100,7 @@ fn download_throughput_benchmark(c: &mut Criterion) {
                                 .key("test-key")
                                 .initiate()
                                 .expect("successful transfer initiate");
-                            drain(&mut dl_handle).await.unwrap();
+                            black_box(drain(&mut dl_handle).await.unwrap());
                         }
                         let elapsed = start.elapsed();
 

--- a/s3-mock-server/src/s3s.rs
+++ b/s3-mock-server/src/s3s.rs
@@ -14,8 +14,8 @@ use aws_smithy_checksums::ChecksumAlgorithm;
 use base64::Engine;
 use bytes::BytesMut;
 use futures_util::StreamExt;
-use s3s::dto::StreamingBlob;
 use s3s::dto::Timestamp;
+use s3s::dto::{HeadBucketInput, HeadBucketOutput, StreamingBlob};
 use s3s::{S3Request, S3Response, S3Result};
 use std::str::FromStr;
 
@@ -528,6 +528,13 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         };
 
         Ok(S3Response::new(output))
+    }
+
+    async fn head_bucket(
+        &self,
+        _req: S3Request<HeadBucketInput>,
+    ) -> S3Result<S3Response<HeadBucketOutput>> {
+        Ok(S3Response::new(HeadBucketOutput::default()))
     }
 }
 

--- a/s3-mock-server/src/storage.rs
+++ b/s3-mock-server/src/storage.rs
@@ -109,7 +109,6 @@ pub(crate) struct CompleteMultipartUploadResponse {
 }
 
 impl StoreObjectRequest {
-    #[cfg(test)]
     pub(crate) fn new(
         key: impl Into<String>,
         body: Pin<Box<dyn Stream<Item = std::result::Result<Bytes, std::io::Error>> + Send>>,
@@ -122,6 +121,11 @@ impl StoreObjectRequest {
             content_type: None,
             user_metadata: HashMap::new(),
         }
+    }
+
+    pub(crate) fn with_user_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+        self.user_metadata = metadata;
+        self
     }
 }
 


### PR DESCRIPTION
*Description of changes:*
Adds some basic benchmarks using the new/experimental mock server. In local testing I compared results to `iperf3` and experimented with `warp` as well. Throughput was slightly above or on par with results from `iperf3` over localhost. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
