### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-*    @awslabs/rust-sdk-s3-hll
-
+* @awslabs/aws-sdk-rust-team @awslabs/rust-sdk-s3-hll


### PR DESCRIPTION
Adds code ownership for @awslabs/aws-sdk-rust-team.