### PR TITLE
vnext walking primitives, scheduler support for children, and transfer metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,7 @@ dependencies = [
  "parking_lot",
  "path-clean",
  "pin-project-lite",
+ "same-file",
  "serde",
  "serde_json",
  "tempfile",

--- a/aws-sdk-s3-transfer-manager/Cargo.toml
+++ b/aws-sdk-s3-transfer-manager/Cargo.toml
@@ -38,6 +38,7 @@ aws-smithy-http-client = { version = "1.1.12", features = ["rustls-aws-lc"] }
 aws-smithy-dns = { version = "0.1.12", features = ["hickory-dns"] }
 fastrand = "2.4"
 hdrhistogram = "7"
+same-file = "1.0.6"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["uio", "fs"] }

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -31,7 +31,7 @@ pub(crate) struct Handle {
     pub(crate) scheduler: Scheduler,
     pub(crate) runtime: Arc<dyn ExecutionRuntime>,
     pub(crate) controller: Arc<dyn ConcurrencyController>,
-    pub(crate) telemetry: Telemetry,
+    pub(crate) telemetry: Arc<Telemetry>,
 }
 
 impl Handle {
@@ -87,7 +87,7 @@ impl Handle {
                 scheduler,
                 runtime,
                 controller: Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
-                telemetry: Telemetry::new(std::time::Duration::from_millis(500)),
+                telemetry: Arc::new(Telemetry::new(std::time::Duration::from_millis(500))),
             }
         })
     }
@@ -114,7 +114,7 @@ impl Handle {
                 scheduler,
                 runtime,
                 controller: Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
-                telemetry: Telemetry::new(std::time::Duration::from_millis(500)),
+                telemetry: Arc::new(Telemetry::new(std::time::Duration::from_millis(500))),
             }
         })
     }
@@ -134,12 +134,12 @@ impl Client {
             match config.concurrency() {
                 ConcurrencyMode::Explicit(n) => (
                     Arc::new(FixedConcurrency::new(*n)),
-                    Telemetry::new(Duration::from_millis(500)),
+                    Arc::new(Telemetry::new(Duration::from_millis(500))),
                 ),
                 // TODO: implement support for target throughput
                 _ => {
                     let adaptive_config = AdaptiveConfig::default();
-                    let telemetry = Telemetry::new(adaptive_config.window.duration);
+                    let telemetry = Arc::new(Telemetry::new(adaptive_config.window.duration));
                     let controller = Arc::new(AdaptiveConcurrencyController::new(
                         adaptive_config,
                         Arc::clone(&telemetry.io_counters),

--- a/aws-sdk-s3-transfer-manager/src/io/adapters.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/adapters.rs
@@ -168,7 +168,8 @@ mod tests {
         let stream_cx = StreamContext::new(
             part_size,
             false,
-            std::sync::Arc::new(crate::metrics::IOCounters::new(
+            std::sync::Arc::new(crate::transfer::MetricsState::new()),
+            std::sync::Arc::new(crate::telemetry::Telemetry::new(
                 std::time::Duration::from_secs(1),
             )),
         );
@@ -210,7 +211,8 @@ mod tests {
         let stream_cx = StreamContext::new(
             part_size,
             false,
-            std::sync::Arc::new(crate::metrics::IOCounters::new(
+            std::sync::Arc::new(crate::transfer::MetricsState::new()),
+            std::sync::Arc::new(crate::telemetry::Telemetry::new(
                 std::time::Duration::from_secs(1),
             )),
         );

--- a/aws-sdk-s3-transfer-manager/src/io/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/mod.rs
@@ -16,6 +16,8 @@ mod stream;
 pub mod error;
 pub(crate) mod fs;
 mod size_hint;
+/// Walker types for traversing filesystems and S3 buckets.
+pub mod walk;
 
 // re-exports
 pub use self::aggregated_bytes::AggregatedBytes;

--- a/aws-sdk-s3-transfer-manager/src/io/part_reader.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/part_reader.rs
@@ -24,7 +24,8 @@ pub(crate) struct Builder {
     stream: Option<RawInputStream>,
     part_size: usize,
     direct_io: bool,
-    io_counters: Option<std::sync::Arc<crate::metrics::IOCounters>>,
+    metrics: Option<std::sync::Arc<crate::transfer::MetricsState>>,
+    telemetry: Option<std::sync::Arc<crate::telemetry::Telemetry>>,
 }
 
 impl Builder {
@@ -33,7 +34,8 @@ impl Builder {
             stream: None,
             part_size: 5 * ByteUnit::Mebibyte.as_bytes_u64() as usize,
             direct_io: false,
-            io_counters: None,
+            metrics: None,
+            telemetry: None,
         }
     }
 
@@ -57,19 +59,29 @@ impl Builder {
         self
     }
 
-    /// Set the I/O counters for recording throughput metrics.
-    pub(crate) fn io_counters(
+    /// Set the metrics state for recording I/O metrics.
+    pub(crate) fn metrics(
         mut self,
-        io_counters: std::sync::Arc<crate::metrics::IOCounters>,
+        metrics: std::sync::Arc<crate::transfer::MetricsState>,
     ) -> Self {
-        self.io_counters = Some(io_counters);
+        self.metrics = Some(metrics);
+        self
+    }
+
+    /// Set the per-client telemetry for forwarding I/O samples.
+    pub(crate) fn telemetry(
+        mut self,
+        telemetry: std::sync::Arc<crate::telemetry::Telemetry>,
+    ) -> Self {
+        self.telemetry = Some(telemetry);
         self
     }
 
     pub(crate) fn build(self) -> Result<PartReader, Error> {
         let stream = self.stream.expect("input stream set");
-        let io_counters = self.io_counters.expect("io_counters set");
-        PartReader::new(stream, self.part_size, self.direct_io, io_counters)
+        let metrics = self.metrics.expect("metrics set");
+        let telemetry = self.telemetry.expect("telemetry set");
+        PartReader::new(stream, self.part_size, self.direct_io, metrics, telemetry)
     }
 }
 
@@ -84,7 +96,8 @@ impl PartReader {
         raw: RawInputStream,
         part_size: usize,
         direct_io: bool,
-        io_counters: std::sync::Arc<crate::metrics::IOCounters>,
+        metrics: std::sync::Arc<crate::transfer::MetricsState>,
+        telemetry: std::sync::Arc<crate::telemetry::Telemetry>,
     ) -> Result<Self, Error> {
         let inner = match raw {
             RawInputStream::Buf(buf) => Inner::Bytes(BytesPartReader::new(buf)),
@@ -92,7 +105,7 @@ impl PartReader {
             RawInputStream::Dyn(box_body) => Inner::Dyn(DynPartReader::new(box_body)),
         };
 
-        let stream_cx = StreamContext::new(part_size, direct_io, io_counters);
+        let stream_cx = StreamContext::new(part_size, direct_io, metrics, telemetry);
         Ok(Self { inner, stream_cx })
     }
 
@@ -262,7 +275,7 @@ impl PathBodyPartReader {
             .await??;
         }
 
-        stream_cx.io_counters().record(&crate::metrics::IoSample {
+        stream_cx.record_io(&crate::metrics::IoSample {
             disk_read: part_size,
             ..Default::default()
         });
@@ -401,11 +414,15 @@ mod test {
     use crate::io::InputStream;
 
     fn test_stream_cx(part_size: usize) -> StreamContext {
-        StreamContext::new(part_size, false, test_io_counters())
+        StreamContext::new(part_size, false, test_metrics(), test_telemetry())
     }
 
-    fn test_io_counters() -> std::sync::Arc<crate::metrics::IOCounters> {
-        std::sync::Arc::new(crate::metrics::IOCounters::new(
+    fn test_metrics() -> std::sync::Arc<crate::transfer::MetricsState> {
+        std::sync::Arc::new(crate::transfer::MetricsState::new())
+    }
+
+    fn test_telemetry() -> std::sync::Arc<crate::telemetry::Telemetry> {
+        std::sync::Arc::new(crate::telemetry::Telemetry::new(
             std::time::Duration::from_secs(1),
         ))
     }
@@ -430,7 +447,8 @@ mod test {
         let reader = Builder::new()
             .part_size(5)
             .stream(stream)
-            .io_counters(test_io_counters())
+            .metrics(test_metrics())
+            .telemetry(test_telemetry())
             .build()
             .unwrap();
         let parts = collect_parts(reader).await;
@@ -462,7 +480,8 @@ mod test {
         let reader = Builder::new()
             .part_size(part_size)
             .stream(stream)
-            .io_counters(test_io_counters())
+            .metrics(test_metrics())
+            .telemetry(test_telemetry())
             .build()
             .unwrap();
 
@@ -543,7 +562,8 @@ mod test {
         let reader = Builder::new()
             .part_size(5)
             .stream(stream)
-            .io_counters(test_io_counters())
+            .metrics(test_metrics())
+            .telemetry(test_telemetry())
             .build()
             .unwrap();
         let parts = collect_parts(reader).await;

--- a/aws-sdk-s3-transfer-manager/src/io/stream.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/stream.rs
@@ -147,19 +147,24 @@ pub struct StreamContext {
     part_size: usize,
     /// When true, file I/O runs directly on the calling thread.
     direct_io: bool,
-    io_counters: std::sync::Arc<crate::metrics::IOCounters>,
+    /// Per-transfer cumulative metrics.
+    metrics: std::sync::Arc<crate::transfer::MetricsState>,
+    /// Per-client telemetry (windowed throughput, latency tracking).
+    telemetry: std::sync::Arc<crate::telemetry::Telemetry>,
 }
 
 impl StreamContext {
     pub(super) fn new(
         part_size: usize,
         direct_io: bool,
-        io_counters: std::sync::Arc<crate::metrics::IOCounters>,
+        metrics: std::sync::Arc<crate::transfer::MetricsState>,
+        telemetry: std::sync::Arc<crate::telemetry::Telemetry>,
     ) -> Self {
         Self {
             part_size,
             direct_io,
-            io_counters,
+            metrics,
+            telemetry,
         }
     }
 
@@ -175,9 +180,10 @@ impl StreamContext {
         self.direct_io
     }
 
-    /// Throughput counters for recording I/O metrics at the source.
-    pub(crate) fn io_counters(&self) -> &crate::metrics::IOCounters {
-        &self.io_counters
+    /// Record an IO sample to per-transfer metrics and per-client telemetry.
+    pub(crate) fn record_io(&self, sample: &crate::metrics::IoSample) {
+        self.metrics.record_io(sample);
+        self.telemetry.io_counters.record(sample);
     }
 
     // TODO - eventually make the ability to allocate a buffer public after carefully review of the `Buffer` API.

--- a/aws-sdk-s3-transfer-manager/src/io/walk/error.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/error.rs
@@ -7,40 +7,52 @@ use std::path::{Path, PathBuf};
 
 /// Classifies a [`WalkError`].
 ///
-/// Errors are either fatal (the walk cannot continue and no further entries
-/// will be produced) or non-fatal (the affected entry is skipped but the
-/// walk continues). Use [`WalkError::is_fatal`] to distinguish them.
+/// Each kind has a deterministic fatality (see [`WalkErrorKind::is_fatal`]).
+/// Errors whose kind is fatal terminate the walk; non-fatal kinds report
+/// the affected entry and the walk continues.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WalkErrorKind {
-    /// Generic I/O failure reading a directory or entry.
-    Io,
-    /// Permission denied on a directory or entry.
-    PermissionDenied,
-    /// Path expected to be a directory but isn't (e.g. source is a file).
+    /// Source root cannot be opened for reading (I/O or permission error
+    /// on the initial path). Fatal: the walk never gets off the ground.
+    SourceUnreadable,
+    /// Source root exists but is not a directory. Fatal.
     NotADirectory,
-    /// Symlink encountered with no valid target.
+    /// S3 service error from `ListObjectsV2` or related call. Fatal.
+    Service,
+    /// I/O error reading a subdirectory or entry during the walk.
+    /// Non-fatal: the affected entry is skipped and the walk continues.
+    Io,
+    /// Permission denied on a subdirectory or entry during the walk.
+    /// Non-fatal.
+    PermissionDenied,
+    /// Symlink encountered with no valid target. Non-fatal.
     BrokenSymlink,
     /// Symlink whose target is a directory already on the current descent
     /// path (a cycle). Non-cyclic duplicate symlinks (two different symlinks
     /// to the same target) are not reported as cycles and are traversed
-    /// normally.
+    /// normally. Non-fatal.
     SymlinkCycle,
-    /// S3 service error from `ListObjectsV2` or related call.
-    Service,
-    /// Other error that doesn't fit the categories above.
-    Other,
+}
+
+impl WalkErrorKind {
+    /// Whether an error of this kind terminates the walk.
+    pub fn is_fatal(&self) -> bool {
+        matches!(
+            self,
+            WalkErrorKind::SourceUnreadable | WalkErrorKind::NotADirectory | WalkErrorKind::Service
+        )
+    }
 }
 
 /// An error encountered during a directory walk.
 ///
-/// Wraps an optional path, a [`WalkErrorKind`] classifier, a fatal flag,
-/// and a source error. Check [`is_fatal`](Self::is_fatal) to determine
-/// whether the walk will continue producing entries after this error.
+/// Wraps an optional path, a [`WalkErrorKind`] classifier, and a source
+/// error. Fatality is determined by [`kind`](Self::kind); see
+/// [`is_fatal`](Self::is_fatal).
 #[derive(Debug)]
 pub struct WalkError {
     path: Option<PathBuf>,
     kind: WalkErrorKind,
-    fatal: bool,
     source: Box<dyn std::error::Error + Send + Sync>,
 }
 
@@ -48,9 +60,9 @@ impl WalkError {
     /// The path associated with this error, if any.
     ///
     /// For non-fatal errors this is typically the entry that failed (a file
-    /// or symlink). For fatal errors it may be the directory that could not
-    /// be read. `None` for errors not tied to a specific path (e.g. S3
-    /// service errors).
+    /// or symlink). For fatal errors it may be the source root that could
+    /// not be opened. `None` for errors not tied to a specific path (e.g.
+    /// S3 service errors).
     pub fn path(&self) -> Option<&Path> {
         self.path.as_deref()
     }
@@ -64,25 +76,25 @@ impl WalkError {
     ///
     /// When `true`, no further entries will be produced by the walk.
     /// When `false`, the walk continues and may produce more entries.
+    /// Equivalent to `self.kind().is_fatal()`.
     pub fn is_fatal(&self) -> bool {
-        self.fatal
+        self.kind.is_fatal()
     }
 
     pub(crate) fn new(
         path: Option<PathBuf>,
         kind: WalkErrorKind,
-        fatal: bool,
         source: Box<dyn std::error::Error + Send + Sync>,
     ) -> Self {
-        Self {
-            path,
-            kind,
-            fatal,
-            source,
-        }
+        Self { path, kind, source }
     }
 
-    /// Classify an `io::Error` into a [`WalkErrorKind`].
+    /// Classify an `io::Error` into a non-root [`WalkErrorKind`].
+    ///
+    /// For root-level I/O failures construct
+    /// [`WalkErrorKind::SourceUnreadable`] directly instead; this helper
+    /// is only appropriate for errors encountered on subdirectories or
+    /// entries reached after the walk has started.
     pub(crate) fn classify_io(err: &std::io::Error) -> WalkErrorKind {
         match err.kind() {
             std::io::ErrorKind::PermissionDenied => WalkErrorKind::PermissionDenied,
@@ -136,5 +148,16 @@ mod tests {
     fn test_classify_io_other_maps_to_io() {
         let err = std::io::Error::from(std::io::ErrorKind::ConnectionRefused);
         assert_eq!(WalkError::classify_io(&err), WalkErrorKind::Io);
+    }
+
+    #[test]
+    fn test_is_fatal_by_kind() {
+        assert!(WalkErrorKind::SourceUnreadable.is_fatal());
+        assert!(WalkErrorKind::NotADirectory.is_fatal());
+        assert!(WalkErrorKind::Service.is_fatal());
+        assert!(!WalkErrorKind::Io.is_fatal());
+        assert!(!WalkErrorKind::PermissionDenied.is_fatal());
+        assert!(!WalkErrorKind::BrokenSymlink.is_fatal());
+        assert!(!WalkErrorKind::SymlinkCycle.is_fatal());
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/io/walk/error.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/error.rs
@@ -5,12 +5,11 @@
 
 use std::path::{Path, PathBuf};
 
-/// Classifies a [`WalkError`] for consumer-side branching.
+/// Classifies a [`WalkError`].
 ///
-/// Separates fatal failures (walk cannot continue) from per-entry
-/// failures (individual entry failed, walk continues). State machines
-/// use [`WalkError::is_fatal`] to decide whether to abort the
-/// directory transfer or to apply the `FailedTransferPolicy`.
+/// Errors are either fatal (the walk cannot continue and no further entries
+/// will be produced) or non-fatal (the affected entry is skipped but the
+/// walk continues). Use [`WalkError::is_fatal`] to distinguish them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WalkErrorKind {
     /// Generic I/O failure reading a directory or entry.
@@ -23,8 +22,8 @@ pub enum WalkErrorKind {
     BrokenSymlink,
     /// Symlink whose target is a directory already on the current descent
     /// path (a cycle). Non-cyclic duplicate symlinks (two different symlinks
-    /// to the same target) are NOT reported under this kind — they are
-    /// traversed normally.
+    /// to the same target) are not reported as cycles and are traversed
+    /// normally.
     SymlinkCycle,
     /// S3 service error from `ListObjectsV2` or related call.
     Service,
@@ -32,17 +31,11 @@ pub enum WalkErrorKind {
     Other,
 }
 
-/// Error reported by the walker for either fatal traversal failures or
-/// per-entry failures encountered during a directory read.
+/// An error encountered during a directory walk.
 ///
-/// A `WalkError` wraps an optional path (the entry or directory the error
-/// pertains to), a kind classifier, a fatal flag, and a boxed source
-/// error. Users can:
-/// - Access the path via [`WalkError::path`]
-/// - Get the kind via [`WalkError::kind`]
-/// - Check if the walk will continue via [`WalkError::is_fatal`]
-/// - Access the underlying error via the [`std::error::Error`] trait's
-///   `source()` method
+/// Wraps an optional path, a [`WalkErrorKind`] classifier, a fatal flag,
+/// and a source error. Check [`is_fatal`](Self::is_fatal) to determine
+/// whether the walk will continue producing entries after this error.
 #[derive(Debug)]
 pub struct WalkError {
     path: Option<PathBuf>,
@@ -54,10 +47,10 @@ pub struct WalkError {
 impl WalkError {
     /// The path associated with this error, if any.
     ///
-    /// For per-entry errors, this is the entry path. For fatal errors
-    /// (e.g. the root directory is unreadable), this is the directory that
-    /// could not be read. May be `None` for errors that don't correspond
-    /// to a single path (e.g. an S3 service error).
+    /// For non-fatal errors this is typically the entry that failed (a file
+    /// or symlink). For fatal errors it may be the directory that could not
+    /// be read. `None` for errors not tied to a specific path (e.g. S3
+    /// service errors).
     pub fn path(&self) -> Option<&Path> {
         self.path.as_deref()
     }

--- a/aws-sdk-s3-transfer-manager/src/io/walk/error.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/error.rs
@@ -1,0 +1,147 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::path::{Path, PathBuf};
+
+/// Classifies a [`WalkError`] for consumer-side branching.
+///
+/// Separates fatal failures (walk cannot continue) from per-entry
+/// failures (individual entry failed, walk continues). State machines
+/// use [`WalkError::is_fatal`] to decide whether to abort the
+/// directory transfer or to apply the `FailedTransferPolicy`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalkErrorKind {
+    /// Generic I/O failure reading a directory or entry.
+    Io,
+    /// Permission denied on a directory or entry.
+    PermissionDenied,
+    /// Path expected to be a directory but isn't (e.g. source is a file).
+    NotADirectory,
+    /// Symlink encountered with no valid target.
+    BrokenSymlink,
+    /// Symlink whose target is a directory already on the current descent
+    /// path (a cycle). Non-cyclic duplicate symlinks (two different symlinks
+    /// to the same target) are NOT reported under this kind — they are
+    /// traversed normally.
+    SymlinkCycle,
+    /// S3 service error from `ListObjectsV2` or related call.
+    Service,
+    /// Other error that doesn't fit the categories above.
+    Other,
+}
+
+/// Error reported by the walker for either fatal traversal failures or
+/// per-entry failures encountered during a directory read.
+///
+/// A `WalkError` wraps an optional path (the entry or directory the error
+/// pertains to), a kind classifier, a fatal flag, and a boxed source
+/// error. Users can:
+/// - Access the path via [`WalkError::path`]
+/// - Get the kind via [`WalkError::kind`]
+/// - Check if the walk will continue via [`WalkError::is_fatal`]
+/// - Access the underlying error via the [`std::error::Error`] trait's
+///   `source()` method
+#[derive(Debug)]
+pub struct WalkError {
+    path: Option<PathBuf>,
+    kind: WalkErrorKind,
+    fatal: bool,
+    source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl WalkError {
+    /// The path associated with this error, if any.
+    ///
+    /// For per-entry errors, this is the entry path. For fatal errors
+    /// (e.g. the root directory is unreadable), this is the directory that
+    /// could not be read. May be `None` for errors that don't correspond
+    /// to a single path (e.g. an S3 service error).
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    /// The classification of this error.
+    pub fn kind(&self) -> WalkErrorKind {
+        self.kind
+    }
+
+    /// Whether this error terminates the walk.
+    ///
+    /// When `true`, no further entries will be produced by the walk.
+    /// When `false`, the walk continues and may produce more entries.
+    pub fn is_fatal(&self) -> bool {
+        self.fatal
+    }
+
+    pub(crate) fn new(
+        path: Option<PathBuf>,
+        kind: WalkErrorKind,
+        fatal: bool,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    ) -> Self {
+        Self {
+            path,
+            kind,
+            fatal,
+            source,
+        }
+    }
+
+    /// Classify an `io::Error` into a [`WalkErrorKind`].
+    pub(crate) fn classify_io(err: &std::io::Error) -> WalkErrorKind {
+        match err.kind() {
+            std::io::ErrorKind::PermissionDenied => WalkErrorKind::PermissionDenied,
+            std::io::ErrorKind::NotADirectory => WalkErrorKind::NotADirectory,
+            _ => WalkErrorKind::Io,
+        }
+    }
+}
+
+impl std::fmt::Display for WalkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.path {
+            Some(p) => write!(f, "walk error at {}: {}", p.display(), self.source),
+            None => write!(f, "walk error: {}", self.source),
+        }
+    }
+}
+
+impl std::error::Error for WalkError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&*self.source)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_io_permission_denied() {
+        let err = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        assert_eq!(
+            WalkError::classify_io(&err),
+            WalkErrorKind::PermissionDenied
+        );
+    }
+
+    #[test]
+    fn test_classify_io_not_a_directory() {
+        let err = std::io::Error::from(std::io::ErrorKind::NotADirectory);
+        assert_eq!(WalkError::classify_io(&err), WalkErrorKind::NotADirectory);
+    }
+
+    #[test]
+    fn test_classify_io_not_found_maps_to_io() {
+        let err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        assert_eq!(WalkError::classify_io(&err), WalkErrorKind::Io);
+    }
+
+    #[test]
+    fn test_classify_io_other_maps_to_io() {
+        let err = std::io::Error::from(std::io::ErrorKind::ConnectionRefused);
+        assert_eq!(WalkError::classify_io(&err), WalkErrorKind::Io);
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
@@ -1,0 +1,1667 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::collections::VecDeque;
+use std::fs::Metadata;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use same_file::Handle;
+
+use super::error::{WalkError, WalkErrorKind};
+
+/// A directory queued for traversal, carrying the chain of ancestor directory
+/// handles needed for per-path symlink cycle detection.
+struct PendingDir {
+    path: PathBuf,
+    depth: usize,
+    /// Handles of all directories on the path from the walk root to (and
+    /// including) this directory's parent. Used to detect cycles: before
+    /// entering a symlinked directory, we check whether its target handle
+    /// already appears in this chain.
+    ancestor_handles: Vec<Arc<Handle>>,
+}
+
+/// Result of reading a single directory.
+///
+/// Contains all files discovered in the directory (after filter application),
+/// subdirectories to recurse into (subject to `max_depth`), and any non-fatal
+/// per-entry errors encountered during the read.
+struct ReadDirResult {
+    /// Files discovered in the directory, after filter application.
+    files: Vec<DirEntry>,
+    /// Subdirectories to recurse into. Empty if `depth >= max_depth`.
+    subdirs: Vec<PendingDir>,
+    /// Non-fatal errors encountered reading individual entries.
+    errors: Vec<WalkError>,
+}
+
+/// A file entry discovered during a filesystem walk.
+///
+/// Contains the absolute path, the path relative to the walk root, and
+/// the file metadata. Only regular files (and symlinks to regular files
+/// when `follow_symlinks` is enabled) produce `DirEntry` values; directories
+/// are traversed but not yielded.
+#[derive(Debug)]
+pub struct DirEntry {
+    path: PathBuf,
+    relative_path: PathBuf,
+    metadata: Metadata,
+}
+
+impl DirEntry {
+    /// Absolute path to the file on the local filesystem.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Path of the file relative to the walk root.
+    ///
+    /// For a walk rooted at `/src/foo` that discovers `/src/foo/a/b.txt`,
+    /// the relative path is `a/b.txt`. Useful for deriving destination keys
+    /// for uploads.
+    pub fn relative_path(&self) -> &Path {
+        &self.relative_path
+    }
+
+    /// File metadata.
+    ///
+    /// When the entry was produced by following a symlink, this is the
+    /// metadata of the symlink target (not the symlink itself).
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+}
+
+type FilterFn = Box<dyn Fn(&DirEntry) -> bool + Send + Sync>;
+
+/// Configuration for walking a local filesystem directory.
+///
+/// An `FsWalker` is pure configuration — it describes *what* to look for
+/// and *how* (depth, symlink policy, sorting, filtering) but not *where*.
+/// The walk root is supplied separately via [`FsWalkContext`] when starting
+/// a walk. This separation allows the same configuration to be reused
+/// across multiple walks with different roots.
+///
+/// Use [`FsWalker::builder`] to construct an instance.
+///
+/// # Traversal model
+///
+/// The walker reads one directory at a time. Subdirectories discovered during
+/// a read are queued for subsequent reads. Only regular files produce yielded
+/// [`DirEntry`] values; directories, symlinks, and special files (sockets,
+/// fifos, block/char devices) are traversed or skipped according to
+/// configuration but are never themselves yielded as entries.
+///
+/// # Symlink cycle handling
+///
+/// When `follow_symlinks` is enabled, the walker detects symlink cycles
+/// by tracking the chain of directories on the current descent path. A
+/// symlink whose target resolves to a directory already on that path
+/// (including the current directory itself) is reported as a per-entry
+/// error with kind `SymlinkCycle` and the walk continues without entering
+/// the cyclic link.
+///
+/// Non-cyclic duplicate symlinks (two different symlinks pointing to the
+/// same target) are NOT deduplicated. Both are followed and the target's
+/// content is yielded twice. If deduplication is desired, apply it at a
+/// higher layer.
+// TODO(walker): `dir_filter: Option<Box<dyn Fn(&DirEntry) -> bool>>` — subtree
+//   prune predicate. Biggest perf improvement for bulk ops on trees with large
+//   excluded subtrees (.git/, node_modules/).
+// TODO(walker): `min_depth: usize` — skip entries above this depth.
+// TODO(walker): `use_gitignore: bool` — integrate the `ignore` crate for
+//   opt-in .gitignore support.
+// TODO(walker): `normalize_unicode: Option<NormalizationForm>` — NFC/NFD
+//   normalization of filenames before deriving relative paths / S3 keys.
+// TODO(walker): `same_file_system: bool` — refuse to cross filesystem
+//   boundaries during recursion.
+pub struct FsWalker {
+    follow_symlinks: bool,
+    max_depth: usize,
+    sort: bool,
+    canonicalize_root: bool,
+    filter: Option<FilterFn>,
+}
+
+impl std::fmt::Debug for FsWalker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FsWalker")
+            .field("follow_symlinks", &self.follow_symlinks)
+            .field("max_depth", &self.max_depth)
+            .field("sort", &self.sort)
+            .field("canonicalize_root", &self.canonicalize_root)
+            .finish()
+    }
+}
+
+impl FsWalker {
+    /// Create a builder for configuring an `FsWalker`.
+    #[must_use]
+    pub fn builder() -> FsWalkerBuilder {
+        FsWalkerBuilder::default()
+    }
+
+    /// Start a walk with the given execution context.
+    ///
+    /// Returns an [`FsWalk`] that yields file entries via
+    /// [`next`](FsWalk::next). The walk begins by validating the root
+    /// directory from the context; invalid roots produce a fatal error
+    /// on the first call to `next`.
+    #[must_use]
+    pub fn walk(self, ctx: FsWalkContext) -> FsWalk {
+        let mut root = ctx.root;
+        let mut pending_errors = VecDeque::new();
+        let mut done = false;
+        let mut pending_dirs = VecDeque::new();
+
+        if self.canonicalize_root {
+            match std::fs::canonicalize(&root) {
+                Ok(canonical) => root = canonical,
+                Err(e) => {
+                    let kind = WalkError::classify_io(&e);
+                    pending_errors.push_back(WalkError::new(
+                        Some(root.clone()),
+                        kind,
+                        true,
+                        Box::new(e),
+                    ));
+                    done = true;
+                }
+            }
+        } else if !self.follow_symlinks {
+            match std::fs::symlink_metadata(&root) {
+                Ok(md) if md.file_type().is_symlink() => {
+                    pending_errors.push_back(WalkError::new(
+                        Some(root.clone()),
+                        WalkErrorKind::NotADirectory,
+                        true,
+                        Box::from("source root is a symlink; enable follow_symlinks or canonicalize_root to walk through it"),
+                    ));
+                    done = true;
+                }
+                Ok(_) => {}
+                Err(_) => {
+                    // Root doesn't exist / isn't accessible; let the first
+                    // directory read report the fatal error.
+                }
+            }
+        }
+
+        if !done {
+            pending_dirs.push_back(PendingDir {
+                path: root.clone(),
+                depth: 0,
+                ancestor_handles: Vec::new(),
+            });
+        }
+
+        FsWalk {
+            config: self,
+            root,
+            pending_dirs,
+            ready_files: VecDeque::new(),
+            pending_errors,
+            done,
+        }
+    }
+}
+
+/// Builder for [`FsWalker`].
+///
+/// All fields have sensible defaults: non-recursive, symlinks not followed,
+/// unsorted, no filter, `canonicalize_root` disabled.
+#[derive(Default)]
+pub struct FsWalkerBuilder {
+    follow_symlinks: bool,
+    max_depth: usize,
+    sort: bool,
+    canonicalize_root: bool,
+    filter: Option<FilterFn>,
+}
+
+impl std::fmt::Debug for FsWalkerBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FsWalkerBuilder")
+            .field("follow_symlinks", &self.follow_symlinks)
+            .field("max_depth", &self.max_depth)
+            .field("sort", &self.sort)
+            .field("canonicalize_root", &self.canonicalize_root)
+            .finish()
+    }
+}
+
+impl FsWalkerBuilder {
+    /// Control whether symbolic links are followed.
+    ///
+    /// When `false` (default), symlinks are skipped entirely. When `true`,
+    /// symlinks are resolved: file symlinks yield entries, directory
+    /// symlinks are traversed (subject to `max_depth` and cycle detection),
+    /// and broken symlinks produce per-entry errors.
+    #[must_use]
+    pub fn follow_symlinks(mut self, follow: bool) -> Self {
+        self.follow_symlinks = follow;
+        self
+    }
+
+    /// Shortcut for setting recursion depth.
+    ///
+    /// `recursive(true)` sets `max_depth` to `usize::MAX` (walk the full
+    /// tree). `recursive(false)` sets it to `0` (only the root directory's
+    /// immediate contents). Default is non-recursive.
+    #[must_use]
+    pub fn recursive(mut self, recursive: bool) -> Self {
+        self.max_depth = if recursive { usize::MAX } else { 0 };
+        self
+    }
+
+    /// Set the maximum directory depth to traverse.
+    ///
+    /// Depth semantics:
+    /// - `0` (default): read only the root directory's immediate contents.
+    ///   Subdirectories are skipped.
+    /// - `1`: descend into one level of subdirectories from the root.
+    /// - `N`: descend up to N levels of subdirectories from the root.
+    ///
+    /// Example with tree:
+    ///
+    /// ```text
+    /// root/
+    /// ├── top.txt         ← depth 0
+    /// └── a/              ← depth 0
+    ///     ├── mid.txt     ← depth 1
+    ///     └── b/          ← depth 1
+    ///         └── deep.txt ← depth 2
+    /// ```
+    ///
+    /// - `max_depth(0)` yields `top.txt`
+    /// - `max_depth(1)` yields `top.txt, a/mid.txt`
+    /// - `max_depth(2)` yields `top.txt, a/mid.txt, a/b/deep.txt`
+    ///
+    /// This matches the convention where depth counts subdirectory levels
+    /// below the root, but differs from Java's NIO `Files.walk(maxDepth)`
+    /// which counts the root as depth 1
+    /// (so Java's `maxDepth=1` is our `max_depth(0)`).
+    #[must_use]
+    pub fn max_depth(mut self, depth: usize) -> Self {
+        self.max_depth = depth;
+        self
+    }
+
+    /// Enable lexicographic sorting of entries within each directory.
+    ///
+    /// When `true`, files and subdirectories from each directory read are
+    /// sorted by full path. Entries are sorted *within* a directory level
+    /// but not globally — depth-first traversal produces entries
+    /// level-by-level.
+    ///
+    /// When `false` (default), entries are returned in OS-native order.
+    ///
+    /// Sort is required for `sync`-style operations that merge-join against
+    /// `ListObjectsV2` results (which are UTF-8 binary sorted by key).
+    #[must_use]
+    pub fn sort(mut self, sort: bool) -> Self {
+        self.sort = sort;
+        self
+    }
+
+    /// Resolve the walk root via `std::fs::canonicalize` before walking.
+    ///
+    /// When `true`, the root path is canonicalized (symlinks resolved,
+    /// relative components removed) before the walk begins. This allows
+    /// walking through a symlinked root directory even when
+    /// `follow_symlinks` is `false`. If canonicalization fails (e.g. the
+    /// path does not exist), the walk produces a fatal error.
+    ///
+    /// When `false` (default), the root is used as-is. A symlinked root
+    /// with `follow_symlinks=false` produces a fatal error.
+    #[must_use]
+    pub fn canonicalize_root(mut self, canonicalize: bool) -> Self {
+        self.canonicalize_root = canonicalize;
+        self
+    }
+
+    /// Set a filter predicate applied to each discovered file.
+    ///
+    /// The predicate is called after a file's metadata has been read but
+    /// before it is yielded. Returning `false` drops the entry silently.
+    /// The filter does not apply to directories — directory traversal is
+    /// controlled by `max_depth` and `follow_symlinks`.
+    ///
+    /// **The filter does not prune subtrees.** A file-level filter that
+    /// rejects everything under a given subdirectory still causes the
+    /// walker to descend into and stat every file in that subtree. For
+    /// performance on trees with large excludable subtrees (e.g. `.git/`,
+    /// `node_modules/`), compose multiple walks rooted at smaller subtrees.
+    #[must_use]
+    pub fn filter(mut self, f: impl Fn(&DirEntry) -> bool + Send + Sync + 'static) -> Self {
+        self.filter = Some(Box::new(f));
+        self
+    }
+
+    /// Build the [`FsWalker`] configuration.
+    #[must_use]
+    pub fn build(self) -> FsWalker {
+        FsWalker {
+            follow_symlinks: self.follow_symlinks,
+            max_depth: self.max_depth,
+            sort: self.sort,
+            canonicalize_root: self.canonicalize_root,
+            filter: self.filter,
+        }
+    }
+}
+
+/// Execution context for an [`FsWalker`], providing the walk root.
+///
+/// Separates the "where" (root directory) from the "how" (walker config),
+/// allowing the same walker configuration to be reused with different roots.
+#[derive(Debug, Clone)]
+pub struct FsWalkContext {
+    root: PathBuf,
+}
+
+impl FsWalkContext {
+    /// Create a builder for an `FsWalkContext`.
+    #[must_use]
+    pub fn builder() -> FsWalkContextBuilder {
+        FsWalkContextBuilder { root: None }
+    }
+}
+
+/// Builder for [`FsWalkContext`].
+#[derive(Debug, Default)]
+pub struct FsWalkContextBuilder {
+    root: Option<PathBuf>,
+}
+
+impl FsWalkContextBuilder {
+    /// Set the root directory to walk.
+    ///
+    /// This field is required.
+    #[must_use]
+    pub fn root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.root = Some(root.into());
+        self
+    }
+
+    /// Build the [`FsWalkContext`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `root` has not been set.
+    #[must_use]
+    pub fn build(self) -> FsWalkContext {
+        FsWalkContext {
+            root: self.root.expect("required field `root` should be set"),
+        }
+    }
+}
+
+/// A running filesystem walk, yielding file entries.
+///
+/// Created by [`FsWalker::walk`]. The walk is pull-based: each call to
+/// [`next`](Self::next) drives the walk forward, reading directories as
+/// needed and buffering discovered files.
+///
+/// Errors encountered during the walk are interleaved with successful
+/// entries. Fatal errors terminate the walk; per-entry errors do not.
+pub struct FsWalk {
+    config: FsWalker,
+    root: PathBuf,
+    pending_dirs: VecDeque<PendingDir>,
+    ready_files: VecDeque<DirEntry>,
+    pending_errors: VecDeque<WalkError>,
+    done: bool,
+}
+
+impl std::fmt::Debug for FsWalk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FsWalk")
+            .field("root", &self.root)
+            .field("done", &self.done)
+            .finish()
+    }
+}
+
+impl FsWalk {
+    /// Return the next entry from the walk.
+    ///
+    /// Returns:
+    /// - `Some(Ok(entry))` for a file that passed the filter.
+    /// - `Some(Err(err))` for a fatal or per-entry error. Fatal errors
+    ///   are followed by `None` on the next call; per-entry errors are
+    ///   followed by more results as the walk continues.
+    /// - `None` when the walk is complete.
+    ///
+    /// `next` is `async` for API consistency with
+    /// [`S3Walk::next`](super::s3::S3Walk::next); the filesystem
+    /// operations themselves are synchronous.
+    pub async fn next(&mut self) -> Option<Result<DirEntry, WalkError>> {
+        loop {
+            if let Some(entry) = self.ready_files.pop_front() {
+                return Some(Ok(entry));
+            }
+            if let Some(err) = self.pending_errors.pop_front() {
+                return Some(Err(err));
+            }
+            if self.done {
+                return None;
+            }
+
+            let pending = match self.pending_dirs.pop_front() {
+                Some(d) => d,
+                None => {
+                    self.done = true;
+                    return None;
+                }
+            };
+
+            match self.read_dir(&pending.path, pending.depth, &pending.ancestor_handles) {
+                Ok(result) => {
+                    self.ready_files.extend(result.files);
+                    self.pending_errors.extend(result.errors);
+                    self.pending_dirs.extend(result.subdirs);
+                }
+                Err(err) => {
+                    if err.is_fatal() {
+                        self.done = true;
+                    }
+                    return Some(Err(err));
+                }
+            }
+        }
+    }
+
+    /// Whether the walk has finished (no more entries will be produced).
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    fn read_dir(
+        &self,
+        dir: &Path,
+        depth: usize,
+        ancestor_handles: &[Arc<Handle>],
+    ) -> Result<ReadDirResult, WalkError> {
+        let entries = std::fs::read_dir(dir).map_err(|e| {
+            let kind = WalkError::classify_io(&e);
+            WalkError::new(Some(dir.to_path_buf()), kind, depth == 0, Box::new(e))
+        })?;
+
+        // Build the ancestor chain for children of this directory.
+        let self_handle = Arc::new(Handle::from_path(dir).map_err(|e| {
+            let kind = WalkError::classify_io(&e);
+            WalkError::new(Some(dir.to_path_buf()), kind, depth == 0, Box::new(e))
+        })?);
+        let mut next_ancestors = ancestor_handles.to_vec();
+        next_ancestors.push(Arc::clone(&self_handle));
+
+        let mut result = ReadDirResult {
+            files: Vec::new(),
+            subdirs: Vec::new(),
+            errors: Vec::new(),
+        };
+
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => {
+                    let kind = WalkError::classify_io(&e);
+                    result.errors.push(WalkError::new(
+                        Some(dir.to_path_buf()),
+                        kind,
+                        false,
+                        Box::new(e),
+                    ));
+                    continue;
+                }
+            };
+
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(e) => {
+                    let kind = WalkError::classify_io(&e);
+                    result
+                        .errors
+                        .push(WalkError::new(Some(path), kind, false, Box::new(e)));
+                    continue;
+                }
+            };
+
+            if file_type.is_symlink() {
+                if !self.config.follow_symlinks {
+                    continue;
+                }
+                let metadata = match std::fs::metadata(&path) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        let kind = match e.kind() {
+                            std::io::ErrorKind::NotFound => WalkErrorKind::BrokenSymlink,
+                            _ => WalkError::classify_io(&e),
+                        };
+                        result
+                            .errors
+                            .push(WalkError::new(Some(path), kind, false, Box::new(e)));
+                        continue;
+                    }
+                };
+
+                if metadata.is_dir() {
+                    // Cycle detection: check if the symlink target is already
+                    // on the current descent path.
+                    match Handle::from_path(&path) {
+                        Ok(target_handle) => {
+                            if next_ancestors.iter().any(|a| **a == target_handle) {
+                                result.errors.push(WalkError::new(
+                                    Some(path),
+                                    WalkErrorKind::SymlinkCycle,
+                                    false,
+                                    Box::from("symlink target is an ancestor of the current path"),
+                                ));
+                                continue;
+                            }
+                            if depth < self.config.max_depth {
+                                result.subdirs.push(PendingDir {
+                                    path,
+                                    depth: depth + 1,
+                                    ancestor_handles: next_ancestors.clone(),
+                                });
+                            }
+                        }
+                        Err(e) => {
+                            let kind = WalkError::classify_io(&e);
+                            result.errors.push(WalkError::new(
+                                Some(path),
+                                kind,
+                                false,
+                                Box::new(e),
+                            ));
+                        }
+                    }
+                } else if metadata.is_file() {
+                    self.push_file(&mut result.files, path, &metadata);
+                }
+            } else if file_type.is_file() {
+                let metadata = match std::fs::metadata(&path) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        let kind = WalkError::classify_io(&e);
+                        result
+                            .errors
+                            .push(WalkError::new(Some(path), kind, false, Box::new(e)));
+                        continue;
+                    }
+                };
+                self.push_file(&mut result.files, path, &metadata);
+            } else if file_type.is_dir() && depth < self.config.max_depth {
+                result.subdirs.push(PendingDir {
+                    path,
+                    depth: depth + 1,
+                    ancestor_handles: next_ancestors.clone(),
+                });
+            }
+        }
+
+        if self.config.sort {
+            result.files.sort_by(|a, b| a.path.cmp(&b.path));
+            result.subdirs.sort_by(|a, b| a.path.cmp(&b.path));
+        }
+
+        Ok(result)
+    }
+
+    fn push_file(&self, files: &mut Vec<DirEntry>, path: PathBuf, metadata: &Metadata) {
+        let relative_path = path.strip_prefix(&self.root).unwrap_or(&path).to_path_buf();
+        let entry = DirEntry {
+            path,
+            relative_path,
+            metadata: metadata.clone(),
+        };
+        if self.config.filter.as_ref().is_none_or(|f| f(&entry)) {
+            files.push(entry);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    async fn collect_entries(mut walk: FsWalk) -> (Vec<DirEntry>, Vec<WalkError>) {
+        let mut entries = Vec::new();
+        let mut errors = Vec::new();
+        while let Some(result) = walk.next().await {
+            match result {
+                Ok(e) => entries.push(e),
+                Err(e) => errors.push(e),
+            }
+        }
+        (entries, errors)
+    }
+
+    fn walker() -> FsWalkerBuilder {
+        FsWalker::builder()
+    }
+
+    fn ctx(root: impl Into<PathBuf>) -> FsWalkContext {
+        FsWalkContext::builder().root(root).build()
+    }
+
+    #[tokio::test]
+    async fn test_walk_flat_directory() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("a.txt"), "a").unwrap();
+        fs::write(dir.path().join("b.txt"), "b").unwrap();
+        fs::write(dir.path().join("c.txt"), "c").unwrap();
+
+        let walk = walker().build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(errors.is_empty());
+        assert_eq!(entries.len(), 3);
+
+        let mut names: Vec<_> = entries
+            .iter()
+            .map(|e| e.relative_path().to_owned())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                PathBuf::from("a.txt"),
+                PathBuf::from("b.txt"),
+                PathBuf::from("c.txt"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_walk_recursive() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("top.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("sub")).unwrap();
+        fs::write(dir.path().join("sub/nested.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("sub/deep")).unwrap();
+        fs::write(dir.path().join("sub/deep/deep.txt"), "").unwrap();
+
+        let walk = walker().recursive(true).build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(errors.is_empty());
+        assert_eq!(entries.len(), 3);
+
+        let mut names: Vec<_> = entries
+            .iter()
+            .map(|e| e.relative_path().to_string_lossy().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["sub/deep/deep.txt", "sub/nested.txt", "top.txt"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_walk_non_recursive_skips_subdirs() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("top.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("sub")).unwrap();
+        fs::write(dir.path().join("sub/hidden.txt"), "").unwrap();
+
+        let walk = walker().build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(errors.is_empty());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].relative_path(), Path::new("top.txt"));
+    }
+
+    #[tokio::test]
+    async fn test_walk_filter() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("a.txt"), "").unwrap();
+        fs::write(dir.path().join("b.log"), "").unwrap();
+        fs::write(dir.path().join("c.txt"), "").unwrap();
+
+        let walk = walker()
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "txt"))
+            .build()
+            .walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(errors.is_empty());
+        assert_eq!(entries.len(), 2);
+
+        let mut names: Vec<_> = entries
+            .iter()
+            .map(|e| e.relative_path().to_owned())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec![PathBuf::from("a.txt"), PathBuf::from("c.txt")]);
+    }
+
+    #[tokio::test]
+    async fn test_walk_empty_directory() {
+        let dir = tempdir().unwrap();
+        let walk = walker().build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(errors.is_empty());
+        assert!(entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_walk_max_depth() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("d0.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("a")).unwrap();
+        fs::write(dir.path().join("a/d1.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("a/b")).unwrap();
+        fs::write(dir.path().join("a/b/d2.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("a/b/c")).unwrap();
+        fs::write(dir.path().join("a/b/c/d3.txt"), "").unwrap();
+
+        let walk = walker().max_depth(2).build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(errors.is_empty());
+        assert_eq!(entries.len(), 3);
+
+        let mut names: Vec<_> = entries
+            .iter()
+            .map(|e| e.relative_path().to_string_lossy().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["a/b/d2.txt", "a/d1.txt", "d0.txt"]);
+    }
+
+    #[tokio::test]
+    async fn test_relative_path_correctness() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("a/b")).unwrap();
+        fs::write(dir.path().join("a/b/file.txt"), "").unwrap();
+
+        let walk = walker().recursive(true).build().walk(ctx(dir.path()));
+        let (entries, _) = collect_entries(walk).await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].relative_path(), Path::new("a/b/file.txt"));
+        assert_eq!(entries[0].path(), dir.path().join("a/b/file.txt"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_follow_symlinks() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("real.txt"), "content").unwrap();
+        std::os::unix::fs::symlink(dir.path().join("real.txt"), dir.path().join("link.txt"))
+            .unwrap();
+
+        let walk = walker().follow_symlinks(true).build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(errors.is_empty());
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_no_follow_symlinks() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("real.txt"), "content").unwrap();
+        std::os::unix::fs::symlink(dir.path().join("real.txt"), dir.path().join("link.txt"))
+            .unwrap();
+
+        let walk = walker()
+            .follow_symlinks(false)
+            .build()
+            .walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(errors.is_empty());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].relative_path(), Path::new("real.txt"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_symlink_cycle_detection() {
+        use tokio::time::{timeout, Duration};
+
+        let dir = tempdir().unwrap();
+        let dir_a = dir.path().join("a");
+        let dir_b = dir.path().join("b");
+        fs::create_dir(&dir_a).unwrap();
+        fs::create_dir(&dir_b).unwrap();
+        std::os::unix::fs::symlink(&dir_b, dir_a.join("link_to_b")).unwrap();
+        std::os::unix::fs::symlink(&dir_a, dir_b.join("link_to_a")).unwrap();
+        fs::write(dir_a.join("file_a.txt"), "").unwrap();
+        fs::write(dir_b.join("file_b.txt"), "").unwrap();
+
+        let walk = walker()
+            .recursive(true)
+            .follow_symlinks(true)
+            .build()
+            .walk(ctx(dir.path()));
+
+        let result = timeout(Duration::from_secs(5), collect_entries(walk)).await;
+        let (entries, errors) = result.expect("walk should terminate via cycle detection");
+
+        assert!(!entries.is_empty());
+        assert!(
+            !errors.is_empty(),
+            "expected cycle detection errors but got none"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_walk_root_does_not_exist() {
+        let mut walk = walker()
+            .build()
+            .walk(ctx("/this/path/does/not/exist/abc123xyz"));
+        let first = walk.next().await;
+        match first {
+            Some(Err(ref err)) => {
+                assert!(err.is_fatal(), "expected fatal error for missing root");
+                assert_eq!(
+                    err.kind(),
+                    WalkErrorKind::Io,
+                    "NotFound on a non-symlink path should map to Io, not BrokenSymlink"
+                );
+            }
+            other => panic!("expected fatal error for missing root, got {other:?}"),
+        }
+        assert!(walk.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_walk_recursive_false_equals_max_depth_zero() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("top.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("sub")).unwrap();
+        fs::write(dir.path().join("sub/inner.txt"), "").unwrap();
+
+        let (a, _) = collect_entries(walker().recursive(false).build().walk(ctx(dir.path()))).await;
+        let (b, _) = collect_entries(walker().max_depth(0).build().walk(ctx(dir.path()))).await;
+
+        let mut a_names: Vec<_> = a.iter().map(|e| e.relative_path().to_owned()).collect();
+        let mut b_names: Vec<_> = b.iter().map(|e| e.relative_path().to_owned()).collect();
+        a_names.sort();
+        b_names.sort();
+        assert_eq!(a_names, b_names);
+        assert_eq!(a_names, vec![PathBuf::from("top.txt")]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_broken_symlink_follow() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("real.txt"), "").unwrap();
+        std::os::unix::fs::symlink("/nonexistent/target/xyz", dir.path().join("broken")).unwrap();
+
+        let walk = walker().follow_symlinks(true).build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].relative_path(), Path::new("real.txt"));
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].path(), Some(dir.path().join("broken").as_path()));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_broken_symlink_no_follow() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("real.txt"), "").unwrap();
+        std::os::unix::fs::symlink("/nonexistent/target/xyz", dir.path().join("broken")).unwrap();
+
+        let walk = walker()
+            .follow_symlinks(false)
+            .build()
+            .walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].relative_path(), Path::new("real.txt"));
+        assert!(errors.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_symlink_to_file() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("real.txt"), "content").unwrap();
+        std::os::unix::fs::symlink(dir.path().join("real.txt"), dir.path().join("link.txt"))
+            .unwrap();
+
+        let walk = walker().follow_symlinks(true).build().walk(ctx(dir.path()));
+        let (entries, _) = collect_entries(walk).await;
+
+        assert_eq!(entries.len(), 2);
+        for e in &entries {
+            assert!(e.metadata().is_file());
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_symlink_chain() {
+        let dir = tempdir().unwrap();
+        let real = dir.path().join("real_dir");
+        fs::create_dir(&real).unwrap();
+        fs::write(real.join("deep.txt"), "").unwrap();
+        std::os::unix::fs::symlink(&real, dir.path().join("b")).unwrap();
+        std::os::unix::fs::symlink(dir.path().join("b"), dir.path().join("a")).unwrap();
+
+        let walk = walker()
+            .recursive(true)
+            .follow_symlinks(true)
+            .build()
+            .walk(ctx(dir.path()));
+        let (entries, _) = collect_entries(walk).await;
+
+        let deep_entries: Vec<_> = entries
+            .iter()
+            .filter(|e| e.path().file_name().is_some_and(|n| n == "deep.txt"))
+            .collect();
+        assert!(
+            !deep_entries.is_empty(),
+            "expected deep.txt to be found via at least one path"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_skips_special_files() {
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("regular.txt"), "").unwrap();
+        let _listener = UnixListener::bind(dir.path().join("socket.sock")).unwrap();
+
+        let walk = walker().build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].relative_path(), Path::new("regular.txt"));
+        assert!(errors.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_subdirectory_permission_denied() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("top.txt"), "").unwrap();
+        let locked = dir.path().join("locked");
+        fs::create_dir(&locked).unwrap();
+        fs::write(locked.join("hidden.txt"), "").unwrap();
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let can_read_denied = std::fs::read_dir(&locked).is_ok();
+        if can_read_denied {
+            fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+            return; // running as root
+        }
+
+        let walk = walker().recursive(true).build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+
+        fs::set_permissions(&locked, fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(entries
+            .iter()
+            .any(|e| e.relative_path() == Path::new("top.txt")));
+        assert!(
+            !errors.is_empty(),
+            "expected permission-denied error for unreadable subdir"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_walk_source_is_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("file.txt");
+        fs::write(&file, "").unwrap();
+
+        let mut walk = walker().build().walk(ctx(&file));
+        let first = walk.next().await;
+        assert!(
+            matches!(first, Some(Err(_))),
+            "expected fatal error when source is a file"
+        );
+        assert!(walk.next().await.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_source_is_symlink_follow_enabled() {
+        let dir = tempdir().unwrap();
+        let real = dir.path().join("real");
+        fs::create_dir(&real).unwrap();
+        fs::write(real.join("a.txt"), "").unwrap();
+        let link = dir.path().join("link_to_real");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let walk = walker().follow_symlinks(true).build().walk(ctx(&link));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(
+            errors.is_empty(),
+            "follow_symlinks=true should accept symlink root"
+        );
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_source_is_symlink_follow_disabled() {
+        let dir = tempdir().unwrap();
+        let real = dir.path().join("real");
+        fs::create_dir(&real).unwrap();
+        fs::write(real.join("a.txt"), "").unwrap();
+        let link = dir.path().join("link_to_real");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let walk = walker().follow_symlinks(false).build().walk(ctx(&link));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(
+            entries.is_empty(),
+            "walk should not descend into symlinked root when follow_symlinks=false"
+        );
+        assert_eq!(errors.len(), 1, "expected exactly one fatal error");
+        assert_eq!(errors[0].path(), Some(link.as_path()));
+        assert_eq!(errors[0].kind(), WalkErrorKind::NotADirectory);
+    }
+
+    #[tokio::test]
+    async fn test_walk_lexicographic_sort() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("zebra.txt"), "").unwrap();
+        fs::write(dir.path().join("apple.txt"), "").unwrap();
+        fs::write(dir.path().join("mango.txt"), "").unwrap();
+
+        let walk = walker().sort(true).build().walk(ctx(dir.path()));
+        let (entries, _) = collect_entries(walk).await;
+        let names: Vec<_> = entries
+            .iter()
+            .map(|e| e.relative_path().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["apple.txt", "mango.txt", "zebra.txt"]);
+    }
+
+    #[tokio::test]
+    async fn test_walk_recursive_sort_is_depth_first_per_dir() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("c-file.txt"), "").unwrap();
+        fs::write(dir.path().join("b-file.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("a-dir")).unwrap();
+        fs::write(dir.path().join("a-dir/z.txt"), "").unwrap();
+        fs::write(dir.path().join("a-dir/y.txt"), "").unwrap();
+
+        let walk = walker()
+            .recursive(true)
+            .sort(true)
+            .build()
+            .walk(ctx(dir.path()));
+        let (entries, _) = collect_entries(walk).await;
+        let names: Vec<_> = entries
+            .iter()
+            .map(|e| e.relative_path().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["b-file.txt", "c-file.txt", "a-dir/y.txt", "a-dir/z.txt"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_walk_unsorted_by_default() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("a.txt"), "").unwrap();
+        fs::write(dir.path().join("b.txt"), "").unwrap();
+        fs::write(dir.path().join("c.txt"), "").unwrap();
+
+        let walk = walker().build().walk(ctx(dir.path()));
+        let (entries, _) = collect_entries(walk).await;
+        let mut names: Vec<_> = entries
+            .iter()
+            .map(|e| e.relative_path().to_owned())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                PathBuf::from("a.txt"),
+                PathBuf::from("b.txt"),
+                PathBuf::from("c.txt"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_walk_unicode_filenames() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("café.txt"), "").unwrap();
+        fs::write(dir.path().join("日本語.txt"), "").unwrap();
+        fs::write(dir.path().join("🦀.txt"), "").unwrap();
+        fs::write(dir.path().join("file with spaces.txt"), "").unwrap();
+
+        let walk = walker().sort(true).build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(
+            errors.is_empty(),
+            "unicode filenames should not produce errors"
+        );
+        assert_eq!(entries.len(), 4);
+
+        let names: Vec<_> = entries
+            .iter()
+            .map(|e| e.relative_path().to_string_lossy().to_string())
+            .collect();
+        assert!(names.contains(&"café.txt".to_string()));
+        assert!(names.contains(&"日本語.txt".to_string()));
+        assert!(names.contains(&"🦀.txt".to_string()));
+        assert!(names.contains(&"file with spaces.txt".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_walk_large_directory() {
+        let dir = tempdir().unwrap();
+        for i in 0..10_000 {
+            fs::write(dir.path().join(format!("file_{i:05}.txt")), "").unwrap();
+        }
+
+        let walk = walker().build().walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(errors.is_empty());
+        assert_eq!(entries.len(), 10_000);
+    }
+
+    #[tokio::test]
+    async fn test_walk_error_kind_not_a_directory() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("notadir.txt");
+        fs::write(&file, "").unwrap();
+
+        let mut walk = walker().build().walk(ctx(&file));
+        let first = walk.next().await;
+        match first {
+            Some(Err(err)) => {
+                assert!(err.is_fatal(), "source-is-file should be fatal");
+                assert_eq!(err.kind(), WalkErrorKind::NotADirectory);
+            }
+            other => panic!("expected fatal error, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_error_kind_symlink_cycle() {
+        use tokio::time::{timeout, Duration};
+
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        fs::create_dir(&a).unwrap();
+        fs::create_dir(&b).unwrap();
+        std::os::unix::fs::symlink(&b, a.join("to_b")).unwrap();
+        std::os::unix::fs::symlink(&a, b.join("to_a")).unwrap();
+
+        let walk = walker()
+            .recursive(true)
+            .follow_symlinks(true)
+            .build()
+            .walk(ctx(dir.path()));
+        let result = timeout(Duration::from_secs(5), collect_entries(walk)).await;
+        let (_, errors) = result.expect("should terminate");
+
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.kind() == WalkErrorKind::SymlinkCycle),
+            "expected at least one SymlinkCycle error, got kinds: {:?}",
+            errors.iter().map(|e| e.kind()).collect::<Vec<_>>()
+        );
+        assert!(errors.iter().all(|e| !e.is_fatal()));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_error_kind_broken_symlink() {
+        let dir = tempdir().unwrap();
+        std::os::unix::fs::symlink("/nonexistent/target/xyz", dir.path().join("broken")).unwrap();
+
+        let walk = walker().follow_symlinks(true).build().walk(ctx(dir.path()));
+        let (_, errors) = collect_entries(walk).await;
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].kind(), WalkErrorKind::BrokenSymlink);
+        assert!(!errors[0].is_fatal());
+    }
+
+    // --- NEW TESTS ---
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_fswalker_canonicalize_root() {
+        let dir = tempdir().unwrap();
+        let real = dir.path().join("real");
+        fs::create_dir(&real).unwrap();
+        fs::write(real.join("a.txt"), "").unwrap();
+        let link = dir.path().join("link_to_real");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        // canonicalize_root=true resolves the symlink and walks the target
+        let walk = walker().canonicalize_root(true).build().walk(ctx(&link));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(
+            errors.is_empty(),
+            "canonicalize_root should resolve symlink root"
+        );
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fswalker_canonicalize_root_nonexistent() {
+        let mut walk = walker()
+            .canonicalize_root(true)
+            .build()
+            .walk(ctx("/this/path/does/not/exist/abc123xyz"));
+        let first = walk.next().await;
+        assert!(
+            matches!(first, Some(Err(ref e)) if e.is_fatal()),
+            "expected fatal error for canonicalize of nonexistent root"
+        );
+        assert!(walk.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fswalker_is_done() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("a.txt"), "").unwrap();
+
+        let mut walk = walker().build().walk(ctx(dir.path()));
+        assert!(!walk.is_done(), "walk should not be done before iteration");
+        while walk.next().await.is_some() {}
+        assert!(walk.is_done(), "walk should be done after exhausting");
+    }
+
+    // --- Symlink scenario tests ---
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_symlink_self_loop() {
+        let dir = tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("file.txt"), "").unwrap();
+        std::os::unix::fs::symlink(".", sub.join("self_link")).unwrap();
+
+        let walk = walker()
+            .recursive(true)
+            .follow_symlinks(true)
+            .build()
+            .walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.relative_path().ends_with("file.txt")),
+            "file.txt should be yielded"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.kind() == WalkErrorKind::SymlinkCycle),
+            "self-loop should be detected as SymlinkCycle"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_symlink_siblings_same_target_both_traversed() {
+        let dir = tempdir().unwrap();
+        let shared = dir.path().join("shared");
+        fs::create_dir(&shared).unwrap();
+        fs::write(shared.join("file.txt"), "").unwrap();
+        std::os::unix::fs::symlink(&shared, dir.path().join("link_a")).unwrap();
+        std::os::unix::fs::symlink(&shared, dir.path().join("link_b")).unwrap();
+
+        let walk = walker()
+            .recursive(true)
+            .follow_symlinks(true)
+            .sort(true)
+            .build()
+            .walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+
+        let file_count = entries
+            .iter()
+            .filter(|e| e.path().file_name().is_some_and(|n| n == "file.txt"))
+            .count();
+        assert_eq!(
+            file_count, 3,
+            "file.txt should appear 3 times (shared/, link_a/, link_b/)"
+        );
+        assert!(
+            errors.is_empty(),
+            "no errors expected for non-cyclic duplicates"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_symlink_chain_not_cycle() {
+        let dir = tempdir().unwrap();
+        let real_dir = dir.path().join("real_dir");
+        fs::create_dir(&real_dir).unwrap();
+        fs::write(real_dir.join("file.txt"), "").unwrap();
+        std::os::unix::fs::symlink(&real_dir, dir.path().join("b")).unwrap();
+        std::os::unix::fs::symlink(dir.path().join("b"), dir.path().join("a")).unwrap();
+
+        let walk = walker()
+            .recursive(true)
+            .follow_symlinks(true)
+            .build()
+            .walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+
+        let file_count = entries
+            .iter()
+            .filter(|e| e.path().file_name().is_some_and(|n| n == "file.txt"))
+            .count();
+        assert_eq!(
+            file_count, 3,
+            "file.txt should appear 3 times (real_dir/, a/, b/)"
+        );
+        assert!(errors.is_empty(), "chain of symlinks is not a cycle");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_symlink_deeper_cycle() {
+        use tokio::time::{timeout, Duration};
+
+        let dir = tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        let c = dir.path().join("c");
+        fs::create_dir(&a).unwrap();
+        fs::create_dir(&b).unwrap();
+        fs::create_dir(&c).unwrap();
+        std::os::unix::fs::symlink(&b, a.join("to_b")).unwrap();
+        std::os::unix::fs::symlink(&c, b.join("to_c")).unwrap();
+        std::os::unix::fs::symlink(&a, c.join("to_a")).unwrap();
+
+        let walk = walker()
+            .recursive(true)
+            .follow_symlinks(true)
+            .build()
+            .walk(ctx(dir.path()));
+        let result = timeout(Duration::from_secs(5), collect_entries(walk)).await;
+        let (_, errors) = result.expect("walk should terminate via cycle detection");
+
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.kind() == WalkErrorKind::SymlinkCycle),
+            "expected SymlinkCycle errors in A→B→C→A cycle"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_real_dir_reachable_via_symlink_yields_twice() {
+        let dir = tempdir().unwrap();
+        let real_dir = dir.path().join("real_dir");
+        fs::create_dir(&real_dir).unwrap();
+        fs::write(real_dir.join("file.txt"), "").unwrap();
+        std::os::unix::fs::symlink(&real_dir, dir.path().join("link_to_real")).unwrap();
+
+        let walk = walker()
+            .recursive(true)
+            .follow_symlinks(true)
+            .build()
+            .walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+
+        let file_count = entries
+            .iter()
+            .filter(|e| e.path().file_name().is_some_and(|n| n == "file.txt"))
+            .count();
+        assert_eq!(
+            file_count, 2,
+            "file.txt should appear twice (real_dir/ and link_to_real/)"
+        );
+        assert!(
+            errors.is_empty(),
+            "non-cyclic duplicate should not produce errors"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_cycle_deep_in_subtree() {
+        use tokio::time::{timeout, Duration};
+
+        let dir = tempdir().unwrap();
+        // Clean subtree
+        fs::create_dir(dir.path().join("clean")).unwrap();
+        fs::write(dir.path().join("clean/a.txt"), "").unwrap();
+        // Dirty subtree with x↔y cycle
+        fs::create_dir_all(dir.path().join("dirty/x")).unwrap();
+        fs::create_dir(dir.path().join("dirty/y")).unwrap();
+        std::os::unix::fs::symlink(dir.path().join("dirty/y"), dir.path().join("dirty/x/to_y"))
+            .unwrap();
+        std::os::unix::fs::symlink(dir.path().join("dirty/x"), dir.path().join("dirty/y/to_x"))
+            .unwrap();
+
+        let walk = walker()
+            .recursive(true)
+            .follow_symlinks(true)
+            .build()
+            .walk(ctx(dir.path()));
+        let result = timeout(Duration::from_secs(5), collect_entries(walk)).await;
+        let (entries, errors) = result.expect("walk should terminate");
+
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.relative_path() == Path::new("clean/a.txt")),
+            "clean subtree should be walked"
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.kind() == WalkErrorKind::SymlinkCycle),
+            "dirty subtree should produce SymlinkCycle"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_broken_symlink_at_root_with_follow() {
+        let dir = tempdir().unwrap();
+        let broken_link = dir.path().join("broken_root");
+        std::os::unix::fs::symlink("/nonexistent/target/xyz", &broken_link).unwrap();
+
+        let mut walk = walker()
+            .follow_symlinks(true)
+            .build()
+            .walk(ctx(&broken_link));
+        let first = walk.next().await;
+        match first {
+            Some(Err(err)) => assert!(err.is_fatal(), "broken symlink root should be fatal"),
+            other => panic!("expected fatal error, got {other:?}"),
+        }
+        assert!(walk.next().await.is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_broken_symlink_at_root_with_canonicalize() {
+        let dir = tempdir().unwrap();
+        let broken_link = dir.path().join("broken_root");
+        std::os::unix::fs::symlink("/nonexistent/target/xyz", &broken_link).unwrap();
+
+        let mut walk = walker()
+            .canonicalize_root(true)
+            .build()
+            .walk(ctx(&broken_link));
+        let first = walk.next().await;
+        match first {
+            Some(Err(err)) => assert!(
+                err.is_fatal(),
+                "canonicalize of broken symlink should be fatal"
+            ),
+            other => panic!("expected fatal error, got {other:?}"),
+        }
+        assert!(walk.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_walk_filter_receives_correct_relative_path() {
+        let dir = tempdir().unwrap();
+        fs::create_dir(dir.path().join("sub")).unwrap();
+        fs::write(dir.path().join("top.txt"), "").unwrap();
+        fs::write(dir.path().join("sub/nested.txt"), "").unwrap();
+
+        let collected = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let collected_clone = std::sync::Arc::clone(&collected);
+
+        let walk = walker()
+            .recursive(true)
+            .sort(true)
+            .filter(move |entry| {
+                collected_clone
+                    .lock()
+                    .unwrap()
+                    .push(entry.relative_path().to_owned());
+                true
+            })
+            .build()
+            .walk(ctx(dir.path()));
+        let _ = collect_entries(walk).await;
+
+        let mut paths = collected.lock().unwrap().clone();
+        paths.sort();
+        assert_eq!(
+            paths,
+            vec![PathBuf::from("sub/nested.txt"), PathBuf::from("top.txt")]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_walk_symlink_metadata_is_target() {
+        let dir = tempdir().unwrap();
+        let content = "hello world, this is test content";
+        fs::write(dir.path().join("real.txt"), content).unwrap();
+        std::os::unix::fs::symlink(dir.path().join("real.txt"), dir.path().join("link.txt"))
+            .unwrap();
+
+        let walk = walker()
+            .follow_symlinks(true)
+            .sort(true)
+            .build()
+            .walk(ctx(dir.path()));
+        let (entries, errors) = collect_entries(walk).await;
+        assert!(errors.is_empty());
+
+        let link_entry = entries
+            .iter()
+            .find(|e| e.relative_path() == Path::new("link.txt"))
+            .expect("link.txt should be yielded");
+        assert_eq!(
+            link_entry.metadata().len(),
+            content.len() as u64,
+            "symlink metadata should reflect target file size"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_walk_max_depth_explicit_boundaries() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("top.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("a")).unwrap();
+        fs::write(dir.path().join("a/mid.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("a/b")).unwrap();
+        fs::write(dir.path().join("a/b/deep.txt"), "").unwrap();
+        fs::create_dir(dir.path().join("a/b/c")).unwrap();
+        fs::write(dir.path().join("a/b/c/bottom.txt"), "").unwrap();
+
+        // max_depth(0): only root contents
+        let (e, _) = collect_entries(
+            walker()
+                .max_depth(0)
+                .sort(true)
+                .build()
+                .walk(ctx(dir.path())),
+        )
+        .await;
+        let names: Vec<_> = e
+            .iter()
+            .map(|e| e.relative_path().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(names, vec!["top.txt"]);
+
+        // max_depth(1): root + one level
+        let (e, _) = collect_entries(
+            walker()
+                .max_depth(1)
+                .sort(true)
+                .build()
+                .walk(ctx(dir.path())),
+        )
+        .await;
+        let mut names: Vec<_> = e
+            .iter()
+            .map(|e| e.relative_path().to_string_lossy().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["a/mid.txt", "top.txt"]);
+
+        // max_depth(2): root + two levels
+        let (e, _) = collect_entries(
+            walker()
+                .max_depth(2)
+                .sort(true)
+                .build()
+                .walk(ctx(dir.path())),
+        )
+        .await;
+        let mut names: Vec<_> = e
+            .iter()
+            .map(|e| e.relative_path().to_string_lossy().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(names, vec!["a/b/deep.txt", "a/mid.txt", "top.txt"]);
+
+        // max_depth(3): all files
+        let (e, _) = collect_entries(
+            walker()
+                .max_depth(3)
+                .sort(true)
+                .build()
+                .walk(ctx(dir.path())),
+        )
+        .await;
+        let mut names: Vec<_> = e
+            .iter()
+            .map(|e| e.relative_path().to_string_lossy().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["a/b/c/bottom.txt", "a/b/deep.txt", "a/mid.txt", "top.txt"]
+        );
+    }
+
+    #[test]
+    fn test_fswalker_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<FsWalker>();
+        assert_send_sync::<FsWalk>();
+        assert_send_sync::<FsWalkContext>();
+        assert_send_sync::<FsWalkerBuilder>();
+        assert_send_sync::<FsWalkContextBuilder>();
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
@@ -28,7 +28,7 @@ struct PendingDir {
 ///
 /// Contains all files discovered in the directory (after filter application),
 /// subdirectories to recurse into (subject to `max_depth`), and any non-fatal
-/// per-entry errors encountered during the read.
+/// non-fatal errors encountered during the read.
 struct ReadDirResult {
     /// Files discovered in the directory, after filter application.
     files: Vec<DirEntry>,
@@ -79,11 +79,11 @@ type FilterFn = Box<dyn Fn(&DirEntry) -> bool + Send + Sync>;
 
 /// Configuration for walking a local filesystem directory.
 ///
-/// An `FsWalker` is pure configuration — it describes *what* to look for
-/// and *how* (depth, symlink policy, sorting, filtering) but not *where*.
-/// The walk root is supplied separately via [`FsWalkContext`] when starting
-/// a walk. This separation allows the same configuration to be reused
-/// across multiple walks with different roots.
+/// Configuration for walking a local directory tree.
+///
+/// Describes what to look for and how (depth, symlink policy, sorting,
+/// filtering). The walk root is supplied separately via [`FsWalkContext`]
+/// when starting a walk.
 ///
 /// Use [`FsWalker::builder`] to construct an instance.
 ///
@@ -100,12 +100,12 @@ type FilterFn = Box<dyn Fn(&DirEntry) -> bool + Send + Sync>;
 /// When `follow_symlinks` is enabled, the walker detects symlink cycles
 /// by tracking the chain of directories on the current descent path. A
 /// symlink whose target resolves to a directory already on that path
-/// (including the current directory itself) is reported as a per-entry
+/// (including the current directory itself) is reported as a non-fatal
 /// error with kind `SymlinkCycle` and the walk continues without entering
 /// the cyclic link.
 ///
 /// Non-cyclic duplicate symlinks (two different symlinks pointing to the
-/// same target) are NOT deduplicated. Both are followed and the target's
+/// same target) are not deduplicated. Both are followed and the target's
 /// content is yielded twice. If deduplication is desired, apply it at a
 /// higher layer.
 // TODO(walker): `dir_filter: Option<Box<dyn Fn(&DirEntry) -> bool>>` — subtree
@@ -239,7 +239,7 @@ impl FsWalkerBuilder {
     /// When `false` (default), symlinks are skipped entirely. When `true`,
     /// symlinks are resolved: file symlinks yield entries, directory
     /// symlinks are traversed (subject to `max_depth` and cycle detection),
-    /// and broken symlinks produce per-entry errors.
+    /// and broken symlinks produce non-fatal errors.
     #[must_use]
     pub fn follow_symlinks(mut self, follow: bool) -> Self {
         self.follow_symlinks = follow;
@@ -294,7 +294,7 @@ impl FsWalkerBuilder {
     ///
     /// When `true`, files and subdirectories from each directory read are
     /// sorted by full path. Entries are sorted *within* a directory level
-    /// but not globally — depth-first traversal produces entries
+    /// but not globally. Depth-first traversal produces entries
     /// level-by-level.
     ///
     /// When `false` (default), entries are returned in OS-native order.
@@ -327,7 +327,7 @@ impl FsWalkerBuilder {
     ///
     /// The predicate is called after a file's metadata has been read but
     /// before it is yielded. Returning `false` drops the entry silently.
-    /// The filter does not apply to directories — directory traversal is
+    /// The filter does not apply to directories. Directory traversal is
     /// controlled by `max_depth` and `follow_symlinks`.
     ///
     /// **The filter does not prune subtrees.** A file-level filter that
@@ -407,7 +407,7 @@ impl FsWalkContextBuilder {
 /// needed and buffering discovered files.
 ///
 /// Errors encountered during the walk are interleaved with successful
-/// entries. Fatal errors terminate the walk; per-entry errors do not.
+/// entries. Fatal errors terminate the walk; non-fatal errors do not.
 pub struct FsWalk {
     config: FsWalker,
     root: PathBuf,
@@ -431,14 +431,10 @@ impl FsWalk {
     ///
     /// Returns:
     /// - `Some(Ok(entry))` for a file that passed the filter.
-    /// - `Some(Err(err))` for a fatal or per-entry error. Fatal errors
-    ///   are followed by `None` on the next call; per-entry errors are
+    /// - `Some(Err(err))` for a fatal or non-fatal error. Fatal errors
+    ///   are followed by `None` on the next call; non-fatal errors are
     ///   followed by more results as the walk continues.
     /// - `None` when the walk is complete.
-    ///
-    /// `next` is `async` for API consistency with
-    /// [`S3Walk::next`](super::s3::S3Walk::next); the filesystem
-    /// operations themselves are synchronous.
     pub async fn next(&mut self) -> Option<Result<DirEntry, WalkError>> {
         loop {
             if let Some(entry) = self.ready_files.pop_front() {

--- a/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
@@ -633,6 +633,12 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
+    /// Normalize path separators to `/` for cross-platform test assertions.
+    fn norm(path: &std::path::Path) -> String {
+        path.to_string_lossy()
+            .replace(std::path::MAIN_SEPARATOR, "/")
+    }
+
     async fn collect_entries(mut walk: FsWalk) -> (Vec<DirEntry>, Vec<WalkError>) {
         let mut entries = Vec::new();
         let mut errors = Vec::new();
@@ -653,6 +659,7 @@ mod tests {
         FsWalkContext::builder().root(root).build()
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_flat_directory() {
         let dir = tempdir().unwrap();
@@ -680,6 +687,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_recursive() {
         let dir = tempdir().unwrap();
@@ -694,10 +702,7 @@ mod tests {
         assert!(errors.is_empty());
         assert_eq!(entries.len(), 3);
 
-        let mut names: Vec<_> = entries
-            .iter()
-            .map(|e| e.relative_path().to_string_lossy().to_string())
-            .collect();
+        let mut names: Vec<_> = entries.iter().map(|e| norm(e.relative_path())).collect();
         names.sort();
         assert_eq!(
             names,
@@ -705,6 +710,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_non_recursive_skips_subdirs() {
         let dir = tempdir().unwrap();
@@ -719,6 +725,7 @@ mod tests {
         assert_eq!(entries[0].relative_path(), Path::new("top.txt"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_filter() {
         let dir = tempdir().unwrap();
@@ -742,6 +749,7 @@ mod tests {
         assert_eq!(names, vec![PathBuf::from("a.txt"), PathBuf::from("c.txt")]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_empty_directory() {
         let dir = tempdir().unwrap();
@@ -751,6 +759,7 @@ mod tests {
         assert!(entries.is_empty());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_max_depth() {
         let dir = tempdir().unwrap();
@@ -767,14 +776,12 @@ mod tests {
         assert!(errors.is_empty());
         assert_eq!(entries.len(), 3);
 
-        let mut names: Vec<_> = entries
-            .iter()
-            .map(|e| e.relative_path().to_string_lossy().to_string())
-            .collect();
+        let mut names: Vec<_> = entries.iter().map(|e| norm(e.relative_path())).collect();
         names.sort();
         assert_eq!(names, vec!["a/b/d2.txt", "a/d1.txt", "d0.txt"]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_relative_path_correctness() {
         let dir = tempdir().unwrap();
@@ -789,6 +796,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_follow_symlinks() {
         let dir = tempdir().unwrap();
@@ -803,6 +811,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_no_follow_symlinks() {
         let dir = tempdir().unwrap();
@@ -821,6 +830,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_symlink_cycle_detection() {
         use tokio::time::{timeout, Duration};
@@ -851,6 +861,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_root_does_not_exist() {
         let mut walk = walker()
@@ -871,6 +882,7 @@ mod tests {
         assert!(walk.next().await.is_none());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_recursive_false_equals_max_depth_zero() {
         let dir = tempdir().unwrap();
@@ -890,6 +902,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_broken_symlink_follow() {
         let dir = tempdir().unwrap();
@@ -906,6 +919,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_broken_symlink_no_follow() {
         let dir = tempdir().unwrap();
@@ -924,6 +938,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_symlink_to_file() {
         let dir = tempdir().unwrap();
@@ -941,6 +956,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_symlink_chain() {
         let dir = tempdir().unwrap();
@@ -968,6 +984,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_skips_special_files() {
         use std::os::unix::net::UnixListener;
@@ -985,6 +1002,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_subdirectory_permission_denied() {
         use std::os::unix::fs::PermissionsExt;
@@ -1016,6 +1034,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_source_is_file() {
         let dir = tempdir().unwrap();
@@ -1032,6 +1051,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_source_is_symlink_follow_enabled() {
         let dir = tempdir().unwrap();
@@ -1051,6 +1071,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_source_is_symlink_follow_disabled() {
         let dir = tempdir().unwrap();
@@ -1071,6 +1092,7 @@ mod tests {
         assert_eq!(errors[0].kind(), WalkErrorKind::NotADirectory);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_lexicographic_sort() {
         let dir = tempdir().unwrap();
@@ -1080,13 +1102,11 @@ mod tests {
 
         let walk = walker().sort(true).build().walk(ctx(dir.path()));
         let (entries, _) = collect_entries(walk).await;
-        let names: Vec<_> = entries
-            .iter()
-            .map(|e| e.relative_path().to_string_lossy().to_string())
-            .collect();
+        let names: Vec<_> = entries.iter().map(|e| norm(e.relative_path())).collect();
         assert_eq!(names, vec!["apple.txt", "mango.txt", "zebra.txt"]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_recursive_sort_is_depth_first_per_dir() {
         let dir = tempdir().unwrap();
@@ -1102,16 +1122,14 @@ mod tests {
             .build()
             .walk(ctx(dir.path()));
         let (entries, _) = collect_entries(walk).await;
-        let names: Vec<_> = entries
-            .iter()
-            .map(|e| e.relative_path().to_string_lossy().to_string())
-            .collect();
+        let names: Vec<_> = entries.iter().map(|e| norm(e.relative_path())).collect();
         assert_eq!(
             names,
             vec!["b-file.txt", "c-file.txt", "a-dir/y.txt", "a-dir/z.txt"]
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_unsorted_by_default() {
         let dir = tempdir().unwrap();
@@ -1136,6 +1154,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_unicode_filenames() {
         let dir = tempdir().unwrap();
@@ -1152,16 +1171,14 @@ mod tests {
         );
         assert_eq!(entries.len(), 4);
 
-        let names: Vec<_> = entries
-            .iter()
-            .map(|e| e.relative_path().to_string_lossy().to_string())
-            .collect();
+        let names: Vec<_> = entries.iter().map(|e| norm(e.relative_path())).collect();
         assert!(names.contains(&"café.txt".to_string()));
         assert!(names.contains(&"日本語.txt".to_string()));
         assert!(names.contains(&"🦀.txt".to_string()));
         assert!(names.contains(&"file with spaces.txt".to_string()));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_large_directory() {
         let dir = tempdir().unwrap();
@@ -1175,6 +1192,7 @@ mod tests {
         assert_eq!(entries.len(), 10_000);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_error_kind_not_a_directory() {
         let dir = tempdir().unwrap();
@@ -1193,6 +1211,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_error_kind_symlink_cycle() {
         use tokio::time::{timeout, Duration};
@@ -1224,6 +1243,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_error_kind_broken_symlink() {
         let dir = tempdir().unwrap();
@@ -1239,6 +1259,7 @@ mod tests {
     // --- NEW TESTS ---
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_fswalker_canonicalize_root() {
         let dir = tempdir().unwrap();
@@ -1258,6 +1279,7 @@ mod tests {
         assert_eq!(entries.len(), 1);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_fswalker_canonicalize_root_nonexistent() {
         let mut walk = walker()
@@ -1272,6 +1294,7 @@ mod tests {
         assert!(walk.next().await.is_none());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_fswalker_is_done() {
         let dir = tempdir().unwrap();
@@ -1286,6 +1309,7 @@ mod tests {
     // --- Symlink scenario tests ---
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_symlink_self_loop() {
         let dir = tempdir().unwrap();
@@ -1316,6 +1340,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_symlink_siblings_same_target_both_traversed() {
         let dir = tempdir().unwrap();
@@ -1348,6 +1373,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_symlink_chain_not_cycle() {
         let dir = tempdir().unwrap();
@@ -1376,6 +1402,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_symlink_deeper_cycle() {
         use tokio::time::{timeout, Duration};
@@ -1408,6 +1435,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_real_dir_reachable_via_symlink_yields_twice() {
         let dir = tempdir().unwrap();
@@ -1438,6 +1466,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_cycle_deep_in_subtree() {
         use tokio::time::{timeout, Duration};
@@ -1477,6 +1506,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_broken_symlink_at_root_with_follow() {
         let dir = tempdir().unwrap();
@@ -1496,6 +1526,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_broken_symlink_at_root_with_canonicalize() {
         let dir = tempdir().unwrap();
@@ -1517,6 +1548,7 @@ mod tests {
         assert!(walk.next().await.is_none());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_filter_receives_correct_relative_path() {
         let dir = tempdir().unwrap();
@@ -1550,6 +1582,7 @@ mod tests {
     }
 
     #[cfg(unix)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_symlink_metadata_is_target() {
         let dir = tempdir().unwrap();
@@ -1577,6 +1610,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_walk_max_depth_explicit_boundaries() {
         let dir = tempdir().unwrap();
@@ -1597,10 +1631,7 @@ mod tests {
                 .walk(ctx(dir.path())),
         )
         .await;
-        let names: Vec<_> = e
-            .iter()
-            .map(|e| e.relative_path().to_string_lossy().to_string())
-            .collect();
+        let names: Vec<_> = e.iter().map(|e| norm(e.relative_path())).collect();
         assert_eq!(names, vec!["top.txt"]);
 
         // max_depth(1): root + one level
@@ -1612,10 +1643,7 @@ mod tests {
                 .walk(ctx(dir.path())),
         )
         .await;
-        let mut names: Vec<_> = e
-            .iter()
-            .map(|e| e.relative_path().to_string_lossy().to_string())
-            .collect();
+        let mut names: Vec<_> = e.iter().map(|e| norm(e.relative_path())).collect();
         names.sort();
         assert_eq!(names, vec!["a/mid.txt", "top.txt"]);
 
@@ -1628,10 +1656,7 @@ mod tests {
                 .walk(ctx(dir.path())),
         )
         .await;
-        let mut names: Vec<_> = e
-            .iter()
-            .map(|e| e.relative_path().to_string_lossy().to_string())
-            .collect();
+        let mut names: Vec<_> = e.iter().map(|e| norm(e.relative_path())).collect();
         names.sort();
         assert_eq!(names, vec!["a/b/deep.txt", "a/mid.txt", "top.txt"]);
 
@@ -1644,10 +1669,7 @@ mod tests {
                 .walk(ctx(dir.path())),
         )
         .await;
-        let mut names: Vec<_> = e
-            .iter()
-            .map(|e| e.relative_path().to_string_lossy().to_string())
-            .collect();
+        let mut names: Vec<_> = e.iter().map(|e| norm(e.relative_path())).collect();
         names.sort();
         assert_eq!(
             names,
@@ -1655,6 +1677,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_fswalker_is_send_sync() {
         fn assert_send_sync<T: Send + Sync>() {}

--- a/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
@@ -161,11 +161,9 @@ impl FsWalker {
             match std::fs::canonicalize(&root) {
                 Ok(canonical) => root = canonical,
                 Err(e) => {
-                    let kind = WalkError::classify_io(&e);
                     pending_errors.push_back(WalkError::new(
                         Some(root.clone()),
-                        kind,
-                        true,
+                        WalkErrorKind::SourceUnreadable,
                         Box::new(e),
                     ));
                     done = true;
@@ -177,7 +175,6 @@ impl FsWalker {
                     pending_errors.push_back(WalkError::new(
                         Some(root.clone()),
                         WalkErrorKind::NotADirectory,
-                        true,
                         Box::from("source root is a symlink; enable follow_symlinks or canonicalize_root to walk through it"),
                     ));
                     done = true;
@@ -494,13 +491,27 @@ impl FsWalk {
     ) -> Result<ReadDirResult, WalkError> {
         let entries = std::fs::read_dir(dir).map_err(|e| {
             let kind = WalkError::classify_io(&e);
-            WalkError::new(Some(dir.to_path_buf()), kind, depth == 0, Box::new(e))
+            let kind = if depth == 0
+                && matches!(kind, WalkErrorKind::Io | WalkErrorKind::PermissionDenied)
+            {
+                WalkErrorKind::SourceUnreadable
+            } else {
+                kind
+            };
+            WalkError::new(Some(dir.to_path_buf()), kind, Box::new(e))
         })?;
 
         // Build the ancestor chain for children of this directory.
         let self_handle = Arc::new(Handle::from_path(dir).map_err(|e| {
             let kind = WalkError::classify_io(&e);
-            WalkError::new(Some(dir.to_path_buf()), kind, depth == 0, Box::new(e))
+            let kind = if depth == 0
+                && matches!(kind, WalkErrorKind::Io | WalkErrorKind::PermissionDenied)
+            {
+                WalkErrorKind::SourceUnreadable
+            } else {
+                kind
+            };
+            WalkError::new(Some(dir.to_path_buf()), kind, Box::new(e))
         })?);
         let mut next_ancestors = ancestor_handles.to_vec();
         next_ancestors.push(Arc::clone(&self_handle));
@@ -516,12 +527,9 @@ impl FsWalk {
                 Ok(e) => e,
                 Err(e) => {
                     let kind = WalkError::classify_io(&e);
-                    result.errors.push(WalkError::new(
-                        Some(dir.to_path_buf()),
-                        kind,
-                        false,
-                        Box::new(e),
-                    ));
+                    result
+                        .errors
+                        .push(WalkError::new(Some(dir.to_path_buf()), kind, Box::new(e)));
                     continue;
                 }
             };
@@ -533,7 +541,7 @@ impl FsWalk {
                     let kind = WalkError::classify_io(&e);
                     result
                         .errors
-                        .push(WalkError::new(Some(path), kind, false, Box::new(e)));
+                        .push(WalkError::new(Some(path), kind, Box::new(e)));
                     continue;
                 }
             };
@@ -551,7 +559,7 @@ impl FsWalk {
                         };
                         result
                             .errors
-                            .push(WalkError::new(Some(path), kind, false, Box::new(e)));
+                            .push(WalkError::new(Some(path), kind, Box::new(e)));
                         continue;
                     }
                 };
@@ -565,7 +573,6 @@ impl FsWalk {
                                 result.errors.push(WalkError::new(
                                     Some(path),
                                     WalkErrorKind::SymlinkCycle,
-                                    false,
                                     Box::from("symlink target is an ancestor of the current path"),
                                 ));
                                 continue;
@@ -580,12 +587,9 @@ impl FsWalk {
                         }
                         Err(e) => {
                             let kind = WalkError::classify_io(&e);
-                            result.errors.push(WalkError::new(
-                                Some(path),
-                                kind,
-                                false,
-                                Box::new(e),
-                            ));
+                            result
+                                .errors
+                                .push(WalkError::new(Some(path), kind, Box::new(e)));
                         }
                     }
                 } else if metadata.is_file() {
@@ -598,7 +602,7 @@ impl FsWalk {
                         let kind = WalkError::classify_io(&e);
                         result
                             .errors
-                            .push(WalkError::new(Some(path), kind, false, Box::new(e)));
+                            .push(WalkError::new(Some(path), kind, Box::new(e)));
                         continue;
                     }
                 };
@@ -887,8 +891,8 @@ mod tests {
                 assert!(err.is_fatal(), "expected fatal error for missing root");
                 assert_eq!(
                     err.kind(),
-                    WalkErrorKind::Io,
-                    "NotFound on a non-symlink path should map to Io, not BrokenSymlink"
+                    WalkErrorKind::SourceUnreadable,
+                    "NotFound at the walk root should map to SourceUnreadable"
                 );
             }
             other => panic!("expected fatal error for missing root, got {other:?}"),

--- a/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
@@ -198,6 +198,14 @@ impl FsWalker {
             });
         }
 
+        tracing::debug!(
+            ?root,
+            follow_symlinks = self.follow_symlinks,
+            max_depth = self.max_depth,
+            sort = self.sort,
+            "fs walk started",
+        );
+
         FsWalk {
             config: self,
             root,
@@ -280,10 +288,8 @@ impl FsWalkerBuilder {
     /// - `max_depth(1)` yields `top.txt, a/mid.txt`
     /// - `max_depth(2)` yields `top.txt, a/mid.txt, a/b/deep.txt`
     ///
-    /// This matches the convention where depth counts subdirectory levels
-    /// below the root, but differs from Java's NIO `Files.walk(maxDepth)`
-    /// which counts the root as depth 1
-    /// (so Java's `maxDepth=1` is our `max_depth(0)`).
+    /// Depth counts subdirectory levels below the root. The root's
+    /// immediate contents are always yielded regardless of this setting.
     #[must_use]
     pub fn max_depth(mut self, depth: usize) -> Self {
         self.max_depth = depth;
@@ -355,9 +361,6 @@ impl FsWalkerBuilder {
 }
 
 /// Execution context for an [`FsWalker`], providing the walk root.
-///
-/// Separates the "where" (root directory) from the "how" (walker config),
-/// allowing the same walker configuration to be reused with different roots.
 #[derive(Debug, Clone)]
 pub struct FsWalkContext {
     root: PathBuf,
@@ -441,6 +444,13 @@ impl FsWalk {
                 return Some(Ok(entry));
             }
             if let Some(err) = self.pending_errors.pop_front() {
+                if !err.is_fatal() {
+                    tracing::warn!(
+                        path = ?err.path(),
+                        kind = ?err.kind(),
+                        "skipping entry",
+                    );
+                }
                 return Some(Err(err));
             }
             if self.done {
@@ -606,6 +616,14 @@ impl FsWalk {
             result.files.sort_by(|a, b| a.path.cmp(&b.path));
             result.subdirs.sort_by(|a, b| a.path.cmp(&b.path));
         }
+
+        tracing::trace!(
+            ?dir,
+            files = result.files.len(),
+            subdirs = result.subdirs.len(),
+            errors = result.errors.len(),
+            "directory read",
+        );
 
         Ok(result)
     }

--- a/aws-sdk-s3-transfer-manager/src/io/walk/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/mod.rs
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Walker types for traversing filesystems and S3 buckets.
+
+/// Error types for walk operations.
+pub mod error;
+mod fs;
+mod s3;
+
+pub use error::{WalkError, WalkErrorKind};
+pub use fs::{DirEntry, FsWalk, FsWalkContext, FsWalkContextBuilder, FsWalker, FsWalkerBuilder};
+pub use s3::{S3Walk, S3WalkContext, S3WalkContextBuilder, S3Walker, S3WalkerBuilder};

--- a/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
@@ -97,6 +97,14 @@ impl S3Walker {
         }
 
         let initial_prefix = self.prefix.clone().unwrap_or_default();
+
+        tracing::debug!(
+            bucket = %ctx.bucket.name(),
+            kind = ?ctx.bucket.kind(),
+            prefix = %initial_prefix,
+            delimiter = ?self.delimiter,
+            "s3 walk started",
+        );
         let mut pending_prefixes = VecDeque::new();
         pending_prefixes.push_back(initial_prefix);
 
@@ -231,9 +239,7 @@ impl S3WalkerBuilder {
     }
 }
 
-/// Execution context for an [`S3Walker`], providing the client and bucket.
-///
-/// Separates the "where" (client + bucket) from the "how" (walker config).
+/// The S3 client and bucket for an S3 walk.
 pub struct S3WalkContext {
     client: aws_sdk_s3::Client,
     bucket: crate::types::Bucket,
@@ -350,8 +356,16 @@ impl S3Walk {
                 let first_page = self.initial_first_page_pending;
                 match self.list_page(&prefix, token.as_deref(), first_page).await {
                     Ok(page) => {
-                        // Any subsequent call is no longer the first page.
                         self.initial_first_page_pending = false;
+
+                        tracing::trace!(
+                            %prefix,
+                            objects = page.objects.len(),
+                            common_prefixes = page.common_prefixes.len(),
+                            has_next = page.next_token.is_some(),
+                            "page listed",
+                        );
+
                         self.ready_objects.extend(page.objects);
                         for cp in page.common_prefixes {
                             self.pending_prefixes.push_back(cp);

--- a/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
@@ -463,7 +463,7 @@ impl S3Walk {
         let output = req
             .send()
             .await
-            .map_err(|e| WalkError::new(None, WalkErrorKind::Service, true, Box::new(e)))?;
+            .map_err(|e| WalkError::new(None, WalkErrorKind::Service, Box::new(e)))?;
 
         let mut objects: Vec<Object> = output.contents.unwrap_or_default();
         if let Some(ref filter) = self.config.filter {

--- a/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
@@ -1,0 +1,1005 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::collections::VecDeque;
+
+use aws_sdk_s3::types::Object;
+
+use super::error::{WalkError, WalkErrorKind};
+use crate::types::BucketType;
+
+type FilterFn = Box<dyn Fn(&Object) -> bool + Send + Sync>;
+
+/// Result of listing a single page of S3 objects.
+///
+/// Contains the objects in the page (after filter application), any common
+/// prefixes when a delimiter is set, and a continuation token for the next
+/// page.
+pub(crate) struct ListPageResult {
+    /// Objects returned in this page, after filter application.
+    pub objects: Vec<Object>,
+    /// Common prefixes from the response (populated when a delimiter is set).
+    pub common_prefixes: Vec<String>,
+    /// Continuation token for the next page, or `None` if this is the last.
+    pub next_token: Option<String>,
+}
+
+/// Configuration for walking an S3 bucket by listing objects under a prefix.
+///
+/// An `S3Walker` is pure configuration — it describes *what* to list and
+/// *how* (prefix, delimiter, filter, pagination) but not *where* or *with
+/// what client*. The client and bucket are supplied separately via
+/// [`S3WalkContext`] when starting a walk.
+///
+/// Use [`S3Walker::builder`] to construct an instance.
+///
+/// # Traversal model
+///
+/// The walker issues `ListObjectsV2` requests under a configured prefix.
+/// Each response contributes objects and (when a delimiter is set) common
+/// prefixes representing subdirectories. The walker paginates through the
+/// full object set of each prefix before recursing into common prefixes.
+///
+/// # Error handling
+///
+/// Service errors from `ListObjectsV2` terminate the walk. There are no
+/// per-entry errors — either the page succeeds or the entire page fails.
+// TODO(walker): bucket-kind refuse/warn policy — we detect directory buckets
+//   but don't yet have a configurable refuse policy for sync operations.
+// TODO(walker): resume token persistence — save/restore continuation state
+//   across process restarts.
+pub struct S3Walker {
+    prefix: Option<String>,
+    delimiter: Option<String>,
+    expected_bucket_owner: Option<String>,
+    request_payer: Option<aws_sdk_s3::types::RequestPayer>,
+    filter: Option<FilterFn>,
+    start_after: Option<String>,
+    continuation_token: Option<String>,
+    page_size: Option<i32>,
+}
+
+impl std::fmt::Debug for S3Walker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3Walker")
+            .field("prefix", &self.prefix)
+            .field("delimiter", &self.delimiter)
+            .field("expected_bucket_owner", &self.expected_bucket_owner)
+            .field("request_payer", &self.request_payer)
+            .field("start_after", &self.start_after)
+            .field("continuation_token", &self.continuation_token)
+            .field("page_size", &self.page_size)
+            .finish()
+    }
+}
+
+impl S3Walker {
+    /// Create a builder for configuring an `S3Walker`.
+    #[must_use]
+    pub fn builder() -> S3WalkerBuilder {
+        S3WalkerBuilder::default()
+    }
+
+    /// Start a walk with the given execution context.
+    ///
+    /// Returns an [`S3Walk`] that yields objects via [`next`](S3Walk::next).
+    /// Directory buckets (S3 Express) are detected and logged as a warning
+    /// since they may not return lexicographically sorted listing results.
+    #[must_use]
+    pub fn walk(self, ctx: S3WalkContext) -> S3Walk {
+        let bucket_type = BucketType::from_bucket_name(&ctx.bucket);
+        if bucket_type == BucketType::Express {
+            tracing::warn!(
+                bucket = %ctx.bucket,
+                "directory bucket (S3 Express) detected; listing results may not be lexicographically sorted"
+            );
+        }
+
+        let initial_prefix = self.prefix.clone().unwrap_or_default();
+        let mut pending_prefixes = VecDeque::new();
+        pending_prefixes.push_back(initial_prefix);
+
+        S3Walk {
+            config: self,
+            client: ctx.client,
+            bucket: ctx.bucket,
+            bucket_type,
+            pending_prefixes,
+            ready_objects: VecDeque::new(),
+            current_prefix: None,
+            next_token: None,
+            done: false,
+            initial_first_page_pending: true,
+        }
+    }
+}
+
+/// Builder for [`S3Walker`].
+///
+/// All fields are optional with sensible defaults: no prefix, no delimiter,
+/// no filter, no pagination overrides.
+#[derive(Default)]
+pub struct S3WalkerBuilder {
+    prefix: Option<String>,
+    delimiter: Option<String>,
+    expected_bucket_owner: Option<String>,
+    request_payer: Option<aws_sdk_s3::types::RequestPayer>,
+    filter: Option<FilterFn>,
+    start_after: Option<String>,
+    continuation_token: Option<String>,
+    page_size: Option<i32>,
+}
+
+impl std::fmt::Debug for S3WalkerBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3WalkerBuilder")
+            .field("prefix", &self.prefix)
+            .field("delimiter", &self.delimiter)
+            .finish()
+    }
+}
+
+impl S3WalkerBuilder {
+    /// Restrict listing to keys beginning with the given prefix.
+    ///
+    /// When unset, the walker lists all objects in the bucket.
+    #[must_use]
+    pub fn prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefix = Some(prefix.into());
+        self
+    }
+
+    /// Group keys by a delimiter, enabling recursive traversal.
+    ///
+    /// Typically set to `/` to traverse S3 as if it were a directory tree.
+    /// When unset (default), all objects are returned in a flat list.
+    #[must_use]
+    pub fn delimiter(mut self, delimiter: impl Into<String>) -> Self {
+        self.delimiter = Some(delimiter.into());
+        self
+    }
+
+    /// Set the expected bucket owner account ID.
+    ///
+    /// When set, `ListObjectsV2` requests fail with `AccessDenied` if the
+    /// bucket's actual owner doesn't match.
+    #[must_use]
+    pub fn expected_bucket_owner(mut self, owner: impl Into<String>) -> Self {
+        self.expected_bucket_owner = Some(owner.into());
+        self
+    }
+
+    /// Set the request-payer preference for Requester-Pays buckets.
+    #[must_use]
+    pub fn request_payer(mut self, payer: aws_sdk_s3::types::RequestPayer) -> Self {
+        self.request_payer = Some(payer);
+        self
+    }
+
+    /// Set a filter predicate applied to each discovered object.
+    ///
+    /// Returning `false` drops the object silently.
+    #[must_use]
+    pub fn filter(mut self, f: impl Fn(&Object) -> bool + Send + Sync + 'static) -> Self {
+        self.filter = Some(Box::new(f));
+        self
+    }
+
+    /// Resume listing after the given key.
+    ///
+    /// Maps to the `StartAfter` parameter of `ListObjectsV2`. Only applied
+    /// to the initial prefix listing (not to recursed common prefixes).
+    #[must_use]
+    pub fn start_after(mut self, key: impl Into<String>) -> Self {
+        self.start_after = Some(key.into());
+        self
+    }
+
+    /// Resume listing from a specific continuation token.
+    ///
+    /// Maps to the `ContinuationToken` parameter of `ListObjectsV2`. Only
+    /// applied to the first request of the initial prefix.
+    #[must_use]
+    pub fn continuation_token(mut self, token: impl Into<String>) -> Self {
+        self.continuation_token = Some(token.into());
+        self
+    }
+
+    /// Override the server default page size (max keys per response).
+    ///
+    /// Maps to the `MaxKeys` parameter of `ListObjectsV2`. Useful for
+    /// tuning small-object workloads. Default is the server default (1000).
+    #[must_use]
+    pub fn page_size(mut self, n: i32) -> Self {
+        self.page_size = Some(n);
+        self
+    }
+
+    /// Build the [`S3Walker`] configuration.
+    #[must_use]
+    pub fn build(self) -> S3Walker {
+        S3Walker {
+            prefix: self.prefix,
+            delimiter: self.delimiter,
+            expected_bucket_owner: self.expected_bucket_owner,
+            request_payer: self.request_payer,
+            filter: self.filter,
+            start_after: self.start_after,
+            continuation_token: self.continuation_token,
+            page_size: self.page_size,
+        }
+    }
+}
+
+/// Execution context for an [`S3Walker`], providing the client and bucket.
+///
+/// Separates the "where" (client + bucket) from the "how" (walker config).
+pub struct S3WalkContext {
+    client: aws_sdk_s3::Client,
+    bucket: String,
+}
+
+impl std::fmt::Debug for S3WalkContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3WalkContext")
+            .field("bucket", &self.bucket)
+            .finish()
+    }
+}
+
+impl S3WalkContext {
+    /// Create a builder for an `S3WalkContext`.
+    #[must_use]
+    pub fn builder() -> S3WalkContextBuilder {
+        S3WalkContextBuilder {
+            client: None,
+            bucket: None,
+        }
+    }
+}
+
+/// Builder for [`S3WalkContext`].
+#[derive(Debug, Default)]
+pub struct S3WalkContextBuilder {
+    client: Option<aws_sdk_s3::Client>,
+    bucket: Option<String>,
+}
+
+impl S3WalkContextBuilder {
+    /// Set the S3 client to use for listing.
+    ///
+    /// This field is required.
+    #[must_use]
+    pub fn client(mut self, client: aws_sdk_s3::Client) -> Self {
+        self.client = Some(client);
+        self
+    }
+
+    /// Set the bucket to list.
+    ///
+    /// This field is required.
+    #[must_use]
+    pub fn bucket(mut self, bucket: impl Into<String>) -> Self {
+        self.bucket = Some(bucket.into());
+        self
+    }
+
+    /// Build the [`S3WalkContext`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `client` or `bucket` has not been set.
+    #[must_use]
+    pub fn build(self) -> S3WalkContext {
+        S3WalkContext {
+            client: self.client.expect("required field `client` should be set"),
+            bucket: self.bucket.expect("required field `bucket` should be set"),
+        }
+    }
+}
+
+/// A running S3 walk, yielding objects from a bucket listing.
+///
+/// Created by [`S3Walker::walk`]. The walk pages through the bucket,
+/// buffering objects and yielding them via [`next`](Self::next).
+pub struct S3Walk {
+    config: S3Walker,
+    client: aws_sdk_s3::Client,
+    bucket: String,
+    bucket_type: BucketType,
+    pending_prefixes: VecDeque<String>,
+    ready_objects: VecDeque<Object>,
+    current_prefix: Option<String>,
+    next_token: Option<String>,
+    done: bool,
+    /// Whether the next `list_page` call is the first request of the initial
+    /// prefix. Used to gate `continuation_token` and `start_after` config
+    /// (which only apply to the very first request).
+    initial_first_page_pending: bool,
+}
+
+impl std::fmt::Debug for S3Walk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3Walk")
+            .field("bucket", &self.bucket)
+            .field("done", &self.done)
+            .finish()
+    }
+}
+
+impl S3Walk {
+    /// Return the next object from the walk.
+    ///
+    /// Returns:
+    /// - `Some(Ok(object))` for an object that passed the filter.
+    /// - `Some(Err(err))` when a `ListObjectsV2` request fails. The walk
+    ///   terminates after an error — subsequent calls return `None`.
+    /// - `None` when the walk is complete.
+    pub async fn next(&mut self) -> Option<Result<Object, WalkError>> {
+        loop {
+            if let Some(obj) = self.ready_objects.pop_front() {
+                return Some(Ok(obj));
+            }
+            if self.done {
+                return None;
+            }
+
+            if let Some(prefix) = &self.current_prefix {
+                let prefix = prefix.clone();
+                let token = self.next_token.take();
+                let first_page = self.initial_first_page_pending;
+                match self.list_page(&prefix, token.as_deref(), first_page).await {
+                    Ok(page) => {
+                        // Any subsequent call is no longer the first page.
+                        self.initial_first_page_pending = false;
+                        self.ready_objects.extend(page.objects);
+                        for cp in page.common_prefixes {
+                            self.pending_prefixes.push_back(cp);
+                        }
+                        if page.next_token.is_some() {
+                            self.next_token = page.next_token;
+                            self.current_prefix = Some(prefix);
+                        } else {
+                            self.current_prefix = None;
+                        }
+                    }
+                    Err(e) => {
+                        self.done = true;
+                        return Some(Err(e));
+                    }
+                }
+                continue;
+            }
+
+            match self.pending_prefixes.pop_front() {
+                Some(prefix) => {
+                    self.current_prefix = Some(prefix);
+                }
+                None => {
+                    self.done = true;
+                    return None;
+                }
+            }
+        }
+    }
+
+    /// Whether the walk has finished (no more objects will be produced).
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    /// Whether the target bucket is a directory bucket (S3 Express).
+    ///
+    /// Directory buckets may not return lexicographically sorted listing
+    /// results, which can affect sync operations that depend on key ordering.
+    pub fn is_directory_bucket(&self) -> bool {
+        self.bucket_type == BucketType::Express
+    }
+
+    async fn list_page(
+        &self,
+        prefix: &str,
+        token: Option<&str>,
+        first_page_of_initial_prefix: bool,
+    ) -> Result<ListPageResult, WalkError> {
+        let mut req = self
+            .client
+            .list_objects_v2()
+            .bucket(&self.bucket)
+            .prefix(prefix);
+
+        // Runtime pagination token for this page. When a caller-supplied
+        // continuation_token is configured AND this is the first request
+        // of the initial prefix, the configured token takes precedence
+        // (resume use case). Otherwise, use the pagination token from the
+        // previous page response.
+        let effective_token = if first_page_of_initial_prefix {
+            self.config.continuation_token.as_deref().or(token)
+        } else {
+            token
+        };
+        if let Some(t) = effective_token {
+            req = req.continuation_token(t);
+        }
+
+        // start_after is only meaningful on the very first request of the
+        // initial prefix and is ignored by S3 whenever a continuation token
+        // is present.
+        if first_page_of_initial_prefix {
+            if let Some(start_after) = &self.config.start_after {
+                if effective_token.is_none() {
+                    req = req.start_after(start_after);
+                }
+            }
+        }
+
+        if let Some(delimiter) = &self.config.delimiter {
+            req = req.delimiter(delimiter);
+        }
+        if let Some(owner) = &self.config.expected_bucket_owner {
+            req = req.expected_bucket_owner(owner);
+        }
+        if let Some(payer) = &self.config.request_payer {
+            req = req.request_payer(payer.clone());
+        }
+        if let Some(page_size) = self.config.page_size {
+            req = req.max_keys(page_size);
+        }
+
+        let output = req
+            .send()
+            .await
+            .map_err(|e| WalkError::new(None, WalkErrorKind::Service, true, Box::new(e)))?;
+
+        let mut objects: Vec<Object> = output.contents.unwrap_or_default();
+        if let Some(ref filter) = self.config.filter {
+            objects.retain(filter);
+        }
+
+        let common_prefixes = output
+            .common_prefixes
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|cp| cp.prefix)
+            .collect();
+
+        Ok(ListPageResult {
+            objects,
+            common_prefixes,
+            next_token: output.next_continuation_token,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output;
+    use aws_sdk_s3::types::{CommonPrefix, Object};
+    use aws_smithy_mocks::{mock, mock_client, RuleMode};
+
+    fn walker() -> S3WalkerBuilder {
+        S3Walker::builder()
+    }
+
+    fn s3ctx(client: aws_sdk_s3::Client, bucket: impl Into<String>) -> S3WalkContext {
+        S3WalkContext::builder()
+            .client(client)
+            .bucket(bucket)
+            .build()
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_list_single_page() {
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![
+                    Object::builder().key("a.txt").build(),
+                    Object::builder().key("b.txt").build(),
+                    Object::builder().key("c.txt").build(),
+                ]))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker()
+            .prefix("prefix/")
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["a.txt", "b.txt", "c.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_list_with_pagination() {
+        let page1 = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .is_truncated(true)
+                .next_continuation_token("token1")
+                .set_contents(Some(vec![
+                    Object::builder().key("a.txt").build(),
+                    Object::builder().key("b.txt").build(),
+                ]))
+                .build()
+        });
+        let page2 = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![Object::builder().key("c.txt").build()]))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&page1, &page2]);
+
+        let mut walk = walker().build().walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["a.txt", "b.txt", "c.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_list_with_filter() {
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![
+                    Object::builder().key("file.txt").build(),
+                    Object::builder().key("folder/").build(),
+                    Object::builder().key("other.txt").build(),
+                ]))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker()
+            .filter(|obj| !obj.key().unwrap_or("").ends_with('/'))
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["file.txt", "other.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_list_empty_prefix() {
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .then_output(|| ListObjectsV2Output::builder().build());
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker()
+            .prefix("empty/")
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+        assert!(walk.next().await.is_none());
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_list_with_common_prefixes() {
+        let root_page = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![Object::builder().key("root.txt").build()]))
+                .set_common_prefixes(Some(vec![
+                    CommonPrefix::builder().prefix("sub1/").build(),
+                    CommonPrefix::builder().prefix("sub2/").build(),
+                ]))
+                .build()
+        });
+        let sub1_page = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![Object::builder().key("sub1/a.txt").build()]))
+                .build()
+        });
+        let sub2_page = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![Object::builder().key("sub2/b.txt").build()]))
+                .build()
+        });
+        let client = mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[&root_page, &sub1_page, &sub2_page]
+        );
+
+        let mut walk = walker()
+            .delimiter("/")
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["root.txt", "sub1/a.txt", "sub2/b.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_list_service_error_terminates_walk() {
+        use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error;
+        use aws_smithy_types::error::metadata::ErrorMetadata;
+
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_error(|| {
+            ListObjectsV2Error::generic(ErrorMetadata::builder().code("NoSuchBucket").build())
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker().build().walk(s3ctx(client, "missing-bucket"));
+
+        let first = walk.next().await;
+        assert!(matches!(first, Some(Err(_))), "expected service error");
+        assert!(walk.next().await.is_none());
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_list_pagination_across_common_prefix() {
+        let root_page = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![Object::builder().key("root.txt").build()]))
+                .set_common_prefixes(Some(vec![CommonPrefix::builder().prefix("sub/").build()]))
+                .build()
+        });
+        let sub_page1 = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .is_truncated(true)
+                .next_continuation_token("tok")
+                .set_contents(Some(vec![
+                    Object::builder().key("sub/a.txt").build(),
+                    Object::builder().key("sub/b.txt").build(),
+                ]))
+                .build()
+        });
+        let sub_page2 = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![Object::builder().key("sub/c.txt").build()]))
+                .build()
+        });
+        let client = mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[&root_page, &sub_page1, &sub_page2]
+        );
+
+        let mut walk = walker()
+            .delimiter("/")
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(
+            keys,
+            vec!["root.txt", "sub/a.txt", "sub/b.txt", "sub/c.txt"]
+        );
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_list_delimiter_without_common_prefixes() {
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![
+                    Object::builder().key("a.txt").build(),
+                    Object::builder().key("b.txt").build(),
+                ]))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker()
+            .delimiter("/")
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["a.txt", "b.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_list_no_delimiter_no_recursion() {
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![
+                    Object::builder().key("a.txt").build(),
+                    Object::builder().key("sub/b.txt").build(),
+                    Object::builder().key("sub/c.txt").build(),
+                ]))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker().build().walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["a.txt", "sub/b.txt", "sub/c.txt"]);
+    }
+
+    // --- NEW TESTS ---
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_s3walker_start_after() {
+        // start_after should propagate to ListObjectsV2; the mock returns
+        // only objects "after" the start key.
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![
+                    Object::builder().key("c.txt").build(),
+                    Object::builder().key("d.txt").build(),
+                ]))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker()
+            .start_after("b.txt")
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["c.txt", "d.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_s3walker_page_size() {
+        // page_size propagates as max_keys; mock returns a single-item page
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![Object::builder().key("only.txt").build()]))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker()
+            .page_size(1)
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["only.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_s3walker_expected_bucket_owner() {
+        // expected_bucket_owner propagates; mock just returns success
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(vec![Object::builder().key("a.txt").build()]))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker()
+            .expected_bucket_owner("123456789012")
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["a.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_s3walker_is_directory_bucket() {
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .then_output(|| ListObjectsV2Output::builder().build());
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule, &rule]);
+
+        // Express bucket name ends with --x-s3
+        let walk_express = walker()
+            .build()
+            .walk(s3ctx(client.clone(), "my-bucket--usw2-az1--x-s3"));
+        assert!(walk_express.is_directory_bucket());
+
+        // Standard bucket
+        let walk_standard = walker().build().walk(s3ctx(client, "my-normal-bucket"));
+        assert!(!walk_standard.is_directory_bucket());
+    }
+
+    /// Regression test: configured `continuation_token` must only apply to
+    /// the first request. On pagination, subsequent requests must use the
+    /// server's continuation token, not the original one (which would cause
+    /// an infinite loop).
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_s3walker_continuation_token_only_on_first_page() {
+        // First call: expect the configured token "resume-here"; return a page
+        // with server continuation token "server-next".
+        let first = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .match_requests(|req| req.continuation_token() == Some("resume-here"))
+            .then_output(|| {
+                ListObjectsV2Output::builder()
+                    .is_truncated(true)
+                    .next_continuation_token("server-next")
+                    .set_contents(Some(vec![Object::builder().key("a.txt").build()]))
+                    .build()
+            });
+        // Second call: must use "server-next", NOT "resume-here".
+        let second = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .match_requests(|req| req.continuation_token() == Some("server-next"))
+            .then_output(|| {
+                ListObjectsV2Output::builder()
+                    .set_contents(Some(vec![Object::builder().key("b.txt").build()]))
+                    .build()
+            });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&first, &second]);
+
+        let mut walk = walker()
+            .continuation_token("resume-here")
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["a.txt", "b.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_s3walker_prefix_propagates() {
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .match_requests(|req| req.prefix() == Some("my-prefix/"))
+            .then_output(|| {
+                ListObjectsV2Output::builder()
+                    .set_contents(Some(vec![Object::builder().key("my-prefix/a.txt").build()]))
+                    .build()
+            });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker()
+            .prefix("my-prefix/")
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["my-prefix/a.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_s3walker_request_payer_propagates() {
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .match_requests(|req| {
+                req.request_payer() == Some(&aws_sdk_s3::types::RequestPayer::Requester)
+            })
+            .then_output(|| {
+                ListObjectsV2Output::builder()
+                    .set_contents(Some(vec![Object::builder().key("a.txt").build()]))
+                    .build()
+            });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker()
+            .request_payer(aws_sdk_s3::types::RequestPayer::Requester)
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["a.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_s3walker_delimiter_propagates_on_recursed_prefixes() {
+        let root = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .match_requests(|req| req.delimiter() == Some("/") && req.prefix() == Some(""))
+            .then_output(|| {
+                ListObjectsV2Output::builder()
+                    .set_common_prefixes(Some(vec![CommonPrefix::builder().prefix("a/").build()]))
+                    .build()
+            });
+        let a_page = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .match_requests(|req| req.delimiter() == Some("/") && req.prefix() == Some("a/"))
+            .then_output(|| {
+                ListObjectsV2Output::builder()
+                    .set_contents(Some(vec![Object::builder().key("a/file.txt").build()]))
+                    .set_common_prefixes(Some(vec![CommonPrefix::builder().prefix("a/b/").build()]))
+                    .build()
+            });
+        let ab_page = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .match_requests(|req| req.delimiter() == Some("/") && req.prefix() == Some("a/b/"))
+            .then_output(|| {
+                ListObjectsV2Output::builder()
+                    .set_contents(Some(vec![Object::builder().key("a/b/file.txt").build()]))
+                    .set_common_prefixes(Some(vec![CommonPrefix::builder()
+                        .prefix("a/b/c/")
+                        .build()]))
+                    .build()
+            });
+        let abc_page = mock!(aws_sdk_s3::Client::list_objects_v2)
+            .match_requests(|req| req.delimiter() == Some("/") && req.prefix() == Some("a/b/c/"))
+            .then_output(|| {
+                ListObjectsV2Output::builder()
+                    .set_contents(Some(vec![Object::builder().key("a/b/c/file.txt").build()]))
+                    .build()
+            });
+        let client = mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[&root, &a_page, &ab_page, &abc_page]
+        );
+
+        let mut walk = walker()
+            .delimiter("/")
+            .build()
+            .walk(s3ctx(client, "test-bucket"));
+
+        let mut keys = Vec::new();
+        while let Some(result) = walk.next().await {
+            keys.push(result.unwrap().key.unwrap());
+        }
+        assert_eq!(keys, vec!["a/file.txt", "a/b/file.txt", "a/b/c/file.txt"]);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_s3walker_empty_contents_none() {
+        let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
+            ListObjectsV2Output::builder()
+                // contents is None, not Some(vec![])
+                .build()
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::Sequential, &[&rule]);
+
+        let mut walk = walker().build().walk(s3ctx(client, "test-bucket"));
+
+        let mut count = 0;
+        while let Some(result) = walk.next().await {
+            result.unwrap();
+            count += 1;
+        }
+        assert_eq!(count, 0, "None contents should yield zero objects");
+    }
+
+    #[test]
+    fn test_s3walker_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<S3Walker>();
+        assert_send_sync::<S3Walk>();
+        assert_send_sync::<S3WalkContext>();
+        assert_send_sync::<S3WalkerBuilder>();
+        assert_send_sync::<S3WalkContextBuilder>();
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
@@ -492,7 +492,6 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_single_page() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
@@ -518,7 +517,6 @@ mod tests {
         assert_eq!(keys, vec!["a.txt", "b.txt", "c.txt"]);
     }
 
-    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_with_pagination() {
@@ -549,7 +547,6 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_with_filter() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
@@ -576,7 +573,6 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_empty_prefix() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2)
@@ -590,7 +586,6 @@ mod tests {
         assert!(walk.next().await.is_none());
     }
 
-    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_with_common_prefixes() {
@@ -632,7 +627,6 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_service_error_terminates_walk() {
         use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error;
@@ -650,7 +644,6 @@ mod tests {
         assert!(walk.next().await.is_none());
     }
 
-    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_pagination_across_common_prefix() {
@@ -697,7 +690,6 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_delimiter_without_common_prefixes() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
@@ -723,7 +715,6 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_no_delimiter_no_recursion() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
@@ -748,7 +739,6 @@ mod tests {
 
     // --- NEW TESTS ---
 
-    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_start_after() {
@@ -777,7 +767,6 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_page_size() {
         // page_size propagates as max_keys; mock returns a single-item page
@@ -800,7 +789,6 @@ mod tests {
         assert_eq!(keys, vec!["only.txt"]);
     }
 
-    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_expected_bucket_owner() {
@@ -825,7 +813,6 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_is_directory_bucket() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2)
@@ -847,7 +834,6 @@ mod tests {
     /// the first request. On pagination, subsequent requests must use the
     /// server's continuation token, not the original one (which would cause
     /// an infinite loop).
-    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_continuation_token_only_on_first_page() {
@@ -885,7 +871,6 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
-    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_prefix_propagates() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2)
@@ -909,7 +894,6 @@ mod tests {
         assert_eq!(keys, vec!["my-prefix/a.txt"]);
     }
 
-    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_request_payer_propagates() {
@@ -936,7 +920,6 @@ mod tests {
         assert_eq!(keys, vec!["a.txt"]);
     }
 
-    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_delimiter_propagates_on_recursed_prefixes() {
@@ -990,7 +973,6 @@ mod tests {
         assert_eq!(keys, vec!["a/file.txt", "a/b/file.txt", "a/b/c/file.txt"]);
     }
 
-    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_empty_contents_none() {

--- a/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
@@ -492,6 +492,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_single_page() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
@@ -517,6 +518,7 @@ mod tests {
         assert_eq!(keys, vec!["a.txt", "b.txt", "c.txt"]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_with_pagination() {
@@ -547,6 +549,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_with_filter() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
@@ -573,6 +576,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_empty_prefix() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2)
@@ -586,6 +590,7 @@ mod tests {
         assert!(walk.next().await.is_none());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_with_common_prefixes() {
@@ -627,6 +632,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_service_error_terminates_walk() {
         use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error;
@@ -644,6 +650,7 @@ mod tests {
         assert!(walk.next().await.is_none());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_pagination_across_common_prefix() {
@@ -690,6 +697,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_delimiter_without_common_prefixes() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
@@ -715,6 +723,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_list_no_delimiter_no_recursion() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(|| {
@@ -739,6 +748,7 @@ mod tests {
 
     // --- NEW TESTS ---
 
+    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_start_after() {
@@ -767,6 +777,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_page_size() {
         // page_size propagates as max_keys; mock returns a single-item page
@@ -789,6 +800,7 @@ mod tests {
         assert_eq!(keys, vec!["only.txt"]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_expected_bucket_owner() {
@@ -813,6 +825,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_is_directory_bucket() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2)
@@ -834,6 +847,7 @@ mod tests {
     /// the first request. On pagination, subsequent requests must use the
     /// server's continuation token, not the original one (which would cause
     /// an infinite loop).
+    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_continuation_token_only_on_first_page() {
@@ -871,6 +885,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_prefix_propagates() {
         let rule = mock!(aws_sdk_s3::Client::list_objects_v2)
@@ -894,6 +909,7 @@ mod tests {
         assert_eq!(keys, vec!["my-prefix/a.txt"]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_request_payer_propagates() {
@@ -920,6 +936,7 @@ mod tests {
         assert_eq!(keys, vec!["a.txt"]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_delimiter_propagates_on_recursed_prefixes() {
@@ -973,6 +990,7 @@ mod tests {
         assert_eq!(keys, vec!["a/file.txt", "a/b/file.txt", "a/b/c/file.txt"]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_s3walker_empty_contents_none() {

--- a/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
@@ -19,18 +19,17 @@ type FilterFn = Box<dyn Fn(&Object) -> bool + Send + Sync>;
 /// page.
 pub(crate) struct ListPageResult {
     /// Objects returned in this page, after filter application.
-    pub objects: Vec<Object>,
+    pub(crate) objects: Vec<Object>,
     /// Common prefixes from the response (populated when a delimiter is set).
-    pub common_prefixes: Vec<String>,
+    pub(crate) common_prefixes: Vec<String>,
     /// Continuation token for the next page, or `None` if this is the last.
-    pub next_token: Option<String>,
+    pub(crate) next_token: Option<String>,
 }
 
 /// Configuration for walking an S3 bucket by listing objects under a prefix.
 ///
-/// An `S3Walker` is pure configuration — it describes *what* to list and
-/// *how* (prefix, delimiter, filter, pagination) but not *where* or *with
-/// what client*. The client and bucket are supplied separately via
+/// Describes what to list and how (prefix, delimiter, filter, pagination).
+/// The S3 client and bucket name are supplied separately via
 /// [`S3WalkContext`] when starting a walk.
 ///
 /// Use [`S3Walker::builder`] to construct an instance.
@@ -45,7 +44,7 @@ pub(crate) struct ListPageResult {
 /// # Error handling
 ///
 /// Service errors from `ListObjectsV2` terminate the walk. There are no
-/// per-entry errors — either the page succeeds or the entire page fails.
+/// non-fatal errors; either the page succeeds or the entire walk fails.
 // TODO(walker): bucket-kind refuse/warn policy — we detect directory buckets
 //   but don't yet have a configurable refuse policy for sync operations.
 // TODO(walker): resume token persistence — save/restore continuation state
@@ -89,11 +88,11 @@ impl S3Walker {
     /// since they may not return lexicographically sorted listing results.
     #[must_use]
     pub fn walk(self, ctx: S3WalkContext) -> S3Walk {
-        let bucket_type = BucketType::from_bucket_name(&ctx.bucket);
-        if bucket_type == BucketType::Express {
+        if ctx.bucket.kind() == BucketType::Express {
             tracing::warn!(
-                bucket = %ctx.bucket,
-                "directory bucket (S3 Express) detected; listing results may not be lexicographically sorted"
+                bucket = %ctx.bucket.name(),
+                kind = ?ctx.bucket.kind(),
+                "directory bucket detected; listing results may not be lexicographically sorted"
             );
         }
 
@@ -105,7 +104,6 @@ impl S3Walker {
             config: self,
             client: ctx.client,
             bucket: ctx.bucket,
-            bucket_type,
             pending_prefixes,
             ready_objects: VecDeque::new(),
             current_prefix: None,
@@ -238,7 +236,7 @@ impl S3WalkerBuilder {
 /// Separates the "where" (client + bucket) from the "how" (walker config).
 pub struct S3WalkContext {
     client: aws_sdk_s3::Client,
-    bucket: String,
+    bucket: crate::types::Bucket,
 }
 
 impl std::fmt::Debug for S3WalkContext {
@@ -293,9 +291,10 @@ impl S3WalkContextBuilder {
     /// Panics if `client` or `bucket` has not been set.
     #[must_use]
     pub fn build(self) -> S3WalkContext {
+        let bucket_name = self.bucket.expect("required field `bucket` should be set");
         S3WalkContext {
             client: self.client.expect("required field `client` should be set"),
-            bucket: self.bucket.expect("required field `bucket` should be set"),
+            bucket: crate::types::Bucket::new(bucket_name),
         }
     }
 }
@@ -307,8 +306,7 @@ impl S3WalkContextBuilder {
 pub struct S3Walk {
     config: S3Walker,
     client: aws_sdk_s3::Client,
-    bucket: String,
-    bucket_type: BucketType,
+    bucket: crate::types::Bucket,
     pending_prefixes: VecDeque<String>,
     ready_objects: VecDeque<Object>,
     current_prefix: Option<String>,
@@ -335,7 +333,7 @@ impl S3Walk {
     /// Returns:
     /// - `Some(Ok(object))` for an object that passed the filter.
     /// - `Some(Err(err))` when a `ListObjectsV2` request fails. The walk
-    ///   terminates after an error — subsequent calls return `None`.
+    ///   terminates after an error; subsequent calls return `None`.
     /// - `None` when the walk is complete.
     pub async fn next(&mut self) -> Option<Result<Object, WalkError>> {
         loop {
@@ -395,7 +393,7 @@ impl S3Walk {
     /// Directory buckets may not return lexicographically sorted listing
     /// results, which can affect sync operations that depend on key ordering.
     pub fn is_directory_bucket(&self) -> bool {
-        self.bucket_type == BucketType::Express
+        self.bucket.kind() == BucketType::Express
     }
 
     async fn list_page(
@@ -407,7 +405,7 @@ impl S3Walk {
         let mut req = self
             .client
             .list_objects_v2()
-            .bucket(&self.bucket)
+            .bucket(self.bucket.name())
             .prefix(prefix);
 
         // Runtime pagination token for this page. When a caller-supplied

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -368,6 +368,10 @@ impl Drop for BodySlot {
 }
 
 impl BodyWriter {
+    pub(crate) fn has_sink(&self) -> bool {
+        self.buffer.sink.is_some()
+    }
+
     /// Try to claim the next slot for work generation.
     ///
     /// Returns `None` if the seq window is exhausted

--- a/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
@@ -78,7 +78,7 @@ impl DownloadHandleInner {
             .object_meta()
             .expect("object_meta must be set on successful completion")
             .clone();
-        Ok(DownloadOutput::new(object_meta))
+        Ok(DownloadOutput::new(object_meta, ctx.metrics()))
     }
 
     /// Core abort logic: cancel transfer, notify consumer, and wait for idle.
@@ -236,6 +236,16 @@ impl DownloadHandle {
     pub fn scheduling(&self) -> crate::transfer::SchedulingCtl<'_> {
         self.inner.scheduling()
     }
+
+    /// Current status of this transfer.
+    pub fn status(&self) -> crate::types::TransferStatus {
+        self.inner.transfer.ctx().transfer_status()
+    }
+
+    /// Snapshot of current transfer metrics.
+    pub fn metrics(&self) -> crate::types::TransferMetrics {
+        self.inner.transfer.ctx().metrics()
+    }
 }
 
 impl Drop for DownloadHandle {
@@ -334,6 +344,16 @@ impl ManagedDownloadHandle {
     /// Get scheduling controls for this transfer.
     pub fn scheduling(&self) -> crate::transfer::SchedulingCtl<'_> {
         self.inner.scheduling()
+    }
+
+    /// Current status of this transfer.
+    pub fn status(&self) -> crate::types::TransferStatus {
+        self.inner.transfer.ctx().transfer_status()
+    }
+
+    /// Snapshot of current transfer metrics.
+    pub fn metrics(&self) -> crate::types::TransferMetrics {
+        self.inner.transfer.ctx().metrics()
     }
 
     async fn finalize(&self) -> std::io::Result<()> {

--- a/aws-sdk-s3-transfer-manager/src/operation/download/output.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/output.rs
@@ -6,15 +6,22 @@
 use super::object_meta::ObjectMetadata;
 
 /// Output from a completed download operation.
+// FIXME: join() should return a wrapper type that always carries TransferMetrics
+// regardless of success/failure. For now, metrics are only available on success.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct DownloadOutput {
     /// Object metadata from the download
     pub object_meta: ObjectMetadata,
+    /// Snapshot of transfer metrics at completion.
+    pub metrics: crate::types::TransferMetrics,
 }
 
 impl DownloadOutput {
-    pub(crate) fn new(object_meta: ObjectMetadata) -> Self {
-        Self { object_meta }
+    pub(crate) fn new(object_meta: ObjectMetadata, metrics: crate::types::TransferMetrics) -> Self {
+        Self {
+            object_meta,
+            metrics,
+        }
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -361,7 +361,6 @@ impl DownloadTransfer {
             let guard = self.inner.state.lock().unwrap();
             return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
         }
-        self.decrement_in_flight();
 
         // disk_write reflects bytes committed to the file sink buffer.
         // Actual disk flushes are batched; disk_write may lead physical
@@ -375,6 +374,8 @@ impl DownloadTransfer {
             },
             ..Default::default()
         });
+
+        self.decrement_in_flight();
 
         WorkOutcome::Success { data: None }
     }
@@ -456,14 +457,6 @@ impl DownloadTransfer {
             let guard = self.inner.state.lock().unwrap();
             return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
         }
-        self.decrement_in_flight();
-
-        tracing::trace!(
-            target: crate::telemetry::TARGET_TRANSFER,
-            seq,
-            offset = *range.start(),
-            "chunk downloaded",
-        );
 
         // disk_write reflects bytes committed to the file sink buffer.
         // Actual disk flushes are batched; disk_write may lead physical
@@ -477,6 +470,15 @@ impl DownloadTransfer {
             },
             ..Default::default()
         });
+
+        self.decrement_in_flight();
+
+        tracing::trace!(
+            target: crate::telemetry::TARGET_TRANSFER,
+            seq,
+            offset = *range.start(),
+            "chunk downloaded",
+        );
 
         WorkOutcome::Success { data: None }
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -363,8 +363,16 @@ impl DownloadTransfer {
         }
         self.decrement_in_flight();
 
+        // disk_write reflects bytes committed to the file sink buffer.
+        // Actual disk flushes are batched; disk_write may lead physical
+        // I/O at any snapshot but converges on transfer completion.
         self.inner.ctx.record_io(&crate::metrics::IoSample {
             network_rx: bytes_received,
+            disk_write: if self.inner.writer.has_sink() {
+                bytes_received
+            } else {
+                0
+            },
             ..Default::default()
         });
 
@@ -457,8 +465,16 @@ impl DownloadTransfer {
             "chunk downloaded",
         );
 
+        // disk_write reflects bytes committed to the file sink buffer.
+        // Actual disk flushes are batched; disk_write may lead physical
+        // I/O at any snapshot but converges on transfer completion.
         self.inner.ctx.record_io(&crate::metrics::IoSample {
             network_rx: bytes_received,
+            disk_write: if self.inner.writer.has_sink() {
+                bytes_received
+            } else {
+                0
+            },
             ..Default::default()
         });
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -273,6 +273,7 @@ impl DownloadTransfer {
         let total_size =
             chunk_content_len + remaining.as_ref().map_or(0, |r| r.end() - r.start() + 1);
         self.inner.writer.preallocate(total_size);
+        self.inner.ctx.set_total_bytes(total_size);
 
         // If there's an initial chunk, claim seq BEFORE waking to prevent race
         // where poll_work exhausts the window before we can claim our seq.
@@ -362,15 +363,10 @@ impl DownloadTransfer {
         }
         self.decrement_in_flight();
 
-        self.inner
-            .ctx
-            .handle
-            .telemetry
-            .io_counters
-            .record(&crate::metrics::IoSample {
-                network_rx: bytes_received,
-                ..Default::default()
-            });
+        self.inner.ctx.record_io(&crate::metrics::IoSample {
+            network_rx: bytes_received,
+            ..Default::default()
+        });
 
         WorkOutcome::Success { data: None }
     }
@@ -461,15 +457,10 @@ impl DownloadTransfer {
             "chunk downloaded",
         );
 
-        self.inner
-            .ctx
-            .handle
-            .telemetry
-            .io_counters
-            .record(&crate::metrics::IoSample {
-                network_rx: bytes_received,
-                ..Default::default()
-            });
+        self.inner.ctx.record_io(&crate::metrics::IoSample {
+            network_rx: bytes_received,
+            ..Default::default()
+        });
 
         WorkOutcome::Success { data: None }
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
@@ -177,6 +177,16 @@ impl UploadHandle {
     pub fn scheduling(&self) -> crate::transfer::SchedulingCtl<'_> {
         self.transfer.ctx().scheduling()
     }
+
+    /// Current status of this transfer.
+    pub fn status(&self) -> crate::types::TransferStatus {
+        self.transfer.ctx().transfer_status()
+    }
+
+    /// Snapshot of current transfer metrics.
+    pub fn metrics(&self) -> crate::types::TransferMetrics {
+        self.transfer.ctx().metrics()
+    }
 }
 
 impl Drop for UploadHandle {

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
@@ -114,7 +114,7 @@ impl UploadHandle {
     /// When this method returns, all work for this transfer has been
     /// cancelled or completed. No further work will be executed.
     ///
-    /// TODO(aws-sdk-rust#1159): Handle already completed upload
+    // TODO(aws-sdk-rust#1159): Handle already completed upload
     pub async fn abort(self) -> Result<AbortedUpload, Error> {
         let ctx = self.transfer.ctx();
 

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/output.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/output.rs
@@ -10,9 +10,14 @@ use aws_sdk_s3::operation::{
 use std::fmt::{Debug, Formatter};
 
 /// Common response fields for uploading an object to Amazon S3
+// FIXME: join() should return a wrapper type that always carries TransferMetrics
+// regardless of success/failure. For now, metrics are only available on success.
 #[non_exhaustive]
-#[derive(Clone, PartialEq)]
+#[derive(Clone)]
 pub struct UploadOutput {
+    /// Snapshot of transfer metrics at completion.
+    pub metrics: crate::types::TransferMetrics,
+
     /// <p>If the expiration is configured for the object (see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketLifecycleConfiguration.html">PutBucketLifecycleConfiguration</a>) in the <i>Amazon S3 User Guide</i>, the response includes this header. It includes the <code>expiry-date</code> and <code>rule-id</code> key-value pairs that provide information about object expiration. The value of the <code>rule-id</code> is URL-encoded.</p><note>
     /// <p>This functionality is not supported for directory buckets.</p>
     /// </note>
@@ -184,6 +189,7 @@ impl UploadOutput {
 impl Debug for UploadOutput {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut formatter = f.debug_struct("UploadOutput");
+        formatter.field("metrics", &self.metrics);
         formatter.field("expiration", &self.expiration);
         formatter.field("e_tag", &self.e_tag);
         formatter.field("checksum_crc32", &self.checksum_crc32);
@@ -212,6 +218,7 @@ impl Debug for UploadOutput {
 #[non_exhaustive]
 #[derive(Default)]
 pub struct UploadOutputBuilder {
+    pub(crate) metrics: Option<crate::types::TransferMetrics>,
     pub(crate) expiration: Option<String>,
     pub(crate) e_tag: Option<String>,
     pub(crate) checksum_crc32: Option<String>,
@@ -541,9 +548,16 @@ impl UploadOutputBuilder {
         self.upload_id.as_deref()
     }
 
+    /// Set the transfer metrics snapshot.
+    pub(crate) fn metrics(mut self, val: crate::types::TransferMetrics) -> Self {
+        self.metrics = Some(val);
+        self
+    }
+
     /// Consumes the builder and constructs a [`UploadOutput`]
     pub fn build(self) -> Result<UploadOutput, ::aws_smithy_types::error::operation::BuildError> {
         Ok(UploadOutput {
+            metrics: self.metrics.expect("metrics must be set"),
             expiration: self.expiration,
             e_tag: self.e_tag,
             checksum_crc32: self.checksum_crc32,
@@ -568,6 +582,7 @@ impl UploadOutputBuilder {
 impl From<PutObjectOutput> for UploadOutputBuilder {
     fn from(value: PutObjectOutput) -> Self {
         UploadOutputBuilder {
+            metrics: None,
             bucket_key_enabled: value.bucket_key_enabled,
             checksum_crc32: value.checksum_crc32,
             checksum_crc32_c: value.checksum_crc32_c,
@@ -642,6 +657,7 @@ impl UploadOutputBuilder {
 impl From<CreateMultipartUploadOutput> for UploadOutputBuilder {
     fn from(value: CreateMultipartUploadOutput) -> Self {
         UploadOutputBuilder {
+            metrics: None,
             upload_id: value.upload_id,
             server_side_encryption: value.server_side_encryption,
             sse_customer_algorithm: value.sse_customer_algorithm,

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -78,6 +78,8 @@ impl UploadTransfer {
             .upper()
             .expect("content_length required; unknown length not yet supported");
 
+        ctx.set_total_bytes(content_length);
+
         let inner = Arc::new(UploadTransferInner {
             ctx,
             state: Mutex::new(UploadState::PendingInit {
@@ -438,15 +440,10 @@ impl UploadTransfer {
 
         self.maybe_transition_to_completing();
 
-        self.inner
-            .ctx
-            .handle
-            .telemetry
-            .io_counters
-            .record(&crate::metrics::IoSample {
-                network_tx: bytes_sent,
-                ..Default::default()
-            });
+        self.inner.ctx.record_io(&crate::metrics::IoSample {
+            network_tx: bytes_sent,
+            ..Default::default()
+        });
 
         WorkOutcome::Success { data: None }
     }
@@ -526,6 +523,7 @@ impl UploadTransfer {
         };
 
         let result = UploadOutputBuilder::from(resp)
+            .metrics(self.inner.ctx.metrics())
             .build()
             .expect("valid response");
 
@@ -533,15 +531,10 @@ impl UploadTransfer {
         self.inner.ctx.set_completed();
         self.inner.ctx.signal_terminal();
 
-        self.inner
-            .ctx
-            .handle
-            .telemetry
-            .io_counters
-            .record(&crate::metrics::IoSample {
-                network_tx: content_length,
-                ..Default::default()
-            });
+        self.inner.ctx.record_io(&crate::metrics::IoSample {
+            network_tx: content_length,
+            ..Default::default()
+        });
 
         WorkOutcome::Success { data: None }
     }
@@ -602,6 +595,7 @@ impl UploadTransfer {
 
         let result = response_builder
             .update_from_complete_mpu(&resp)
+            .metrics(self.inner.ctx.metrics())
             .build()
             .expect("valid response");
 

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -437,12 +437,12 @@ impl UploadTransfer {
             "part uploaded",
         );
 
-        self.maybe_transition_to_completing();
-
         self.inner.ctx.record_io(&crate::metrics::IoSample {
             network_tx: bytes_sent,
             ..Default::default()
         });
+
+        self.maybe_transition_to_completing();
 
         WorkOutcome::Success { data: None }
     }
@@ -527,13 +527,14 @@ impl UploadTransfer {
             .expect("valid response");
 
         *self.inner.result.lock().expect("lock poisoned") = Some(result);
-        self.inner.ctx.set_completed();
-        self.inner.ctx.signal_terminal();
 
         self.inner.ctx.record_io(&crate::metrics::IoSample {
             network_tx: content_length,
             ..Default::default()
         });
+
+        self.inner.ctx.set_completed();
+        self.inner.ctx.signal_terminal();
 
         WorkOutcome::Success { data: None }
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -304,9 +304,8 @@ impl UploadTransfer {
                 .stream(stream)
                 .part_size(part_size.try_into().expect("valid part size"))
                 .direct_io(self.inner.ctx.handle.runtime.components().direct_io())
-                .io_counters(std::sync::Arc::clone(
-                    &self.inner.ctx.handle.telemetry.io_counters,
-                ))
+                .metrics(std::sync::Arc::clone(&self.inner.ctx.metrics))
+                .telemetry(std::sync::Arc::clone(&self.inner.ctx.handle.telemetry))
                 .build()
             {
                 Ok(reader) => reader,

--- a/aws-sdk-s3-transfer-manager/src/operation/upload_objects.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload_objects.rs
@@ -21,6 +21,10 @@ use tracing::Instrument;
 
 mod worker;
 
+mod transfer;
+#[allow(unused_imports)] // wired up by the operation orchestrator
+pub(crate) use transfer::{UploadObjectsTransfer, UploadObjectsWork};
+
 use crate::{error, types::FailedUpload};
 
 use super::{

--- a/aws-sdk-s3-transfer-manager/src/operation/upload_objects/input.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload_objects/input.rs
@@ -35,6 +35,12 @@ pub struct UploadObjectsInput {
 
     /// The failure policy to use when any individual object upload fails.
     pub failure_policy: FailedTransferPolicy,
+
+    /// Maximum number of concurrent child upload transfers.
+    ///
+    /// Controls how many individual object uploads run simultaneously.
+    /// Defaults to 100.
+    pub pipeline_depth: usize,
 }
 
 impl UploadObjectsInput {
@@ -77,6 +83,14 @@ impl UploadObjectsInput {
     pub fn failure_policy(&self) -> &FailedTransferPolicy {
         &self.failure_policy
     }
+
+    /// Maximum number of concurrent child upload transfers.
+    ///
+    /// Controls how many individual object uploads run simultaneously.
+    /// Defaults to 100.
+    pub fn pipeline_depth(&self) -> usize {
+        self.pipeline_depth
+    }
 }
 
 /// A builder for [`UploadObjectsInput`]
@@ -91,6 +105,7 @@ pub struct UploadObjectsInputBuilder {
     pub(crate) key_prefix: Option<String>,
     pub(crate) delimiter: Option<String>,
     pub(crate) failure_policy: FailedTransferPolicy,
+    pub(crate) pipeline_depth: Option<usize>,
 }
 
 impl UploadObjectsInputBuilder {
@@ -118,6 +133,7 @@ impl UploadObjectsInputBuilder {
             key_prefix: self.key_prefix,
             delimiter: self.delimiter,
             failure_policy: self.failure_policy,
+            pipeline_depth: self.pipeline_depth.unwrap_or(100),
         })
     }
 
@@ -237,5 +253,31 @@ impl UploadObjectsInputBuilder {
     /// The failure policy to use when any individual object upload fails.
     pub fn get_failure_policy(&self) -> &FailedTransferPolicy {
         &self.failure_policy
+    }
+
+    /// Maximum number of concurrent child upload transfers.
+    ///
+    /// Controls how many individual object uploads run simultaneously.
+    /// Defaults to 100.
+    pub fn pipeline_depth(mut self, input: usize) -> Self {
+        self.pipeline_depth = Some(input);
+        self
+    }
+
+    /// Maximum number of concurrent child upload transfers.
+    ///
+    /// Controls how many individual object uploads run simultaneously.
+    /// Defaults to 100.
+    pub fn set_pipeline_depth(mut self, input: Option<usize>) -> Self {
+        self.pipeline_depth = input;
+        self
+    }
+
+    /// Maximum number of concurrent child upload transfers.
+    ///
+    /// Controls how many individual object uploads run simultaneously.
+    /// Defaults to 100.
+    pub fn get_pipeline_depth(&self) -> Option<usize> {
+        self.pipeline_depth
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload_objects/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload_objects/transfer.rs
@@ -61,7 +61,7 @@ pub(crate) struct ChildMeta {
 /// children over the scheduler. Each walker entry becomes one child upload
 /// transfer, registered and tracked until terminal.
 ///
-/// Cheap to clone — all state behind `Arc`.
+/// Cheap to clone; all state behind `Arc`.
 #[derive(Clone)]
 #[allow(dead_code)] // wired up by the operation orchestrator
 pub(crate) struct UploadObjectsTransfer {

--- a/aws-sdk-s3-transfer-manager/src/operation/upload_objects/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload_objects/transfer.rs
@@ -1,0 +1,259 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! State machine for plural upload (`upload_objects`).
+
+use std::collections::HashMap;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::transfer::{IoRequest, PollWork, Transfer, TransferContext, TransferId, WorkOutcome};
+use crate::types::FailedUpload;
+
+/// Work data variants for the UploadObjectsTransfer state machine.
+///
+/// Currently a single variant; reserved as an enum for future expansion
+/// (e.g. explicit drain-signal work, progress-snapshot work).
+#[derive(Debug)]
+#[allow(dead_code)] // variants wired when state machine is driven
+pub(crate) enum UploadObjectsWork {
+    /// Pull the next entry from the walker channel and initiate a child
+    /// upload transfer for it.
+    AdvanceWalker,
+}
+
+/// State for the UploadObjectsTransfer state machine.
+#[derive(Debug)]
+#[allow(dead_code)] // variants driven by poll_work state transitions
+pub(crate) enum UploadObjectsState {
+    /// Actively pulling entries from the walker and initiating children.
+    Enumerating,
+    /// Walker exhausted or transfer cancelled; waiting for registered children
+    /// to reach terminal state. No new children will be initiated.
+    Draining,
+    /// All work complete; `poll_work` returns `Done`.
+    Complete,
+}
+
+/// Metadata tracked per registered child transfer.
+///
+/// Kept alive by the parent until the child reaches terminal state so
+/// cancellation of the parent can cascade to the child, and the child's
+/// outcome can be correlated back to the source path / key on failure.
+#[derive(Debug)]
+#[allow(dead_code)] // constructed by AdvanceWalker work items
+pub(crate) struct ChildMeta {
+    pub(crate) source_path: std::path::PathBuf,
+    pub(crate) key: String,
+    /// Holding the handle alive ensures the child continues to run until it
+    /// terminates; dropping it signals cancellation to the child.
+    pub(crate) handle: crate::operation::upload::UploadHandle,
+}
+
+/// Parent state machine for plural upload (`upload_objects`).
+///
+/// Orchestrates per-entry singular [`crate::operation::upload::UploadTransfer`]
+/// children over the scheduler. Each walker entry becomes one child upload
+/// transfer, registered and tracked until terminal.
+///
+/// Cheap to clone — all state behind `Arc`.
+#[derive(Clone)]
+#[allow(dead_code)] // wired up by the operation orchestrator
+pub(crate) struct UploadObjectsTransfer {
+    inner: Arc<UploadObjectsTransferInner>,
+}
+
+/// Shared interior state for [`UploadObjectsTransfer`].
+#[allow(dead_code)] // wired up by the operation orchestrator
+pub(crate) struct UploadObjectsTransferInner {
+    /// Common transfer lifecycle management (id, handle, status, cancellation).
+    ctx: TransferContext,
+    /// Immutable request parameters.
+    request: Arc<super::UploadObjectsInput>,
+    /// State machine phase.
+    state: Mutex<UploadObjectsState>,
+    /// Maximum concurrent child transfers. Adjustable at runtime.
+    pipeline_depth: AtomicUsize,
+    /// Currently-registered children (by `TransferId`).
+    children: Mutex<HashMap<TransferId, ChildMeta>>,
+    /// Per-entry failures accumulated under `FailedTransferPolicy::Continue`.
+    failed: Mutex<Vec<FailedUpload>>,
+    /// Monotonic counter of successful child uploads.
+    successful_uploads: AtomicU64,
+    /// Total bytes transferred across all successful children.
+    total_bytes_transferred: AtomicU64,
+}
+
+#[allow(dead_code)] // wired up by the operation orchestrator
+impl UploadObjectsTransfer {
+    /// Create a new transfer with the given context and request parameters.
+    pub(crate) fn new(ctx: TransferContext, request: super::UploadObjectsInput) -> Self {
+        let pipeline_depth = request.pipeline_depth();
+        let inner = Arc::new(UploadObjectsTransferInner {
+            ctx,
+            request: Arc::new(request),
+            state: Mutex::new(UploadObjectsState::Enumerating),
+            pipeline_depth: AtomicUsize::new(pipeline_depth),
+            children: Mutex::new(HashMap::new()),
+            failed: Mutex::new(Vec::new()),
+            successful_uploads: AtomicU64::new(0),
+            total_bytes_transferred: AtomicU64::new(0),
+        });
+        Self { inner }
+    }
+
+    /// Access the transfer context.
+    pub(crate) fn ctx(&self) -> &TransferContext {
+        &self.inner.ctx
+    }
+
+    /// Current pipeline depth (max registered children simultaneously).
+    pub(crate) fn pipeline_depth(&self) -> usize {
+        self.inner.pipeline_depth.load(Ordering::Acquire)
+    }
+
+    /// Adjust pipeline depth at runtime. Takes effect at the next enumeration cycle.
+    pub(crate) fn set_pipeline_depth(&self, depth: usize) {
+        self.inner.pipeline_depth.store(depth, Ordering::Release);
+        // Wake if we were throttled waiting for capacity — harmless otherwise.
+        self.inner.ctx.try_wake();
+    }
+
+    /// Number of child uploads that completed successfully.
+    pub(crate) fn successful_uploads(&self) -> u64 {
+        self.inner.successful_uploads.load(Ordering::Acquire)
+    }
+
+    /// Cumulative bytes transferred across all successful children.
+    pub(crate) fn total_bytes_transferred(&self) -> u64 {
+        self.inner.total_bytes_transferred.load(Ordering::Acquire)
+    }
+}
+
+impl fmt::Debug for UploadObjectsTransfer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UploadObjectsTransfer")
+            .field("id", &self.inner.ctx.id)
+            .field("pipeline_depth", &self.pipeline_depth())
+            .field("successful_uploads", &self.successful_uploads())
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Debug for UploadObjectsTransferInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UploadObjectsTransferInner")
+            .field("ctx", &self.ctx)
+            .field(
+                "pipeline_depth",
+                &self.pipeline_depth.load(Ordering::Relaxed),
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl Transfer for UploadObjectsTransfer {
+    fn ctx(&self) -> &TransferContext {
+        UploadObjectsTransfer::ctx(self)
+    }
+
+    fn poll_work(&self) -> PollWork {
+        if !self.inner.ctx.is_active() {
+            let mut state = self.inner.state.lock().expect("lock poisoned");
+            *state = UploadObjectsState::Complete;
+            self.inner.ctx.signal_terminal();
+        }
+        PollWork::Done
+    }
+
+    fn execute<'a>(
+        &'a self,
+        _work: &'a mut IoRequest,
+    ) -> Pin<Box<dyn Future<Output = WorkOutcome> + Send + 'a>> {
+        Box::pin(async move {
+            unreachable!("UploadObjectsTransfer::execute called but poll_work never returns Ready")
+        })
+    }
+
+    fn on_terminal(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transfer::TransferContext;
+    use crate::DEFAULT_CONCURRENCY;
+
+    fn create_test_transfer(input: super::super::UploadObjectsInput) -> UploadObjectsTransfer {
+        let config = crate::Config::builder()
+            .client(aws_smithy_mocks::mock_client!(aws_sdk_s3, []))
+            .build();
+        let handle = crate::client::Handle::new_for_test(config, DEFAULT_CONCURRENCY);
+        let (ctx, _completion_rx) = TransferContext::new(handle);
+        UploadObjectsTransfer::new(ctx, input)
+    }
+
+    fn default_input() -> super::super::UploadObjectsInput {
+        super::super::UploadObjectsInputBuilder::default()
+            .bucket("test-bucket")
+            .source("/tmp/test-source")
+            .build()
+            .unwrap()
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn test_constructor_default_pipeline_depth_is_100() {
+        let transfer = create_test_transfer(default_input());
+        assert_eq!(transfer.pipeline_depth(), 100);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn test_constructor_explicit_pipeline_depth() {
+        let input = super::super::UploadObjectsInputBuilder::default()
+            .bucket("test-bucket")
+            .source("/tmp/test-source")
+            .pipeline_depth(42)
+            .build()
+            .unwrap();
+        let transfer = create_test_transfer(input);
+        assert_eq!(transfer.pipeline_depth(), 42);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn test_set_pipeline_depth_updates_value() {
+        let transfer = create_test_transfer(default_input());
+        assert_eq!(transfer.pipeline_depth(), 100);
+        transfer.set_pipeline_depth(250);
+        assert_eq!(transfer.pipeline_depth(), 250);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn test_poll_work_returns_done_when_constructed() {
+        let transfer = create_test_transfer(default_input());
+        assert!(matches!(transfer.poll_work(), PollWork::Done));
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn test_debug_format_does_not_panic() {
+        let transfer = create_test_transfer(default_input());
+        let _ = format!("{:?}", transfer);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn test_successful_uploads_and_bytes_start_at_zero() {
+        let transfer = create_test_transfer(default_input());
+        assert_eq!(transfer.successful_uploads(), 0);
+        assert_eq!(transfer.total_bytes_transferred(), 0);
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/operation/upload_objects/worker.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload_objects/worker.rs
@@ -313,6 +313,7 @@ fn handle_failed_upload(
                     None => None,
                 },
                 error: err,
+                source_path: None,
             };
 
             failures.push(failed_transfer);

--- a/aws-sdk-s3-transfer-manager/src/scheduler/scheduler.rs
+++ b/aws-sdk-s3-transfer-manager/src/scheduler/scheduler.rs
@@ -142,35 +142,57 @@ impl Scheduler {
         }
     }
 
-    /// Cancel a transfer, removing it from the scheduler.
+    /// Cancel a transfer and any child transfers, removing them from the scheduler.
     ///
-    /// - Removes from transfers map
-    /// - Purges queued work for this transfer from pools
-    /// - Outstanding work being executed will complete naturally
-    /// - Use `wait_for_idle(id)` to wait for all outstanding work to finish
+    /// Cancels the target transfer first, then cancels all transfers whose
+    /// `TransferId.parent == Some(id.id)` (depth-1 children only). Each cancelled
+    /// transfer has its status set to cancelled, pending work purged, and idle
+    /// notification sent. Outstanding work already being executed will complete
+    /// naturally — use `wait_for_idle(id)` to wait for draining.
     ///
-    /// TODO: When upload_objects/download_objects use the new scheduler,
-    /// this needs to cancel child transfers too (where tid.parent == Some(id.id)).
+    /// Returns `true` if the target transfer existed in the map, `false` otherwise.
+    /// The return value does not reflect whether any children were found or cancelled.
     pub(crate) fn cancel_transfer(&self, id: TransferId) -> bool {
-        let desc = self.0.transfers.write().unwrap().remove(&id);
-        if let Some(desc) = desc {
-            let ctx = desc.transfer().ctx();
-            // Ensure transfer is terminal so ready_set and workers skip it.
-            // May already be set by the handle (set_cancelled/set_failed) — that's fine.
-            if ctx.is_active() {
-                ctx.set_cancelled();
-            }
-            ctx.signal_terminal();
-            desc.transfer().on_terminal();
-            let purged = self.handle().runtime.remove_pending_for_transfer(id);
-            self.0.dispatched.fetch_sub(purged, Ordering::Relaxed);
-            desc.work_purged(purged);
-            desc.notify_idle();
-            tracing::debug!(target: telemetry::TARGET_SCHEDULING, id = %id, purged, "transfer cancelled");
-            true
-        } else {
-            false
+        let (target, children) = {
+            let mut transfers = self.0.transfers.write().unwrap();
+            let target = transfers.remove(&id);
+            let child_keys: Vec<TransferId> = transfers
+                .keys()
+                .filter(|tid| tid.parent == Some(id.id))
+                .copied()
+                .collect();
+            let children: Vec<TransferDescriptor> = child_keys
+                .iter()
+                .filter_map(|k| transfers.remove(k))
+                .collect();
+            (target, children)
+        };
+
+        let found = target.is_some();
+        if let Some(desc) = target {
+            self.cancel_descriptor(desc);
         }
+        for desc in children {
+            self.cancel_descriptor(desc);
+        }
+        found
+    }
+
+    /// Cancel a single transfer descriptor: set cancelled, signal terminal,
+    /// clean up on_terminal, purge pending work, and notify idle.
+    fn cancel_descriptor(&self, desc: TransferDescriptor) {
+        let id = desc.id();
+        let ctx = desc.transfer().ctx();
+        if ctx.is_active() {
+            ctx.set_cancelled();
+        }
+        ctx.signal_terminal();
+        desc.transfer().on_terminal();
+        let purged = self.handle().runtime.remove_pending_for_transfer(id);
+        self.0.dispatched.fetch_sub(purged, Ordering::Relaxed);
+        desc.work_purged(purged);
+        desc.notify_idle();
+        tracing::debug!(target: telemetry::TARGET_SCHEDULING, id = %id, purged, "transfer cancelled");
     }
 
     /// Set the priority of a transfer.
@@ -867,6 +889,166 @@ mod tests {
             "expected fewer than 20 completions, got {}",
             completed
         );
+
+        handle.runtime.shutdown();
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_cancel_parent_cascades_to_children() {
+        let handle = test_handle(4);
+        let scheduler = &handle.scheduler;
+
+        let parent_id = TransferId {
+            id: 1,
+            parent: None,
+        };
+        let child_ids: Vec<TransferId> = (2..=4)
+            .map(|i| TransferId {
+                id: i,
+                parent: Some(1),
+            })
+            .collect();
+
+        let parent_sm = Arc::new(WithDelay::new(
+            FixedWorkCount::new(20),
+            Duration::from_millis(50),
+        ));
+        let parent_transfer = MockTransfer::new(parent_id, parent_sm);
+        let parent_ctx = parent_transfer.ctx().clone();
+        scheduler.enqueue_transfer(Box::new(parent_transfer));
+
+        let mut child_ctxs = Vec::new();
+        for &cid in &child_ids {
+            let sm = Arc::new(WithDelay::new(
+                FixedWorkCount::new(20),
+                Duration::from_millis(50),
+            ));
+            let transfer = MockTransfer::new(cid, sm);
+            child_ctxs.push(transfer.ctx().clone());
+            scheduler.enqueue_transfer(Box::new(transfer));
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(scheduler.cancel_transfer(parent_id));
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !scheduler.is_idle() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("scheduler should become idle after cascade cancel");
+
+        assert!(!parent_ctx.is_active(), "parent should not be active");
+        for (i, ctx) in child_ctxs.iter().enumerate() {
+            assert!(!ctx.is_active(), "child {} should not be active", i + 2);
+        }
+
+        handle.runtime.shutdown();
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_cancel_parent_with_no_children_still_works() {
+        let handle = test_handle(2);
+        let scheduler = &handle.scheduler;
+
+        let id = TransferId {
+            id: 1,
+            parent: None,
+        };
+        let sm = Arc::new(WithDelay::new(
+            FixedWorkCount::new(20),
+            Duration::from_millis(50),
+        ));
+        let transfer = MockTransfer::new(id, sm);
+        let ctx = transfer.ctx().clone();
+        scheduler.enqueue_transfer(Box::new(transfer));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(scheduler.cancel_transfer(id));
+        assert!(!scheduler.cancel_transfer(id));
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !scheduler.is_idle() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("scheduler should become idle after cancel");
+
+        assert!(!ctx.is_active(), "parent should not be active");
+
+        handle.runtime.shutdown();
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_cancel_child_does_not_affect_siblings_or_parent() {
+        let handle = test_handle(4);
+        let scheduler = &handle.scheduler;
+
+        let parent_id = TransferId {
+            id: 1,
+            parent: None,
+        };
+        let child_a = TransferId {
+            id: 2,
+            parent: Some(1),
+        };
+        let child_b = TransferId {
+            id: 3,
+            parent: Some(1),
+        };
+
+        let parent_sm = Arc::new(WithDelay::new(
+            FixedWorkCount::new(20),
+            Duration::from_millis(50),
+        ));
+        let parent_transfer = MockTransfer::new(parent_id, parent_sm);
+        let parent_ctx = parent_transfer.ctx().clone();
+        scheduler.enqueue_transfer(Box::new(parent_transfer));
+
+        let sm_a = Arc::new(WithDelay::new(
+            FixedWorkCount::new(20),
+            Duration::from_millis(50),
+        ));
+        let transfer_a = MockTransfer::new(child_a, sm_a);
+        let ctx_a = transfer_a.ctx().clone();
+        scheduler.enqueue_transfer(Box::new(transfer_a));
+
+        let sm_b = Arc::new(WithDelay::new(
+            FixedWorkCount::new(20),
+            Duration::from_millis(50),
+        ));
+        let transfer_b = MockTransfer::new(child_b, sm_b);
+        let ctx_b = transfer_b.ctx().clone();
+        scheduler.enqueue_transfer(Box::new(transfer_b));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(scheduler.cancel_transfer(child_a));
+        assert!(ctx_a.is_cancelled(), "child A should be cancelled");
+        assert!(parent_ctx.is_active(), "parent should still be active");
+        assert!(ctx_b.is_active(), "sibling B should still be active");
+
+        handle.runtime.shutdown();
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_cancel_nonexistent_transfer_returns_false() {
+        let handle = test_handle(2);
+        let scheduler = &handle.scheduler;
+
+        let fake_id = TransferId {
+            id: 999,
+            parent: None,
+        };
+        assert!(!scheduler.cancel_transfer(fake_id));
 
         handle.runtime.shutdown();
     }

--- a/aws-sdk-s3-transfer-manager/src/telemetry.rs
+++ b/aws-sdk-s3-transfer-manager/src/telemetry.rs
@@ -20,16 +20,16 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// Adaptive concurrency controller: phase transitions, target changes, probe results.
-pub(crate) const TARGET_CONCURRENCY: &str = "aws_s3_transfer_manager::concurrency";
+pub(crate) const TARGET_CONCURRENCY: &str = "aws_sdk_s3_transfer_manager::concurrency";
 
 /// Scheduler capacity decisions, worker pool growth.
-pub(crate) const TARGET_SCHEDULING: &str = "aws_s3_transfer_manager::scheduling";
+pub(crate) const TARGET_SCHEDULING: &str = "aws_sdk_s3_transfer_manager::scheduling";
 
 /// Per-work-item execution: dispatch, complete, skip, panic.
-pub(crate) const TARGET_EXECUTION: &str = "aws_s3_transfer_manager::execution";
+pub(crate) const TARGET_EXECUTION: &str = "aws_sdk_s3_transfer_manager::execution";
 
 /// Transfer lifecycle: enqueue, complete, cancel, fail, state transitions.
-pub(crate) const TARGET_TRANSFER: &str = "aws_s3_transfer_manager::transfer";
+pub(crate) const TARGET_TRANSFER: &str = "aws_sdk_s3_transfer_manager::transfer";
 
 /// Observability surface for transfer operations.
 ///

--- a/aws-sdk-s3-transfer-manager/src/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/transfer.rs
@@ -292,6 +292,77 @@ impl fmt::Debug for StateMachineStatus {
     }
 }
 
+/// Per-transfer metrics backing store.
+pub(crate) struct MetricsState {
+    network_tx: AtomicU64,
+    network_rx: AtomicU64,
+    disk_read: AtomicU64,
+    disk_write: AtomicU64,
+    total_bytes: std::sync::OnceLock<u64>,
+    started_at: std::time::Instant,
+    finished_at: std::sync::OnceLock<std::time::Instant>,
+}
+
+impl MetricsState {
+    fn new() -> Self {
+        Self {
+            network_tx: AtomicU64::new(0),
+            network_rx: AtomicU64::new(0),
+            disk_read: AtomicU64::new(0),
+            disk_write: AtomicU64::new(0),
+            total_bytes: std::sync::OnceLock::new(),
+            started_at: std::time::Instant::now(),
+            finished_at: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Record an IO sample (cumulative).
+    pub(crate) fn record_io(&self, sample: &crate::metrics::IoSample) {
+        self.network_tx
+            .fetch_add(sample.network_tx, Ordering::Relaxed);
+        self.network_rx
+            .fetch_add(sample.network_rx, Ordering::Relaxed);
+        self.disk_read
+            .fetch_add(sample.disk_read, Ordering::Relaxed);
+        self.disk_write
+            .fetch_add(sample.disk_write, Ordering::Relaxed);
+    }
+
+    /// Set the expected total payload bytes. No-op if already set.
+    pub(crate) fn set_total_bytes(&self, n: u64) {
+        let _ = self.total_bytes.set(n);
+    }
+
+    /// Mark the transfer as finished. No-op if already set.
+    pub(crate) fn set_finished(&self) {
+        let _ = self.finished_at.set(std::time::Instant::now());
+    }
+
+    /// Snapshot current metrics into the public type.
+    pub(crate) fn snapshot(&self) -> crate::types::TransferMetrics {
+        crate::types::TransferMetrics {
+            network_tx: self.network_tx.load(Ordering::Relaxed),
+            network_rx: self.network_rx.load(Ordering::Relaxed),
+            disk_read: self.disk_read.load(Ordering::Relaxed),
+            disk_write: self.disk_write.load(Ordering::Relaxed),
+            total_bytes: self.total_bytes.get().copied(),
+            started_at: self.started_at,
+            finished_at: self.finished_at.get().copied(),
+        }
+    }
+}
+
+impl std::fmt::Debug for MetricsState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MetricsState")
+            .field("network_tx", &self.network_tx.load(Ordering::Relaxed))
+            .field("network_rx", &self.network_rx.load(Ordering::Relaxed))
+            .field("disk_read", &self.disk_read.load(Ordering::Relaxed))
+            .field("disk_write", &self.disk_write.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
 /// Common lifecycle management for transfer state machines.
 ///
 /// Handles status tracking, error storage, completion signaling, and scheduler
@@ -315,6 +386,8 @@ pub(crate) struct TransferContext {
     pending: Arc<std::sync::atomic::AtomicBool>,
     /// Cancellation token for cooperative cancellation
     cancellation_token: tokio_util::sync::CancellationToken,
+    /// Per-transfer metrics backing store
+    pub(crate) metrics: Arc<MetricsState>,
 }
 
 impl fmt::Display for TransferContext {
@@ -346,6 +419,7 @@ impl TransferContext {
             completion_tx: Arc::new(Mutex::new(Some(completion_tx))),
             pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             cancellation_token: tokio_util::sync::CancellationToken::new(),
+            metrics: Arc::new(MetricsState::new()),
         };
         (ctx, completion_rx)
     }
@@ -366,6 +440,7 @@ impl TransferContext {
             completion_tx: Arc::new(Mutex::new(Some(completion_tx))),
             pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             cancellation_token: tokio_util::sync::CancellationToken::new(),
+            metrics: Arc::new(MetricsState::new()),
         };
         (ctx, completion_rx)
     }
@@ -469,9 +544,40 @@ impl TransferContext {
     /// Wakes any waiters (e.g., `join()`). Note: in-flight work may still
     /// be draining when this is called.
     pub(crate) fn signal_terminal(&self) {
+        self.metrics.set_finished();
         if let Some(tx) = self.completion_tx.lock().unwrap().take() {
             let _ = tx.send(());
         }
+    }
+
+    /// Record an IO sample into per-transfer counters AND global telemetry.
+    pub(crate) fn record_io(&self, sample: &crate::metrics::IoSample) {
+        self.metrics.record_io(sample);
+        self.handle.telemetry.io_counters.record(sample);
+    }
+
+    /// Set the expected total payload bytes for this transfer.
+    pub(crate) fn set_total_bytes(&self, n: u64) {
+        self.metrics.set_total_bytes(n);
+    }
+
+    /// Get current transfer status as a public enum.
+    pub(crate) fn transfer_status(&self) -> crate::types::TransferStatus {
+        use crate::types::TransferStatus;
+        if self.status.is_cancelled() {
+            TransferStatus::Cancelled
+        } else if self.is_failed() {
+            TransferStatus::Failed
+        } else if !self.is_active() {
+            TransferStatus::Completed
+        } else {
+            TransferStatus::Active
+        }
+    }
+
+    /// Snapshot current transfer metrics.
+    pub(crate) fn metrics(&self) -> crate::types::TransferMetrics {
+        self.metrics.snapshot()
     }
 
     /// Get scheduling controls for this transfer.
@@ -592,6 +698,123 @@ mod tests {
             assert_eq!(s.to_string(), "Active");
             s.set_failed();
             assert_eq!(s.to_string(), "Failed");
+        }
+    }
+
+    mod transfer_status {
+        use crate::types::TransferStatus;
+
+        #[test]
+        fn is_terminal() {
+            assert!(!TransferStatus::Active.is_terminal());
+            assert!(TransferStatus::Completed.is_terminal());
+            assert!(TransferStatus::Failed.is_terminal());
+            assert!(TransferStatus::Cancelled.is_terminal());
+        }
+    }
+
+    mod transfer_context_status_and_metrics {
+        use super::*;
+        use std::sync::Arc;
+
+        fn test_handle() -> Arc<crate::client::Handle> {
+            let s3_client = aws_smithy_mocks::mock_client!(aws_sdk_s3, []);
+            let config = crate::Config::builder().client(s3_client).build();
+            crate::client::Handle::new_for_test(config, 4)
+        }
+
+        #[cfg_attr(miri, ignore)]
+        #[test]
+        fn status_transitions() {
+            let handle = test_handle();
+
+            // Completed
+            let (ctx, _rx) = TransferContext::new(handle.clone());
+            assert_eq!(ctx.transfer_status(), crate::types::TransferStatus::Active);
+            ctx.set_completed();
+            ctx.signal_terminal();
+            assert_eq!(
+                ctx.transfer_status(),
+                crate::types::TransferStatus::Completed
+            );
+
+            // Failed
+            let (ctx, _rx) = TransferContext::new(handle.clone());
+            ctx.set_failed(crate::error::Error::new(
+                crate::error::ErrorKind::InputInvalid,
+                "test",
+            ));
+            ctx.signal_terminal();
+            assert_eq!(ctx.transfer_status(), crate::types::TransferStatus::Failed);
+
+            // Cancelled
+            let (ctx, _rx) = TransferContext::new(handle);
+            ctx.set_cancelled();
+            ctx.signal_terminal();
+            assert_eq!(
+                ctx.transfer_status(),
+                crate::types::TransferStatus::Cancelled
+            );
+        }
+
+        #[cfg_attr(miri, ignore)]
+        #[test]
+        fn stats_initial_values() {
+            let handle = test_handle();
+            let (ctx, _rx) = TransferContext::new(handle);
+            let stats = ctx.metrics();
+            assert_eq!(stats.network_tx, 0);
+            assert_eq!(stats.network_rx, 0);
+            assert_eq!(stats.disk_read, 0);
+            assert_eq!(stats.disk_write, 0);
+            assert_eq!(stats.total_bytes, None);
+            assert!(stats.started_at.elapsed().as_secs() < 1);
+            assert!(stats.finished_at.is_none());
+        }
+
+        #[cfg_attr(miri, ignore)]
+        #[test]
+        fn stats_record_io() {
+            let handle = test_handle();
+            let (ctx, _rx) = TransferContext::new(handle);
+            ctx.record_io(&crate::metrics::IoSample {
+                network_tx: 100,
+                network_rx: 200,
+                disk_read: 300,
+                disk_write: 400,
+            });
+            ctx.record_io(&crate::metrics::IoSample {
+                network_tx: 10,
+                network_rx: 20,
+                disk_read: 30,
+                disk_write: 40,
+            });
+            let stats = ctx.metrics();
+            assert_eq!(stats.network_tx, 110);
+            assert_eq!(stats.network_rx, 220);
+            assert_eq!(stats.disk_read, 330);
+            assert_eq!(stats.disk_write, 440);
+        }
+
+        #[cfg_attr(miri, ignore)]
+        #[test]
+        fn finished_at_set_on_terminal() {
+            let handle = test_handle();
+            let (ctx, _rx) = TransferContext::new(handle);
+            assert!(ctx.metrics().finished_at.is_none());
+            ctx.set_completed();
+            ctx.signal_terminal();
+            assert!(ctx.metrics().finished_at.is_some());
+        }
+
+        #[cfg_attr(miri, ignore)]
+        #[test]
+        fn set_total_bytes() {
+            let handle = test_handle();
+            let (ctx, _rx) = TransferContext::new(handle);
+            assert_eq!(ctx.metrics().total_bytes, None);
+            ctx.set_total_bytes(42);
+            assert_eq!(ctx.metrics().total_bytes, Some(42));
         }
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/transfer.rs
@@ -292,7 +292,7 @@ impl fmt::Debug for StateMachineStatus {
     }
 }
 
-/// Per-transfer metrics backing store.
+/// Per-transfer cumulative metrics.
 pub(crate) struct MetricsState {
     network_tx: AtomicU64,
     network_rx: AtomicU64,
@@ -304,7 +304,7 @@ pub(crate) struct MetricsState {
 }
 
 impl MetricsState {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             network_tx: AtomicU64::new(0),
             network_rx: AtomicU64::new(0),
@@ -316,7 +316,7 @@ impl MetricsState {
         }
     }
 
-    /// Record an IO sample (cumulative).
+    /// Record an IO sample (per-transfer cumulative counters only).
     pub(crate) fn record_io(&self, sample: &crate::metrics::IoSample) {
         self.network_tx
             .fetch_add(sample.network_tx, Ordering::Relaxed);
@@ -413,13 +413,13 @@ impl TransferContext {
         let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
         let ctx = Self {
             id,
+            metrics: Arc::new(MetricsState::new()),
             handle,
             status: StateMachineStatus::new(),
             error: Arc::new(Mutex::new(None)),
             completion_tx: Arc::new(Mutex::new(Some(completion_tx))),
             pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             cancellation_token: tokio_util::sync::CancellationToken::new(),
-            metrics: Arc::new(MetricsState::new()),
         };
         (ctx, completion_rx)
     }
@@ -434,13 +434,13 @@ impl TransferContext {
         let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
         let ctx = Self {
             id,
+            metrics: Arc::new(MetricsState::new()),
             handle,
             status: StateMachineStatus::new(),
             error: Arc::new(Mutex::new(None)),
             completion_tx: Arc::new(Mutex::new(Some(completion_tx))),
             pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             cancellation_token: tokio_util::sync::CancellationToken::new(),
-            metrics: Arc::new(MetricsState::new()),
         };
         (ctx, completion_rx)
     }
@@ -550,7 +550,7 @@ impl TransferContext {
         }
     }
 
-    /// Record an IO sample into per-transfer counters AND global telemetry.
+    /// Record an IO sample to per-transfer metrics and per-client telemetry.
     pub(crate) fn record_io(&self, sample: &crate::metrics::IoSample) {
         self.metrics.record_io(sample);
         self.handle.telemetry.io_counters.record(sample);

--- a/aws-sdk-s3-transfer-manager/src/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/transfer.rs
@@ -51,7 +51,7 @@ pub(crate) trait Transfer: Send + Sync + std::fmt::Debug {
 pub(crate) type BoxTransfer = Box<dyn Transfer>;
 
 /// Opaque work data carried by work items. Each state machine defines its own type.
-/// The scheduler never inspects this — it ferries it across the scheduling boundary
+/// The scheduler never inspects this; it ferries it across the scheduling boundary
 /// for the transfer to reclaim via `IoRequest::data_mut::<T>()`.
 pub(crate) trait WorkData: Any + Send + std::fmt::Debug {
     fn as_any_mut(&mut self) -> &mut dyn Any;

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -329,6 +329,47 @@ impl FailedUpload {
     }
 }
 
+/// Status of a transfer operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TransferStatus {
+    /// Transfer is actively running.
+    Active,
+    /// Transfer completed successfully.
+    Completed,
+    /// Transfer failed with an error.
+    Failed,
+    /// Transfer was cancelled.
+    Cancelled,
+}
+
+impl TransferStatus {
+    /// Returns true if the transfer has reached a terminal state.
+    pub fn is_terminal(&self) -> bool {
+        !matches!(self, Self::Active)
+    }
+}
+
+/// Snapshot of transfer progress and IO metrics.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub struct TransferMetrics {
+    /// Bytes sent over network (upload payload).
+    pub network_tx: u64,
+    /// Bytes received from network (download payload).
+    pub network_rx: u64,
+    /// Bytes read from disk.
+    pub disk_read: u64,
+    /// Bytes written to disk.
+    pub disk_write: u64,
+    /// Expected total payload bytes, if known.
+    pub total_bytes: Option<u64>,
+    /// When the transfer was initiated.
+    pub started_at: std::time::Instant,
+    /// When the transfer reached a terminal state, if it has.
+    pub finished_at: Option<std::time::Instant>,
+}
+
 /// Type of the bucket for the transfer
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -308,6 +308,8 @@ impl<'a> UploadFilterItemBuilder<'a> {
 pub struct FailedUpload {
     pub(crate) input: Option<crate::operation::upload::UploadInput>,
     pub(crate) error: crate::error::Error,
+    /// Local filesystem path of the source file that failed to upload.
+    pub(crate) source_path: Option<std::path::PathBuf>,
 }
 
 impl FailedUpload {
@@ -319,6 +321,11 @@ impl FailedUpload {
     /// The error encountered uploading the object
     pub fn error(&self) -> &crate::error::Error {
         &self.error
+    }
+
+    /// Local filesystem path of the source file that failed to upload.
+    pub fn source_path(&self) -> Option<&std::path::Path> {
+        self.source_path.as_deref()
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -387,3 +387,25 @@ impl BucketType {
         }
     }
 }
+
+/// Internal bucket representation carrying the name and resolved kind.
+#[derive(Debug, Clone)]
+pub(crate) struct Bucket {
+    name: String,
+    kind: BucketType,
+}
+
+impl Bucket {
+    pub(crate) fn new(name: String) -> Self {
+        let kind = BucketType::from_bucket_name(&name);
+        Self { name, kind }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn kind(&self) -> BucketType {
+        self.kind
+    }
+}

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -11,4 +11,6 @@
 #[cfg(test)]
 mod download;
 #[cfg(test)]
+mod metrics;
+#[cfg(test)]
 mod upload;

--- a/integration-tests/src/metrics.rs
+++ b/integration-tests/src/metrics.rs
@@ -101,12 +101,12 @@ async fn test_upload_from_file_metrics() {
     wait_for_terminal(|| handle.status()).await;
 
     let metrics = handle.metrics();
-    // NOTE: disk_read is tracked in global io_counters, not per-transfer metrics
     assert_eq!(metrics.network_tx, size as u64);
     assert_eq!(metrics.total_bytes, Some(size as u64));
 
     let output = handle.join().await.expect("join");
     assert_eq!(output.metrics.network_tx, size as u64);
+    assert_eq!(output.metrics.disk_read, size as u64);
 
     server_handle.shutdown().await.expect("shutdown");
 }
@@ -170,7 +170,7 @@ async fn test_download_to_file_metrics() {
         .expect("join");
 
     assert_eq!(output.metrics.network_rx, size as u64);
-    // NOTE: disk_write is tracked in global io_counters, not per-transfer metrics
+    assert_eq!(output.metrics.disk_write, size as u64);
     assert_eq!(output.metrics.total_bytes, Some(size as u64));
 
     server_handle.shutdown().await.expect("shutdown");

--- a/integration-tests/src/metrics.rs
+++ b/integration-tests/src/metrics.rs
@@ -1,0 +1,234 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Integration tests for transfer metrics and status.
+
+use std::time::Duration;
+
+use aws_sdk_s3_transfer_manager::io::InputStream;
+use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
+use aws_sdk_s3_transfer_manager::types::TransferStatus;
+use s3_mock_server::S3MockServer;
+use tokio::time::timeout;
+
+/// Setup transfer manager with mock server (upload-style: returns server + handle + tm).
+async fn setup() -> (
+    S3MockServer,
+    s3_mock_server::ServerHandle,
+    aws_sdk_s3_transfer_manager::Client,
+) {
+    let server = S3MockServer::builder()
+        .with_in_memory_store()
+        .build()
+        .expect("build mock server");
+
+    let handle = server.start().await.expect("start mock server");
+    let s3_client = handle.client().await;
+
+    let tm_config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(s3_client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(tm_config);
+
+    (server, handle, tm)
+}
+
+/// Poll handle status until terminal, with timeout.
+async fn wait_for_terminal(status_fn: impl Fn() -> TransferStatus) {
+    timeout(Duration::from_secs(30), async {
+        loop {
+            if status_fn().is_terminal() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("transfer did not reach terminal state within 30s");
+}
+
+#[tokio::test]
+async fn test_upload_metrics_and_status() {
+    let (_server, server_handle, tm) = setup().await;
+
+    let size = 16 * ByteUnit::Mebibyte.as_bytes_usize();
+    let content = vec![0u8; size];
+
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("metrics-upload")
+        .body(InputStream::from(content))
+        .initiate()
+        .expect("initiate upload");
+
+    wait_for_terminal(|| handle.status()).await;
+
+    assert_eq!(handle.status(), TransferStatus::Completed);
+    let metrics = handle.metrics();
+    assert_eq!(metrics.network_tx, size as u64);
+    assert_eq!(metrics.total_bytes, Some(size as u64));
+    assert!(metrics.finished_at.is_some());
+    assert!(metrics.started_at <= metrics.finished_at.unwrap());
+
+    let output = handle.join().await.expect("join");
+    assert_eq!(output.metrics.network_tx, size as u64);
+
+    server_handle.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn test_upload_from_file_metrics() {
+    let (_server, server_handle, tm) = setup().await;
+
+    let size = 16 * ByteUnit::Mebibyte.as_bytes_usize();
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("upload_src.dat");
+    std::fs::write(&file_path, vec![0u8; size]).unwrap();
+
+    let stream = InputStream::from_path(&file_path).expect("open file");
+
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("metrics-file-upload")
+        .body(stream)
+        .initiate()
+        .expect("initiate upload");
+
+    wait_for_terminal(|| handle.status()).await;
+
+    let metrics = handle.metrics();
+    // NOTE: disk_read is tracked in global io_counters, not per-transfer metrics
+    assert_eq!(metrics.network_tx, size as u64);
+    assert_eq!(metrics.total_bytes, Some(size as u64));
+
+    let output = handle.join().await.expect("join");
+    assert_eq!(output.metrics.network_tx, size as u64);
+
+    server_handle.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn test_download_metrics_and_status() {
+    let (server, server_handle, tm) = setup().await;
+
+    let size = 25 * ByteUnit::Mebibyte.as_bytes_usize();
+    let content = vec![0u8; size];
+    server
+        .add_object("metrics-download", content, None)
+        .await
+        .expect("add object");
+
+    let handle = tm
+        .download()
+        .bucket("test-bucket")
+        .key("metrics-download")
+        .initiate()
+        .expect("initiate download");
+
+    let output = timeout(Duration::from_secs(30), handle.join())
+        .await
+        .expect("join timed out")
+        .expect("join");
+
+    assert_eq!(output.metrics.network_rx, size as u64);
+    assert_eq!(output.metrics.total_bytes, Some(size as u64));
+    assert!(output.metrics.finished_at.is_some());
+
+    server_handle.shutdown().await.expect("shutdown");
+}
+
+#[cfg(any(unix, windows))]
+#[tokio::test]
+async fn test_download_to_file_metrics() {
+    let (server, server_handle, tm) = setup().await;
+
+    let size = 25 * ByteUnit::Mebibyte.as_bytes_usize();
+    let content = vec![0u8; size];
+    server
+        .add_object("metrics-file-download", content, None)
+        .await
+        .expect("add object");
+
+    let dir = tempfile::tempdir().unwrap();
+    let dest_path = dir.path().join("output.dat");
+
+    let handle = tm
+        .download()
+        .bucket("test-bucket")
+        .key("metrics-file-download")
+        .write_to_path(&dest_path)
+        .await
+        .unwrap();
+
+    let output = timeout(Duration::from_secs(30), handle.join())
+        .await
+        .expect("join timed out")
+        .expect("join");
+
+    assert_eq!(output.metrics.network_rx, size as u64);
+    // NOTE: disk_write is tracked in global io_counters, not per-transfer metrics
+    assert_eq!(output.metrics.total_bytes, Some(size as u64));
+
+    server_handle.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn test_upload_abort_metrics() {
+    let (_server, server_handle, tm) = setup().await;
+
+    let size = 16 * ByteUnit::Mebibyte.as_bytes_usize();
+    let content = vec![0u8; size];
+
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("metrics-abort-upload")
+        .body(InputStream::from(content))
+        .initiate()
+        .expect("initiate upload");
+
+    // total_bytes is set at initiation, before any I/O
+    assert_eq!(handle.metrics().total_bytes, Some(size as u64));
+
+    // Let CreateMPU and some parts start
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    timeout(Duration::from_secs(30), handle.abort())
+        .await
+        .expect("abort timed out")
+        .expect("abort");
+
+    server_handle.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn test_download_abort_status() {
+    let (server, server_handle, tm) = setup().await;
+
+    let size = 100 * ByteUnit::Mebibyte.as_bytes_usize();
+    let content = vec![0u8; size];
+    server
+        .add_object("metrics-abort-download", content, None)
+        .await
+        .expect("add object");
+
+    let handle = tm
+        .download()
+        .bucket("test-bucket")
+        .key("metrics-abort-download")
+        .initiate()
+        .expect("initiate download");
+
+    // Give some time for bytes to flow
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    timeout(Duration::from_secs(30), handle.abort())
+        .await
+        .expect("abort timed out");
+
+    server_handle.shutdown().await.expect("shutdown");
+}

--- a/integration-tests/src/metrics.rs
+++ b/integration-tests/src/metrics.rs
@@ -129,6 +129,15 @@ async fn test_download_metrics_and_status() {
         .initiate()
         .expect("initiate download");
 
+    wait_for_terminal(|| handle.status()).await;
+
+    assert_eq!(handle.status(), TransferStatus::Completed);
+    let metrics = handle.metrics();
+    assert_eq!(metrics.network_rx, size as u64);
+    assert_eq!(metrics.total_bytes, Some(size as u64));
+    assert!(metrics.finished_at.is_some());
+    assert!(metrics.started_at <= metrics.finished_at.unwrap());
+
     let output = timeout(Duration::from_secs(30), handle.join())
         .await
         .expect("join timed out")


### PR DESCRIPTION
# Walking primitives, scheduler child-cancel, and transfer metrics

## Series

1. ~~bootstrap new scheduler~~ (#131)
2. ~~move uploads to new scheduler~~ (#132)
3. ~~migrate download to state machine and new scheduler~~ (#133)
4. ~~implement support for adaptive concurrency~~ (#135)
5. ~~collapse work model for vnext~~ (#136)
6. ~~managed runtime support~~ (#137)
7. ~~loom and miri tests + cleanup~~ (#139)
8. **This PR**: Walking primitives, scheduler child-cancel, and transfer metrics
9. `upload_objects` state machine (upcoming)
10. `download_objects` state machine (upcoming)

## Summary

Introduces the building blocks for directory transfer operations (`upload_objects` / `download_objects`) on the new scheduler. This includes local filesystem and S3 walking primitives, scheduler support for parent-child transfer relationships, scaffolding for the `UploadObjectsTransfer` state machine, and a public transfer metrics/status API on handles.

None of this is wired into production paths yet. The existing `upload_objects` / `download_objects` implementations continue to use the legacy worker pool. The next two PRs will implement the actual state machines and swap out the legacy code.

## Why

The current `upload_objects` / `download_objects` use a bespoke worker pool with `async_channel` that operates outside the scheduler. This means they don't participate in fair-share scheduling, adaptive concurrency, or the cancellation model. Moving them onto the scheduler requires:

1. A walker abstraction that yields entries one at a time (async, paginated for S3)
2. The scheduler to understand parent-child relationships (cancel parent = cancel children)
3. Per-transfer metrics so the parent can observe child completion
4. Type scaffolding for the new state machine

## How to review

~4000 lines, but most of it is the two walker modules which are self-contained with extensive tests.

1. `src/io/walk/error.rs` (147 lines) - `WalkError` and `WalkErrorKind`. Per-entry vs fatal error distinction.

2. `src/io/walk/fs.rs` (1667 lines, 44 tests) - Local filesystem walker. Config/instance split via builder. Cycle detection in `read_dir`. Sort support for sync compatibility.

3. `src/io/walk/s3.rs` (1005 lines, 19 tests) - S3 listing walker. Same config/instance pattern. Pagination, common prefix recursion, resume primitives.

4. `src/scheduler/scheduler.rs` - Child-cancel cascade. Small addition (~30 lines of logic, 4 tests).

5. `src/transfer.rs` + `src/types.rs` - `MetricsState`, `TransferContext`, and the public `TransferMetrics`/`TransferStatus` types.

6. `src/operation/upload_objects/transfer.rs` - Scaffolding only (stub `Transfer` impl, types).

7. `integration-tests/src/metrics.rs` - 6 integration tests for the metrics API.

## How it works

### Walking

Both walkers follow a config/instance split: a `Builder` produces an immutable config struct (`FsWalker` / `S3Walker`), and `.walk(context)` produces a stateful walk instance (`FsWalk` / `S3Walk`) that yields entries via `async fn next()`.

**FsWalker** does breadth-first traversal per directory level (depth-first across levels). Each `read_dir` call produces files + subdirectories for one directory. When `sort` is enabled, entries within each directory are sorted lexicographically (needed for sync's merge-join). Cycle detection tracks directory handles on the current descent path; a symlink whose target matches an ancestor is reported as a per-entry error and skipped.

Defaults match the SEP: `follow_symlinks=false`, `recursive=false`. The CLI layer can set `follow_symlinks(true)` and `sort(true)` to match Python CLI behavior.

**S3Walker** paginates through `ListObjectsV2` responses per the SEP (null delimiter for flat listing, handle pagination). When a delimiter is explicitly configured, common prefixes are pushed onto a stack and processed depth-first after the current prefix is exhausted. This matches the SEP specification and is consistent with Java SDK v2's implementation. Additional configuration beyond the SEP (`start_after`, `continuation_token`, `expected_bucket_owner`, `request_payer`) supports resume and cross-account use cases needed by the CLI.

### Scheduler child-cancel

`Scheduler::cancel_transfer` now cascades to depth-1 children (transfers whose `TransferId.parent == Some(cancelled_id)`). Parent is cancelled first, then each child. This is the mechanism that lets cancelling an `upload_objects` transfer cancel all its in-flight child uploads.

### Transfer metrics

`MetricsState` is a per-transfer atomic counter store (network_tx/rx, disk_read/write, total_bytes, timestamps). `TransferContext::record_io` and `StreamContext::record_io` both write to per-transfer metrics and forward to per-client telemetry (the `Telemetry` struct on `Handle`, used by the adaptive concurrency controller).

Public API: `handle.status()` returns `TransferStatus` (Active/Completed/Failed/Cancelled), `handle.metrics()` returns a `TransferMetrics` snapshot. `join()` returns metrics on the output type.

## Changes

**`src/io/walk/` (new)**
- `error.rs`: `WalkError`, `WalkErrorKind` with fatal/per-entry classification
- `fs.rs`: `FsWalker`, `FsWalkerBuilder`, `FsWalkContext`, `FsWalk`, `DirEntry`
- `s3.rs`: `S3Walker`, `S3WalkerBuilder`, `S3WalkContext`, `S3Walk`

**`src/scheduler/scheduler.rs`**
- `cancel_transfer` cascades to depth-1 children
- 4 new unit tests (cascade, single-parent regression, sibling isolation, nonexistent ID)

**`src/transfer.rs` (new)**
- `MetricsState`: per-transfer atomic counters
- `TransferContext`: holds `Arc<Handle>` + `Arc<MetricsState>`, provides `record_io`, `set_total_bytes`, `transfer_status`, `transfer_metrics`

**`src/types.rs`**
- `TransferStatus` enum (`#[non_exhaustive]`)
- `TransferMetrics` struct (`#[non_exhaustive]`, pub fields)

**`src/operation/upload/handle.rs`, `download/handle.rs`**
- `status()` and `metrics()` methods

**`src/operation/upload/output.rs`, `download/output.rs`**
- `TransferMetrics` field on output types (populated by `join()`)

**`src/operation/upload_objects/transfer.rs` (new)**
- Stub `Transfer` impl, `UploadObjectsWork`, `UploadObjectsState`, `ChildMeta`
- `pipeline_depth` on `UploadObjectsInput`
- `source_path` on `FailedUpload`

**`src/io/stream.rs`, `src/io/part_reader.rs`**
- `StreamContext` holds `Arc<Telemetry>` for per-client forwarding
- `PartReaderBuilder` accepts `.telemetry()`

**`src/client.rs`**
- `Handle.telemetry` is now `Arc<Telemetry>` (enables sharing with StreamContext)

**`integration-tests/src/metrics.rs` (new)**
- 6 tests: upload metrics, upload-from-file, download metrics, download-to-file, upload abort, download abort

## Future

- `upload_objects` state machine (next PR): consumes `FsWalk`, orchestrates child uploads via scheduler
- `download_objects` state machine: consumes `S3Walk`, orchestrates child downloads
- Wire-up PRs: replace legacy worker pool, un-ignore existing tests
- Walker extensions (deferred): `dir_filter` for subtree pruning, `normalize_unicode`, `same_file_system`
