### PR TITLE
vnext mock server improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ env:
   # Change to specific Rust release to pin
   rust_stable: stable
   rust_nightly: nightly-2026-03-31
-  rust_clippy: '1.91.1'
+  rust_clippy: '1.92.0'
   # When updating this, also update relevant docs
-  rust_min: '1.91.1'
+  rust_min: '1.92.0'
   CI_ROLE_ARN: ${{ secrets.CI_ROLE_ARN }}
   AWS_REGION: us-west-2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 4
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -31,15 +31,24 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arrayvec"
@@ -59,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -99,9 +108,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -125,9 +134,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
@@ -150,8 +159,8 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.3.1",
- "sha1",
+ "http 1.4.0",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -173,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -184,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
 dependencies = [
  "cc",
  "cmake",
@@ -213,7 +222,7 @@ dependencies = [
  "bytes-utils",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
@@ -245,14 +254,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -284,7 +293,7 @@ dependencies = [
  "futures-test",
  "futures-util",
  "hdrhistogram",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "jemallocator",
  "loom",
@@ -309,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.97.0"
+version = "1.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+checksum = "f64a6eded248c6b453966e915d32aeddb48ea63ad17932682774eb026fbef5b1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -326,16 +335,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.99.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+checksum = "db96d720d3c622fcbe08bae1c4b04a72ce6257d8b0584cb5418da00ae20a344f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -350,16 +359,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "fafbdda43b93f57f699c5dfe8328db590b967b8a820a13ccdd6687355dfcc7ca"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -375,7 +384,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "regex-lite",
  "tracing",
 ]
@@ -395,13 +404,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "p256",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -432,10 +441,10 @@ dependencies = [
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
- "md-5",
+ "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -450,13 +459,13 @@ dependencies = [
  "bytes",
  "crc-fast",
  "hex",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "md-5",
+ "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -495,7 +504,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "percent-encoding",
  "pin-project-lite",
@@ -516,7 +525,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -536,22 +545,22 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "h2 0.3.26",
- "h2 0.4.12",
+ "h2 0.3.27",
+ "h2 0.4.13",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 0.14.32",
- "hyper 1.6.0",
+ "hyper 1.8.1",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.7",
  "hyper-util",
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.31",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "s2n-tls",
@@ -560,8 +569,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-rustls 0.26.2",
- "tower 0.5.2",
+ "tokio-rustls 0.26.4",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -583,7 +592,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -649,7 +658,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -671,7 +680,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -700,7 +709,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -748,7 +757,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -760,7 +769,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -774,7 +783,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -815,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benches"
@@ -835,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -849,10 +858,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.1"
+name = "block-buffer"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -872,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -900,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "bytestring"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
+checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
 dependencies = [
  "bytes",
 ]
@@ -923,7 +941,7 @@ dependencies = [
  "chrono",
  "data-encoding",
  "half",
- "nom",
+ "nom 7.1.3",
  "num-bigint",
  "num-rational",
  "num-traits",
@@ -934,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -946,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -958,9 +976,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "num-traits",
 ]
@@ -994,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1004,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1014,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1026,18 +1044,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
 
 [[package]]
 name = "concurrent-queue"
@@ -1094,16 +1118,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "const-str"
-version = "0.6.4"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451d0640545a0553814b4c646eb549343561618838e9b42495f466131fe3ad49"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1146,36 +1170,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rustversion",
  "spin",
 ]
 
 [[package]]
-name = "crc32c"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crc64fast-nvme"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
-dependencies = [
- "crc",
 ]
 
 [[package]]
@@ -1263,9 +1269,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1291,19 +1297,37 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.9.0"
+name = "crypto-common"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -1311,15 +1335,15 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -1336,9 +1360,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1385,7 +1421,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
  "der",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1416,19 +1452,19 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1447,9 +1483,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1469,9 +1505,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1485,15 +1521,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1506,9 +1548,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1521,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1531,15 +1573,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1548,15 +1590,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1564,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1575,21 +1617,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-test"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961fb6311645f46e2cdc2964a8bfae6743fd72315eaec181a71ae3eb2467113"
+checksum = "32d24b40cb9018c6b0f9d891b74a86a777d5db37972a115016d1150257b1c793"
 dependencies = [
  "futures-core",
  "futures-executor",
@@ -1603,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1615,7 +1657,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1646,25 +1687,38 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1680,9 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1690,7 +1744,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1699,17 +1753,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
- "indexmap 2.10.0",
+ "http 1.4.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1718,12 +1772,13 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1734,9 +1789,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1746,7 +1804,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1759,7 +1817,7 @@ dependencies = [
  "byteorder",
  "crossbeam-channel",
  "flate2",
- "nom",
+ "nom 7.1.3",
  "num-traits",
 ]
 
@@ -1837,7 +1895,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1853,12 +1920,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1880,7 +1946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1891,7 +1957,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1910,9 +1976,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1924,14 +1999,14 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1940,20 +2015,22 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
- "h2 0.4.12",
- "http 1.3.1",
+ "futures-core",
+ "h2 0.4.13",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1976,19 +2053,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
- "http 1.3.1",
- "hyper 1.6.0",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
- "rustls 0.23.31",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.2",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -1998,7 +2074,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.6.0",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2007,18 +2083,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.6.0",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2031,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2044,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2057,11 +2132,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -2072,42 +2146,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -2116,10 +2186,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "1.0.3"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -2148,13 +2224,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.3",
+ "hashbrown 0.16.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2172,22 +2249,21 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "widestring",
- "windows-registry",
- "windows-result",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
+ "winreg",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
@@ -2209,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jemalloc-sys"
@@ -2235,19 +2311,19 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2260,22 +2336,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.184"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -2288,9 +2370,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loom"
@@ -2338,7 +2420,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e715bb6f273068fc89403d6c4f5eeb83708c62b74c8d43e3e8772ca73a6288"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2349,9 +2441,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -2367,29 +2459,30 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -2425,21 +2518,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.1"
+name = "nom"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
- "windows-sys 0.52.0",
+ "memchr",
 ]
 
 [[package]]
-name = "nugine-rust-utils"
-version = "0.3.1"
+name = "nu-ansi-term"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dcd9cfa92246a9c7ca0671e00733c4e9d77ee1fa0ae08c9a181b7c8802aea2"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "simdutf8",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2454,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -2495,9 +2588,9 @@ checksum = "a3c00a0c9600379bd32f8972de90676a7672cba3bf4886986bc05902afc1e093"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -2511,9 +2604,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "outref"
@@ -2529,7 +2622,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2540,9 +2633,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2550,15 +2643,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -2569,24 +2662,24 @@ checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2595,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -2607,9 +2700,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -2662,9 +2755,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -2692,6 +2785,16 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -2756,9 +2859,15 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2807,7 +2916,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2816,7 +2925,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2841,18 +2950,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2862,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2873,15 +2982,15 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "resolv-conf"
@@ -2896,7 +3005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -2908,7 +3017,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
@@ -2934,15 +3043,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2959,23 +3068,23 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2985,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
@@ -3004,9 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3016,9 +3125,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -3028,9 +3137,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s2n-tls"
-version = "0.3.36"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d22c36f207d0bb6a38272d5d1fa1cd99094335c70db1bfef54e0b8b672ae26f"
+checksum = "0c0a7d9ebee45d6297f0138a17bd6f97e3c4d2035f4d9244cd3bf7aadf2ab1d8"
 dependencies = [
  "errno",
  "hex",
@@ -3045,8 +3154,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f48b9922eed6521a7f9d5b444bcc36a5df988161b67579112cc5377ca021ed78"
 dependencies = [
- "http 1.3.1",
- "hyper 1.6.0",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
  "s2n-tls",
  "s2n-tls-tokio",
@@ -3055,9 +3164,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-sys"
-version = "0.3.36"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf9e3b136cdd2c99f0cee2811d80b9f6bc44b5fd48c172857de32babb506f5e"
+checksum = "db941ce38358061fb322ad9d1e65220133f5f4c7b4e97337c51164cc3cb3722a"
 dependencies = [
  "aws-lc-rs",
  "cc",
@@ -3066,9 +3175,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-tokio"
-version = "0.3.36"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0ab00b075ab482e89509de51e1972a8f38ff70e1dbd5279caa0fd8d25f86cb"
+checksum = "0a0bf0c2d06fb48e8772e81e3bd33c3a1e66ed12d097e1af67847e5f33209f96"
 dependencies = [
  "errno",
  "libc",
@@ -3091,14 +3200,15 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "http 1.4.0",
  "hyper-util",
  "md5",
  "pin-project",
  "s3s",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3110,50 +3220,52 @@ dependencies = [
 
 [[package]]
 name = "s3s"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd98b3516a12e23867b6addf48d6f1425a3ca291a172ba89b769acedf98e3fa4"
+checksum = "fcf5572ca9bae5fd92d4e5a3e934c73793ab743bcbc761cd5e86a622c2a5e98a"
 dependencies = [
+ "arc-swap",
  "arrayvec",
  "async-trait",
  "atoi",
  "base64-simd",
  "bytes",
  "bytestring",
+ "cfg-if",
  "chrono",
- "const-str",
- "crc32c",
- "crc32fast",
- "crc64fast-nvme",
- "digest",
+ "crc-fast",
  "futures",
  "hex-simd",
- "hmac",
+ "hmac 0.13.0-rc.5",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "httparse",
- "hyper 1.6.0",
+ "hyper 1.8.1",
  "itoa",
+ "md-5 0.11.0-rc.5",
  "memchr",
  "mime",
- "nom",
- "nugine-rust-utils",
+ "nom 8.0.0",
  "numeric_cast",
  "pin-project-lite",
  "quick-xml",
  "serde",
+ "serde_json",
  "serde_urlencoded",
- "sha1",
- "sha2",
+ "sha1 0.11.0-rc.5",
+ "sha2 0.11.0-rc.5",
  "smallvec",
  "std-next",
+ "subtle",
  "sync_wrapper",
  "thiserror",
  "time",
  "tokio",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tracing",
  "transform-stream",
+ "url",
  "urlencoding",
  "zeroize",
 ]
@@ -3169,11 +3281,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3214,9 +3326,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3227,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3237,9 +3349,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "separator"
@@ -3283,7 +3395,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -3311,7 +3423,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3322,7 +3445,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3342,10 +3476,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -3355,9 +3490,15 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simdutf8"
@@ -3367,24 +3508,21 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3418,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std-next"
@@ -3474,15 +3612,15 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3493,25 +3631,25 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-mocks-experimental",
  "bytes",
- "http 1.3.1",
+ "http 1.4.0",
  "tempfile",
  "uuid",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3520,40 +3658,39 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3561,9 +3698,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3581,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3635,19 +3772,19 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.31",
+ "rustls 0.23.37",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3656,12 +3793,10 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
 dependencies = [
- "async-stream",
- "bytes",
  "futures-core",
  "tokio",
  "tokio-stream",
@@ -3691,17 +3826,17 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.12",
- "http 1.3.1",
+ "h2 0.4.13",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -3732,9 +3867,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3861,15 +3996,21 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -3885,13 +4026,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3908,11 +4050,13 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3954,24 +4098,33 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3981,24 +4134,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4006,31 +4145,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.80"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4044,11 +4217,11 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4056,17 +4229,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"
@@ -4078,12 +4240,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-strings"
-version = "0.5.1"
+name = "windows-sys"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-link",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4092,16 +4254,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4115,19 +4268,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4137,9 +4311,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4155,9 +4341,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4167,9 +4365,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4178,19 +4388,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "winreg"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
  "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xmlparser"
@@ -4206,11 +4505,10 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -4218,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4230,18 +4528,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4271,15 +4569,15 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4288,9 +4586,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4299,9 +4597,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.96.0"
+version = "1.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64a6eded248c6b453966e915d32aeddb48ea63ad17932682774eb026fbef5b1"
+checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -342,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.98.0"
+version = "1.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db96d720d3c622fcbe08bae1c4b04a72ce6257d8b0584cb5418da00ae20a344f"
+checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.100.0"
+version = "1.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafbdda43b93f57f699c5dfe8328db590b967b8a820a13ccdd6687355dfcc7ca"
+checksum = "0fc35b7a14cabdad13795fbbbd26d5ddec0882c01492ceedf2af575aad5f37dd"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -546,21 +546,21 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "h2 0.3.27",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 0.14.32",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.9",
  "hyper-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "s2n-tls",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -844,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "bytestring"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
 dependencies = [
  "bytes",
 ]
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1050,18 +1050,18 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "concurrent-queue"
@@ -1159,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
@@ -1316,18 +1316,18 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -1367,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1744,7 +1744,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1753,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1763,7 +1763,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1806,6 +1806,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdrhistogram"
@@ -1859,7 +1865,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "thiserror",
  "tinyvec",
@@ -1881,7 +1887,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -1904,7 +1910,7 @@ version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1982,9 +1988,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2015,22 +2021,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2053,16 +2058,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -2074,7 +2078,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2093,7 +2097,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2106,12 +2110,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -2119,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2132,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2146,15 +2151,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -2166,15 +2171,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2204,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2224,12 +2229,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2249,14 +2254,15 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2285,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc-sys"
@@ -2321,10 +2327,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2343,9 +2351,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2355,9 +2363,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2391,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2430,7 +2438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e715bb6f273068fc89403d6c4f5eeb83708c62b74c8d43e3e8772ca73a6288"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2469,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -2480,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -2497,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2547,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2668,18 +2676,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2755,9 +2763,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2871,9 +2879,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2882,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2930,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3068,14 +3076,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3094,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -3113,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3137,9 +3145,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s2n-tls"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0a7d9ebee45d6297f0138a17bd6f97e3c4d2035f4d9244cd3bf7aadf2ab1d8"
+checksum = "5d22c36f207d0bb6a38272d5d1fa1cd99094335c70db1bfef54e0b8b672ae26f"
 dependencies = [
  "errno",
  "hex",
@@ -3155,7 +3163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f48b9922eed6521a7f9d5b444bcc36a5df988161b67579112cc5377ca021ed78"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "s2n-tls",
  "s2n-tls-tokio",
@@ -3164,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-sys"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db941ce38358061fb322ad9d1e65220133f5f4c7b4e97337c51164cc3cb3722a"
+checksum = "bcf9e3b136cdd2c99f0cee2811d80b9f6bc44b5fd48c172857de32babb506f5e"
 dependencies = [
  "aws-lc-rs",
  "cc",
@@ -3175,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-tokio"
-version = "0.3.35"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0bf0c2d06fb48e8772e81e3bd33c3a1e66ed12d097e1af67847e5f33209f96"
+checksum = "0e0ab00b075ab482e89509de51e1972a8f38ff70e1dbd5279caa0fd8d25f86cb"
 dependencies = [
  "errno",
  "libc",
@@ -3241,7 +3249,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "httparse",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "itoa",
  "md-5 0.11.0-rc.5",
  "memchr",
@@ -3349,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "separator"
@@ -3395,7 +3403,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3434,7 +3442,7 @@ checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3456,7 +3464,7 @@ checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3496,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -3698,9 +3706,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3733,9 +3741,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3751,9 +3759,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3776,7 +3784,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -3826,11 +3834,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -3856,7 +3864,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -3996,9 +4004,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -4050,9 +4058,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4104,11 +4112,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4117,14 +4125,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4135,9 +4143,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4145,9 +4153,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4158,9 +4166,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4182,7 +4190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4195,15 +4203,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4231,6 +4239,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4240,12 +4259,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-strings"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-link",
 ]
 
 [[package]]
@@ -4254,7 +4273,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4268,40 +4287,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4311,21 +4309,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4341,21 +4327,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4365,37 +4339,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"
@@ -4405,6 +4357,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -4425,7 +4383,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4456,7 +4414,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4475,7 +4433,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4487,9 +4445,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xmlparser"
@@ -4505,9 +4463,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4516,9 +4474,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4528,18 +4486,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4548,18 +4506,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4575,9 +4533,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4586,9 +4544,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4597,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -53,7 +53,7 @@ async fn setup_test(
 
     let data = Bytes::from(vec![0u8; size]);
     mock_server
-        .add_object("test-key", data, None)
+        .add_object("test-bucket", "test-key", data, None)
         .await
         .unwrap();
 

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -100,7 +100,8 @@ fn download_throughput_benchmark(c: &mut Criterion) {
                                 .key("test-key")
                                 .initiate()
                                 .expect("successful transfer initiate");
-                            black_box(drain(&mut dl_handle).await.unwrap());
+                            drain(&mut dl_handle).await.unwrap();
+                            black_box(&dl_handle);
                         }
                         let elapsed = start.elapsed();
 

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -94,7 +94,7 @@ async fn test_download_basic() {
     let expected = content.clone();
 
     server
-        .add_object("test-key", content, None)
+        .add_object("test-bucket", "test-key", content, None)
         .await
         .expect("add object");
 
@@ -120,7 +120,7 @@ async fn test_download_body_not_consumed() {
 
     let content = vec![0u8; 16 * ByteUnit::Mebibyte.as_bytes_usize()];
     server
-        .add_object("test-key", content, None)
+        .add_object("test-bucket", "test-key", content, None)
         .await
         .expect("add object");
 
@@ -147,7 +147,7 @@ async fn test_download_abort() {
 
     let content = vec![0u8; 25 * ByteUnit::Mebibyte.as_bytes_usize()];
     server
-        .add_object("test-key", content, None)
+        .add_object("test-bucket", "test-key", content, None)
         .await
         .expect("add object");
 
@@ -193,7 +193,7 @@ async fn test_download_object_meta() {
 
     let content = vec![42u8; ByteUnit::Mebibyte.as_bytes_usize()];
     server
-        .add_object("test-key", content.clone(), None)
+        .add_object("test-bucket", "test-key", content.clone(), None)
         .await
         .expect("add object");
 
@@ -225,7 +225,7 @@ async fn test_download_concurrent() {
             .map(|j| ((i + j) % 256) as u8)
             .collect();
         server
-            .add_object(&format!("concurrent-key-{}", i), content, None)
+            .add_object("test-bucket", &format!("concurrent-key-{}", i), content, None)
             .await
             .expect("add object");
     }
@@ -271,7 +271,7 @@ async fn test_download_write_to_path() {
     let size = 100 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = deterministic_data(size);
     server
-        .add_object("write-to-path-key", content.clone(), None)
+        .add_object("test-bucket", "write-to-path-key", content.clone(), None)
         .await
         .expect("add object");
 
@@ -313,7 +313,7 @@ async fn test_download_write_to_file() {
     let size = 50 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = deterministic_data(size);
     server
-        .add_object("write-to-file-key", content.clone(), None)
+        .add_object("test-bucket", "write-to-file-key", content.clone(), None)
         .await
         .expect("add object");
 
@@ -347,7 +347,7 @@ async fn test_download_write_to_path_ranged() {
     let size = 100 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = deterministic_data(size);
     server
-        .add_object("ranged-key", content.clone(), None)
+        .add_object("test-bucket", "ranged-key", content.clone(), None)
         .await
         .expect("add object");
 
@@ -387,7 +387,7 @@ async fn test_download_write_to_path_single_part() {
     let size = 2 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = deterministic_data(size);
     server
-        .add_object("single-part-key", content.clone(), None)
+        .add_object("test-bucket", "single-part-key", content.clone(), None)
         .await
         .expect("add object");
 
@@ -422,7 +422,7 @@ async fn test_download_write_to_path_integrity() {
     let size = 100 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = deterministic_data(size);
     server
-        .add_object("integrity-key", content.clone(), None)
+        .add_object("test-bucket", "integrity-key", content.clone(), None)
         .await
         .expect("add object");
 

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -485,7 +485,7 @@ async fn test_download_empty_object() {
     let (server, server_handle, tm) = setup().await;
 
     server
-        .add_object("empty-key", vec![], None)
+        .add_object("test-bucket", "empty-key", vec![], None)
         .await
         .expect("add object");
 

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -225,7 +225,12 @@ async fn test_download_concurrent() {
             .map(|j| ((i + j) % 256) as u8)
             .collect();
         server
-            .add_object("test-bucket", &format!("concurrent-key-{}", i), content, None)
+            .add_object(
+                "test-bucket",
+                &format!("concurrent-key-{}", i),
+                content,
+                None,
+            )
             .await
             .expect("add object");
     }

--- a/integration-tests/src/metrics.rs
+++ b/integration-tests/src/metrics.rs
@@ -118,7 +118,7 @@ async fn test_download_metrics_and_status() {
     let size = 25 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = vec![0u8; size];
     server
-        .add_object("metrics-download", content, None)
+        .add_object("test-bucket", "metrics-download", content, None)
         .await
         .expect("add object");
 
@@ -158,7 +158,7 @@ async fn test_download_to_file_metrics() {
     let size = 25 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = vec![0u8; size];
     server
-        .add_object("metrics-file-download", content, None)
+        .add_object("test-bucket", "metrics-file-download", content, None)
         .await
         .expect("add object");
 
@@ -221,7 +221,7 @@ async fn test_download_abort_status() {
     let size = 100 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = vec![0u8; size];
     server
-        .add_object("metrics-abort-download", content, None)
+        .add_object("test-bucket", "metrics-abort-download", content, None)
         .await
         .expect("add object");
 

--- a/s3-mock-server/Cargo.toml
+++ b/s3-mock-server/Cargo.toml
@@ -20,7 +20,7 @@ hex = "0.4.3"
 hyper-util = {  version = "0.1.13", features = ["server-graceful", "server-auto", "server", "http1", "http2", "tokio"]}
 md5 = "0.7.0"
 pin-project = "1.1.10"
-s3s = { version = "0.11.0", features = ["tower"] }
+s3s = "0.13.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2"
@@ -36,3 +36,4 @@ crc-fast = "1.3.0"
 sha1 = "0.10.6"
 sha2 = "0.10.8"
 base64 = "0.22.1"
+http = "1.4.0"

--- a/s3-mock-server/Cargo.toml
+++ b/s3-mock-server/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "1.7.0", features = ["v4"] }
 [dev-dependencies]
 tempfile = "3.12.0"
 tracing-subscriber = "0.3.19"
-crc-fast = "1.3.0"
+crc-fast = "1.9.0"
 sha1 = "0.10.6"
 sha2 = "0.10.8"
 base64 = "0.22.1"

--- a/s3-mock-server/src/lib.rs
+++ b/s3-mock-server/src/lib.rs
@@ -19,4 +19,6 @@ mod types;
 
 pub use error::Error;
 pub use error::Result;
-pub use server::{S3MockServer, S3MockServerBuilder, ServerConfig, ServerHandle};
+pub use server::{
+    ObjectData, ObjectListEntry, S3MockServer, S3MockServerBuilder, ServerConfig, ServerHandle,
+};

--- a/s3-mock-server/src/lib.rs
+++ b/s3-mock-server/src/lib.rs
@@ -20,5 +20,6 @@ mod types;
 pub use error::Error;
 pub use error::Result;
 pub use server::{
-    ObjectData, ObjectListEntry, S3MockServer, S3MockServerBuilder, ServerConfig, ServerHandle,
+    AddObjectRequest, ObjectData, ObjectListEntry, S3MockServer, S3MockServerBuilder, ServerConfig,
+    ServerHandle,
 };

--- a/s3-mock-server/src/s3s.rs
+++ b/s3-mock-server/src/s3s.rs
@@ -115,9 +115,10 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         output.last_modified = Some(timestamp);
 
         if let Some(content_type) = stream_metadata.content_type {
-            if let Ok(mime) = content_type.parse() {
-                output.content_type = Some(mime);
-            }
+            let mime = content_type
+                .parse()
+                .expect("stored content_type should be valid");
+            output.content_type = Some(mime);
         }
 
         output.metadata = Some(stream_metadata.user_metadata);
@@ -430,6 +431,12 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
     ) -> S3Result<S3Response<s3s::dto::ListObjectsV2Output>> {
         let input = req.input;
         tracing::trace!(bucket = %input.bucket, prefix = ?input.prefix, delimiter = ?input.delimiter, "ListObjectsV2");
+
+        // Real S3 returns NoSuchBucket if the bucket doesn't exist
+        if !self.storage.head_bucket(&input.bucket).await? {
+            return Err(s3s::s3_error!(NoSuchBucket));
+        }
+
         let prefix = input.prefix.as_deref();
         let delimiter = input.delimiter.as_deref();
         let max_keys = input.max_keys.unwrap_or(1000).min(1000) as usize;

--- a/s3-mock-server/src/s3s.rs
+++ b/s3-mock-server/src/s3s.rs
@@ -48,7 +48,6 @@ impl<S: StorageBackend + 'static> Inner<S> {
 
 #[async_trait]
 impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
-    #[tracing::instrument(level = "debug")]
     async fn get_object(
         &self,
         req: S3Request<s3s::dto::GetObjectInput>,
@@ -56,6 +55,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         let input = req.input;
         let bucket = &input.bucket;
         let key = &input.key;
+        tracing::trace!(%bucket, %key, "GetObject");
 
         // Get metadata first to validate range
         let metadata = match self.storage.head_object(bucket, key).await? {
@@ -132,7 +132,6 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         Ok(S3Response::new(output))
     }
 
-    #[tracing::instrument(level = "debug")]
     async fn head_object(
         &self,
         req: S3Request<s3s::dto::HeadObjectInput>,
@@ -140,6 +139,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         let input = req.input;
         let bucket = &input.bucket;
         let key = &input.key;
+        tracing::trace!(%bucket, %key, "HeadObject");
 
         // Get object metadata from storage
         let metadata = match self.storage.head_object(bucket, key).await? {
@@ -168,12 +168,12 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         Ok(S3Response::new(output))
     }
 
-    #[tracing::instrument(level = "debug")]
     async fn put_object(
         &self,
         req: S3Request<s3s::dto::PutObjectInput>,
     ) -> S3Result<S3Response<s3s::dto::PutObjectOutput>> {
         let input = req.input;
+        tracing::trace!(bucket = %input.bucket, key = %input.key, "PutObject");
         if input.key.is_empty() {
             return Err(s3s::s3_error!(InvalidRequest));
         }
@@ -205,12 +205,12 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         Ok(S3Response::new(output))
     }
 
-    #[tracing::instrument(level = "debug")]
     async fn create_multipart_upload(
         &self,
         req: S3Request<s3s::dto::CreateMultipartUploadInput>,
     ) -> S3Result<S3Response<s3s::dto::CreateMultipartUploadOutput>> {
         let input = req.input;
+        tracing::trace!(bucket = %input.bucket, key = %input.key, "CreateMultipartUpload");
         let key = &input.key;
 
         // Extract checksum algorithm if provided, default to CRC64NVME
@@ -291,7 +291,6 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         Ok(S3Response::new(output))
     }
 
-    #[tracing::instrument(level = "debug")]
     async fn upload_part(
         &self,
         req: S3Request<s3s::dto::UploadPartInput>,
@@ -299,6 +298,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         let input = req.input;
         let upload_id = &input.upload_id;
         let part_number = input.part_number;
+        tracing::trace!(%upload_id, part_number, "UploadPart");
 
         let client_checksums = crate::types::ClientChecksums::from(&input);
         let mut integrity_checks = crate::types::ObjectIntegrityChecks::from(&client_checksums);
@@ -346,12 +346,12 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         Ok(S3Response::new(output))
     }
 
-    #[tracing::instrument(level = "debug")]
     async fn complete_multipart_upload(
         &self,
         req: S3Request<s3s::dto::CompleteMultipartUploadInput>,
     ) -> S3Result<S3Response<s3s::dto::CompleteMultipartUploadOutput>> {
         let input = req.input;
+        tracing::trace!(bucket = %input.bucket, key = %input.key, upload_id = %input.upload_id, "CompleteMultipartUpload");
         let bucket = input.bucket.clone();
         let upload_id = &input.upload_id;
 
@@ -408,12 +408,12 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         Ok(S3Response::new(output))
     }
 
-    #[tracing::instrument(level = "debug")]
     async fn abort_multipart_upload(
         &self,
         req: S3Request<s3s::dto::AbortMultipartUploadInput>,
     ) -> S3Result<S3Response<s3s::dto::AbortMultipartUploadOutput>> {
         let input = req.input;
+        tracing::trace!(bucket = %input.bucket, key = %input.key, upload_id = %input.upload_id, "AbortMultipartUpload");
         let upload_id = &input.upload_id;
 
         // Abort the multipart upload
@@ -424,12 +424,12 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         ))
     }
 
-    #[tracing::instrument(level = "debug")]
     async fn list_objects_v2(
         &self,
         req: S3Request<s3s::dto::ListObjectsV2Input>,
     ) -> S3Result<S3Response<s3s::dto::ListObjectsV2Output>> {
         let input = req.input;
+        tracing::trace!(bucket = %input.bucket, prefix = ?input.prefix, delimiter = ?input.delimiter, "ListObjectsV2");
         let prefix = input.prefix.as_deref();
         let delimiter = input.delimiter.as_deref();
         let max_keys = input.max_keys.unwrap_or(1000).min(1000) as usize;
@@ -553,6 +553,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         req: S3Request<HeadBucketInput>,
     ) -> S3Result<S3Response<HeadBucketOutput>> {
         let input = req.input;
+        tracing::trace!(bucket = %input.bucket, "HeadBucket");
         if self.storage.head_bucket(&input.bucket).await? {
             Ok(S3Response::new(HeadBucketOutput::default()))
         } else {
@@ -565,6 +566,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         req: S3Request<s3s::dto::DeleteObjectInput>,
     ) -> S3Result<S3Response<s3s::dto::DeleteObjectOutput>> {
         let input = req.input;
+        tracing::trace!(bucket = %input.bucket, key = %input.key, "DeleteObject");
         self.storage
             .delete_object(&input.bucket, &input.key)
             .await?;
@@ -576,6 +578,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         req: S3Request<s3s::dto::CreateBucketInput>,
     ) -> S3Result<S3Response<s3s::dto::CreateBucketOutput>> {
         let input = req.input;
+        tracing::trace!(bucket = %input.bucket, "CreateBucket");
         self.storage.create_bucket(&input.bucket).await?;
         let output = s3s::dto::CreateBucketOutput {
             location: Some(format!("/{}", input.bucket)),
@@ -588,6 +591,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         req: S3Request<s3s::dto::DeleteBucketInput>,
     ) -> S3Result<S3Response<s3s::dto::DeleteBucketOutput>> {
         let input = req.input;
+        tracing::trace!(bucket = %input.bucket, "DeleteBucket");
         self.storage.delete_bucket(&input.bucket).await?;
         Ok(S3Response::new(s3s::dto::DeleteBucketOutput::default()))
     }
@@ -596,6 +600,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         &self,
         _req: S3Request<s3s::dto::ListBucketsInput>,
     ) -> S3Result<S3Response<s3s::dto::ListBucketsOutput>> {
+        tracing::trace!("ListBuckets");
         let buckets = self.storage.list_buckets().await?;
         let bucket_list: Vec<s3s::dto::Bucket> = buckets
             .into_iter()

--- a/s3-mock-server/src/s3s.rs
+++ b/s3-mock-server/src/s3s.rs
@@ -15,9 +15,19 @@ use base64::Engine;
 use bytes::BytesMut;
 use futures_util::StreamExt;
 use s3s::dto::Timestamp;
-use s3s::dto::{HeadBucketInput, HeadBucketOutput, StreamingBlob};
+use s3s::dto::{ETag, HeadBucketInput, HeadBucketOutput, StreamingBlob};
 use s3s::{S3Request, S3Response, S3Result};
 use std::str::FromStr;
+
+/// Convert a quoted etag string (e.g. `"\"abc123\""`) to `ETag::Strong("abc123")`.
+fn etag_from_quoted(s: &str) -> ETag {
+    ETag::Strong(s.trim_matches('"').to_owned())
+}
+
+/// Convert a quoted etag string to `Option<ETag::Strong>`.
+fn opt_etag_from_quoted(s: Option<String>) -> Option<ETag> {
+    s.map(|v| etag_from_quoted(&v))
+}
 
 /// Inner implementation of the s3s::S3 trait.
 ///
@@ -97,7 +107,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         // Use the stream directly
         output.body = Some(StreamingBlob::wrap(stream));
 
-        output.e_tag = Some(stream_metadata.etag);
+        output.e_tag = Some(etag_from_quoted(&stream_metadata.etag));
 
         let timestamp = Timestamp::from(stream_metadata.last_modified);
         output.last_modified = Some(timestamp);
@@ -138,7 +148,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         let content_type = metadata.content_type.and_then(|ct| ct.parse().ok());
         let mut output = s3s::dto::HeadObjectOutput {
             content_length: Some(metadata.content_length as i64),
-            e_tag: Some(metadata.etag),
+            e_tag: Some(etag_from_quoted(&metadata.etag)),
             last_modified: Some(Timestamp::from(metadata.last_modified)),
             content_type,
             metadata: Some(metadata.user_metadata),
@@ -180,7 +190,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         }
 
         let output = s3s::dto::PutObjectOutput {
-            e_tag: stored_meta.object_integrity.etag(),
+            e_tag: opt_etag_from_quoted(stored_meta.object_integrity.etag()),
             checksum_crc32: stored_meta.object_integrity.crc32,
             checksum_crc32c: stored_meta.object_integrity.crc32c,
             checksum_sha1: stored_meta.object_integrity.sha1,
@@ -320,7 +330,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
 
         // Build response with checksums
         let output = s3s::dto::UploadPartOutput {
-            e_tag: Some(response.etag),
+            e_tag: Some(etag_from_quoted(&response.etag)),
             checksum_crc32: calculated_integrity.crc32,
             checksum_crc32c: calculated_integrity.crc32c,
             checksum_sha1: calculated_integrity.sha1,
@@ -352,7 +362,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
                     .part_number
                     .ok_or_else(|| s3s::s3_error!(InvalidRequest))?;
                 let etag = part.e_tag.ok_or_else(|| s3s::s3_error!(InvalidRequest))?;
-                parts.push((part_number, etag));
+                parts.push((part_number, format!("\"{}\"", etag.value())));
             }
         }
 
@@ -380,7 +390,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
 
         let output = s3s::dto::CompleteMultipartUploadOutput {
             key: Some(response.key),
-            e_tag: Some(response.etag),
+            e_tag: Some(etag_from_quoted(&response.etag)),
             bucket: Some(bucket),
             checksum_crc32: response.object_integrity.crc32,
             checksum_crc32c: response.object_integrity.crc32c,
@@ -472,7 +482,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
                 let object = s3s::dto::Object {
                     key: Some(obj.key),
                     size: Some(obj.metadata.content_length as i64),
-                    e_tag: Some(obj.metadata.etag),
+                    e_tag: Some(etag_from_quoted(&obj.metadata.etag)),
                     last_modified: Some(Timestamp::from(obj.metadata.last_modified)),
                     ..Default::default()
                 };
@@ -485,7 +495,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
                 let object = s3s::dto::Object {
                     key: Some(obj.key),
                     size: Some(obj.metadata.content_length as i64),
-                    e_tag: Some(obj.metadata.etag),
+                    e_tag: Some(etag_from_quoted(&obj.metadata.etag)),
                     last_modified: Some(Timestamp::from(obj.metadata.last_modified)),
                     ..Default::default()
                 };
@@ -587,6 +597,20 @@ mod tests {
     use futures::stream;
     use s3s::S3;
 
+    fn s3_request<T>(input: T) -> S3Request<T> {
+        S3Request {
+            input,
+            method: http::Method::GET,
+            uri: http::Uri::default(),
+            headers: http::HeaderMap::new(),
+            extensions: http::Extensions::new(),
+            credentials: None,
+            region: None,
+            service: None,
+            trailing_headers: None,
+        }
+    }
+
     fn create_get_object_input(bucket: &str, key: &str) -> s3s::dto::GetObjectInput {
         s3s::dto::GetObjectInput::builder()
             .bucket(s3s::dto::BucketName::from(bucket))
@@ -614,7 +638,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let req = S3Request::new(input);
+        let req = s3_request(input);
         inner.put_object(req).await.expect("Failed to put object")
     }
 
@@ -629,7 +653,7 @@ mod tests {
         let mut input = create_get_object_input("test-bucket", "test-key");
         input.range = Some(s3s::dto::Range::parse("bytes=0-49").unwrap());
 
-        let req = S3Request::new(input);
+        let req = s3_request(input);
 
         // Call the method
         let result = inner.get_object(req).await.expect("Get object failed");
@@ -642,8 +666,8 @@ mod tests {
         assert_eq!(output.content_range, Some("bytes 0-49/100".to_string()));
 
         // The etag should be the MD5 hash of the content (calculated during put_object)
-        let expected_etag = format!("\"{}\"", hex::encode(md5::compute(content).0));
-        assert_eq!(output.e_tag.unwrap().as_str(), &expected_etag);
+        let expected_etag = hex::encode(md5::compute(content).0);
+        assert_eq!(output.e_tag.unwrap().value(), &expected_etag);
 
         let mut body = output.body.unwrap();
 
@@ -670,7 +694,7 @@ mod tests {
         // Test case 1: Range at the beginning
         let mut input = create_get_object_input("test-bucket", "test-key");
         input.range = Some(s3s::dto::Range::parse("bytes=0-4").unwrap());
-        let req = S3Request::new(input);
+        let req = s3_request(input);
         let result = inner.get_object(req).await.expect("Get object failed");
         let output = result.output;
 
@@ -680,7 +704,7 @@ mod tests {
         // Test case 2: Range at the end
         let mut input = create_get_object_input("test-bucket", "test-key");
         input.range = Some(s3s::dto::Range::parse("bytes=5-9").unwrap());
-        let req = S3Request::new(input);
+        let req = s3_request(input);
         let result = inner.get_object(req).await.expect("Get object failed");
         let output = result.output;
 
@@ -690,7 +714,7 @@ mod tests {
         // Test case 3: Single byte range
         let mut input = create_get_object_input("test-bucket", "test-key");
         input.range = Some(s3s::dto::Range::parse("bytes=3-3").unwrap());
-        let req = S3Request::new(input);
+        let req = s3_request(input);
         let result = inner.get_object(req).await.expect("Get object failed");
         let output = result.output;
 
@@ -725,7 +749,7 @@ mod tests {
             .unwrap();
 
         let result = inner
-            .put_object(S3Request::new(input))
+            .put_object(s3_request(input))
             .await
             .expect("Put should succeed");
         assert_eq!(result.output.checksum_crc32, Some(expected_crc32));
@@ -743,7 +767,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let result_wrong = inner.put_object(S3Request::new(input_wrong)).await;
+        let result_wrong = inner.put_object(s3_request(input_wrong)).await;
         assert!(result_wrong.is_err());
     }
 
@@ -767,7 +791,7 @@ mod tests {
             .unwrap();
 
         let result = inner
-            .put_object(S3Request::new(input))
+            .put_object(s3_request(input))
             .await
             .expect("Put should succeed");
 
@@ -791,7 +815,7 @@ mod tests {
             .unwrap();
 
         let create_result = inner
-            .create_multipart_upload(S3Request::new(create_input))
+            .create_multipart_upload(s3_request(create_input))
             .await
             .expect("Create multipart upload failed");
         let upload_id = create_result.output.upload_id.unwrap();
@@ -820,7 +844,7 @@ mod tests {
             .unwrap();
 
         let result = inner
-            .upload_part(S3Request::new(input))
+            .upload_part(s3_request(input))
             .await
             .expect("Upload part should succeed");
         assert_eq!(result.output.checksum_crc32, Some(expected_crc32));
@@ -840,7 +864,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let result_wrong = inner.upload_part(S3Request::new(input_wrong)).await;
+        let result_wrong = inner.upload_part(s3_request(input_wrong)).await;
         assert!(result_wrong.is_err());
     }
 
@@ -857,7 +881,7 @@ mod tests {
             .unwrap();
 
         let create_result = inner
-            .create_multipart_upload(S3Request::new(create_input))
+            .create_multipart_upload(s3_request(create_input))
             .await
             .expect("Create multipart upload failed");
         let upload_id = create_result.output.upload_id.unwrap();
@@ -880,7 +904,7 @@ mod tests {
                 .unwrap();
 
             let result = inner
-                .upload_part(S3Request::new(input))
+                .upload_part(s3_request(input))
                 .await
                 .expect("Upload part failed");
             part_etags.push(result.output.e_tag.unwrap());
@@ -910,7 +934,7 @@ mod tests {
             .unwrap();
 
         let valid_result = inner
-            .complete_multipart_upload(S3Request::new(valid_input))
+            .complete_multipart_upload(s3_request(valid_input))
             .await;
         assert!(valid_result.is_ok());
 
@@ -922,7 +946,7 @@ mod tests {
             .unwrap();
 
         let create_result2 = inner
-            .create_multipart_upload(S3Request::new(create_input2))
+            .create_multipart_upload(s3_request(create_input2))
             .await
             .expect("Create multipart upload failed");
         let upload_id2 = create_result2.output.upload_id.unwrap();
@@ -931,12 +955,12 @@ mod tests {
         let invalid_parts = vec![
             s3s::dto::CompletedPart {
                 part_number: Some(1),
-                e_tag: Some("etag1".to_string()),
+                e_tag: Some(ETag::Strong("etag1".to_string())),
                 ..Default::default()
             },
             s3s::dto::CompletedPart {
                 part_number: Some(3),
-                e_tag: Some("etag3".to_string()),
+                e_tag: Some(ETag::Strong("etag3".to_string())),
                 ..Default::default()
             },
         ];
@@ -951,7 +975,7 @@ mod tests {
             .unwrap();
 
         let invalid_result = inner
-            .complete_multipart_upload(S3Request::new(invalid_input))
+            .complete_multipart_upload(s3_request(invalid_input))
             .await;
         assert!(invalid_result.is_err());
     }
@@ -968,7 +992,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let result = inner.create_multipart_upload(S3Request::new(input)).await;
+        let result = inner.create_multipart_upload(s3_request(input)).await;
         assert!(result.is_ok());
 
         // The response should include the default CRC64NVME algorithm
@@ -1000,7 +1024,7 @@ mod tests {
             .unwrap();
 
         let result = inner
-            .create_multipart_upload(S3Request::new(invalid_input))
+            .create_multipart_upload(s3_request(invalid_input))
             .await;
         assert!(result.is_err());
 
@@ -1016,7 +1040,7 @@ mod tests {
             .unwrap();
 
         let result2 = inner
-            .create_multipart_upload(S3Request::new(invalid_input2))
+            .create_multipart_upload(s3_request(invalid_input2))
             .await;
         assert!(result2.is_err());
 
@@ -1029,9 +1053,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let result3 = inner
-            .create_multipart_upload(S3Request::new(valid_input))
-            .await;
+        let result3 = inner.create_multipart_upload(s3_request(valid_input)).await;
         assert!(result3.is_ok());
         let output = result3.unwrap().output;
         assert_eq!(

--- a/s3-mock-server/src/s3s.rs
+++ b/s3-mock-server/src/s3s.rs
@@ -130,6 +130,15 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         output.checksum_sha256 = stream_metadata.sha256;
         output.checksum_crc64nvme = stream_metadata.crc64nvme;
 
+        // Return stored HTTP headers
+        output.storage_class = stream_metadata.storage_class.map(|s| s.parse().unwrap());
+        output.cache_control = stream_metadata.cache_control.map(|s| s.parse().unwrap());
+        output.content_encoding = stream_metadata.content_encoding.map(|s| s.parse().unwrap());
+        output.content_disposition = stream_metadata
+            .content_disposition
+            .map(|s| s.parse().unwrap());
+        output.content_language = stream_metadata.content_language.map(|s| s.parse().unwrap());
+
         Ok(S3Response::new(output))
     }
 
@@ -165,6 +174,13 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         output.checksum_sha1 = metadata.sha1;
         output.checksum_sha256 = metadata.sha256;
         output.checksum_crc64nvme = metadata.crc64nvme;
+
+        // Return stored HTTP headers
+        output.storage_class = metadata.storage_class.map(|s| s.parse().unwrap());
+        output.cache_control = metadata.cache_control.map(|s| s.parse().unwrap());
+        output.content_encoding = metadata.content_encoding.map(|s| s.parse().unwrap());
+        output.content_disposition = metadata.content_disposition.map(|s| s.parse().unwrap());
+        output.content_language = metadata.content_language.map(|s| s.parse().unwrap());
 
         Ok(S3Response::new(output))
     }
@@ -434,7 +450,10 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
 
         // Real S3 returns NoSuchBucket if the bucket doesn't exist
         if !self.storage.head_bucket(&input.bucket).await? {
-            return Err(s3s::s3_error!(NoSuchBucket));
+            return Err(s3s::s3_error!(
+                NoSuchBucket,
+                "The specified bucket does not exist"
+            ));
         }
 
         let prefix = input.prefix.as_deref();
@@ -564,7 +583,10 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         if self.storage.head_bucket(&input.bucket).await? {
             Ok(S3Response::new(HeadBucketOutput::default()))
         } else {
-            Err(s3s::s3_error!(NoSuchBucket))
+            Err(s3s::s3_error!(
+                NoSuchBucket,
+                "The specified bucket does not exist"
+            ))
         }
     }
 

--- a/s3-mock-server/src/s3s.rs
+++ b/s3-mock-server/src/s3s.rs
@@ -29,6 +29,51 @@ fn opt_etag_from_quoted(s: Option<String>) -> Option<ETag> {
     s.map(|v| etag_from_quoted(&v))
 }
 
+/// Apply defaults to a HeadObject response matching post-2023 prod S3
+/// behavior on a fresh bucket: SSE-S3 (AES256) default encryption, and
+/// `ChecksumType::FullObject` whenever any checksum is present.
+fn apply_response_defaults_head(output: &mut s3s::dto::HeadObjectOutput) {
+    if output.server_side_encryption.is_none() {
+        output.server_side_encryption = Some(s3s::dto::ServerSideEncryption::from_static(
+            s3s::dto::ServerSideEncryption::AES256,
+        ));
+    }
+    if output.checksum_type.is_none() && has_any_checksum_head(output) {
+        output.checksum_type = Some(s3s::dto::ChecksumType::from_static(
+            s3s::dto::ChecksumType::FULL_OBJECT,
+        ));
+    }
+}
+
+fn apply_response_defaults_get(output: &mut s3s::dto::GetObjectOutput) {
+    if output.server_side_encryption.is_none() {
+        output.server_side_encryption = Some(s3s::dto::ServerSideEncryption::from_static(
+            s3s::dto::ServerSideEncryption::AES256,
+        ));
+    }
+    if output.checksum_type.is_none() && has_any_checksum_get(output) {
+        output.checksum_type = Some(s3s::dto::ChecksumType::from_static(
+            s3s::dto::ChecksumType::FULL_OBJECT,
+        ));
+    }
+}
+
+fn has_any_checksum_head(o: &s3s::dto::HeadObjectOutput) -> bool {
+    o.checksum_crc32.is_some()
+        || o.checksum_crc32c.is_some()
+        || o.checksum_crc64nvme.is_some()
+        || o.checksum_sha1.is_some()
+        || o.checksum_sha256.is_some()
+}
+
+fn has_any_checksum_get(o: &s3s::dto::GetObjectOutput) -> bool {
+    o.checksum_crc32.is_some()
+        || o.checksum_crc32c.is_some()
+        || o.checksum_crc64nvme.is_some()
+        || o.checksum_sha1.is_some()
+        || o.checksum_sha256.is_some()
+}
+
 /// Inner implementation of the s3s::S3 trait.
 ///
 /// This struct implements the s3s::S3 trait, delegating all operations to the storage backend.
@@ -139,6 +184,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
             .map(|s| s.parse().unwrap());
         output.content_language = stream_metadata.content_language.map(|s| s.parse().unwrap());
 
+        apply_response_defaults_get(&mut output);
         Ok(S3Response::new(output))
     }
 
@@ -182,6 +228,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         output.content_disposition = metadata.content_disposition.map(|s| s.parse().unwrap());
         output.content_language = metadata.content_language.map(|s| s.parse().unwrap());
 
+        apply_response_defaults_head(&mut output);
         Ok(S3Response::new(output))
     }
 

--- a/s3-mock-server/src/s3s.rs
+++ b/s3-mock-server/src/s3s.rs
@@ -54,10 +54,11 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         req: S3Request<s3s::dto::GetObjectInput>,
     ) -> S3Result<S3Response<s3s::dto::GetObjectOutput>> {
         let input = req.input;
+        let bucket = &input.bucket;
         let key = &input.key;
 
         // Get metadata first to validate range
-        let metadata = match self.storage.head_object(key).await? {
+        let metadata = match self.storage.head_object(bucket, key).await? {
             Some(metadata) => metadata,
             None => return Err(Error::NoSuchKey.into()),
         };
@@ -75,6 +76,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
 
         // Get object stream with validated range
         let request = crate::storage::GetObjectRequest {
+            bucket,
             key,
             range: range.clone(),
         };
@@ -136,10 +138,11 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         req: S3Request<s3s::dto::HeadObjectInput>,
     ) -> S3Result<S3Response<s3s::dto::HeadObjectOutput>> {
         let input = req.input;
+        let bucket = &input.bucket;
         let key = &input.key;
 
         // Get object metadata from storage
-        let metadata = match self.storage.head_object(key).await? {
+        let metadata = match self.storage.head_object(bucket, key).await? {
             Some(metadata) => metadata,
             None => return Err(Error::NoSuchKey.into()),
         };
@@ -264,6 +267,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
             ..Default::default()
         };
         let request = crate::storage::CreateMultipartUploadRequest {
+            bucket: &input.bucket,
             key,
             upload_id: &upload_id,
             metadata,
@@ -378,6 +382,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
 
         // Complete the multipart upload
         let request = crate::storage::CompleteMultipartUploadRequest {
+            bucket: &bucket,
             upload_id,
             parts,
             client_checksums: if client_checksums.has_any() {
@@ -432,7 +437,10 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         let continuation_token = input.continuation_token.as_deref();
 
         // List objects from storage
-        let request = crate::storage::ListObjectsRequest { prefix };
+        let request = crate::storage::ListObjectsRequest {
+            bucket: &input.bucket,
+            prefix,
+        };
         let mut response = self.storage.list_objects(request).await?;
 
         // Apply start_after or continuation token if specified
@@ -532,7 +540,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
             max_keys: Some(max_keys as i32),
             prefix: prefix.map(|s| s.to_string()),
             delimiter: delimiter.map(|s| s.to_string()),
-            name: Some("mock-bucket".to_string()),
+            name: Some(input.bucket.to_string()),
             next_continuation_token,
             ..Default::default()
         };
@@ -542,9 +550,66 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
 
     async fn head_bucket(
         &self,
-        _req: S3Request<HeadBucketInput>,
+        req: S3Request<HeadBucketInput>,
     ) -> S3Result<S3Response<HeadBucketOutput>> {
-        Ok(S3Response::new(HeadBucketOutput::default()))
+        let input = req.input;
+        if self.storage.head_bucket(&input.bucket).await? {
+            Ok(S3Response::new(HeadBucketOutput::default()))
+        } else {
+            Err(s3s::s3_error!(NoSuchBucket))
+        }
+    }
+
+    async fn delete_object(
+        &self,
+        req: S3Request<s3s::dto::DeleteObjectInput>,
+    ) -> S3Result<S3Response<s3s::dto::DeleteObjectOutput>> {
+        let input = req.input;
+        self.storage
+            .delete_object(&input.bucket, &input.key)
+            .await?;
+        Ok(S3Response::new(s3s::dto::DeleteObjectOutput::default()))
+    }
+
+    async fn create_bucket(
+        &self,
+        req: S3Request<s3s::dto::CreateBucketInput>,
+    ) -> S3Result<S3Response<s3s::dto::CreateBucketOutput>> {
+        let input = req.input;
+        self.storage.create_bucket(&input.bucket).await?;
+        let output = s3s::dto::CreateBucketOutput {
+            location: Some(format!("/{}", input.bucket)),
+        };
+        Ok(S3Response::new(output))
+    }
+
+    async fn delete_bucket(
+        &self,
+        req: S3Request<s3s::dto::DeleteBucketInput>,
+    ) -> S3Result<S3Response<s3s::dto::DeleteBucketOutput>> {
+        let input = req.input;
+        self.storage.delete_bucket(&input.bucket).await?;
+        Ok(S3Response::new(s3s::dto::DeleteBucketOutput::default()))
+    }
+
+    async fn list_buckets(
+        &self,
+        _req: S3Request<s3s::dto::ListBucketsInput>,
+    ) -> S3Result<S3Response<s3s::dto::ListBucketsOutput>> {
+        let buckets = self.storage.list_buckets().await?;
+        let bucket_list: Vec<s3s::dto::Bucket> = buckets
+            .into_iter()
+            .map(|b| s3s::dto::Bucket {
+                name: Some(b.name),
+                creation_date: Some(Timestamp::from(b.creation_date)),
+                ..Default::default()
+            })
+            .collect();
+        let output = s3s::dto::ListBucketsOutput {
+            buckets: Some(bucket_list),
+            ..Default::default()
+        };
+        Ok(S3Response::new(output))
     }
 }
 

--- a/s3-mock-server/src/server.rs
+++ b/s3-mock-server/src/server.rs
@@ -182,6 +182,40 @@ pub struct ObjectListEntry {
     pub etag: String,
 }
 
+/// Request for adding an object via the direct (non-S3-protocol) API.
+pub struct AddObjectRequest {
+    pub content: bytes::Bytes,
+    pub content_type: Option<String>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
+    pub last_modified: Option<std::time::SystemTime>,
+}
+
+impl AddObjectRequest {
+    pub fn new(content: impl Into<bytes::Bytes>) -> Self {
+        Self {
+            content: content.into(),
+            content_type: None,
+            metadata: None,
+            last_modified: None,
+        }
+    }
+
+    pub fn content_type(mut self, ct: impl Into<String>) -> Self {
+        self.content_type = Some(ct.into());
+        self
+    }
+
+    pub fn metadata(mut self, meta: std::collections::HashMap<String, String>) -> Self {
+        self.metadata = Some(meta);
+        self
+    }
+
+    pub fn last_modified(mut self, time: std::time::SystemTime) -> Self {
+        self.last_modified = Some(time);
+        self
+    }
+}
+
 /// S3 Mock Server.
 pub struct S3MockServer {
     /// Storage backend.
@@ -205,23 +239,37 @@ impl S3MockServer {
         content: impl Into<bytes::Bytes>,
         metadata: Option<std::collections::HashMap<String, String>>,
     ) -> Result<()> {
+        let mut req = AddObjectRequest::new(content);
+        req.metadata = metadata;
+        self.add_object_with(bucket, key, req).await
+    }
+
+    /// Add an object with full control over metadata fields.
+    pub async fn add_object_with(
+        &self,
+        bucket: &str,
+        key: &str,
+        request: AddObjectRequest,
+    ) -> Result<()> {
         use crate::storage::StoreObjectRequest;
         use crate::types::ObjectIntegrityChecks;
         use futures::stream;
 
-        let bytes = content.into();
+        let bytes = request.content;
         let stream = stream::once(async move { Ok(bytes) });
         let boxed_stream = Box::pin(stream);
 
-        let request = StoreObjectRequest::new(
+        let mut store_req = StoreObjectRequest::new(
             bucket,
             key.to_string(),
             boxed_stream,
             ObjectIntegrityChecks::new(),
         )
-        .with_user_metadata(metadata.unwrap_or_default());
+        .with_user_metadata(request.metadata.unwrap_or_default());
+        store_req.content_type = request.content_type;
+        store_req.last_modified = request.last_modified;
 
-        self.storage.put_object(request).await?;
+        self.storage.put_object(store_req).await?;
         Ok(())
     }
 

--- a/s3-mock-server/src/server.rs
+++ b/s3-mock-server/src/server.rs
@@ -219,7 +219,7 @@ impl S3MockServer {
             let service = {
                 let mut b = S3ServiceBuilder::new(inner);
                 b.set_auth(SimpleAuth::from_single(TEST_ACCESS_KEY, TEST_SECRET_KEY));
-                b.build().into_shared()
+                b.build()
             };
             loop {
                 let (socket, _) = tokio::select! {

--- a/s3-mock-server/src/server.rs
+++ b/s3-mock-server/src/server.rs
@@ -66,6 +66,7 @@ impl ServerHandle {
 
     /// Shutdown the server.
     pub async fn shutdown(self) -> Result<()> {
+        tracing::debug!(addr = %self.address, "shutting down mock server");
         let _ = self.shutdown_tx.send(());
         match self.server_task.await {
             Ok(result) => result,

--- a/s3-mock-server/src/server.rs
+++ b/s3-mock-server/src/server.rs
@@ -154,6 +154,34 @@ impl S3MockServerBuilder {
     }
 }
 
+/// Object data returned from direct storage inspection.
+pub struct ObjectData {
+    /// The object body.
+    pub body: bytes::Bytes,
+    /// Content type of the object.
+    pub content_type: Option<String>,
+    /// Size of the object in bytes.
+    pub content_length: u64,
+    /// ETag of the object.
+    pub etag: String,
+    /// Last modified time.
+    pub last_modified: std::time::SystemTime,
+    /// User-defined metadata.
+    pub metadata: std::collections::HashMap<String, String>,
+}
+
+/// Summary information about an object in a listing.
+pub struct ObjectListEntry {
+    /// The object key.
+    pub key: String,
+    /// Size of the object in bytes.
+    pub size: u64,
+    /// Last modified time.
+    pub last_modified: std::time::SystemTime,
+    /// ETag of the object.
+    pub etag: String,
+}
+
 /// S3 Mock Server.
 pub struct S3MockServer {
     /// Storage backend.
@@ -172,6 +200,7 @@ impl S3MockServer {
     /// Add an object to the mock server storage.
     pub async fn add_object(
         &self,
+        bucket: &str,
         key: &str,
         content: impl Into<bytes::Bytes>,
         metadata: Option<std::collections::HashMap<String, String>>,
@@ -184,12 +213,90 @@ impl S3MockServer {
         let stream = stream::once(async move { Ok(bytes) });
         let boxed_stream = Box::pin(stream);
 
-        let request =
-            StoreObjectRequest::new(key.to_string(), boxed_stream, ObjectIntegrityChecks::new())
-                .with_user_metadata(metadata.unwrap_or_default());
+        let request = StoreObjectRequest::new(
+            bucket,
+            key.to_string(),
+            boxed_stream,
+            ObjectIntegrityChecks::new(),
+        )
+        .with_user_metadata(metadata.unwrap_or_default());
 
         self.storage.put_object(request).await?;
         Ok(())
+    }
+
+    /// Create a bucket in the mock server.
+    pub async fn create_bucket(&self, bucket: &str) -> Result<()> {
+        self.storage.create_bucket(bucket).await
+    }
+
+    /// Check if an object exists.
+    pub async fn object_exists(&self, bucket: &str, key: &str) -> Result<bool> {
+        Ok(self.storage.head_object(bucket, key).await?.is_some())
+    }
+
+    /// Get object content and metadata directly from storage.
+    pub async fn get_object(&self, bucket: &str, key: &str) -> Result<Option<ObjectData>> {
+        use crate::storage::GetObjectRequest;
+        use futures::StreamExt;
+
+        let request = GetObjectRequest {
+            bucket,
+            key,
+            range: None,
+        };
+        let response = match self.storage.get_object(request).await? {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+
+        let mut body = Vec::new();
+        let mut stream = response.stream;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| Error::Internal(format!("Stream error: {}", e)))?;
+            body.extend_from_slice(&chunk);
+        }
+
+        Ok(Some(ObjectData {
+            body: bytes::Bytes::from(body),
+            content_type: response.metadata.content_type,
+            content_length: response.metadata.content_length,
+            etag: response.metadata.etag,
+            last_modified: response.metadata.last_modified,
+            metadata: response.metadata.user_metadata,
+        }))
+    }
+
+    /// List objects in a bucket with optional prefix.
+    pub async fn list_objects(
+        &self,
+        bucket: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<ObjectListEntry>> {
+        use crate::storage::ListObjectsRequest;
+
+        let request = ListObjectsRequest { bucket, prefix };
+        let response = self.storage.list_objects(request).await?;
+        Ok(response
+            .objects
+            .into_iter()
+            .map(|o| ObjectListEntry {
+                key: o.key,
+                size: o.metadata.content_length,
+                last_modified: o.metadata.last_modified,
+                etag: o.metadata.etag,
+            })
+            .collect())
+    }
+
+    /// Delete an object.
+    pub async fn delete_object(&self, bucket: &str, key: &str) -> Result<()> {
+        self.storage.delete_object(bucket, key).await
+    }
+
+    /// Reset all state (clear all buckets, objects, and in-flight uploads).
+    pub async fn reset(&self) -> Result<()> {
+        self.storage.reset().await
     }
 
     /// Start the server.

--- a/s3-mock-server/src/server.rs
+++ b/s3-mock-server/src/server.rs
@@ -260,13 +260,14 @@ impl S3MockServer {
         let stream = stream::once(async move { Ok(bytes) });
         let boxed_stream = Box::pin(stream);
 
-        let mut store_req = StoreObjectRequest::new(
-            bucket,
-            key.to_string(),
-            boxed_stream,
-            ObjectIntegrityChecks::new(),
-        )
-        .with_user_metadata(request.metadata.unwrap_or_default());
+        // Match HTTP PutObject path's default integrity checks so seeded
+        // objects have the same HeadObject state (ETag via md5, default
+        // CRC64NVME checksum) as objects uploaded via the S3 API.
+        let integrity_checks = ObjectIntegrityChecks::new().with_md5().with_crc64nvme();
+
+        let mut store_req =
+            StoreObjectRequest::new(bucket, key.to_string(), boxed_stream, integrity_checks)
+                .with_user_metadata(request.metadata.unwrap_or_default());
         store_req.content_type = request.content_type;
         store_req.last_modified = request.last_modified;
 
@@ -378,7 +379,7 @@ impl S3MockServer {
                 b.build()
             };
             loop {
-                let (socket, _) = tokio::select! {
+                let (socket, peer) = tokio::select! {
                         res =  listener.accept() => {
                             match res {
                                 Ok(conn) => conn,
@@ -389,14 +390,20 @@ impl S3MockServer {
                             }
                         }
                         _ =  &mut shutdown_rx => {
+                            tracing::debug!("shutdown signal received, breaking accept loop");
                             break;
                         }
                 };
+                tracing::trace!(port = %addr.port(), %peer, "accepted connection");
 
-                let conn = http_server.serve_connection(TokioIo::new(socket), service.clone());
-                let conn = graceful.watch(conn.into_owned());
+                let conn = http_server
+                    .serve_connection(TokioIo::new(socket), service.clone())
+                    .into_owned();
+                let conn = graceful.watch(conn);
                 tokio::spawn(async move {
-                    let _ = conn.await;
+                    if let Err(e) = conn.await {
+                        tracing::trace!("connection error: {e}");
+                    }
                 });
             }
 

--- a/s3-mock-server/src/storage.rs
+++ b/s3-mock-server/src/storage.rs
@@ -288,6 +288,7 @@ pub(crate) trait StorageBackend: Send + Sync + Debug {
     async fn upload_part(&self, request: UploadPartRequest<'_>) -> Result<UploadPartResponse>;
 
     /// List all parts for a multipart upload.
+    #[allow(dead_code)]
     async fn list_parts(&self, upload_id: &str) -> Result<Vec<PartInfo>>;
 
     /// Complete a multipart upload by combining parts into a final object.

--- a/s3-mock-server/src/storage.rs
+++ b/s3-mock-server/src/storage.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::Stream;
 use futures_util::TryStreamExt;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::Range;
@@ -40,6 +41,12 @@ pub struct StoreObjectRequest {
     /// `SystemTime::now()`. This is only useful for the direct (non-S3-protocol)
     /// seeding API — the S3 PutObject operation never sets this.
     pub last_modified: Option<SystemTime>,
+    pub storage_class: Option<String>,
+    pub server_side_encryption: Option<String>,
+    pub cache_control: Option<String>,
+    pub content_encoding: Option<String>,
+    pub content_disposition: Option<String>,
+    pub content_language: Option<String>,
 }
 
 /// Request for retrieving an object.
@@ -139,6 +146,12 @@ impl StoreObjectRequest {
             content_type: None,
             user_metadata: HashMap::new(),
             last_modified: None,
+            storage_class: None,
+            server_side_encryption: None,
+            cache_control: None,
+            content_encoding: None,
+            content_disposition: None,
+            content_language: None,
         }
     }
 
@@ -168,6 +181,24 @@ impl From<s3s::dto::PutObjectInput> for StoreObjectRequest {
             content_type: input.content_type.map(|mime| mime.to_string()),
             user_metadata: input.metadata.unwrap_or_default(),
             last_modified: None,
+            storage_class: input
+                .storage_class
+                .map(|s| Cow::<str>::from(s).into_owned()),
+            server_side_encryption: input
+                .server_side_encryption
+                .map(|s| Cow::<str>::from(s).into_owned()),
+            cache_control: input
+                .cache_control
+                .map(|s| Cow::<str>::from(s).into_owned()),
+            content_encoding: input
+                .content_encoding
+                .map(|s| Cow::<str>::from(s).into_owned()),
+            content_disposition: input
+                .content_disposition
+                .map(|s| Cow::<str>::from(s).into_owned()),
+            content_language: input
+                .content_language
+                .map(|s| Cow::<str>::from(s).into_owned()),
         }
     }
 }

--- a/s3-mock-server/src/storage.rs
+++ b/s3-mock-server/src/storage.rs
@@ -36,6 +36,10 @@ pub struct StoreObjectRequest {
     pub integrity_checks: ObjectIntegrityChecks,
     pub content_type: Option<String>,
     pub user_metadata: HashMap<String, String>,
+    /// Override the stored last-modified timestamp. When `None`, backends use
+    /// `SystemTime::now()`. This is only useful for the direct (non-S3-protocol)
+    /// seeding API — the S3 PutObject operation never sets this.
+    pub last_modified: Option<SystemTime>,
 }
 
 /// Request for retrieving an object.
@@ -134,6 +138,7 @@ impl StoreObjectRequest {
             integrity_checks,
             content_type: None,
             user_metadata: HashMap::new(),
+            last_modified: None,
         }
     }
 
@@ -162,6 +167,7 @@ impl From<s3s::dto::PutObjectInput> for StoreObjectRequest {
             integrity_checks: ObjectIntegrityChecks::new().with_md5(),
             content_type: input.content_type.map(|mime| mime.to_string()),
             user_metadata: input.metadata.unwrap_or_default(),
+            last_modified: None,
         }
     }
 }

--- a/s3-mock-server/src/storage.rs
+++ b/s3-mock-server/src/storage.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::Range;
 use std::pin::Pin;
+use std::time::SystemTime;
 
 use crate::storage::models::ObjectMetadata;
 use crate::types::{ClientChecksums, ObjectIntegrity, ObjectIntegrityChecks, StoredObjectMetadata};
@@ -29,6 +30,7 @@ mod tests;
 
 /// Request for storing an object with all necessary metadata and options.
 pub struct StoreObjectRequest {
+    pub bucket: String,
     pub key: String,
     pub body: Pin<Box<dyn Stream<Item = std::result::Result<Bytes, std::io::Error>> + Send>>,
     pub integrity_checks: ObjectIntegrityChecks,
@@ -38,6 +40,7 @@ pub struct StoreObjectRequest {
 
 /// Request for retrieving an object.
 pub(crate) struct GetObjectRequest<'a> {
+    pub bucket: &'a str,
     pub key: &'a str,
     pub range: Option<Range<u64>>,
 }
@@ -51,6 +54,7 @@ pub(crate) struct GetObjectResponse {
 
 /// Request for listing objects.
 pub(crate) struct ListObjectsRequest<'a> {
+    pub bucket: &'a str,
     pub prefix: Option<&'a str>,
 }
 
@@ -65,8 +69,15 @@ pub(crate) struct ObjectInfo {
     pub metadata: ObjectMetadata,
 }
 
+/// Information about a bucket.
+pub(crate) struct BucketInfo {
+    pub name: String,
+    pub creation_date: SystemTime,
+}
+
 /// Request for creating a multipart upload.
 pub(crate) struct CreateMultipartUploadRequest<'a> {
+    pub bucket: &'a str,
     pub key: &'a str,
     pub upload_id: &'a str,
     pub metadata: ObjectMetadata,
@@ -95,6 +106,7 @@ pub(crate) struct PartInfo {
 
 /// Request for completing a multipart upload.
 pub(crate) struct CompleteMultipartUploadRequest<'a> {
+    pub bucket: &'a str,
     pub upload_id: &'a str,
     pub parts: Vec<(i32, String)>,
     pub client_checksums: Option<&'a ClientChecksums>,
@@ -110,11 +122,13 @@ pub(crate) struct CompleteMultipartUploadResponse {
 
 impl StoreObjectRequest {
     pub(crate) fn new(
+        bucket: impl Into<String>,
         key: impl Into<String>,
         body: Pin<Box<dyn Stream<Item = std::result::Result<Bytes, std::io::Error>> + Send>>,
         integrity_checks: ObjectIntegrityChecks,
     ) -> Self {
         Self {
+            bucket: bucket.into(),
             key: key.into(),
             body,
             integrity_checks,
@@ -142,6 +156,7 @@ impl From<s3s::dto::PutObjectInput> for StoreObjectRequest {
             .map_err(std::io::Error::other);
 
         Self {
+            bucket: input.bucket,
             key: input.key,
             body: Box::pin(stream),
             integrity_checks: ObjectIntegrityChecks::new().with_md5(),
@@ -202,107 +217,53 @@ pub(crate) trait StorageBackend: Send + Sync + Debug {
     async fn get_object(&self, request: GetObjectRequest<'_>) -> Result<Option<GetObjectResponse>>;
 
     /// Delete an object and its metadata.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The object key
-    ///
-    /// # Returns
-    ///
-    /// Success or an error if the operation fails
-    #[allow(dead_code)]
-    async fn delete_object(&self, key: &str) -> Result<()>;
+    async fn delete_object(&self, bucket: &str, key: &str) -> Result<()>;
 
     /// List all objects with a given prefix.
-    ///
-    /// # Arguments
-    ///
-    /// * `prefix` - Optional prefix to filter objects
-    ///
-    /// # Returns
-    ///
-    /// A vector of (key, metadata) pairs for matching objects
     async fn list_objects(&self, request: ListObjectsRequest<'_>) -> Result<ListObjectsResponse>;
 
     /// Get object metadata without fetching the data.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The object key
-    ///
-    /// # Returns
-    ///
-    /// The object metadata, or None if the object doesn't exist
-    async fn head_object(&self, key: &str) -> Result<Option<ObjectMetadata>>;
+    async fn head_object(&self, bucket: &str, key: &str) -> Result<Option<ObjectMetadata>>;
+
+    // Bucket operations
+
+    /// Create a new bucket.
+    async fn create_bucket(&self, bucket: &str) -> Result<()>;
+
+    /// Delete a bucket. Fails if the bucket is non-empty.
+    async fn delete_bucket(&self, bucket: &str) -> Result<()>;
+
+    /// Check if a bucket exists.
+    async fn head_bucket(&self, bucket: &str) -> Result<bool>;
+
+    /// List all buckets, returning sorted bucket names and creation times.
+    async fn list_buckets(&self) -> Result<Vec<BucketInfo>>;
 
     // Multipart upload operations
 
     /// Create a new multipart upload.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The object key for the final object
-    /// * `upload_id` - The unique upload identifier
-    /// * `metadata` - Initial metadata for the object being uploaded
-    ///
-    /// # Returns
-    ///
-    /// Success or an error if the operation fails
     async fn create_multipart_upload(
         &self,
         request: CreateMultipartUploadRequest<'_>,
     ) -> Result<()>;
 
     /// Upload a part for a multipart upload.
-    ///
-    /// # Arguments
-    ///
-    /// * `upload_id` - The upload identifier
-    /// * `part_number` - The part number (1-based)
-    /// * `content` - The part data
-    ///
-    /// # Returns
-    ///
-    /// The ETag for the uploaded part
     async fn upload_part(&self, request: UploadPartRequest<'_>) -> Result<UploadPartResponse>;
 
     /// List all parts for a multipart upload.
-    ///
-    /// # Arguments
-    ///
-    /// * `upload_id` - The upload identifier
-    ///
-    /// # Returns
-    ///
-    /// A vector of (part_number, etag, size) tuples for all uploaded parts
-    #[allow(dead_code)]
     async fn list_parts(&self, upload_id: &str) -> Result<Vec<PartInfo>>;
 
     /// Complete a multipart upload by combining parts into a final object.
-    ///
-    /// # Arguments
-    ///
-    /// * `upload_id` - The upload identifier
-    /// * `parts` - Vector of (part_number, etag) pairs in the order they should be combined
-    ///
-    /// # Returns
-    ///
-    /// A tuple of (final_object_key, final_object_metadata) for the completed object
     async fn complete_multipart_upload(
         &self,
         request: CompleteMultipartUploadRequest<'_>,
     ) -> Result<CompleteMultipartUploadResponse>;
 
     /// Abort a multipart upload and clean up all associated data.
-    ///
-    /// # Arguments
-    ///
-    /// * `upload_id` - The upload identifier
-    ///
-    /// # Returns
-    ///
-    /// Success or an error if the operation fails
     async fn abort_multipart_upload(&self, upload_id: &str) -> Result<()>;
+
+    /// Reset all state, removing all buckets, objects, and in-flight uploads.
+    async fn reset(&self) -> Result<()>;
 }
 
 // Implement the trait for Arc<dyn StorageBackend> to allow for dynamic dispatch
@@ -316,12 +277,32 @@ impl StorageBackend for std::sync::Arc<dyn StorageBackend + '_> {
         (**self).get_object(request).await
     }
 
-    async fn delete_object(&self, key: &str) -> Result<()> {
-        (**self).delete_object(key).await
+    async fn delete_object(&self, bucket: &str, key: &str) -> Result<()> {
+        (**self).delete_object(bucket, key).await
     }
 
     async fn list_objects(&self, request: ListObjectsRequest<'_>) -> Result<ListObjectsResponse> {
         (**self).list_objects(request).await
+    }
+
+    async fn head_object(&self, bucket: &str, key: &str) -> Result<Option<ObjectMetadata>> {
+        (**self).head_object(bucket, key).await
+    }
+
+    async fn create_bucket(&self, bucket: &str) -> Result<()> {
+        (**self).create_bucket(bucket).await
+    }
+
+    async fn delete_bucket(&self, bucket: &str) -> Result<()> {
+        (**self).delete_bucket(bucket).await
+    }
+
+    async fn head_bucket(&self, bucket: &str) -> Result<bool> {
+        (**self).head_bucket(bucket).await
+    }
+
+    async fn list_buckets(&self) -> Result<Vec<BucketInfo>> {
+        (**self).list_buckets().await
     }
 
     async fn create_multipart_upload(
@@ -350,7 +331,7 @@ impl StorageBackend for std::sync::Arc<dyn StorageBackend + '_> {
         (**self).abort_multipart_upload(upload_id).await
     }
 
-    async fn head_object(&self, key: &str) -> Result<Option<ObjectMetadata>> {
-        (**self).head_object(key).await
+    async fn reset(&self) -> Result<()> {
+        (**self).reset().await
     }
 }

--- a/s3-mock-server/src/storage/filesystem.rs
+++ b/s3-mock-server/src/storage/filesystem.rs
@@ -366,10 +366,10 @@ impl StorageBackend for FilesystemStorage {
         let path = self.get_object_path(bucket, key);
         let metadata_path = self.get_object_metadata_path(bucket, key);
 
-        // Delete both data and metadata files
+        // DeleteObject is idempotent: deleting a non-existent key is not an error.
         match fs::remove_file(&path).await {
             Ok(()) => (),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Err(Error::NoSuchKey),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
             Err(e) => return Err(Error::Io(e)),
         }
 

--- a/s3-mock-server/src/storage/filesystem.rs
+++ b/s3-mock-server/src/storage/filesystem.rs
@@ -97,86 +97,68 @@ where
 ///
 /// ```text
 /// root/
-/// ├── objects/
-/// │   ├── my-file.txt              # Object data
-/// │   └── my-file.txt.metadata     # Object metadata (JSON)
-/// ├── uploads/
-/// │   ├── upload-123/
-/// │   │   ├── metadata.json        # Upload metadata
-/// │   │   ├── part-1.dat          # Part data
-/// │   │   └── part-1.metadata     # Part metadata
-/// │   └── ...
+/// ├── my-bucket/
+/// │   ├── objects/
+/// │   │   ├── my-file.txt              # Object data
+/// │   │   └── my-file.txt.metadata     # Object metadata (JSON)
+/// │   └── uploads/
+/// │       ├── upload-123/
+/// │       │   ├── metadata.json        # Upload metadata
+/// │       │   ├── part-1.dat          # Part data
+/// │       │   └── part-1.metadata     # Part metadata
+/// │       └── ...
 /// ```
 #[derive(Debug)]
 pub(crate) struct FilesystemStorage {
-    objects_dir: PathBuf,
-    uploads_dir: PathBuf,
+    root_dir: PathBuf,
 }
 
 impl FilesystemStorage {
     /// Create a new filesystem storage backend.
-    ///
-    /// # Arguments
-    ///
-    /// * `root_dir` - The root directory for storing objects and uploads
-    ///
-    /// # Returns
-    ///
-    /// A new FilesystemStorage instance
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the directories cannot be created
     pub(crate) async fn new(root_dir: impl AsRef<Path>) -> Result<Self> {
         let root_dir = root_dir.as_ref().to_path_buf();
-        let objects_dir = root_dir.join("objects");
-        let uploads_dir = root_dir.join("uploads");
-
-        // Create directories if they don't exist
-        fs::create_dir_all(&objects_dir).await?;
-        fs::create_dir_all(&uploads_dir).await?;
-
-        Ok(Self {
-            objects_dir,
-            uploads_dir,
-        })
+        fs::create_dir_all(&root_dir).await?;
+        Ok(Self { root_dir })
     }
 
-    // Helper method to get the path for an object's data
-    fn get_object_path(&self, key: &str) -> PathBuf {
-        // Handle empty key as a special case
+    fn objects_dir(&self, bucket: &str) -> PathBuf {
+        self.root_dir.join(bucket).join("objects")
+    }
+
+    /// Ensure bucket directories exist (auto-create for backward compat).
+    async fn ensure_bucket(&self, bucket: &str) -> Result<()> {
+        fs::create_dir_all(self.objects_dir(bucket)).await?;
+        fs::create_dir_all(self.root_dir.join("uploads")).await?;
+        Ok(())
+    }
+
+    fn get_object_path(&self, bucket: &str, key: &str) -> PathBuf {
         if key.is_empty() {
-            return self.objects_dir.join("empty_key");
+            return self.objects_dir(bucket).join("empty_key");
         }
-        object_key_to_path(&self.objects_dir, key)
+        object_key_to_path(&self.objects_dir(bucket), key)
     }
 
-    // Helper method to get the path for an object's metadata
-    fn get_object_metadata_path(&self, key: &str) -> PathBuf {
-        // Handle empty key as a special case
+    fn get_object_metadata_path(&self, bucket: &str, key: &str) -> PathBuf {
         if key.is_empty() {
-            return self.objects_dir.join("empty_key.metadata");
+            return self.objects_dir(bucket).join("empty_key.metadata");
         }
-        object_key_to_path(&self.objects_dir, &format!("{}.metadata", key))
+        object_key_to_path(&self.objects_dir(bucket), &format!("{}.metadata", key))
     }
 
-    // Helper method to get the directory for an upload
     fn get_upload_dir(&self, upload_id: &str) -> PathBuf {
-        self.uploads_dir.join(upload_id)
+        self.root_dir.join("uploads").join(upload_id)
     }
 
-    // Helper method to get the path for an upload's metadata
     fn get_upload_metadata_path(&self, upload_id: &str) -> PathBuf {
         self.get_upload_dir(upload_id).join("metadata.json")
     }
 
-    // Helper method to get the path for a part's data
     fn get_part_path(&self, upload_id: &str, part_number: i32) -> PathBuf {
         self.get_upload_dir(upload_id)
             .join(format!("part-{}.dat", part_number))
     }
 
-    // Helper method to get the path for a part's metadata
     fn get_part_metadata_path(&self, upload_id: &str, part_number: i32) -> PathBuf {
         self.get_upload_dir(upload_id)
             .join(format!("part-{}.metadata", part_number))
@@ -209,28 +191,30 @@ impl FilesystemStorage {
         }
     }
 
-    // Helper method to list all objects in a directory
-    // Helper method to list all objects in a directory recursively
     fn list_directory<'a>(
         &'a self,
         dir: &'a Path,
+        objects_dir: &'a Path,
         prefix: Option<&'a str>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Vec<PathBuf>>> + Send + 'a>>
     {
         Box::pin(async move {
             let mut entries = Vec::new();
-            let mut read_dir = fs::read_dir(dir).await?;
+            let mut read_dir = match fs::read_dir(dir).await {
+                Ok(rd) => rd,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(entries),
+                Err(e) => return Err(e.into()),
+            };
 
             while let Some(entry) = read_dir.next_entry().await? {
                 let path = entry.path();
                 let metadata = fs::metadata(&path).await?;
 
                 if metadata.is_dir() {
-                    // Recursively list subdirectories
-                    let mut sub_entries = self.list_directory(&path, prefix).await?;
+                    let mut sub_entries = self.list_directory(&path, objects_dir, prefix).await?;
                     entries.append(&mut sub_entries);
                 } else if path.extension().is_none_or(|ext| ext != "metadata") {
-                    if let Some(key) = path_to_object_key(&self.objects_dir, &path) {
+                    if let Some(key) = path_to_object_key(objects_dir, &path) {
                         if let Some(prefix) = prefix {
                             if !key.starts_with(prefix) {
                                 continue;
@@ -268,9 +252,12 @@ impl StorageBackend for FilesystemStorage {
         &self,
         request: crate::storage::StoreObjectRequest,
     ) -> Result<StoredObjectMetadata> {
+        // Auto-create bucket directories
+        self.ensure_bucket(&request.bucket).await?;
+
         let mut body = request.body;
         let mut integrity_checks = request.integrity_checks;
-        let path = self.get_object_path(&request.key);
+        let path = self.get_object_path(&request.bucket, &request.key);
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).await?;
         }
@@ -302,7 +289,7 @@ impl StorageBackend for FilesystemStorage {
             sha1: object_integrity.sha1.clone(),
             sha256: object_integrity.sha256.clone(),
         };
-        let metadata_path = self.get_object_metadata_path(&request.key);
+        let metadata_path = self.get_object_metadata_path(&request.bucket, &request.key);
         Self::save_metadata(&metadata_path, &metadata).await?;
 
         Ok(StoredObjectMetadata { object_integrity })
@@ -312,8 +299,8 @@ impl StorageBackend for FilesystemStorage {
         &self,
         request: crate::storage::GetObjectRequest<'_>,
     ) -> Result<Option<crate::storage::GetObjectResponse>> {
-        let path = self.get_object_path(request.key);
-        let metadata_path = self.get_object_metadata_path(request.key);
+        let path = self.get_object_path(request.bucket, request.key);
+        let metadata_path = self.get_object_metadata_path(request.bucket, request.key);
 
         // Load metadata first to check if object exists
         let metadata: ObjectMetadata = match Self::load_metadata(&metadata_path).await? {
@@ -369,9 +356,9 @@ impl StorageBackend for FilesystemStorage {
         }))
     }
 
-    async fn delete_object(&self, key: &str) -> Result<()> {
-        let path = self.get_object_path(key);
-        let metadata_path = self.get_object_metadata_path(key);
+    async fn delete_object(&self, bucket: &str, key: &str) -> Result<()> {
+        let path = self.get_object_path(bucket, key);
+        let metadata_path = self.get_object_metadata_path(bucket, key);
 
         // Delete both data and metadata files
         match fs::remove_file(&path).await {
@@ -391,16 +378,15 @@ impl StorageBackend for FilesystemStorage {
         request: crate::storage::ListObjectsRequest<'_>,
     ) -> Result<crate::storage::ListObjectsResponse> {
         let mut matching_objects = Vec::new();
+        let objects_dir = self.objects_dir(request.bucket);
 
-        // List all objects in the directory
         let entries = self
-            .list_directory(&self.objects_dir, request.prefix)
+            .list_directory(&objects_dir, &objects_dir, request.prefix)
             .await?;
 
-        // Load metadata for each object
         for path in entries {
-            if let Some(key) = path_to_object_key(&self.objects_dir, &path) {
-                let metadata_path = self.get_object_metadata_path(&key);
+            if let Some(key) = path_to_object_key(&objects_dir, &path) {
+                let metadata_path = self.get_object_metadata_path(request.bucket, &key);
                 if let Some(metadata) = Self::load_metadata(&metadata_path).await? {
                     matching_objects.push(crate::storage::ObjectInfo { key, metadata });
                 }
@@ -416,6 +402,7 @@ impl StorageBackend for FilesystemStorage {
         &self,
         request: crate::storage::CreateMultipartUploadRequest<'_>,
     ) -> Result<()> {
+        self.ensure_bucket(request.bucket).await?;
         let upload_dir = self.get_upload_dir(request.upload_id);
         fs::create_dir_all(&upload_dir).await?;
 
@@ -425,6 +412,7 @@ impl StorageBackend for FilesystemStorage {
             metadata: request.metadata,
             parts: Default::default(),
             checksum_type: Some(request.checksum_type),
+            bucket: Some(request.bucket.to_string()),
         };
 
         let metadata_path = self.get_upload_metadata_path(request.upload_id);
@@ -437,7 +425,6 @@ impl StorageBackend for FilesystemStorage {
         &self,
         request: crate::storage::UploadPartRequest<'_>,
     ) -> Result<crate::storage::UploadPartResponse> {
-        // Verify the upload exists and get checksum algorithm
         let metadata_path = self.get_upload_metadata_path(request.upload_id);
         let mut upload_metadata: MultipartUploadMetadata = Self::load_metadata(&metadata_path)
             .await?
@@ -533,6 +520,7 @@ impl StorageBackend for FilesystemStorage {
             .await?
             .ok_or(Error::NoSuchUpload)?;
 
+        let bucket = upload_metadata.bucket.as_deref().unwrap_or(request.bucket);
         let checksum_algorithm = upload_metadata.metadata.checksum_algorithm;
         let checksum_type = upload_metadata.checksum_type;
 
@@ -631,8 +619,8 @@ impl StorageBackend for FilesystemStorage {
 
         // Save the final object
         let combined_data = combined.freeze();
-        let object_path = self.get_object_path(&upload_metadata.key);
-        let metadata_path = self.get_object_metadata_path(&upload_metadata.key);
+        let object_path = self.get_object_path(bucket, &upload_metadata.key);
+        let obj_metadata_path = self.get_object_metadata_path(bucket, &upload_metadata.key);
 
         // Ensure parent directory exists
         if let Some(parent) = object_path.parent() {
@@ -643,7 +631,7 @@ impl StorageBackend for FilesystemStorage {
         fs::write(&object_path, &combined_data).await?;
         let metadata_json = serde_json::to_string_pretty(&final_metadata)
             .map_err(|e| Error::Internal(format!("Failed to serialize metadata: {}", e)))?;
-        fs::write(&metadata_path, metadata_json).await?;
+        fs::write(&obj_metadata_path, metadata_json).await?;
 
         // Clean up the multipart upload
         let _ = fs::remove_dir_all(self.get_upload_dir(request.upload_id)).await;
@@ -655,15 +643,64 @@ impl StorageBackend for FilesystemStorage {
         })
     }
 
-    async fn head_object(&self, key: &str) -> Result<Option<ObjectMetadata>> {
-        let metadata_path = self.get_object_metadata_path(key);
+    async fn head_object(&self, bucket: &str, key: &str) -> Result<Option<ObjectMetadata>> {
+        let metadata_path = self.get_object_metadata_path(bucket, key);
         Self::load_metadata(&metadata_path).await
+    }
+
+    async fn create_bucket(&self, bucket: &str) -> Result<()> {
+        self.ensure_bucket(bucket).await
+    }
+
+    async fn delete_bucket(&self, bucket: &str) -> Result<()> {
+        let bucket_dir = self.root_dir.join(bucket);
+        if !bucket_dir.exists() {
+            return Err(Error::NoSuchBucket);
+        }
+        // Check if objects dir has any entries
+        let objects_dir = self.objects_dir(bucket);
+        if objects_dir.exists() {
+            let mut rd = fs::read_dir(&objects_dir).await?;
+            if rd.next_entry().await?.is_some() {
+                return Err(Error::Internal("bucket is not empty".to_string()));
+            }
+        }
+        fs::remove_dir_all(&bucket_dir).await?;
+        Ok(())
+    }
+
+    async fn head_bucket(&self, bucket: &str) -> Result<bool> {
+        Ok(self.root_dir.join(bucket).exists())
+    }
+
+    async fn list_buckets(&self) -> Result<Vec<crate::storage::BucketInfo>> {
+        let mut result = Vec::new();
+        let mut rd = fs::read_dir(&self.root_dir).await?;
+        while let Some(entry) = rd.next_entry().await? {
+            let path = entry.path();
+            if path.is_dir() {
+                // Skip the global uploads directory
+                if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                    if name != "uploads" {
+                        let creation_date = fs::metadata(&path)
+                            .await
+                            .and_then(|m| m.created().or_else(|_| m.modified()))
+                            .unwrap_or(SystemTime::UNIX_EPOCH);
+                        result.push(crate::storage::BucketInfo {
+                            name: name.to_string(),
+                            creation_date,
+                        });
+                    }
+                }
+            }
+        }
+        result.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(result)
     }
 
     async fn abort_multipart_upload(&self, upload_id: &str) -> Result<()> {
         let upload_dir = self.get_upload_dir(upload_id);
 
-        // Verify the upload exists
         let metadata_path = self.get_upload_metadata_path(upload_id);
         if !metadata_path.exists() {
             return Err(Error::NoSuchUpload);
@@ -672,6 +709,13 @@ impl StorageBackend for FilesystemStorage {
         // Remove the entire upload directory
         fs::remove_dir_all(upload_dir).await?;
 
+        Ok(())
+    }
+
+    async fn reset(&self) -> Result<()> {
+        // Remove everything under root and recreate it
+        fs::remove_dir_all(&self.root_dir).await?;
+        fs::create_dir_all(&self.root_dir).await?;
         Ok(())
     }
 }
@@ -683,6 +727,8 @@ mod tests {
     use futures::StreamExt;
     use std::collections::HashMap;
     use tempfile::tempdir;
+
+    const TEST_BUCKET: &str = "test-bucket";
 
     // Helper function to collect stream data into bytes
     async fn collect_stream_data(
@@ -724,10 +770,10 @@ mod tests {
         let content = Bytes::from("test content");
         let integrity_checks = ObjectIntegrityChecks::new().with_md5();
 
-        // Put object
         let stream = bytes_to_stream(content.clone());
         storage
             .put_object(crate::storage::StoreObjectRequest::new(
+                TEST_BUCKET,
                 key,
                 stream,
                 integrity_checks,
@@ -735,18 +781,18 @@ mod tests {
             .await
             .unwrap();
 
-        // Get object
-        let request = crate::storage::GetObjectRequest { key, range: None };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_some());
         let response = result.unwrap();
-        let retrieved_stream = response.stream;
-        let retrieved_metadata = response.metadata;
-        let retrieved_content = collect_stream_data(retrieved_stream).await;
+        let retrieved_content = collect_stream_data(response.stream).await;
         assert_eq!(retrieved_content, content);
-        assert_eq!(retrieved_metadata.content_length, content.len() as u64);
-        // Content type is not preserved in the new streaming API
-        assert_eq!(retrieved_metadata.content_type, None);
+        assert_eq!(response.metadata.content_length, content.len() as u64);
+        assert_eq!(response.metadata.content_type, None);
     }
 
     #[tokio::test]
@@ -757,10 +803,10 @@ mod tests {
         let content = Bytes::from("0123456789");
         let integrity_checks = ObjectIntegrityChecks::new().with_md5();
 
-        // Put object
         let stream = bytes_to_stream(content);
         storage
             .put_object(crate::storage::StoreObjectRequest::new(
+                TEST_BUCKET,
                 key,
                 stream,
                 integrity_checks,
@@ -768,14 +814,15 @@ mod tests {
             .await
             .unwrap();
 
-        // Get range
-        let range = Some(2..5);
-        let request = crate::storage::GetObjectRequest { key, range };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: Some(2..5),
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_some());
         let response = result.unwrap();
-        let retrieved_stream = response.stream;
-        let retrieved_content = collect_stream_data(retrieved_stream).await;
+        let retrieved_content = collect_stream_data(response.stream).await;
         assert_eq!(retrieved_content, Bytes::from("234"));
     }
 
@@ -787,10 +834,10 @@ mod tests {
         let content = Bytes::from("test content");
         let integrity_checks = ObjectIntegrityChecks::new().with_md5();
 
-        // Put object
         let stream = bytes_to_stream(content);
         storage
             .put_object(crate::storage::StoreObjectRequest::new(
+                TEST_BUCKET,
                 key,
                 stream,
                 integrity_checks,
@@ -798,16 +845,21 @@ mod tests {
             .await
             .unwrap();
 
-        // Verify it exists
-        let request = crate::storage::GetObjectRequest { key, range: None };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_some());
 
-        // Delete object
-        storage.delete_object(key).await.unwrap();
+        storage.delete_object(TEST_BUCKET, key).await.unwrap();
 
-        // Verify it's gone
-        let request = crate::storage::GetObjectRequest { key, range: None };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_none());
     }
@@ -818,13 +870,13 @@ mod tests {
         let storage = FilesystemStorage::new(temp_dir.path()).await.unwrap();
         let content = Bytes::from("test content");
 
-        // Put multiple objects
         for i in 0..3 {
             let key = format!("test-key-{}", i);
             let integrity_checks = ObjectIntegrityChecks::new().with_md5();
             let stream = bytes_to_stream(content.clone());
             storage
                 .put_object(crate::storage::StoreObjectRequest::new(
+                    TEST_BUCKET,
                     &key,
                     stream,
                     integrity_checks,
@@ -833,13 +885,15 @@ mod tests {
                 .unwrap();
         }
 
-        // List all objects
-        let request = crate::storage::ListObjectsRequest { prefix: None };
+        let request = crate::storage::ListObjectsRequest {
+            bucket: TEST_BUCKET,
+            prefix: None,
+        };
         let objects = storage.list_objects(request).await.unwrap();
         assert_eq!(objects.objects.len(), 3);
 
-        // List with prefix
         let request = crate::storage::ListObjectsRequest {
+            bucket: TEST_BUCKET,
             prefix: Some("test-key-1"),
         };
         let objects = storage.list_objects(request).await.unwrap();
@@ -853,10 +907,10 @@ mod tests {
         let storage = FilesystemStorage::new(temp_dir.path()).await.unwrap();
         let upload_id = "test-upload-123";
         let key = "test-multipart-key";
-        let metadata = create_test_metadata(0); // Will be updated on completion
+        let metadata = create_test_metadata(0);
 
-        // Create multipart upload
         let request = crate::storage::CreateMultipartUploadRequest {
+            bucket: TEST_BUCKET,
             key,
             upload_id,
             metadata,
@@ -864,7 +918,6 @@ mod tests {
         };
         storage.create_multipart_upload(request).await.unwrap();
 
-        // Upload parts
         let part1 = Bytes::from("part1");
         let part2 = Bytes::from("part2");
 
@@ -881,14 +934,13 @@ mod tests {
         };
         let etag2 = storage.upload_part(request2).await.unwrap();
 
-        // List parts
         let parts = storage.list_parts(upload_id).await.unwrap();
         assert_eq!(parts.len(), 2);
-        assert_eq!(parts[0].part_number, 1); // part number
+        assert_eq!(parts[0].part_number, 1);
 
-        // Complete multipart upload
         let parts_to_complete = vec![(1, etag1.etag), (2, etag2.etag)];
         let request = crate::storage::CompleteMultipartUploadRequest {
+            bucket: TEST_BUCKET,
             upload_id,
             parts: parts_to_complete,
             client_checksums: None,
@@ -897,8 +949,11 @@ mod tests {
 
         assert_eq!(response.key, key);
 
-        // Verify the final object exists and has correct content length
-        let request = crate::storage::GetObjectRequest { key, range: None };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_some());
         let response = result.unwrap();
@@ -906,8 +961,7 @@ mod tests {
             response.metadata.content_length,
             (part1.len() + part2.len()) as u64
         );
-        let final_stream = response.stream;
-        let final_content = collect_stream_data(final_stream).await;
+        let final_content = collect_stream_data(response.stream).await;
         assert_eq!(final_content, Bytes::from("part1part2"));
     }
 
@@ -919,8 +973,8 @@ mod tests {
         let key = "test-multipart-key";
         let metadata = create_test_metadata(0);
 
-        // Create multipart upload
         let request = crate::storage::CreateMultipartUploadRequest {
+            bucket: TEST_BUCKET,
             key,
             upload_id,
             metadata,
@@ -928,7 +982,6 @@ mod tests {
         };
         storage.create_multipart_upload(request).await.unwrap();
 
-        // Upload only one part
         let part1 = Bytes::from("part1");
         let request = crate::storage::UploadPartRequest {
             upload_id,
@@ -937,9 +990,9 @@ mod tests {
         };
         let etag1 = storage.upload_part(request).await.unwrap();
 
-        // Try to complete with a missing part
         let parts_to_complete = vec![(1, etag1.etag), (2, "missing-etag".to_string())];
         let request = crate::storage::CompleteMultipartUploadRequest {
+            bucket: TEST_BUCKET,
             upload_id,
             parts: parts_to_complete,
             client_checksums: None,
@@ -956,8 +1009,8 @@ mod tests {
         let key = "test-multipart-key";
         let metadata = create_test_metadata(0);
 
-        // Create multipart upload
         let request = crate::storage::CreateMultipartUploadRequest {
+            bucket: TEST_BUCKET,
             key,
             upload_id,
             metadata,
@@ -965,7 +1018,6 @@ mod tests {
         };
         storage.create_multipart_upload(request).await.unwrap();
 
-        // Upload a part
         let part1 = Bytes::from("part1");
         let request = crate::storage::UploadPartRequest {
             upload_id,
@@ -974,10 +1026,8 @@ mod tests {
         };
         storage.upload_part(request).await.unwrap();
 
-        // Abort the upload
         storage.abort_multipart_upload(upload_id).await.unwrap();
 
-        // Verify we can't list parts anymore
         let result = storage.list_parts(upload_id).await;
         assert!(result.is_err());
     }
@@ -990,10 +1040,10 @@ mod tests {
         let content = Bytes::from("test content");
         let integrity_checks = ObjectIntegrityChecks::new().with_md5();
 
-        // Put object
         let stream = bytes_to_stream(content.clone());
         storage
             .put_object(crate::storage::StoreObjectRequest::new(
+                TEST_BUCKET,
                 key,
                 stream,
                 integrity_checks,
@@ -1001,17 +1051,19 @@ mod tests {
             .await
             .unwrap();
 
-        // Get object
-        let request = crate::storage::GetObjectRequest { key, range: None };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_some());
         let response = result.unwrap();
-        let retrieved_stream = response.stream;
-        let retrieved_content = collect_stream_data(retrieved_stream).await;
+        let retrieved_content = collect_stream_data(response.stream).await;
         assert_eq!(retrieved_content, content);
 
-        // List objects
         let request = crate::storage::ListObjectsRequest {
+            bucket: TEST_BUCKET,
             prefix: Some("nested/"),
         };
         let objects = storage.list_objects(request).await.unwrap();
@@ -1027,10 +1079,10 @@ mod tests {
         let content = Bytes::from("test content");
         let integrity_checks = ObjectIntegrityChecks::new().with_md5();
 
-        // Put object
         let stream = bytes_to_stream(content.clone());
         storage
             .put_object(crate::storage::StoreObjectRequest::new(
+                TEST_BUCKET,
                 key,
                 stream,
                 integrity_checks,
@@ -1038,13 +1090,15 @@ mod tests {
             .await
             .unwrap();
 
-        // Get object
-        let request = crate::storage::GetObjectRequest { key, range: None };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_some());
         let response = result.unwrap();
-        let retrieved_stream = response.stream;
-        let retrieved_content = collect_stream_data(retrieved_stream).await;
+        let retrieved_content = collect_stream_data(response.stream).await;
         assert_eq!(retrieved_content, content);
     }
 }

--- a/s3-mock-server/src/storage/filesystem.rs
+++ b/s3-mock-server/src/storage/filesystem.rs
@@ -274,7 +274,7 @@ impl StorageBackend for FilesystemStorage {
         file.flush().await?;
 
         let object_integrity = integrity_checks.finalize();
-        let last_modified = SystemTime::now();
+        let last_modified = request.last_modified.unwrap_or_else(SystemTime::now);
 
         let metadata = ObjectMetadata {
             content_type: request.content_type,

--- a/s3-mock-server/src/storage/filesystem.rs
+++ b/s3-mock-server/src/storage/filesystem.rs
@@ -288,6 +288,12 @@ impl StorageBackend for FilesystemStorage {
             crc64nvme: object_integrity.crc64nvme.clone(),
             sha1: object_integrity.sha1.clone(),
             sha256: object_integrity.sha256.clone(),
+            storage_class: request.storage_class,
+            server_side_encryption: request.server_side_encryption,
+            cache_control: request.cache_control,
+            content_encoding: request.content_encoding,
+            content_disposition: request.content_disposition,
+            content_language: request.content_language,
         };
         let metadata_path = self.get_object_metadata_path(&request.bucket, &request.key);
         Self::save_metadata(&metadata_path, &metadata).await?;

--- a/s3-mock-server/src/storage/in_memory.rs
+++ b/s3-mock-server/src/storage/in_memory.rs
@@ -100,6 +100,12 @@ impl StorageBackend for InMemoryStorage {
             crc64nvme: object_integrity.crc64nvme.clone(),
             sha1: object_integrity.sha1.clone(),
             sha256: object_integrity.sha256.clone(),
+            storage_class: request.storage_class,
+            server_side_encryption: request.server_side_encryption,
+            cache_control: request.cache_control,
+            content_encoding: request.content_encoding,
+            content_disposition: request.content_disposition,
+            content_language: request.content_language,
         };
 
         let mut buckets = self.buckets.write().await;

--- a/s3-mock-server/src/storage/in_memory.rs
+++ b/s3-mock-server/src/storage/in_memory.rs
@@ -159,10 +159,9 @@ impl StorageBackend for InMemoryStorage {
 
     async fn delete_object(&self, bucket: &str, key: &str) -> Result<()> {
         let mut buckets = self.buckets.write().await;
-        let bucket_state = buckets.get_mut(bucket).ok_or(Error::NoSuchKey)?;
-        if bucket_state.objects.remove(key).is_none() {
-            return Err(Error::NoSuchKey);
-        }
+        let bucket_state = buckets.get_mut(bucket).ok_or(Error::NoSuchBucket)?;
+        // DeleteObject is idempotent: deleting a non-existent key is not an error.
+        bucket_state.objects.remove(key);
         Ok(())
     }
 

--- a/s3-mock-server/src/storage/in_memory.rs
+++ b/s3-mock-server/src/storage/in_memory.rs
@@ -86,7 +86,7 @@ impl StorageBackend for InMemoryStorage {
         let content = content.freeze();
         let content_length = content.len() as u64;
         let object_integrity = integrity_checks.finalize();
-        let last_modified = SystemTime::now();
+        let last_modified = request.last_modified.unwrap_or_else(SystemTime::now);
 
         let metadata = ObjectMetadata {
             content_type: request.content_type,

--- a/s3-mock-server/src/storage/in_memory.rs
+++ b/s3-mock-server/src/storage/in_memory.rs
@@ -23,6 +23,22 @@ use crate::types::StoredObjectMetadata;
 /// Type alias for complex part storage structure
 type PartStorage = HashMap<i32, (Bytes, PartMetadata)>;
 
+/// State for a single bucket, including its creation time and objects.
+#[derive(Debug)]
+struct BucketState {
+    created_at: SystemTime,
+    objects: HashMap<String, (Bytes, ObjectMetadata)>,
+}
+
+impl BucketState {
+    fn new() -> Self {
+        Self {
+            created_at: SystemTime::now(),
+            objects: HashMap::new(),
+        }
+    }
+}
+
 /// An in-memory implementation of the StorageBackend trait.
 ///
 /// This implementation stores all objects, metadata, and multipart uploads in memory,
@@ -30,8 +46,8 @@ type PartStorage = HashMap<i32, (Bytes, PartMetadata)>;
 /// instance is dropped.
 #[derive(Debug)]
 pub(crate) struct InMemoryStorage {
-    /// Objects stored as (key -> (data, metadata))
-    objects: RwLock<HashMap<String, (Bytes, ObjectMetadata)>>,
+    /// Objects stored as bucket_name → BucketState { created_at, objects: key → (data, metadata) }
+    buckets: RwLock<HashMap<String, BucketState>>,
 
     /// Active multipart uploads stored as (upload_id -> upload_metadata)
     multipart_uploads: RwLock<HashMap<String, MultipartUploadMetadata>>,
@@ -44,7 +60,7 @@ impl InMemoryStorage {
     /// Create a new in-memory storage backend.
     pub(crate) fn new() -> Self {
         Self {
-            objects: RwLock::new(HashMap::new()),
+            buckets: RwLock::new(HashMap::new()),
             multipart_uploads: RwLock::new(HashMap::new()),
             parts: RwLock::new(HashMap::new()),
         }
@@ -72,7 +88,6 @@ impl StorageBackend for InMemoryStorage {
         let object_integrity = integrity_checks.finalize();
         let last_modified = SystemTime::now();
 
-        // Store with checksum metadata
         let metadata = ObjectMetadata {
             content_type: request.content_type,
             content_length,
@@ -87,8 +102,14 @@ impl StorageBackend for InMemoryStorage {
             sha256: object_integrity.sha256.clone(),
         };
 
-        let mut objects = self.objects.write().await;
-        objects.insert(request.key.clone(), (content, metadata));
+        let mut buckets = self.buckets.write().await;
+        // Auto-create bucket if it doesn't exist (backward compatibility)
+        let bucket_state = buckets
+            .entry(request.bucket)
+            .or_insert_with(BucketState::new);
+        bucket_state
+            .objects
+            .insert(request.key.clone(), (content, metadata));
 
         Ok(StoredObjectMetadata { object_integrity })
     }
@@ -97,9 +118,13 @@ impl StorageBackend for InMemoryStorage {
         &self,
         request: crate::storage::GetObjectRequest<'_>,
     ) -> Result<Option<crate::storage::GetObjectResponse>> {
-        let objects = self.objects.read().await;
-        let (data, metadata) = match objects.get(request.key) {
-            Some((data, metadata)) => (data, metadata),
+        let buckets = self.buckets.read().await;
+        let bucket_state = match buckets.get(request.bucket) {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        let (data, metadata) = match bucket_state.objects.get(request.key) {
+            Some(entry) => entry,
             None => return Ok(None),
         };
 
@@ -115,7 +140,6 @@ impl StorageBackend for InMemoryStorage {
             dyn Stream<Item = std::result::Result<Bytes, std::io::Error>> + Send + Sync + Unpin,
         > = Box::new(stream);
 
-        // Clear checksums for range requests since they apply to full object
         let mut response_metadata = metadata.clone();
         if is_range_request {
             response_metadata.clear_checksums();
@@ -127,9 +151,10 @@ impl StorageBackend for InMemoryStorage {
         }))
     }
 
-    async fn delete_object(&self, key: &str) -> Result<()> {
-        let mut objects = self.objects.write().await;
-        if objects.remove(key).is_none() {
+    async fn delete_object(&self, bucket: &str, key: &str) -> Result<()> {
+        let mut buckets = self.buckets.write().await;
+        let bucket_state = buckets.get_mut(bucket).ok_or(Error::NoSuchKey)?;
+        if bucket_state.objects.remove(key).is_none() {
             return Err(Error::NoSuchKey);
         }
         Ok(())
@@ -139,10 +164,18 @@ impl StorageBackend for InMemoryStorage {
         &self,
         request: crate::storage::ListObjectsRequest<'_>,
     ) -> Result<crate::storage::ListObjectsResponse> {
-        let objects = self.objects.read().await;
-        let mut matching_objects = Vec::new();
+        let buckets = self.buckets.read().await;
+        let bucket_state = match buckets.get(request.bucket) {
+            Some(s) => s,
+            None => {
+                return Ok(crate::storage::ListObjectsResponse {
+                    objects: Vec::new(),
+                })
+            }
+        };
 
-        for (key, (_, metadata)) in objects.iter() {
+        let mut matching_objects = Vec::new();
+        for (key, (_, metadata)) in bucket_state.objects.iter() {
             if let Some(prefix) = request.prefix {
                 if !key.starts_with(prefix) {
                     continue;
@@ -154,12 +187,63 @@ impl StorageBackend for InMemoryStorage {
             });
         }
 
-        // Sort by key for consistent ordering
         matching_objects.sort_by(|a, b| a.key.cmp(&b.key));
 
         Ok(crate::storage::ListObjectsResponse {
             objects: matching_objects,
         })
+    }
+
+    async fn head_object(&self, bucket: &str, key: &str) -> Result<Option<ObjectMetadata>> {
+        let buckets = self.buckets.read().await;
+        let bucket_state = match buckets.get(bucket) {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+        Ok(bucket_state
+            .objects
+            .get(key)
+            .map(|(_, metadata)| metadata.clone()))
+    }
+
+    async fn create_bucket(&self, bucket: &str) -> Result<()> {
+        let mut buckets = self.buckets.write().await;
+        buckets
+            .entry(bucket.to_string())
+            .or_insert_with(BucketState::new);
+        Ok(())
+    }
+
+    async fn delete_bucket(&self, bucket: &str) -> Result<()> {
+        let mut buckets = self.buckets.write().await;
+        match buckets.get(bucket) {
+            Some(state) if !state.objects.is_empty() => {
+                Err(Error::Internal("bucket is not empty".to_string()))
+            }
+            Some(_) => {
+                buckets.remove(bucket);
+                Ok(())
+            }
+            None => Err(Error::NoSuchBucket),
+        }
+    }
+
+    async fn head_bucket(&self, bucket: &str) -> Result<bool> {
+        let buckets = self.buckets.read().await;
+        Ok(buckets.contains_key(bucket))
+    }
+
+    async fn list_buckets(&self) -> Result<Vec<crate::storage::BucketInfo>> {
+        let buckets = self.buckets.read().await;
+        let mut result: Vec<crate::storage::BucketInfo> = buckets
+            .iter()
+            .map(|(name, state)| crate::storage::BucketInfo {
+                name: name.clone(),
+                creation_date: state.created_at,
+            })
+            .collect();
+        result.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(result)
     }
 
     async fn create_multipart_upload(
@@ -173,6 +257,7 @@ impl StorageBackend for InMemoryStorage {
             metadata: request.metadata,
             parts: HashMap::new(),
             checksum_type: Some(request.checksum_type),
+            bucket: Some(request.bucket.to_string()),
         };
         uploads.insert(request.upload_id.to_string(), upload_metadata);
 
@@ -277,12 +362,13 @@ impl StorageBackend for InMemoryStorage {
         request: crate::storage::CompleteMultipartUploadRequest<'_>,
     ) -> Result<crate::storage::CompleteMultipartUploadResponse> {
         // Get the upload metadata
-        let (key, mut final_metadata, checksum_algorithm, checksum_type) = {
+        let (bucket, key, mut final_metadata, checksum_algorithm, checksum_type) = {
             let mut uploads = self.multipart_uploads.write().await;
             let upload = uploads
                 .remove(request.upload_id)
                 .ok_or(Error::NoSuchUpload)?;
             (
+                upload.bucket.unwrap_or_else(|| request.bucket.to_string()),
                 upload.key,
                 upload.metadata.clone(),
                 upload.metadata.checksum_algorithm,
@@ -428,8 +514,12 @@ impl StorageBackend for InMemoryStorage {
 
         // Store the final object
         let combined_data = combined.freeze();
-        let mut objects = self.objects.write().await;
-        objects.insert(key.clone(), (combined_data, final_metadata.clone()));
+        let mut buckets = self.buckets.write().await;
+        // Auto-create bucket if it doesn't exist
+        let bucket_state = buckets.entry(bucket).or_insert_with(BucketState::new);
+        bucket_state
+            .objects
+            .insert(key.clone(), (combined_data, final_metadata.clone()));
 
         Ok(crate::storage::CompleteMultipartUploadResponse {
             key: key.clone(),
@@ -456,9 +546,11 @@ impl StorageBackend for InMemoryStorage {
         Ok(())
     }
 
-    async fn head_object(&self, key: &str) -> Result<Option<ObjectMetadata>> {
-        let objects = self.objects.read().await;
-        Ok(objects.get(key).map(|(_, metadata)| metadata.clone()))
+    async fn reset(&self) -> Result<()> {
+        self.buckets.write().await.clear();
+        self.multipart_uploads.write().await.clear();
+        self.parts.write().await.clear();
+        Ok(())
     }
 }
 
@@ -469,6 +561,8 @@ mod tests {
     use futures::StreamExt;
     use std::collections::HashMap;
     use std::pin::Pin;
+
+    const TEST_BUCKET: &str = "test-bucket";
 
     // Helper function to collect stream data into bytes
     async fn collect_stream_data(
@@ -495,7 +589,6 @@ mod tests {
         }
     }
 
-    // Helper function to convert Bytes to a stream for testing
     fn bytes_to_stream(
         data: Bytes,
     ) -> Pin<Box<dyn Stream<Item = std::result::Result<Bytes, std::io::Error>> + Send>> {
@@ -513,6 +606,7 @@ mod tests {
         let stream = bytes_to_stream(content.clone());
         storage
             .put_object(crate::storage::StoreObjectRequest::new(
+                TEST_BUCKET,
                 key,
                 stream,
                 integrity_checks,
@@ -521,17 +615,18 @@ mod tests {
             .unwrap();
 
         // Get object
-        let request = crate::storage::GetObjectRequest { key, range: None };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_some());
         let response = result.unwrap();
-        let retrieved_stream = response.stream;
-        let retrieved_metadata = response.metadata;
-        let retrieved_content = collect_stream_data(retrieved_stream).await;
+        let retrieved_content = collect_stream_data(response.stream).await;
         assert_eq!(retrieved_content, content);
-        assert_eq!(retrieved_metadata.content_length, content.len() as u64);
-        // Content type is not preserved in the new streaming API
-        assert_eq!(retrieved_metadata.content_type, None);
+        assert_eq!(response.metadata.content_length, content.len() as u64);
+        assert_eq!(response.metadata.content_type, None);
     }
 
     #[tokio::test]
@@ -541,10 +636,10 @@ mod tests {
         let content = Bytes::from("0123456789");
         let integrity_checks = ObjectIntegrityChecks::new().with_md5();
 
-        // Put object
         let stream = bytes_to_stream(content);
         storage
             .put_object(crate::storage::StoreObjectRequest::new(
+                TEST_BUCKET,
                 key,
                 stream,
                 integrity_checks,
@@ -552,14 +647,15 @@ mod tests {
             .await
             .unwrap();
 
-        // Get range
-        let range = Some(2..5);
-        let request = crate::storage::GetObjectRequest { key, range };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: Some(2..5),
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_some());
         let response = result.unwrap();
-        let retrieved_stream = response.stream;
-        let retrieved_content = collect_stream_data(retrieved_stream).await;
+        let retrieved_content = collect_stream_data(response.stream).await;
         assert_eq!(retrieved_content, Bytes::from("234"));
     }
 
@@ -570,10 +666,10 @@ mod tests {
         let content = Bytes::from("test content");
         let integrity_checks = ObjectIntegrityChecks::new().with_md5();
 
-        // Put object
         let stream = bytes_to_stream(content);
         storage
             .put_object(crate::storage::StoreObjectRequest::new(
+                TEST_BUCKET,
                 key,
                 stream,
                 integrity_checks,
@@ -581,16 +677,21 @@ mod tests {
             .await
             .unwrap();
 
-        // Verify it exists
-        let request = crate::storage::GetObjectRequest { key, range: None };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_some());
 
-        // Delete object
-        storage.delete_object(key).await.unwrap();
+        storage.delete_object(TEST_BUCKET, key).await.unwrap();
 
-        // Verify it's gone
-        let request = crate::storage::GetObjectRequest { key, range: None };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_none());
     }
@@ -600,13 +701,13 @@ mod tests {
         let storage = InMemoryStorage::new();
         let content = Bytes::from("test content");
 
-        // Put multiple objects
         for i in 0..3 {
             let key = format!("test-key-{}", i);
             let integrity_checks = ObjectIntegrityChecks::new().with_md5();
             let stream = bytes_to_stream(content.clone());
             storage
                 .put_object(crate::storage::StoreObjectRequest::new(
+                    TEST_BUCKET,
                     &key,
                     stream,
                     integrity_checks,
@@ -615,13 +716,15 @@ mod tests {
                 .unwrap();
         }
 
-        // List all objects
-        let request = crate::storage::ListObjectsRequest { prefix: None };
+        let request = crate::storage::ListObjectsRequest {
+            bucket: TEST_BUCKET,
+            prefix: None,
+        };
         let objects = storage.list_objects(request).await.unwrap();
         assert_eq!(objects.objects.len(), 3);
 
-        // List with prefix
         let request = crate::storage::ListObjectsRequest {
+            bucket: TEST_BUCKET,
             prefix: Some("test-key-1"),
         };
         let objects = storage.list_objects(request).await.unwrap();
@@ -634,10 +737,10 @@ mod tests {
         let storage = InMemoryStorage::new();
         let upload_id = "test-upload-123";
         let key = "test-multipart-key";
-        let metadata = create_test_metadata(0); // Will be updated on completion
+        let metadata = create_test_metadata(0);
 
-        // Create multipart upload
         let request = crate::storage::CreateMultipartUploadRequest {
+            bucket: TEST_BUCKET,
             key,
             upload_id,
             metadata,
@@ -645,7 +748,6 @@ mod tests {
         };
         storage.create_multipart_upload(request).await.unwrap();
 
-        // Upload parts
         let part1 = Bytes::from("part1");
         let part2 = Bytes::from("part2");
 
@@ -662,14 +764,13 @@ mod tests {
         };
         let etag2 = storage.upload_part(request2).await.unwrap();
 
-        // List parts
         let parts = storage.list_parts(upload_id).await.unwrap();
         assert_eq!(parts.len(), 2);
-        assert_eq!(parts[0].part_number, 1); // part number
+        assert_eq!(parts[0].part_number, 1);
 
-        // Complete multipart upload
         let parts_to_complete = vec![(1, etag1.etag), (2, etag2.etag)];
         let request = crate::storage::CompleteMultipartUploadRequest {
+            bucket: TEST_BUCKET,
             upload_id,
             parts: parts_to_complete,
             client_checksums: None,
@@ -678,8 +779,11 @@ mod tests {
 
         assert_eq!(response.key, key);
 
-        // Verify the final object exists and has correct content length
-        let request = crate::storage::GetObjectRequest { key, range: None };
+        let request = crate::storage::GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let result = storage.get_object(request).await.unwrap();
         assert!(result.is_some());
         let response = result.unwrap();
@@ -687,8 +791,7 @@ mod tests {
             response.metadata.content_length,
             (part1.len() + part2.len()) as u64
         );
-        let final_stream = response.stream;
-        let final_content = collect_stream_data(final_stream).await;
+        let final_content = collect_stream_data(response.stream).await;
         assert_eq!(final_content, Bytes::from("part1part2"));
     }
 
@@ -699,8 +802,8 @@ mod tests {
         let key = "test-multipart-key";
         let metadata = create_test_metadata(0);
 
-        // Create multipart upload
         let request = crate::storage::CreateMultipartUploadRequest {
+            bucket: TEST_BUCKET,
             key,
             upload_id,
             metadata,
@@ -708,7 +811,6 @@ mod tests {
         };
         storage.create_multipart_upload(request).await.unwrap();
 
-        // Upload only one part
         let part1 = Bytes::from("part1");
         let request = crate::storage::UploadPartRequest {
             upload_id,
@@ -717,9 +819,9 @@ mod tests {
         };
         let etag1 = storage.upload_part(request).await.unwrap();
 
-        // Try to complete with a missing part
         let parts_to_complete = vec![(1, etag1.etag), (2, "missing-etag".to_string())];
         let request = crate::storage::CompleteMultipartUploadRequest {
+            bucket: TEST_BUCKET,
             upload_id,
             parts: parts_to_complete,
             client_checksums: None,
@@ -735,8 +837,8 @@ mod tests {
         let key = "test-multipart-key";
         let metadata = create_test_metadata(0);
 
-        // Create multipart upload
         let request = crate::storage::CreateMultipartUploadRequest {
+            bucket: TEST_BUCKET,
             key,
             upload_id,
             metadata,
@@ -744,7 +846,6 @@ mod tests {
         };
         storage.create_multipart_upload(request).await.unwrap();
 
-        // Upload a part
         let part1 = Bytes::from("part1");
         let request = crate::storage::UploadPartRequest {
             upload_id,
@@ -753,10 +854,8 @@ mod tests {
         };
         storage.upload_part(request).await.unwrap();
 
-        // Abort the upload
         storage.abort_multipart_upload(upload_id).await.unwrap();
 
-        // Verify we can't list parts anymore
         let result = storage.list_parts(upload_id).await;
         assert!(result.is_err());
     }

--- a/s3-mock-server/src/storage/models.rs
+++ b/s3-mock-server/src/storage/models.rs
@@ -152,6 +152,10 @@ pub(crate) struct PartMetadata {
 /// Metadata for a multipart upload.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct MultipartUploadMetadata {
+    /// Bucket the completed object belongs to.
+    #[serde(default)]
+    pub bucket: Option<String>,
+
     /// Key of the object being uploaded.
     pub key: String,
 

--- a/s3-mock-server/src/storage/models.rs
+++ b/s3-mock-server/src/storage/models.rs
@@ -101,6 +101,13 @@ pub(crate) struct ObjectMetadata {
     pub crc64nvme: Option<String>,
     pub sha1: Option<String>,
     pub sha256: Option<String>,
+
+    pub storage_class: Option<String>,
+    pub server_side_encryption: Option<String>,
+    pub cache_control: Option<String>,
+    pub content_encoding: Option<String>,
+    pub content_disposition: Option<String>,
+    pub content_language: Option<String>,
 }
 
 impl ObjectMetadata {
@@ -128,6 +135,12 @@ impl Default for ObjectMetadata {
             crc64nvme: None,
             sha1: None,
             sha256: None,
+            storage_class: None,
+            server_side_encryption: None,
+            cache_control: None,
+            content_encoding: None,
+            content_disposition: None,
+            content_language: None,
         }
     }
 }

--- a/s3-mock-server/src/storage/tests.rs
+++ b/s3-mock-server/src/storage/tests.rs
@@ -179,6 +179,12 @@ async fn test_concurrent_operations<S: StorageBackend>(storage: &S) {
             content_type: Some("text/plain".to_string()),
             user_metadata: HashMap::new(),
             last_modified: None,
+            storage_class: None,
+            server_side_encryption: None,
+            cache_control: None,
+            content_encoding: None,
+            content_disposition: None,
+            content_language: None,
         };
 
         storage.put_object(request).await.unwrap();
@@ -237,6 +243,12 @@ async fn test_storage_backend_consistency() {
             content_type: Some("text/plain".to_string()),
             user_metadata: HashMap::new(),
             last_modified: None,
+            storage_class: None,
+            server_side_encryption: None,
+            cache_control: None,
+            content_encoding: None,
+            content_disposition: None,
+            content_language: None,
         };
         let stored_metadata = storage.put_object(request).await.unwrap();
 

--- a/s3-mock-server/src/storage/tests.rs
+++ b/s3-mock-server/src/storage/tests.rs
@@ -17,6 +17,8 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 use tempfile::tempdir;
 
+const TEST_BUCKET: &str = "test-bucket";
+
 /// Helper function to collect stream data into bytes
 async fn collect_stream_data(
     mut stream: Box<
@@ -46,8 +48,8 @@ async fn test_multipart_streaming_comprehensive<S: StorageBackend>(storage: &S) 
         ..Default::default()
     };
 
-    // Create multipart upload
     let request = CreateMultipartUploadRequest {
+        bucket: TEST_BUCKET,
         key,
         upload_id,
         metadata,
@@ -83,6 +85,7 @@ async fn test_multipart_streaming_comprehensive<S: StorageBackend>(storage: &S) 
 
     // Complete multipart upload
     let complete_request = CompleteMultipartUploadRequest {
+        bucket: TEST_BUCKET,
         upload_id,
         parts: vec![(1, etag1), (2, etag2), (3, etag3)],
         client_checksums: None,
@@ -106,6 +109,7 @@ async fn test_multipart_streaming_comprehensive<S: StorageBackend>(storage: &S) 
 
     for (range, expected_size) in test_cases {
         let get_request = GetObjectRequest {
+            bucket: TEST_BUCKET,
             key,
             range: range.clone(),
         };
@@ -156,42 +160,38 @@ async fn test_multipart_streaming_comprehensive<S: StorageBackend>(storage: &S) 
     }
 
     // Clean up
-    storage.delete_object(key).await.unwrap();
+    storage.delete_object(TEST_BUCKET, key).await.unwrap();
 }
 
 /// Test concurrent operations to ensure thread safety
 async fn test_concurrent_operations<S: StorageBackend>(storage: &S) {
-    let tasks = (0..10).map(|i| {
-        async move {
-            let key = format!("concurrent-object-{}", i);
-            let content = Bytes::from(format!("Content for object {}", i));
+    let tasks = (0..10).map(|i| async move {
+        let key = format!("concurrent-object-{}", i);
+        let content = Bytes::from(format!("Content for object {}", i));
 
-            // Create a streaming request
-            let content_for_stream = content.clone();
-            let stream = futures::stream::once(async move { Ok(content_for_stream) });
-            let request = StoreObjectRequest {
-                key: key.clone(),
-                body: Box::pin(stream),
-                integrity_checks: ObjectIntegrityChecks::new().with_md5(),
-                content_type: Some("text/plain".to_string()),
-                user_metadata: HashMap::new(),
-            };
+        let content_for_stream = content.clone();
+        let stream = futures::stream::once(async move { Ok(content_for_stream) });
+        let request = StoreObjectRequest {
+            bucket: TEST_BUCKET.to_string(),
+            key: key.clone(),
+            body: Box::pin(stream),
+            integrity_checks: ObjectIntegrityChecks::new().with_md5(),
+            content_type: Some("text/plain".to_string()),
+            user_metadata: HashMap::new(),
+        };
 
-            // Put object
-            storage.put_object(request).await.unwrap();
+        storage.put_object(request).await.unwrap();
 
-            // Get object
-            let get_request = GetObjectRequest {
-                key: &key,
-                range: None,
-            };
-            let response = storage.get_object(get_request).await.unwrap().unwrap();
-            let retrieved_content = collect_stream_data(response.stream).await.unwrap();
-            assert_eq!(retrieved_content, content);
+        let get_request = GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key: &key,
+            range: None,
+        };
+        let response = storage.get_object(get_request).await.unwrap().unwrap();
+        let retrieved_content = collect_stream_data(response.stream).await.unwrap();
+        assert_eq!(retrieved_content, content);
 
-            // Delete object
-            storage.delete_object(&key).await.unwrap();
-        }
+        storage.delete_object(TEST_BUCKET, &key).await.unwrap();
     });
 
     futures::future::join_all(tasks).await;
@@ -222,15 +222,14 @@ async fn test_storage_backend_consistency() {
     let key = "consistency-test";
     let content = Bytes::from("Test content for consistency");
 
-    // Test both storages with the same operations
     for storage in [
         &fs_storage as &dyn StorageBackend,
         &mem_storage as &dyn StorageBackend,
     ] {
-        // Store object
         let content_for_stream = content.clone();
         let stream = futures::stream::once(async move { Ok(content_for_stream) });
         let request = StoreObjectRequest {
+            bucket: TEST_BUCKET.to_string(),
             key: key.to_string(),
             body: Box::pin(stream),
             integrity_checks: ObjectIntegrityChecks::new().with_md5(),
@@ -239,19 +238,19 @@ async fn test_storage_backend_consistency() {
         };
         let stored_metadata = storage.put_object(request).await.unwrap();
 
-        // Retrieve object
-        let get_request = GetObjectRequest { key, range: None };
+        let get_request = GetObjectRequest {
+            bucket: TEST_BUCKET,
+            key,
+            range: None,
+        };
         let response = storage.get_object(get_request).await.unwrap().unwrap();
         let retrieved_content = collect_stream_data(response.stream).await.unwrap();
 
-        // Verify consistency
         assert_eq!(retrieved_content, content);
         assert_eq!(response.metadata.content_length, content.len() as u64);
-        // Verify object integrity was calculated
         assert!(stored_metadata.object_integrity.etag().is_some());
 
-        // Clean up
-        storage.delete_object(key).await.unwrap();
+        storage.delete_object(TEST_BUCKET, key).await.unwrap();
     }
 }
 
@@ -270,27 +269,26 @@ async fn test_checksum_storage_backend<S: StorageBackend + ?Sized>(storage: &S) 
     let key = "test-checksum-object";
     let test_data = Bytes::from("Hello, checksum world!");
 
-    // Create integrity checks with multiple algorithms
     let integrity_checks = ObjectIntegrityChecks::new()
         .with_md5()
         .with_crc32()
         .with_sha256();
 
     let stream = Box::pin(futures::stream::once(async move { Ok(test_data) }));
-    let request = StoreObjectRequest::new(key, stream, integrity_checks);
+    let request = StoreObjectRequest::new(TEST_BUCKET, key, stream, integrity_checks);
 
-    // Store the object
     let stored_meta = storage.put_object(request).await.unwrap();
 
-    // Verify checksums were calculated
     assert!(stored_meta.object_integrity.etag().is_some());
     assert!(stored_meta.object_integrity.crc32.is_some());
     assert!(stored_meta.object_integrity.sha256.is_some());
 
-    // Retrieve object metadata
-    let retrieved_meta = storage.head_object(key).await.unwrap().unwrap();
+    let retrieved_meta = storage
+        .head_object(TEST_BUCKET, key)
+        .await
+        .unwrap()
+        .unwrap();
 
-    // Verify checksums are stored in metadata
     assert!(retrieved_meta.crc32.is_some());
     assert!(retrieved_meta.sha256.is_some());
     assert_eq!(

--- a/s3-mock-server/src/storage/tests.rs
+++ b/s3-mock-server/src/storage/tests.rs
@@ -178,6 +178,7 @@ async fn test_concurrent_operations<S: StorageBackend>(storage: &S) {
             integrity_checks: ObjectIntegrityChecks::new().with_md5(),
             content_type: Some("text/plain".to_string()),
             user_metadata: HashMap::new(),
+            last_modified: None,
         };
 
         storage.put_object(request).await.unwrap();
@@ -235,6 +236,7 @@ async fn test_storage_backend_consistency() {
             integrity_checks: ObjectIntegrityChecks::new().with_md5(),
             content_type: Some("text/plain".to_string()),
             user_metadata: HashMap::new(),
+            last_modified: None,
         };
         let stored_metadata = storage.put_object(request).await.unwrap();
 

--- a/s3-mock-server/src/streaming.rs
+++ b/s3-mock-server/src/streaming.rs
@@ -14,7 +14,7 @@ use std::collections::VecDeque;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-/// A stream that yields bytes from a Vec<Bytes> in memory.
+/// A stream that yields bytes from a `Vec<Bytes>` in memory.
 ///
 /// This is similar to s3s::stream::VecByteStream but adapted for our needs.
 /// It's useful for implementing streaming GetObject for in-memory storage.

--- a/s3-mock-server/src/streaming.rs
+++ b/s3-mock-server/src/streaming.rs
@@ -180,11 +180,17 @@ mod tests {
         let integrity_checks = ObjectIntegrityChecks::new().with_md5();
         let test_data_clone = test_data.clone();
         let stream = Box::pin(futures::stream::once(async move { Ok(test_data_clone) }));
-        let request = crate::storage::StoreObjectRequest::new("test-key", stream, integrity_checks);
+        let request = crate::storage::StoreObjectRequest::new(
+            "test-bucket",
+            "test-key",
+            stream,
+            integrity_checks,
+        );
         storage.put_object(request).await.unwrap();
 
         // Get the object as a stream
         let request = crate::storage::GetObjectRequest {
+            bucket: "test-bucket",
             key: "test-key",
             range: None,
         };

--- a/s3-mock-server/tests/operations.rs
+++ b/s3-mock-server/tests/operations.rs
@@ -584,3 +584,167 @@ async fn test_concurrent_operations() -> Result<()> {
     handle.shutdown().await?;
     Ok(())
 }
+
+#[tokio::test]
+async fn test_delete_object() -> Result<()> {
+    let server = S3MockServer::builder()
+        .with_in_memory_store()
+        .build()
+        .expect("Failed to build server");
+
+    let handle = server.start().await.expect("Failed to start mock server");
+    let s3 = handle.client().await;
+    let bucket = format!("test-bucket-{}", Uuid::new_v4());
+    let key = "delete-me.txt";
+
+    // Put an object
+    s3.put_object()
+        .bucket(&bucket)
+        .key(key)
+        .body(ByteStream::from_static(b"to be deleted"))
+        .send()
+        .await
+        .expect("Failed to put object");
+
+    // Verify it exists
+    s3.head_object()
+        .bucket(&bucket)
+        .key(key)
+        .send()
+        .await
+        .expect("Object should exist before delete");
+
+    // Delete it
+    s3.delete_object()
+        .bucket(&bucket)
+        .key(key)
+        .send()
+        .await
+        .expect("Failed to delete object");
+
+    // Verify it's gone
+    let result = s3.head_object().bucket(&bucket).key(key).send().await;
+    assert!(result.is_err(), "Object should not exist after delete");
+
+    handle.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_create_and_delete_bucket() -> Result<()> {
+    let server = S3MockServer::builder()
+        .with_in_memory_store()
+        .build()
+        .expect("Failed to build server");
+
+    let handle = server.start().await.expect("Failed to start mock server");
+    let s3 = handle.client().await;
+    let bucket = format!("test-bucket-{}", Uuid::new_v4());
+
+    // Create bucket
+    s3.create_bucket()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("Failed to create bucket");
+
+    // Verify head_bucket succeeds
+    s3.head_bucket()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("Bucket should exist after create");
+
+    // Delete bucket (empty)
+    s3.delete_bucket()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("Failed to delete empty bucket");
+
+    // Verify head_bucket fails
+    let result = s3.head_bucket().bucket(&bucket).send().await;
+    assert!(result.is_err(), "Bucket should not exist after delete");
+
+    handle.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_list_buckets() -> Result<()> {
+    let server = S3MockServer::builder()
+        .with_in_memory_store()
+        .build()
+        .expect("Failed to build server");
+
+    let handle = server.start().await.expect("Failed to start mock server");
+    let s3 = handle.client().await;
+
+    // Create two buckets by putting objects into them (auto-create)
+    let bucket_a = format!("bucket-a-{}", Uuid::new_v4());
+    let bucket_b = format!("bucket-b-{}", Uuid::new_v4());
+
+    s3.put_object()
+        .bucket(&bucket_a)
+        .key("obj1.txt")
+        .body(ByteStream::from_static(b"a"))
+        .send()
+        .await
+        .expect("Failed to put object in bucket_a");
+
+    s3.put_object()
+        .bucket(&bucket_b)
+        .key("obj2.txt")
+        .body(ByteStream::from_static(b"b"))
+        .send()
+        .await
+        .expect("Failed to put object in bucket_b");
+
+    let resp = s3
+        .list_buckets()
+        .send()
+        .await
+        .expect("Failed to list buckets");
+
+    let names: Vec<&str> = resp.buckets().iter().filter_map(|b| b.name()).collect();
+
+    assert!(
+        names.contains(&bucket_a.as_str()),
+        "bucket_a not found in list"
+    );
+    assert!(
+        names.contains(&bucket_b.as_str()),
+        "bucket_b not found in list"
+    );
+
+    handle.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_delete_nonempty_bucket() -> Result<()> {
+    let server = S3MockServer::builder()
+        .with_in_memory_store()
+        .build()
+        .expect("Failed to build server");
+
+    let handle = server.start().await.expect("Failed to start mock server");
+    let s3 = handle.client().await;
+    let bucket = format!("test-bucket-{}", Uuid::new_v4());
+
+    // Put an object (auto-creates bucket)
+    s3.put_object()
+        .bucket(&bucket)
+        .key("still-here.txt")
+        .body(ByteStream::from_static(b"data"))
+        .send()
+        .await
+        .expect("Failed to put object");
+
+    // Try to delete non-empty bucket — should fail
+    let result = s3.delete_bucket().bucket(&bucket).send().await;
+    assert!(result.is_err(), "Deleting a non-empty bucket should fail");
+
+    handle.shutdown().await?;
+    Ok(())
+}


### PR DESCRIPTION
# Mock server enhancements

## Summary

Upgrades the `s3-mock-server` crate to support bucket-aware operations, richer object metadata, and additional S3 operations needed for integration testing tooling built on top of the transfer manager.

## Changes

### s3-mock-server

- **Bucket-aware storage** — both in-memory and filesystem backends now scope objects per bucket with `create_bucket`/`delete_bucket` support
- **Updated s3s dependency** to latest (0.13.0), adapting the service layer accordingly
- **New S3 operations** — `ListBuckets`, `CreateBucket`, `DeleteBucket`, `DeleteObject`, `ListObjectsV2` with prefix/delimiter support
- **`add_object` API change** — now takes `(bucket, key, content, metadata)` (breaking: added `bucket` parameter)
- **`add_object_with` API** — new method accepting `AddObjectRequest` for full control over content-type, metadata, and last-modified
- **Object integrity** — seeded objects now get the same checksums (MD5 ETag, CRC64NVME) as objects uploaded via the S3 protocol path
- **Plumbed metadata fields** — content-type, last-modified, user metadata flow through storage layers to HeadObject/GetObject responses
- **Tracing** — added `tracing` instrumentation to the mock server for debugging
- **Operation tests** — new `tests/operations.rs` covering the added S3 operations


