### PR TITLE
vnext checksum and integrity checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
       - name: test s3-transfer-manager e2e
         run: |
           RUSTFLAGS="--cfg e2e_test" cargo test --test e2e_transfer_test
+          RUSTFLAGS="--cfg e2e_test" cargo test -p integration-tests
 
   fmt:
     name: fmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,18 +90,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,12 +110,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -292,7 +274,6 @@ dependencies = [
 name = "aws-sdk-s3-transfer-manager"
 version = "0.1.3"
 dependencies = [
- "async-channel",
  "aws-config",
  "aws-runtime",
  "aws-sdk-s3",
@@ -304,7 +285,6 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
- "blocking",
  "bytes",
  "bytes-utils",
  "clap",
@@ -901,19 +881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
-]
-
-[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,15 +1094,6 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "console-api"
@@ -1671,27 +1629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,16 +1746,6 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -3101,12 +3028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3193,17 +3114,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-sdk-s3-transfer-manager",
+ "aws-smithy-checksums 0.64.6",
  "s3-mock-server",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,6 +2421,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -4488,9 +4489,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/aws-sdk-s3-transfer-manager/Cargo.toml
+++ b/aws-sdk-s3-transfer-manager/Cargo.toml
@@ -14,14 +14,12 @@ categories = ["asynchronous", "concurrency"]
 keywords = ["AWS", "Amazon", "S3", "high-performance", "transfer-manager"]
 
 [dependencies]
-async-channel = "2.3.1"
 aws-config = { version = "1.8.15", features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1.128.0", features = ["behavior-version-latest"] }
 aws-smithy-runtime-api = "1.11.6"
 aws-runtime = "1.7.2"
 aws-smithy-types = "1.4.7"
 aws-types = "1.3.14"
-blocking = "1.6.1"
 bytes = "1"
 bytes-utils = "0.1.4"
 futures-util = "0.3.31"

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -17,6 +17,23 @@ use std::time::Duration;
 
 use crate::runtime::ExecutionRuntime;
 
+/// Disable the SDK's stalled-stream protection on a config builder the transfer
+/// manager constructs (the `from_env`/`s3_config` path).
+///
+/// The transfer manager owns stall detection for the bodies it drives (an
+/// adaptive, transfer-aware deadline in the download path), and it applies
+/// backpressure: a chunk body may be intentionally left unpolled while the slot
+/// buffer is full. The SDK's body-level minimum-throughput guard cannot tell
+/// that apart from a dead connection and would abort a healthy, backpressured
+/// chunk. A client supplied directly via `client()` is left untouched (the
+/// caller owns its configuration); this applies only to clients the transfer
+/// manager builds itself.
+fn without_stalled_stream_protection(
+    builder: aws_sdk_s3::config::Builder,
+) -> aws_sdk_s3::config::Builder {
+    builder.stalled_stream_protection(aws_sdk_s3::config::StalledStreamProtectionConfig::disabled())
+}
+
 /// Transfer manager client for Amazon Simple Storage Service.
 #[derive(Debug, Clone)]
 pub struct Client {
@@ -78,7 +95,9 @@ impl Handle {
             let s3_client = match config.take_s3_client_source() {
                 crate::config::S3ClientSource::Provided(client) => client,
                 crate::config::S3ClientSource::FromConfig(s3_config) => {
-                    aws_sdk_s3::Client::from_conf(s3_config.builder.build())
+                    aws_sdk_s3::Client::from_conf(
+                        without_stalled_stream_protection(s3_config.builder).build(),
+                    )
                 }
             };
             Self {
@@ -136,7 +155,9 @@ impl Handle {
             let s3_client = match config.take_s3_client_source() {
                 crate::config::S3ClientSource::Provided(client) => client,
                 crate::config::S3ClientSource::FromConfig(s3_config) => {
-                    aws_sdk_s3::Client::from_conf(s3_config.builder.build())
+                    aws_sdk_s3::Client::from_conf(
+                        without_stalled_stream_protection(s3_config.builder).build(),
+                    )
                 }
             };
             Self {
@@ -199,7 +220,7 @@ impl Client {
             let s3_client = match config.take_s3_client_source() {
                 crate::config::S3ClientSource::Provided(client) => client,
                 crate::config::S3ClientSource::FromConfig(s3_config) => {
-                    let mut builder = s3_config.builder;
+                    let mut builder = without_stalled_stream_protection(s3_config.builder);
                     if s3_config.enable_runtime_http {
                         if let Some(http_client) = runtime.components().http_client() {
                             builder = builder.http_client(http_client.clone());

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -60,6 +60,14 @@ impl Handle {
         }
     }
 
+    /// Whether the user pinned an explicit part size (vs leaving it `Auto`).
+    /// When `Auto`, the transfer manager owns part sizing and may override it
+    /// (e.g. align download ranges to an object's stored part size for
+    /// validation); an explicit size is respected as set.
+    pub(crate) fn user_set_part_size(&self) -> bool {
+        matches!(self.config.part_size(), PartSize::Target(_))
+    }
+
     /// Create a Handle for testing with a custom scheduler factory.
     #[cfg(test)]
     pub(crate) fn new_for_test(mut config: crate::Config, concurrency: usize) -> Arc<Self> {

--- a/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
@@ -20,6 +20,11 @@ pub(crate) enum DownloadState {
         ranges_in_flight: usize,
         /// ETag for consistency (shared across all range requests)
         etag: Option<std::sync::Arc<str>>,
+        /// Per-chunk size used to slice `remaining`. Normally the configured
+        /// download part size; for a multipart object being validated it is the
+        /// object's stored part size so each range aligns to a stored part
+        /// boundary (S3 returns a per-part checksum only for an aligned range).
+        part_size: u64,
     },
 
     /// Terminal state - transfer ended (success, failure, or cancelled)

--- a/aws-sdk-s3-transfer-manager/src/operation/download/discovery.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/discovery.rs
@@ -41,6 +41,20 @@ pub(super) struct ObjectDiscovery {
 
     /// the first chunk of data if fetched during discovery
     pub(super) initial_chunk: Option<ByteStream>,
+
+    /// Per-chunk size the transfer should slice remaining ranges at. Normally the
+    /// configured download part size; for a validated multipart object it is the
+    /// object's stored part size so every range aligns to a stored part boundary
+    /// (the precondition for per-part download validation).
+    pub(super) effective_part_size: u64,
+}
+
+/// Parse the stored part count from an MPU ETag of the form `"<hash>-<N>"`.
+/// Returns `None` for a single-part ETag (no `-N` suffix) or unparseable input.
+fn parts_from_etag(etag: &str) -> Option<u32> {
+    let trimmed = etag.trim_matches('"');
+    let (_, n) = trimmed.rsplit_once('-')?;
+    n.parse::<u32>().ok().filter(|&n| n > 1)
 }
 
 impl ObjectDiscoveryStrategy {
@@ -71,10 +85,13 @@ impl ObjectDiscoveryStrategy {
 pub(super) async fn discover_obj(
     transfer: &DownloadTransfer,
     input: &DownloadInput,
+    validation_enabled: bool,
 ) -> Result<ObjectDiscovery, crate::error::Error> {
+    let configured_part_size = transfer.ctx().handle.download_part_size_bytes();
     let strategy = ObjectDiscoveryStrategy::from_request(input)?;
     tracing::trace!("discovering object with strategy {:?}", strategy);
-    let discovery = match strategy {
+    let user_explicit_part_size = transfer.ctx().handle.user_set_part_size();
+    let mut discovery = match strategy {
         ObjectDiscoveryStrategy::HeadObject => {
             discover_obj_with_head(transfer, input)
                 .instrument(tracing::debug_span!("send-head-object-for-discovery"))
@@ -86,11 +103,54 @@ pub(super) async fn discover_obj(
                 .await
         }
     }?;
+    // Default: slice at the configured download part size. The alignment path
+    // below overrides this with the stored part size when validating a multipart
+    // object.
+    discovery.effective_part_size = configured_part_size;
+
+    // Align download ranges to the object's stored part size so each ranged GET
+    // matches a stored part boundary and S3 returns the part's checksum for the
+    // SDK to validate. Only for: validation on, no user range, a multipart object
+    // (ETag carries `-N`), and the user did not pin an explicit part size.
+    //
+    // The initial ranged discovery fetched `[0, configured)`, whose chunk length
+    // is the CONFIGURED size, not the stored part size, so it cannot tell us the
+    // stored layout. Re-issue via partNumber=1, whose response reports the exact
+    // first-part (= stored part) size via Content-Range; slice every range at that
+    // size so all chunks align to stored boundaries (incl. the ragged tail). One
+    // extra request, only on this path.
+    //
+    // TODO(vnext): a wire checksum over arbitrary response bytes removes the need
+    // to align, so this partNumber re-issue can go away once that exists.
+    let is_multipart = discovery
+        .object_meta
+        .e_tag
+        .as_deref()
+        .and_then(parts_from_etag)
+        .is_some();
+    if validation_enabled && input.range().is_none() && is_multipart && !user_explicit_part_size {
+        let mut aligned = discover_obj_with_get_first_part(transfer, input).await?;
+        let stored_part_size = aligned
+            .chunk_meta
+            .as_ref()
+            .and_then(|m| m.content_length)
+            .map(|len| len as u64)
+            .filter(|&len| len != 0)
+            .unwrap_or(configured_part_size);
+        tracing::debug!(
+            configured_part_size,
+            stored_part_size,
+            "realigned multipart download to stored part size for validation"
+        );
+        aligned.effective_part_size = stored_part_size;
+        discovery = aligned;
+    }
 
     tracing::trace!(
-        "discovered object, remaining: {:?}; initial chunk set: {}",
-        discovery.remaining,
-        discovery.initial_chunk.is_some()
+        remaining = ?discovery.remaining,
+        initial_chunk = discovery.initial_chunk.is_some(),
+        effective_part_size = discovery.effective_part_size,
+        "discovered object",
     );
 
     Ok(discovery)
@@ -133,6 +193,8 @@ async fn discover_obj_with_head(
         chunk_meta: None,
         object_meta,
         initial_chunk: None,
+        // Filled in by discover_obj (configured size, or stored size when aligning).
+        effective_part_size: 0,
     })
 }
 
@@ -208,6 +270,8 @@ fn first_chunk_response_handler(
         chunk_meta: Some(chunk_meta),
         object_meta,
         initial_chunk,
+        // Filled in by discover_obj (configured size, or stored size when aligning).
+        effective_part_size: 0,
     })
 }
 
@@ -250,6 +314,14 @@ mod tests {
             .client(client)
             .set_target_part_size(PartSize::Target(target_part_size))
             .build();
+        let tm = crate::Client::new(tm_config);
+        tm.handle.clone()
+    }
+
+    // Handle with an Auto part size (download Auto = 5 MiB), so the multipart
+    // alignment branch (gated on `!user_set_part_size`) can be exercised.
+    fn test_handle_auto(client: aws_sdk_s3::Client) -> Arc<crate::client::Handle> {
+        let tm_config = crate::Config::builder().client(client).build();
         let tm = crate::Client::new(tm_config);
         tm.handle.clone()
     }
@@ -338,7 +410,7 @@ mod tests {
 
         let transfer = test_transfer(test_handle(client, target_part_size), &request);
 
-        let discovery = discover_obj(&transfer, &request).await.unwrap();
+        let discovery = discover_obj(&transfer, &request, false).await.unwrap();
         let remaining = discovery.remaining.unwrap();
         assert_eq!(200, remaining.clone().count());
         assert_eq!(500..=699, remaining);
@@ -376,7 +448,7 @@ mod tests {
 
         let transfer = test_transfer(test_handle(client, target_part_size), &request);
 
-        let discovery = discover_obj(&transfer, &request).await.unwrap();
+        let discovery = discover_obj(&transfer, &request, false).await.unwrap();
         assert!(discovery.remaining.is_none());
 
         let initial_chunk = discovery
@@ -386,6 +458,89 @@ mod tests {
             .await
             .expect("valid body");
         assert_eq!(400, initial_chunk.remaining());
+    }
+
+    // A validating download of a multipart object (ETag `-N`) with an Auto part
+    // size re-issues discovery via partNumber=1 to learn the exact stored part
+    // size and aligns subsequent ranges to it. Download Auto = 5 MiB, but the
+    // stored part is 8 MiB; effective_part_size must become 8 MiB.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_discover_obj_aligns_multipart_when_validating() {
+        const MIB: u64 = 1024 * 1024;
+        let download_default = 5 * MIB; // Auto download part size
+        let stored_part = 8 * MIB;
+        let total = 20 * MIB; // 8 + 8 + 4 -> 3 parts
+        let ranged = mock!(Client::get_object)
+            .match_requests(move |r| {
+                r.range() == Some(format!("bytes=0-{}", download_default - 1).as_str())
+                    && r.part_number().is_none()
+            })
+            .then_output(move || {
+                GetObjectOutput::builder()
+                    .content_length(download_default as i64)
+                    .content_range(format!("0-{}/{}", download_default - 1, total))
+                    .e_tag("\"abc-3\"")
+                    .body(ByteStream::from_static(&[0u8; 8]))
+                    .build()
+            });
+        let part1 = mock!(Client::get_object)
+            .match_requests(|r| r.part_number() == Some(1))
+            .then_output(move || {
+                GetObjectOutput::builder()
+                    .content_length(stored_part as i64)
+                    .content_range(format!("0-{}/{}", stored_part - 1, total))
+                    .e_tag("\"abc-3\"")
+                    .parts_count(3)
+                    .body(ByteStream::from_static(&[0u8; 8]))
+                    .build()
+            });
+        let client = mock_client!(aws_sdk_s3, &[&ranged, &part1]);
+
+        let request = DownloadInput::builder()
+            .bucket("test-bucket")
+            .key("test-key")
+            .build()
+            .unwrap();
+        let transfer = test_transfer(test_handle_auto(client), &request);
+
+        let discovery = discover_obj(&transfer, &request, true).await.unwrap();
+
+        // Aligned to the stored part size (8 MiB), not the Auto default (5 MiB).
+        assert_eq!(discovery.effective_part_size, stored_part);
+        // remaining starts at the first stored boundary (after part 1).
+        assert_eq!(discovery.remaining, Some(stored_part..=total - 1));
+    }
+
+    // Without validation, no partNumber re-issue: the slice size stays the
+    // configured part size even for a multipart object.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_discover_obj_no_align_when_validation_disabled() {
+        let configured = 500;
+        let ranged = mock!(Client::get_object)
+            .match_requests(|r| r.range() == Some("bytes=0-499"))
+            .then_output(|| {
+                GetObjectOutput::builder()
+                    .content_length(500)
+                    .content_range("0-499/700")
+                    .e_tag("\"abc-2\"")
+                    .body(ByteStream::from_static(&[0u8; 500]))
+                    .build()
+            });
+        let client = mock_client!(aws_sdk_s3, &[&ranged]);
+
+        let request = DownloadInput::builder()
+            .bucket("test-bucket")
+            .key("test-key")
+            .build()
+            .unwrap();
+        let transfer = test_transfer(test_handle(client, configured), &request);
+
+        let discovery = discover_obj(&transfer, &request, false).await.unwrap();
+
+        assert_eq!(discovery.effective_part_size, configured);
+        assert_eq!(discovery.remaining, Some(500..=699));
     }
 
     #[cfg_attr(miri, ignore)]
@@ -413,7 +568,7 @@ mod tests {
 
         let transfer = test_transfer(test_handle(client, target_part_size), &request);
 
-        let discovery = discover_obj(&transfer, &request).await.unwrap();
+        let discovery = discover_obj(&transfer, &request, false).await.unwrap();
         let remaining = discovery.remaining.unwrap();
         assert_eq!(200, remaining.clone().count());
         assert_eq!(300..=499, remaining);
@@ -452,7 +607,7 @@ mod tests {
 
         let transfer = test_transfer(test_handle(client, target_part_size), &request);
 
-        let discovery = discover_obj(&transfer, &request).await.unwrap();
+        let discovery = discover_obj(&transfer, &request, false).await.unwrap();
         assert!(discovery.remaining.is_none());
 
         let initial_chunk = discovery
@@ -486,7 +641,7 @@ mod tests {
 
         let transfer = test_transfer(test_handle(client, target_part_size), &request);
 
-        let discovery = discover_obj(&transfer, &request).await.unwrap();
+        let discovery = discover_obj(&transfer, &request, false).await.unwrap();
         assert!(discovery.remaining.is_none());
         assert!(discovery.initial_chunk.is_none());
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
@@ -88,7 +88,16 @@ impl DownloadHandleInner {
             .object_meta()
             .expect("object_meta must be set on successful completion")
             .clone();
-        Ok(DownloadOutput::new(object_meta, ctx.metrics()))
+        let integrity_checks = self
+            .transfer
+            .integrity_checks()
+            .expect("integrity_checks must be set on successful completion")
+            .clone();
+        Ok(DownloadOutput::new(
+            object_meta,
+            ctx.metrics(),
+            integrity_checks,
+        ))
     }
 
     /// Core abort logic: cancel transfer, notify consumer, and wait for idle.

--- a/aws-sdk-s3-transfer-manager/src/operation/download/output.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/output.rs
@@ -4,6 +4,7 @@
  */
 
 use super::object_meta::ObjectMetadata;
+use crate::types::IntegrityChecks;
 
 /// Output from a completed download operation.
 // FIXME: join() should return a wrapper type that always carries TransferMetrics
@@ -15,13 +16,27 @@ pub struct DownloadOutput {
     pub object_meta: ObjectMetadata,
     /// Snapshot of transfer metrics at completion.
     pub metrics: crate::types::TransferMetrics,
+    /// Object-integrity information: the object's reported checksum values and
+    /// whether the delivered bytes were checksum-validated.
+    integrity_checks: IntegrityChecks,
 }
 
 impl DownloadOutput {
-    pub(crate) fn new(object_meta: ObjectMetadata, metrics: crate::types::TransferMetrics) -> Self {
+    pub(crate) fn new(
+        object_meta: ObjectMetadata,
+        metrics: crate::types::TransferMetrics,
+        integrity_checks: IntegrityChecks,
+    ) -> Self {
         Self {
             object_meta,
             metrics,
+            integrity_checks,
         }
+    }
+
+    /// Object-integrity information for this download: the object's reported
+    /// checksum values and whether the delivered bytes were checksum-validated.
+    pub fn integrity_checks(&self) -> &IntegrityChecks {
+        &self.integrity_checks
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -335,7 +335,10 @@ impl DownloadTransfer {
             let data = match result {
                 Ok(data) => data,
                 Err(e) => {
-                    self.decrement_in_flight();
+                    // Go terminal before any wake: fail() sets Terminal under the
+                    // lock, so a woken poll_work cannot observe ranges_in_flight==0
+                    // and complete() the transfer over this error. The in-flight
+                    // count is abandoned with the Transferring state.
                     let guard = self.inner.state.lock().unwrap();
                     return self.fail(guard, error::chunk_failed(ChunkId::Download(seq), e));
                 }
@@ -362,7 +365,7 @@ impl DownloadTransfer {
 
         slot.fill(chunk);
         if let Err(e) = self.inner.writer.try_flush() {
-            self.decrement_in_flight();
+            // Go terminal before any wake (see fail_range).
             let guard = self.inner.state.lock().unwrap();
             return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
         }
@@ -457,7 +460,7 @@ impl DownloadTransfer {
 
         slot.fill(chunk);
         if let Err(e) = self.inner.writer.try_flush() {
-            self.decrement_in_flight();
+            // Go terminal before any wake (see fail_range).
             let guard = self.inner.state.lock().unwrap();
             return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
         }
@@ -489,7 +492,9 @@ impl DownloadTransfer {
 
     /// Fail a range request with an error.
     fn fail_range(&self, seq: u64, e: impl Into<crate::error::BoxError>) -> WorkOutcome {
-        self.decrement_in_flight();
+        // Go terminal before any wake (see the discovery-body error path). Do not
+        // decrement_in_flight first: that wakes poll_work, which would observe
+        // ranges_in_flight==0 and complete() over this error.
         let guard = self.inner.state.lock().unwrap();
         self.fail(guard, error::chunk_failed(ChunkId::Download(seq), e))
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -82,6 +82,8 @@ struct DownloadTransferInner {
     writer: BodyWriter,
     /// Object metadata from discovery (set once discovery completes)
     object_meta: std::sync::OnceLock<ObjectMetadata>,
+    /// Object-integrity result (set once discovery completes)
+    integrity_checks: std::sync::OnceLock<crate::types::IntegrityChecks>,
     /// Notified when discovery completes (success or failure)
     discovery_notify: tokio::sync::Notify,
 }
@@ -100,6 +102,7 @@ impl DownloadTransfer {
             bucket_type,
             writer,
             object_meta: std::sync::OnceLock::new(),
+            integrity_checks: std::sync::OnceLock::new(),
             discovery_notify: tokio::sync::Notify::new(),
         });
         Self { inner }
@@ -123,6 +126,11 @@ impl DownloadTransfer {
     /// Object metadata from discovery.
     pub(crate) fn object_meta(&self) -> Option<&ObjectMetadata> {
         self.inner.object_meta.get()
+    }
+
+    /// Object-integrity result from discovery.
+    pub(crate) fn integrity_checks(&self) -> Option<&crate::types::IntegrityChecks> {
+        self.inner.integrity_checks.get()
     }
 
     /// Notified when discovery completes.
@@ -243,6 +251,18 @@ impl DownloadTransfer {
 
         // Store object_meta for object_meta() and join()
         let _ = self.inner.object_meta.set(object_meta.clone());
+
+        // Object checksum is known only when the whole object arrived in this
+        // chunk. A larger multipart object's discovery chunk carries part 1's
+        // checksum, which is not the object checksum.
+        let whole_object_in_chunk = input.range.is_none() && remaining.is_none();
+        let integrity = build_integrity_checks(
+            chunk_meta.as_ref(),
+            whole_object_in_chunk,
+            input.checksum_mode.as_ref(),
+        );
+        let _ = self.inner.integrity_checks.set(integrity);
+
         // Notify waiters that discovery completed
         self.inner.discovery_notify.notify_waiters();
 
@@ -579,6 +599,52 @@ fn validate_content_range(
     }
 }
 
+/// Build the object-integrity result for a completed download.
+///
+/// `whole_object_in_chunk` must be true only when the entire object arrived in
+/// the discovery chunk, the one case where the chunk checksum is the object
+/// checksum. Otherwise value members are left `None`.
+///
+/// Validation is reported `Disabled` when not requested, else
+/// `NotValidated{Unavailable}`. `Validated{algorithm}` requires a per-response
+/// validation outcome the Rust SDK does not currently expose.
+// TODO(vnext): resolve `Validated{algorithm}` from an SDK-reported per-response
+// validation outcome once the SDK exposes one, instead of always reporting
+// NotValidated when validation is enabled.
+fn build_integrity_checks(
+    chunk_meta: Option<&ChunkMetadata>,
+    whole_object_in_chunk: bool,
+    checksum_mode: Option<&aws_sdk_s3::types::ChecksumMode>,
+) -> crate::types::IntegrityChecks {
+    use crate::types::{ChecksumValidation, NotValidatedReason};
+
+    let validation_enabled = matches!(
+        checksum_mode,
+        Some(aws_sdk_s3::types::ChecksumMode::Enabled)
+    );
+    let checksum_validation = if validation_enabled {
+        ChecksumValidation::NotValidated {
+            reason: NotValidatedReason::Unavailable,
+        }
+    } else {
+        ChecksumValidation::NotValidated {
+            reason: NotValidatedReason::Disabled,
+        }
+    };
+
+    // Surface checksum values only when they describe the whole object.
+    let cm = chunk_meta.filter(|_| whole_object_in_chunk);
+    crate::types::IntegrityChecks::new(
+        cm.and_then(|m| m.checksum_crc32.clone()),
+        cm.and_then(|m| m.checksum_crc32_c.clone()),
+        cm.and_then(|m| m.checksum_crc64_nvme.clone()),
+        cm.and_then(|m| m.checksum_sha1.clone()),
+        cm.and_then(|m| m.checksum_sha256.clone()),
+        cm.and_then(|m| m.checksum_type.clone()),
+        checksum_validation,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -592,6 +658,58 @@ mod tests {
     use aws_smithy_mocks::{mock, mock_client, RuleMode};
 
     const MB: u64 = 1024 * 1024;
+
+    use crate::operation::download::chunk_meta::ChunkMetadata;
+    use crate::types::{ChecksumValidation, NotValidatedReason};
+    use aws_sdk_s3::types::{ChecksumMode, ChecksumType};
+
+    fn chunk_with_crc32(value: &str) -> ChunkMetadata {
+        let mut m = ChunkMetadata::default();
+        m.checksum_crc32 = Some(value.to_string());
+        m.checksum_type = Some(ChecksumType::FullObject);
+        m
+    }
+
+    #[test]
+    fn integrity_disabled_when_mode_off() {
+        let ic = build_integrity_checks(Some(&chunk_with_crc32("DUoRhQ==")), true, None);
+        assert_eq!(
+            *ic.checksum_validation(),
+            ChecksumValidation::NotValidated {
+                reason: NotValidatedReason::Disabled
+            }
+        );
+    }
+
+    #[test]
+    fn integrity_unavailable_when_enabled_pending_sdk_signal() {
+        // TODO(vnext): becomes Validated once the SDK reports a validation outcome.
+        let ic = build_integrity_checks(
+            Some(&chunk_with_crc32("DUoRhQ==")),
+            true,
+            Some(&ChecksumMode::Enabled),
+        );
+        assert_eq!(
+            *ic.checksum_validation(),
+            ChecksumValidation::NotValidated {
+                reason: NotValidatedReason::Unavailable
+            }
+        );
+    }
+
+    #[test]
+    fn integrity_surfaces_value_only_for_whole_object_chunk() {
+        // Whole object in the discovery chunk -> the chunk checksum IS the object's.
+        let whole = build_integrity_checks(Some(&chunk_with_crc32("DUoRhQ==")), true, None);
+        assert_eq!(whole.checksum_crc32(), Some("DUoRhQ=="));
+        assert_eq!(whole.checksum_type(), Some(&ChecksumType::FullObject));
+
+        // Multipart (object did not fit in the discovery chunk) -> part-1 value is
+        // NOT surfaced as the object value.
+        let multipart = build_integrity_checks(Some(&chunk_with_crc32("DUoRhQ==")), false, None);
+        assert_eq!(multipart.checksum_crc32(), None);
+        assert_eq!(multipart.checksum_type(), None);
+    }
 
     fn create_download(object_size: u64, part_size: u64) -> DownloadTransfer {
         let chunk = vec![0u8; part_size as usize];

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -12,6 +12,8 @@ use std::sync::{Arc, Mutex};
 
 use bytes_utils::SegmentedBuf;
 
+use aws_sdk_s3::operation::get_object::builders::GetObjectInputBuilder;
+
 use crate::error::{self, ChunkId, Error};
 use crate::io::AggregatedBytes;
 use crate::operation::download::body::{BodySlot, BodyWriter, ChunkOutput};
@@ -383,21 +385,20 @@ impl DownloadTransfer {
                 let rh = range_header.clone();
                 let etag = etag.clone();
                 let ctx = self.inner.ctx.clone();
-                let mut req = self
-                    .inner
-                    .ctx
-                    .s3_client()
-                    .get_object()
-                    .bucket(input.bucket().unwrap_or_default())
-                    .key(input.key().unwrap_or_default())
-                    .range(rh.clone());
-
-                if let Some(ref etag) = etag {
-                    req = req.if_match(etag.as_ref());
+                // Every chunk GET must carry the same request fields as discovery
+                // (checksum_mode, SSE-C key, version_id, ...). Derive from the input
+                // conversion, then pin this chunk's range and the discovered etag.
+                let mut builder: GetObjectInputBuilder = input.clone().into();
+                builder = builder.set_range(Some(rh.clone()));
+                if let Some(etag) = etag.as_ref() {
+                    builder = builder.if_match(etag.as_ref());
                 }
 
                 async move {
-                    let resp = req.send().await.map_err(crate::error::Error::from)?;
+                    let resp = builder
+                        .send_with(ctx.s3_client())
+                        .await
+                        .map_err(crate::error::Error::from)?;
                     validate_content_range(seq, &rh, resp.content_range())?;
                     let chunk_meta = ChunkMetadata::from(&resp);
                     let mut segmented = SegmentedBuf::new();

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -256,10 +256,26 @@ impl DownloadTransfer {
         // chunk. A larger multipart object's discovery chunk carries part 1's
         // checksum, which is not the object checksum.
         let whole_object_in_chunk = input.range.is_none() && remaining.is_none();
+        // Resolve the effective validation state the same way the SDK's GetObject
+        // mutator does: enabled if the request set ChecksumMode=Enabled, or the
+        // request left it unset and the client's ResponseChecksumValidation is not
+        // WhenRequired (WhenSupported, the default, and unknown values enable it).
+        let validation_enabled = match input.checksum_mode {
+            Some(aws_sdk_s3::types::ChecksumMode::Enabled) => true,
+            _ => !matches!(
+                self.ctx()
+                    .s3_client()
+                    .config()
+                    .response_checksum_validation()
+                    .copied()
+                    .unwrap_or_default(),
+                aws_sdk_s3::config::ResponseChecksumValidation::WhenRequired
+            ),
+        };
         let integrity = build_integrity_checks(
             chunk_meta.as_ref(),
             whole_object_in_chunk,
-            input.checksum_mode.as_ref(),
+            validation_enabled,
         );
         let _ = self.inner.integrity_checks.set(integrity);
 
@@ -619,14 +635,10 @@ fn validate_content_range(
 fn build_integrity_checks(
     chunk_meta: Option<&ChunkMetadata>,
     whole_object_in_chunk: bool,
-    checksum_mode: Option<&aws_sdk_s3::types::ChecksumMode>,
+    validation_enabled: bool,
 ) -> crate::types::IntegrityChecks {
     use crate::types::{ChecksumValidation, NotValidatedReason};
 
-    let validation_enabled = matches!(
-        checksum_mode,
-        Some(aws_sdk_s3::types::ChecksumMode::Enabled)
-    );
     let checksum_validation = if validation_enabled {
         ChecksumValidation::NotValidated {
             reason: NotValidatedReason::Unavailable,
@@ -666,7 +678,7 @@ mod tests {
 
     use crate::operation::download::chunk_meta::ChunkMetadata;
     use crate::types::{ChecksumValidation, NotValidatedReason};
-    use aws_sdk_s3::types::{ChecksumMode, ChecksumType};
+    use aws_sdk_s3::types::ChecksumType;
 
     fn chunk_with_crc32(value: &str) -> ChunkMetadata {
         let mut m = ChunkMetadata::default();
@@ -676,8 +688,10 @@ mod tests {
     }
 
     #[test]
-    fn integrity_disabled_when_mode_off() {
-        let ic = build_integrity_checks(Some(&chunk_with_crc32("DUoRhQ==")), true, None);
+    fn integrity_disabled_when_validation_not_enabled() {
+        // validation_enabled=false models a WhenRequired client with no request
+        // override: no validation is attempted, so the verdict is Disabled.
+        let ic = build_integrity_checks(Some(&chunk_with_crc32("DUoRhQ==")), true, false);
         assert_eq!(
             *ic.checksum_validation(),
             ChecksumValidation::NotValidated {
@@ -689,11 +703,7 @@ mod tests {
     #[test]
     fn integrity_unavailable_when_enabled_pending_sdk_signal() {
         // TODO(vnext): becomes Validated once the SDK reports a validation outcome.
-        let ic = build_integrity_checks(
-            Some(&chunk_with_crc32("DUoRhQ==")),
-            true,
-            Some(&ChecksumMode::Enabled),
-        );
+        let ic = build_integrity_checks(Some(&chunk_with_crc32("DUoRhQ==")), true, true);
         assert_eq!(
             *ic.checksum_validation(),
             ChecksumValidation::NotValidated {
@@ -705,13 +715,13 @@ mod tests {
     #[test]
     fn integrity_surfaces_value_only_for_whole_object_chunk() {
         // Whole object in the discovery chunk -> the chunk checksum IS the object's.
-        let whole = build_integrity_checks(Some(&chunk_with_crc32("DUoRhQ==")), true, None);
+        let whole = build_integrity_checks(Some(&chunk_with_crc32("DUoRhQ==")), true, false);
         assert_eq!(whole.checksum_crc32(), Some("DUoRhQ=="));
         assert_eq!(whole.checksum_type(), Some(&ChecksumType::FullObject));
 
         // Multipart (object did not fit in the discovery chunk) -> part-1 value is
         // NOT surfaced as the object value.
-        let multipart = build_integrity_checks(Some(&chunk_with_crc32("DUoRhQ==")), false, None);
+        let multipart = build_integrity_checks(Some(&chunk_with_crc32("DUoRhQ==")), false, false);
         assert_eq!(multipart.checksum_crc32(), None);
         assert_eq!(multipart.checksum_type(), None);
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -138,9 +138,24 @@ impl DownloadTransfer {
         &self.inner.discovery_notify
     }
 
-    /// The target part size to use for this download.
-    fn target_part_size_bytes(&self) -> u64 {
-        self.inner.ctx.handle.download_part_size_bytes()
+    /// Whether download checksum validation is in effect, resolved the same way
+    /// the SDK's GetObject mutator does: enabled if the request set
+    /// `ChecksumMode=Enabled`, or it is unset and the client's
+    /// `ResponseChecksumValidation` is not `WhenRequired` (`WhenSupported`, the
+    /// default, and unknown values enable it).
+    fn validation_enabled(&self, input: &DownloadInput) -> bool {
+        match input.checksum_mode {
+            Some(aws_sdk_s3::types::ChecksumMode::Enabled) => true,
+            _ => !matches!(
+                self.ctx()
+                    .s3_client()
+                    .config()
+                    .response_checksum_validation()
+                    .copied()
+                    .unwrap_or_default(),
+                aws_sdk_s3::config::ResponseChecksumValidation::WhenRequired
+            ),
+        }
     }
 
     /// Poll for the next work item.
@@ -173,6 +188,7 @@ impl DownloadTransfer {
                 remaining,
                 ranges_in_flight,
                 etag,
+                part_size,
                 ..
             } => {
                 // Check seq window before generating work
@@ -182,7 +198,11 @@ impl DownloadTransfer {
                 };
 
                 if let Some(range) = remaining.take() {
-                    let part_size = self.target_part_size_bytes();
+                    // `part_size` is the stored part size for a validated multipart
+                    // object (so each range aligns to a stored part boundary and S3
+                    // returns the part's checksum for the SDK to validate), else the
+                    // configured download part size. Set at discovery.
+                    let part_size = *part_size;
                     let start = *range.start();
                     let end = *range.end();
                     let chunk_end = cmp::min(start + part_size - 1, end);
@@ -234,7 +254,14 @@ impl DownloadTransfer {
     async fn execute_discovery(&self) -> WorkOutcome {
         let input = self.inner.request.as_ref();
 
-        let discovery = match discover_obj(self, input).await {
+        // Resolve the effective validation state the same way the SDK's GetObject
+        // mutator does: enabled if the request set ChecksumMode=Enabled, or the
+        // request left it unset and the client's ResponseChecksumValidation is not
+        // WhenRequired (WhenSupported, the default, and unknown values enable it).
+        // Computed before discovery because it drives range alignment.
+        let validation_enabled = self.validation_enabled(input);
+
+        let discovery = match discover_obj(self, input, validation_enabled).await {
             Ok(d) => d,
             Err(e) => {
                 let guard = self.inner.state.lock().unwrap();
@@ -247,6 +274,7 @@ impl DownloadTransfer {
             object_meta,
             initial_chunk,
             chunk_meta,
+            effective_part_size,
         } = discovery;
 
         // Store object_meta for object_meta() and join()
@@ -256,22 +284,6 @@ impl DownloadTransfer {
         // chunk. A larger multipart object's discovery chunk carries part 1's
         // checksum, which is not the object checksum.
         let whole_object_in_chunk = input.range.is_none() && remaining.is_none();
-        // Resolve the effective validation state the same way the SDK's GetObject
-        // mutator does: enabled if the request set ChecksumMode=Enabled, or the
-        // request left it unset and the client's ResponseChecksumValidation is not
-        // WhenRequired (WhenSupported, the default, and unknown values enable it).
-        let validation_enabled = match input.checksum_mode {
-            Some(aws_sdk_s3::types::ChecksumMode::Enabled) => true,
-            _ => !matches!(
-                self.ctx()
-                    .s3_client()
-                    .config()
-                    .response_checksum_validation()
-                    .copied()
-                    .unwrap_or_default(),
-                aws_sdk_s3::config::ResponseChecksumValidation::WhenRequired
-            ),
-        };
         let integrity = build_integrity_checks(
             chunk_meta.as_ref(),
             whole_object_in_chunk,
@@ -320,6 +332,7 @@ impl DownloadTransfer {
                 remaining,
                 ranges_in_flight: if initial_work.is_some() { 1 } else { 0 },
                 etag,
+                part_size: effective_part_size,
             };
         }
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download_objects/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download_objects/transfer.rs
@@ -564,19 +564,10 @@ impl DownloadObjectsTransfer {
                         error: err,
                     });
                     if self.inner.failure_policy == FailedTransferPolicy::Abort {
-                        self.inner.ctx.set_failed(Error::new(
+                        self.inner.ctx.set_failed_and_signal(Error::new(
                             ErrorKind::ChildOperationFailed,
                             format!("download failed for key '{key}'"),
                         ));
-                        // set_failed makes the transfer terminal but does not
-                        // signal; signal here so the terminal transition is
-                        // observable before returning to the scheduler. A
-                        // terminal transfer that returns idle without signaling
-                        // can be removed by the scheduler with its completion
-                        // channel never fired, hanging the owning handle. Any
-                        // surviving children are cancelled when the handle's
-                        // join()/drop calls cancel_transfer(parent_id).
-                        self.inner.ctx.signal_terminal();
                     }
                 }
             }
@@ -707,6 +698,7 @@ impl DownloadObjectsTransfer {
             if let Err(err) = self.validate_destination() {
                 let mut state = self.inner.state.lock();
                 state.walk_in_flight = false;
+                // set_failed alone: check_terminal arbitrates the terminal signal once in-flight work (children/walks/reaps) drains.
                 self.inner.ctx.set_failed(err);
                 if self.check_terminal(&state).is_some() {
                     return WorkOutcome::Success { data: None };
@@ -829,19 +821,10 @@ impl DownloadObjectsTransfer {
                         error: err,
                     });
                     if self.inner.failure_policy == FailedTransferPolicy::Abort {
-                        self.inner.ctx.set_failed(Error::new(
+                        self.inner.ctx.set_failed_and_signal(Error::new(
                             ErrorKind::ChildOperationFailed,
                             format!("download failed for key '{key}'"),
                         ));
-                        // set_failed makes the transfer terminal but does not
-                        // signal; signal here so the terminal transition is
-                        // observable before returning to the scheduler. A
-                        // terminal transfer that returns idle without signaling
-                        // can be removed by the scheduler with its completion
-                        // channel never fired, hanging the owning handle. Any
-                        // surviving children are cancelled when the handle's
-                        // join()/drop calls cancel_transfer(parent_id).
-                        self.inner.ctx.signal_terminal();
                     }
                 }
             }

--- a/aws-sdk-s3-transfer-manager/src/operation/download_objects/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download_objects/transfer.rs
@@ -568,6 +568,15 @@ impl DownloadObjectsTransfer {
                             ErrorKind::ChildOperationFailed,
                             format!("download failed for key '{key}'"),
                         ));
+                        // set_failed makes the transfer terminal but does not
+                        // signal; signal here so the terminal transition is
+                        // observable before returning to the scheduler. A
+                        // terminal transfer that returns idle without signaling
+                        // can be removed by the scheduler with its completion
+                        // channel never fired, hanging the owning handle. Any
+                        // surviving children are cancelled when the handle's
+                        // join()/drop calls cancel_transfer(parent_id).
+                        self.inner.ctx.signal_terminal();
                     }
                 }
             }
@@ -824,6 +833,15 @@ impl DownloadObjectsTransfer {
                             ErrorKind::ChildOperationFailed,
                             format!("download failed for key '{key}'"),
                         ));
+                        // set_failed makes the transfer terminal but does not
+                        // signal; signal here so the terminal transition is
+                        // observable before returning to the scheduler. A
+                        // terminal transfer that returns idle without signaling
+                        // can be removed by the scheduler with its completion
+                        // channel never fired, hanging the owning handle. Any
+                        // surviving children are cancelled when the handle's
+                        // join()/drop calls cancel_transfer(parent_id).
+                        self.inner.ctx.signal_terminal();
                     }
                 }
             }
@@ -1630,6 +1648,58 @@ mod tests {
             m.disk_write, 40,
             "child disk_write must aggregate to parent"
         );
+    }
+
+    /// Under `Abort`, a child failure sets the parent failed in an execute
+    /// callback, which must signal terminal there. Many keys keep sibling
+    /// children in flight when the failure fires, so the parent goes terminal
+    /// while children remain; its `join()` (completion) must resolve rather
+    /// than hang on the scheduler removing the terminal parent.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_child_failure_abort_managed_runtime_does_not_strand() {
+        let dir = tempdir().unwrap();
+
+        // Many keys so several children spawn; GetObject always errors so the
+        // first reaped failure aborts while siblings are still registered.
+        let objects: Vec<Object> = (0..20)
+            .map(|i| {
+                Object::builder()
+                    .key(format!("file{i:02}.txt"))
+                    .size(2)
+                    .build()
+            })
+            .collect();
+        let list = mock!(aws_sdk_s3::Client::list_objects_v2).then_output(move || {
+            ListObjectsV2Output::builder()
+                .set_contents(Some(objects.clone()))
+                .build()
+        });
+        let get = mock!(aws_sdk_s3::Client::get_object).then_error(|| {
+            aws_sdk_s3::operation::get_object::GetObjectError::generic(
+                aws_sdk_s3::error::ErrorMetadata::builder()
+                    .code("NoSuchKey")
+                    .message("not found")
+                    .build(),
+            )
+        });
+        let s3_client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[list, get]);
+
+        let config = crate::Config::builder().client(s3_client.clone()).build();
+        let handle = crate::client::Handle::test_handle_managed(config);
+
+        let (transfer, completion_rx) =
+            setup_enqueued(dir.path(), FailedTransferPolicy::Abort, s3_client, handle);
+
+        // The parent's completion must resolve promptly rather than stranding
+        // when the scheduler removes the terminal parent.
+        timeout(Duration::from_secs(10), async {
+            let _ = completion_rx.await;
+        })
+        .await
+        .expect("Abort failure must signal parent terminal, not strand join()");
+
+        assert!(transfer.ctx().is_failed());
     }
 
     #[cfg_attr(miri, ignore)]

--- a/aws-sdk-s3-transfer-manager/src/operation/upload_objects/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload_objects/transfer.rs
@@ -575,11 +575,12 @@ impl UploadObjectsTransfer {
             tid = %self.inner.ctx.id,
             "upload_objects aborting: {cause}"
         );
-        self.inner.ctx.set_failed(crate::error::Error::new(
-            crate::error::ErrorKind::ChildOperationFailed,
-            format!("upload_objects aborted: {cause}"),
-        ));
-        self.inner.ctx.signal_terminal();
+        self.inner
+            .ctx
+            .set_failed_and_signal(crate::error::Error::new(
+                crate::error::ErrorKind::ChildOperationFailed,
+                format!("upload_objects aborted: {cause}"),
+            ));
         PollWork::Done
     }
 
@@ -968,11 +969,10 @@ impl UploadObjectsTransfer {
             );
             // Transfer is failing: drop the walker (no walk_back).
             slot.consume(&mut state, None);
-            ctx.set_failed(crate::error::Error::new(
+            ctx.set_failed_and_signal(crate::error::Error::new(
                 crate::error::ErrorKind::IOError,
                 fatal.to_string(),
             ));
-            ctx.signal_terminal();
             return WorkOutcome::Failed {
                 classification: None,
             };

--- a/aws-sdk-s3-transfer-manager/src/scheduler/scheduler.rs
+++ b/aws-sdk-s3-transfer-manager/src/scheduler/scheduler.rs
@@ -475,7 +475,7 @@ impl Scheduler {
         // which would otherwise orphan the child.
         if desc.is_terminal() && is_idle {
             let desc_id = desc.id();
-            let (_completed, orphans) = self.remove_transfer_atomic(desc_id);
+            let (completed, orphans) = self.remove_transfer_atomic(desc_id);
             if !orphans.is_empty() {
                 tracing::warn!(
                     target: telemetry::TARGET_SCHEDULING,
@@ -488,6 +488,14 @@ impl Scheduler {
                 for desc in orphans {
                     self.cancel_descriptor(desc);
                 }
+            }
+            // Signal the removed transfer's terminal. A transfer that became
+            // terminal but was removed here before signaling would leave its
+            // completion channel unfired, hanging the owning handle. Signal
+            // after cancelling orphans so children are torn down before the
+            // handle observes completion. Idempotent if already signaled.
+            if let Some(completed) = completed {
+                completed.transfer().ctx().signal_terminal();
             }
         }
 
@@ -761,7 +769,8 @@ impl Scheduler {
 mod tests {
     use crate::client::Handle;
     use crate::scheduler::transfer::mock::{
-        BuggyDoneMock, FixedWorkCount, MockStateMachine, WithDelay, WithExecute,
+        BuggyDoneMock, FixedWorkCount, MockStateMachine, TerminalWithoutSignalMock, WithDelay,
+        WithExecute,
     };
     use crate::scheduler::MockTransfer;
     use crate::transfer::{IoRequest, PollWork, Transfer, TransferId, WorkOutcome};
@@ -2205,6 +2214,44 @@ mod tests {
                 .expect("child terminal should fire (cancelled by Done branch)")
                 .expect("terminal sender should not have been dropped");
         }
+
+        handle.runtime.shutdown();
+    }
+
+    /// A transfer that becomes terminal without calling `signal_terminal`,
+    /// while a child is still registered, is removed by `on_completion`'s
+    /// terminal+idle path. The scheduler must signal the removed transfer's
+    /// terminal so its owning handle's `join()` resolves rather than hanging.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_terminal_without_signal_does_not_strand_handle() {
+        let _logs = show_test_logs();
+        let handle = test_handle(2);
+        let scheduler = &handle.scheduler;
+
+        let parent_id = TransferId {
+            id: 1,
+            parent: None,
+        };
+        let (mock, completion_rx) = TerminalWithoutSignalMock::new(parent_id, handle.clone());
+        scheduler.enqueue_transfer(Box::new(mock));
+
+        // The parent goes terminal without signaling; the scheduler removes it
+        // (terminal+idle) and must signal its completion. The handle's join
+        // (modeled here by awaiting completion_rx) must resolve, not hang.
+        tokio::time::timeout(Duration::from_secs(2), completion_rx)
+            .await
+            .expect("parent completion must be signaled on scheduler removal, not strand")
+            .expect("terminal sender should not have been dropped");
+
+        // And the scheduler drains (orphan child cleaned up).
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !scheduler.is_idle() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("scheduler should reach idle");
 
         handle.runtime.shutdown();
     }

--- a/aws-sdk-s3-transfer-manager/src/scheduler/transfer/mock.rs
+++ b/aws-sdk-s3-transfer-manager/src/scheduler/transfer/mock.rs
@@ -903,6 +903,82 @@ impl Transfer for NoopChild {
     }
 }
 
+/// A parent that transitions itself to a terminal state in an execute callback
+/// without calling `signal_terminal`, while a child is still registered. Models
+/// a state machine that calls `set_failed`/`set_completed` without the paired
+/// `signal_terminal` (e.g. an `Abort`-policy directory transfer): the scheduler
+/// observes the parent terminal-and-idle and removes it, and the owning handle's
+/// `join()` resolves only if the scheduler signals the removed transfer.
+pub(crate) struct TerminalWithoutSignalMock {
+    ctx: TransferContext,
+    handle: Arc<crate::client::Handle>,
+    spawned: AtomicBool,
+}
+
+impl std::fmt::Debug for TerminalWithoutSignalMock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TerminalWithoutSignalMock").finish()
+    }
+}
+
+impl TerminalWithoutSignalMock {
+    /// Returns the mock plus its own completion receiver (the parent handle's
+    /// channel) so a test can assert the parent's terminal was signaled.
+    pub(crate) fn new(
+        id: TransferId,
+        handle: Arc<crate::client::Handle>,
+    ) -> (Self, StateMachineTerminalReceiver) {
+        let (ctx, completion_rx) = TransferContext::with_id(id, handle.clone());
+        (
+            Self {
+                ctx,
+                handle,
+                spawned: AtomicBool::new(false),
+            },
+            completion_rx,
+        )
+    }
+}
+
+impl Transfer for TerminalWithoutSignalMock {
+    fn ctx(&self) -> &TransferContext {
+        &self.ctx
+    }
+
+    fn poll_work(&self) -> PollWork {
+        if !self.spawned.swap(true, Ordering::SeqCst) {
+            // Register a live child that never completes on its own, then emit
+            // one work item. After it executes (set_failed without signal), the
+            // parent is terminal-and-idle with a live child.
+            let child_id = TransferId {
+                id: 200_000,
+                parent: Some(self.ctx.id.id),
+            };
+            let (child, _term_rx) = NoopChild::new(child_id, self.handle.clone());
+            self.handle.scheduler.enqueue_transfer(Box::new(child));
+            return PollWork::Ready(IoRequest { data: None });
+        }
+        // No further work; the transfer is already terminal (set in execute).
+        self.ctx.set_pending();
+        PollWork::Pending
+    }
+
+    fn execute<'a>(
+        &'a self,
+        _work: &'a mut IoRequest,
+    ) -> Pin<Box<dyn Future<Output = WorkOutcome> + Send + 'a>> {
+        Box::pin(async move {
+            // Go terminal without signaling. Return Success (not Failed) so the
+            // transfer is not auto-signaled; completion flows through the
+            // scheduler's on_completion terminal+idle path.
+            self.ctx.set_failed(crate::error::from_kind(
+                crate::error::ErrorKind::RuntimeError,
+            )("terminal without signal"));
+            WorkOutcome::Success { data: None }
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aws-sdk-s3-transfer-manager/src/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/transfer.rs
@@ -639,6 +639,14 @@ impl TransferContext {
 
     /// Mark transfer as failed and store the error.
     /// First-write-wins - returns true if this call set the status.
+    ///
+    /// Setting the status alone is not observable to the owning handle: a
+    /// terminal transition must be signalled via [`signal_terminal`] (directly,
+    /// or once in-flight work drains). For the common fail-and-abort case use
+    /// [`set_failed_and_signal`], which bundles both.
+    ///
+    /// [`signal_terminal`]: Self::signal_terminal
+    /// [`set_failed_and_signal`]: Self::set_failed_and_signal
     pub(crate) fn set_failed(&self, err: error::Error) -> bool {
         if self.status.set_failed() {
             *self.error.lock().unwrap() = Some(Box::new(err));
@@ -702,11 +710,17 @@ impl TransferContext {
         self.status.is_active()
     }
 
-    /// Signal that the transfer state machine has reached a terminal state.
+    /// Signal that the transfer has reached a terminal state.
     ///
-    /// Call this after `set_completed()`/`set_failed()`/`set_cancelled()`.
-    /// Wakes any waiters (e.g., `join()`). Note: in-flight work may still
-    /// be draining when this is called.
+    /// Call this after `set_completed()`/`set_failed()`/`set_cancelled()`. Wakes
+    /// any waiters (`join()`) and the parent transfer (so it can reap this child).
+    ///
+    /// Setting a terminal status is not enough on its own. A transfer that has
+    /// gone terminal but returns idle to the scheduler WITHOUT signalling can be
+    /// removed by the scheduler with its completion channel never fired — a
+    /// permanent hang of the owning handle, not merely a delay. Every terminal
+    /// transition must therefore reach exactly one `signal_terminal`. It is safe
+    /// to call while in-flight work is still draining.
     pub(crate) fn signal_terminal(&self) {
         self.metrics.set_finished();
         if let Some(tx) = self.completion_tx.lock().unwrap().take() {
@@ -719,6 +733,24 @@ impl TransferContext {
                 parent: None,
             });
         }
+    }
+
+    /// Mark the transfer failed and immediately signal terminal (the
+    /// fail-and-abort path: the transfer is terminal now, with nothing to wait
+    /// for — see [`signal_terminal`]). Bundling the two calls keeps an abort site
+    /// from setting the status without making the transition observable. When the
+    /// signal must instead wait for in-flight work to drain, call [`set_failed`]
+    /// alone and signal once that work completes.
+    ///
+    /// Returns the result of [`set_failed`] (first-write-wins: `true` if this
+    /// call set the status).
+    ///
+    /// [`signal_terminal`]: Self::signal_terminal
+    /// [`set_failed`]: Self::set_failed
+    pub(crate) fn set_failed_and_signal(&self, err: error::Error) -> bool {
+        let set = self.set_failed(err);
+        self.signal_terminal();
+        set
     }
 
     /// Record an IO sample to per-transfer metrics and per-client telemetry.

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -323,11 +323,13 @@ impl IntegrityChecks {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChecksumValidation {
     /// Every delivered byte was validated against a checksum and matched.
+    #[non_exhaustive]
     Validated {
         /// The algorithm used to validate.
         algorithm: aws_sdk_s3::types::ChecksumAlgorithm,
     },
     /// No whole-object validation occurred. `reason` explains why.
+    #[non_exhaustive]
     NotValidated {
         /// Why validation did not cover the whole object.
         reason: NotValidatedReason,

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -253,3 +253,123 @@ impl Bucket {
         self.kind
     }
 }
+
+/// Object-integrity information for a completed download.
+///
+/// Carries the object's reported checksum values (as returned by S3) and the
+/// outcome of checksum validation over the delivered bytes. Validation is a
+/// completion-time fact, distinct from the discovery-time [`ObjectMetadata`].
+///
+/// A checksum mismatch is not represented here; it surfaces as an `Err` from the
+/// download's `join()`. On a successful `DownloadOutput`, [`ChecksumValidation`]
+/// distinguishes "validated" from "validation did not happen".
+///
+/// [`ObjectMetadata`]: crate::operation::download::ObjectMetadata
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct IntegrityChecks {
+    checksum_crc32: Option<String>,
+    checksum_crc32c: Option<String>,
+    checksum_crc64_nvme: Option<String>,
+    checksum_sha1: Option<String>,
+    checksum_sha256: Option<String>,
+    checksum_type: Option<aws_sdk_s3::types::ChecksumType>,
+    checksum_validation: ChecksumValidation,
+}
+
+impl IntegrityChecks {
+    /// The outcome of checksum validation over the delivered object bytes.
+    pub fn checksum_validation(&self) -> &ChecksumValidation {
+        &self.checksum_validation
+    }
+
+    /// The base64-encoded CRC-32 checksum reported by S3, if present.
+    pub fn checksum_crc32(&self) -> Option<&str> {
+        self.checksum_crc32.as_deref()
+    }
+
+    /// The base64-encoded CRC-32C checksum reported by S3, if present.
+    pub fn checksum_crc32c(&self) -> Option<&str> {
+        self.checksum_crc32c.as_deref()
+    }
+
+    /// The base64-encoded CRC-64/NVME checksum reported by S3, if present.
+    pub fn checksum_crc64_nvme(&self) -> Option<&str> {
+        self.checksum_crc64_nvme.as_deref()
+    }
+
+    /// The base64-encoded SHA-1 checksum reported by S3, if present.
+    pub fn checksum_sha1(&self) -> Option<&str> {
+        self.checksum_sha1.as_deref()
+    }
+
+    /// The base64-encoded SHA-256 checksum reported by S3, if present.
+    pub fn checksum_sha256(&self) -> Option<&str> {
+        self.checksum_sha256.as_deref()
+    }
+
+    /// The object's checksum type (full-object vs composite), if reported.
+    pub fn checksum_type(&self) -> Option<&aws_sdk_s3::types::ChecksumType> {
+        self.checksum_type.as_ref()
+    }
+}
+
+/// Whether the bytes delivered by a download were validated against a checksum.
+///
+/// `Validated` means the *entire* delivered object was covered by a checksum and
+/// matched. Anything short of whole-object coverage is `NotValidated` with a
+/// [`NotValidatedReason`]; there is no partial state.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChecksumValidation {
+    /// Every delivered byte was validated against a checksum and matched.
+    Validated {
+        /// The algorithm used to validate.
+        algorithm: aws_sdk_s3::types::ChecksumAlgorithm,
+    },
+    /// No whole-object validation occurred. `reason` explains why.
+    NotValidated {
+        /// Why validation did not cover the whole object.
+        reason: NotValidatedReason,
+    },
+}
+
+/// Why a download's bytes were not whole-object checksum-validated.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotValidatedReason {
+    /// Checksum validation was not enabled for the request (client
+    /// `ResponseChecksumValidation::WhenRequired` with no request override).
+    Disabled,
+    /// The object carries only a composite (`-N`) checksum, which cannot be
+    /// validated against delivered bytes.
+    CompositeChecksum,
+    /// Some delivered bytes were validated but not the whole object.
+    PartialCoverage,
+    /// No checksum covered the delivered bytes (object has no stored checksum,
+    /// or the requested range did not align to a stored part).
+    Unavailable,
+}
+
+impl IntegrityChecks {
+    /// Build from the object's reported checksum fields and a resolved verdict.
+    pub(crate) fn new(
+        checksum_crc32: Option<String>,
+        checksum_crc32c: Option<String>,
+        checksum_crc64_nvme: Option<String>,
+        checksum_sha1: Option<String>,
+        checksum_sha256: Option<String>,
+        checksum_type: Option<aws_sdk_s3::types::ChecksumType>,
+        checksum_validation: ChecksumValidation,
+    ) -> Self {
+        Self {
+            checksum_crc32,
+            checksum_crc32c,
+            checksum_crc64_nvme,
+            checksum_sha1,
+            checksum_sha256,
+            checksum_type,
+            checksum_validation,
+        }
+    }
+}

--- a/aws-sdk-s3-transfer-manager/tests/download_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/download_test.rs
@@ -639,9 +639,39 @@ async fn test_download_write_to_path_error_cleans_up() {
     assert!(tmp_files.is_empty(), "leftover temp files: {:?}", tmp_files);
 }
 
-/// Single-part (whole object in the discovery chunk) response carrying an
-/// optional CRC32 checksum header. `data` must match `crc32` (the SDK validates
-/// any present checksum header under the default `WhenSupported` setting).
+/// Download requests carry `x-amz-checksum-mode: ENABLED` by default. The SDK's
+/// GetObject operation auto-enables it when the client resolves
+/// `ResponseChecksumValidation` to `WHEN_SUPPORTED` (the default), so the TM gets
+/// response validation without setting the mode itself. This guards against a
+/// regression (SDK change or client config) that would silently stop requesting
+/// the stored checksum and therefore stop validating downloads.
+#[tokio::test]
+async fn test_checksum_mode_enabled_by_default() {
+    // Multipart object so the assertion covers the discovery GET and every
+    // subsequent range-chunk GET.
+    let data = rand_data(20 * ByteUnit::Mebibyte.as_bytes_usize());
+    let part_size = 8 * ByteUnit::Mebibyte.as_bytes_usize();
+    let (tm, http_client) = simple_test_tm(&data, part_size);
+
+    let mut handle = tm
+        .download()
+        .bucket("test-bucket")
+        .key("test-object")
+        .initiate()
+        .unwrap();
+    let _ = drain(&mut handle).await.unwrap();
+
+    let requests = http_client.actual_requests().collect::<Vec<_>>();
+    assert!(requests.len() > 1, "expected multiple GETs (multipart)");
+    for (i, req) in requests.iter().enumerate() {
+        assert_eq!(
+            req.headers().get("x-amz-checksum-mode"),
+            Some("ENABLED"),
+            "GET #{i} must carry x-amz-checksum-mode=ENABLED by default"
+        );
+    }
+}
+
 fn single_part_connector(data: &Bytes, crc32: Option<&str>) -> StaticReplayClient {
     let mut resp = http::Response::builder()
         .status(200)
@@ -665,14 +695,62 @@ fn single_part_connector(data: &Bytes, crc32: Option<&str>) -> StaticReplayClien
 const HELLO: &[u8] = b"hello world";
 const HELLO_CRC32: &str = "DUoRhQ==";
 
-/// checksum_mode off → validation reported as Disabled, regardless of headers.
+/// Default checksum_mode (unset): the SDK auto-enables validation when the client
+/// resolves ResponseChecksumValidation to WhenSupported (the default), so the
+/// verdict is Unavailable (validation attempted) — NOT Disabled. See
+/// `test_integrity_checks_disabled_when_validation_when_required` for the only
+/// genuinely-disabled case.
 #[tokio::test]
-async fn test_integrity_checks_disabled_when_mode_off() {
+async fn test_integrity_checks_default_mode_attempts_validation() {
     use aws_sdk_s3_transfer_manager::types::{ChecksumValidation, NotValidatedReason};
 
     let data = Bytes::from_static(HELLO);
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
     let tm = test_tm(single_part_connector(&data, Some(HELLO_CRC32)), part_size);
+
+    let mut handle = tm
+        .download()
+        .bucket("test-bucket")
+        .key("test-object")
+        .initiate()
+        .unwrap();
+    let _ = drain(&mut handle).await.unwrap();
+    let output = handle.join().await.unwrap();
+
+    assert_eq!(
+        *output.integrity_checks().checksum_validation(),
+        ChecksumValidation::NotValidated {
+            reason: NotValidatedReason::Unavailable
+        }
+    );
+}
+
+/// Client ResponseChecksumValidation=WhenRequired with no request override: the
+/// SDK does not auto-enable ChecksumMode, so validation is genuinely off and the
+/// verdict is Disabled.
+#[tokio::test]
+async fn test_integrity_checks_disabled_when_validation_when_required() {
+    use aws_sdk_s3_transfer_manager::types::{ChecksumValidation, NotValidatedReason};
+
+    let data = Bytes::from_static(HELLO);
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let http_client = single_part_connector(&data, Some(HELLO_CRC32));
+    let s3_client = aws_sdk_s3::Client::from_conf(
+        aws_sdk_s3::config::Config::builder()
+            .http_client(http_client)
+            .region(Region::from_static("us-west-2"))
+            .response_checksum_validation(
+                aws_sdk_s3::config::ResponseChecksumValidation::WhenRequired,
+            )
+            .with_test_defaults()
+            .build(),
+    );
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(s3_client)
+        .part_size(PartSize::Target(part_size as u64))
+        .concurrency(ConcurrencyMode::Explicit(1))
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
 
     let mut handle = tm
         .download()

--- a/aws-sdk-s3-transfer-manager/tests/download_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/download_test.rs
@@ -638,3 +638,131 @@ async fn test_download_write_to_path_error_cleans_up() {
         .collect();
     assert!(tmp_files.is_empty(), "leftover temp files: {:?}", tmp_files);
 }
+
+/// Single-part (whole object in the discovery chunk) response carrying an
+/// optional CRC32 checksum header. `data` must match `crc32` (the SDK validates
+/// any present checksum header under the default `WhenSupported` setting).
+fn single_part_connector(data: &Bytes, crc32: Option<&str>) -> StaticReplayClient {
+    let mut resp = http::Response::builder()
+        .status(200)
+        .header("Content-Length", format!("{}", data.len()))
+        .header(
+            "Content-Range",
+            format!("bytes 0-{}/{}", data.len() - 1, data.len()),
+        )
+        .header("ETag", "my-etag");
+    if let Some(c) = crc32 {
+        resp = resp.header("x-amz-checksum-crc32", c);
+    }
+    StaticReplayClient::new(vec![ReplayEvent::new(
+        dummy_expected_request(),
+        resp.body(SdkBody::from(data.clone())).unwrap(),
+    )])
+}
+
+// "hello world" has CRC32 `DUoRhQ==`. Using a correct value lets the SDK's
+// default validation pass so we exercise the success path.
+const HELLO: &[u8] = b"hello world";
+const HELLO_CRC32: &str = "DUoRhQ==";
+
+/// checksum_mode off → validation reported as Disabled, regardless of headers.
+#[tokio::test]
+async fn test_integrity_checks_disabled_when_mode_off() {
+    use aws_sdk_s3_transfer_manager::types::{ChecksumValidation, NotValidatedReason};
+
+    let data = Bytes::from_static(HELLO);
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let tm = test_tm(single_part_connector(&data, Some(HELLO_CRC32)), part_size);
+
+    let mut handle = tm
+        .download()
+        .bucket("test-bucket")
+        .key("test-object")
+        .initiate()
+        .unwrap();
+    let _ = drain(&mut handle).await.unwrap();
+    let output = handle.join().await.unwrap();
+
+    assert_eq!(
+        *output.integrity_checks().checksum_validation(),
+        ChecksumValidation::NotValidated {
+            reason: NotValidatedReason::Disabled
+        }
+    );
+}
+
+/// checksum_mode on → reported as NotValidated (never falsely Validated) until
+/// the SDK surfaces a positive validation outcome. Guards that an unconfirmed
+/// chunk MUST NOT read Validated.
+#[tokio::test]
+async fn test_integrity_checks_enabled_not_falsely_validated() {
+    use aws_sdk_s3_transfer_manager::types::ChecksumValidation;
+
+    let data = Bytes::from_static(HELLO);
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let tm = test_tm(single_part_connector(&data, Some(HELLO_CRC32)), part_size);
+
+    let mut handle = tm
+        .download()
+        .bucket("test-bucket")
+        .key("test-object")
+        .checksum_mode(aws_sdk_s3::types::ChecksumMode::Enabled)
+        .initiate()
+        .unwrap();
+    let _ = drain(&mut handle).await.unwrap();
+    let output = handle.join().await.unwrap();
+
+    assert!(
+        !matches!(
+            output.integrity_checks().checksum_validation(),
+            ChecksumValidation::Validated { .. }
+        ),
+        "must not report Validated without an SDK-confirmed outcome"
+    );
+}
+
+/// Whole object in the discovery chunk → the response checksum IS the object's,
+/// surfaced on the value members.
+#[tokio::test]
+async fn test_integrity_checks_surfaces_whole_object_checksum() {
+    let data = Bytes::from_static(HELLO);
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let tm = test_tm(single_part_connector(&data, Some(HELLO_CRC32)), part_size);
+
+    let mut handle = tm
+        .download()
+        .bucket("test-bucket")
+        .key("test-object")
+        .initiate()
+        .unwrap();
+    let _ = drain(&mut handle).await.unwrap();
+    let output = handle.join().await.unwrap();
+
+    assert_eq!(
+        output.integrity_checks().checksum_crc32(),
+        Some(HELLO_CRC32)
+    );
+}
+
+/// Multipart object (data larger than part_size) → discovery chunk carries only
+/// part 1's checksum, which MUST NOT be surfaced as the object's checksum.
+#[tokio::test]
+async fn test_integrity_checks_multipart_does_not_surface_part_checksum() {
+    let data = rand_data(12 * ByteUnit::Mebibyte.as_bytes_usize());
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    // simple_object_connector splits into parts and stamps no checksum header,
+    // but even if part 1 carried one, it must not be reported as the object value.
+    let (tm, _c) = simple_test_tm(&data, part_size);
+
+    let mut handle = tm
+        .download()
+        .bucket("test-bucket")
+        .key("test-object")
+        .initiate()
+        .unwrap();
+    let _ = drain(&mut handle).await.unwrap();
+    let output = handle.join().await.unwrap();
+
+    assert_eq!(output.integrity_checks().checksum_crc32(), None);
+    assert_eq!(output.integrity_checks().checksum_type(), None);
+}

--- a/aws-sdk-s3-transfer-manager/tests/download_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/download_test.rs
@@ -717,12 +717,12 @@ async fn test_integrity_checks_default_mode_attempts_validation() {
     let _ = drain(&mut handle).await.unwrap();
     let output = handle.join().await.unwrap();
 
-    assert_eq!(
-        *output.integrity_checks().checksum_validation(),
-        ChecksumValidation::NotValidated {
-            reason: NotValidatedReason::Unavailable
+    match output.integrity_checks().checksum_validation() {
+        ChecksumValidation::NotValidated { reason, .. } => {
+            assert_eq!(*reason, NotValidatedReason::Unavailable);
         }
-    );
+        other => panic!("expected NotValidated{{Unavailable}}, got {other:?}"),
+    }
 }
 
 /// Client ResponseChecksumValidation=WhenRequired with no request override: the
@@ -761,12 +761,12 @@ async fn test_integrity_checks_disabled_when_validation_when_required() {
     let _ = drain(&mut handle).await.unwrap();
     let output = handle.join().await.unwrap();
 
-    assert_eq!(
-        *output.integrity_checks().checksum_validation(),
-        ChecksumValidation::NotValidated {
-            reason: NotValidatedReason::Disabled
+    match output.integrity_checks().checksum_validation() {
+        ChecksumValidation::NotValidated { reason, .. } => {
+            assert_eq!(*reason, NotValidatedReason::Disabled);
         }
-    );
+        other => panic!("expected NotValidated{{Disabled}}, got {other:?}"),
+    }
 }
 
 /// checksum_mode on → reported as NotValidated (never falsely Validated) until

--- a/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -3,6 +3,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+// TODO(vnext): fold these tests into the integration-tests e2e harness (see integration-tests/src/harness.rs Target).
 // Tests here requires AWS account with pre-configured S3 bucket to run the tests.
 // Refer to https://github.com/awslabs/aws-c-s3/tree/main/tests/test_helper to help set up the S3 in the account
 // Set S3_TEST_BUCKET_NAME_RS environment variables to the bucket created.
@@ -438,10 +439,6 @@ async fn test_object_download_range_failures() {
     }
 }
 
-// FIXME: upload_objects/download_objects still use the old scheduler and panic
-// when the managed thread runtime's per-thread HTTP client is invoked from a
-// non-managed thread. Re-enable after migrating _objects paths to the new scheduler.
-#[ignore]
 #[tokio::test]
 async fn test_objects_transfer() {
     let _logs = show_test_logs();

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -17,3 +17,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(e2e_test)'] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -17,6 +17,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile = "3"
+uuid = { version = "1.23.2", features = ["v4"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(e2e_test)'] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -18,6 +18,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 tempfile = "3"
 uuid = { version = "1.23.2", features = ["v4"] }
+aws-smithy-checksums = "0.64.6"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(e2e_test)'] }

--- a/integration-tests/src/harness.rs
+++ b/integration-tests/src/harness.rs
@@ -105,6 +105,10 @@ impl Target {
 pub(crate) struct TmTestClient {
     tm: TmClient,
     bucket: String,
+    /// A per-instance key prefix so concurrent tests sharing one (real) bucket do
+    /// not collide on object keys. Each `connect()` gets a fresh prefix; callers
+    /// pass logical keys (e.g. `"obj"`) and the harness namespaces them.
+    key_prefix: String,
     /// Present for mock targets. Owns the server; held until `shutdown`.
     mock: Option<MockBackend>,
     /// Present for real-S3 targets; used for direct SDK calls (e.g. HeadObject).
@@ -156,6 +160,7 @@ impl TmTestClient {
         Self {
             tm: TmClient::new(builder.build()),
             bucket: "test-bucket".to_string(),
+            key_prefix: format!("it-{}", uuid::Uuid::new_v4()),
             mock: Some(MockBackend { server, handle }),
             #[cfg(e2e_test)]
             s3_client: None,
@@ -185,6 +190,7 @@ impl TmTestClient {
         Self {
             tm: TmClient::new(loader.load().await),
             bucket,
+            key_prefix: format!("it-{}", uuid::Uuid::new_v4()),
             mock: None,
             s3_client: Some(s3_client),
         }
@@ -193,6 +199,15 @@ impl TmTestClient {
     /// The bucket name to target.
     pub(crate) fn bucket(&self) -> &str {
         &self.bucket
+    }
+
+    /// Namespace a logical key with this instance's unique prefix so concurrent
+    /// tests sharing one bucket do not collide. Keys live under `upload/` so the
+    /// test bucket's lifecycle expiration policy reaps the objects (the same
+    /// prefix the legacy e2e tests use; `pre-existing` fixtures are deliberately
+    /// outside it and not reaped).
+    pub(crate) fn key(&self, key: &str) -> String {
+        format!("upload/{}/{}", self.key_prefix, key)
     }
 
     /// The mock server, for fault injection and direct inspection. `None` on a
@@ -220,7 +235,7 @@ impl TmTestClient {
         self.tm
             .upload()
             .bucket(&self.bucket)
-            .key(key)
+            .key(self.key(key))
             .checksum_strategy(strategy)
             .body(aws_sdk_s3_transfer_manager::io::InputStream::from(data))
             .initiate()
@@ -244,7 +259,7 @@ impl TmTestClient {
         ),
         aws_sdk_s3_transfer_manager::error::Error,
     > {
-        let mut builder = self.tm.download().bucket(&self.bucket).key(key);
+        let mut builder = self.tm.download().bucket(&self.bucket).key(self.key(key));
         if let Some(mode) = checksum_mode {
             builder = builder.checksum_mode(mode);
         }
@@ -278,7 +293,7 @@ impl TmTestClient {
         aws_sdk_s3_transfer_manager::operation::download::DownloadOutput,
         aws_sdk_s3_transfer_manager::error::Error,
     > {
-        let mut builder = self.tm.download().bucket(&self.bucket).key(key);
+        let mut builder = self.tm.download().bucket(&self.bucket).key(self.key(key));
         if let Some(mode) = checksum_mode {
             builder = builder.checksum_mode(mode);
         }

--- a/integration-tests/src/harness.rs
+++ b/integration-tests/src/harness.rs
@@ -245,6 +245,30 @@ impl TmTestClient {
             .expect("upload complete");
     }
 
+    /// Upload the file at `path` under `key`, streaming from disk via
+    /// `InputStream::from_path` (the body is never held in memory). Use this for
+    /// large objects instead of `put`, which takes an in-memory buffer.
+    pub(crate) async fn put_from_path(
+        &self,
+        key: &str,
+        path: &std::path::Path,
+        strategy: aws_sdk_s3_transfer_manager::operation::upload::ChecksumStrategy,
+    ) {
+        let body = aws_sdk_s3_transfer_manager::io::InputStream::from_path(path)
+            .expect("open upload source file");
+        self.tm
+            .upload()
+            .bucket(&self.bucket)
+            .key(self.key(key))
+            .checksum_strategy(strategy)
+            .body(body)
+            .initiate()
+            .expect("initiate upload")
+            .join()
+            .await
+            .expect("upload complete");
+    }
+
     /// Download `key`, fully draining the body. Returns the bytes and the output
     /// (carrying `integrity_checks()`). `checksum_mode` controls whether the
     /// request asks S3 to return and the SDK to validate stored checksums.

--- a/integration-tests/src/harness.rs
+++ b/integration-tests/src/harness.rs
@@ -1,0 +1,263 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Test harness for driving the transfer manager against a backend.
+//!
+//! A [`Target`] is a `Backend` (mock server or real S3) crossed with a
+//! `BucketKind` (general purpose or S3 Express). [`Target::connect`] yields a
+//! [`TmTestClient`] that exposes a transfer manager wired to that backend plus
+//! the bucket name to use. The same test body runs across every target.
+//!
+//! Real-S3 targets are compiled only under `--cfg e2e_test` and require the
+//! account setup the existing e2e tests use (`S3_TEST_BUCKET_NAME_RS`). Mock
+//! targets run in normal CI.
+
+use aws_sdk_s3_transfer_manager::Client as TmClient;
+use s3_mock_server::S3MockServer;
+
+/// Which backend serves S3 requests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Backend {
+    /// In-process `s3-mock-server` over a local HTTP socket.
+    Mock,
+    /// Real S3. Compiled only under `--cfg e2e_test`.
+    #[cfg(e2e_test)]
+    RealS3,
+}
+
+/// Which kind of bucket the target uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BucketKind {
+    GeneralPurpose,
+    // TODO(vnext): add S3 Express coverage. The mock does not yet distinguish
+    // directory buckets, so an Express target against the mock would not exercise
+    // real Express behavior. Real-S3 Express is covered by the existing e2e tests
+    // until those migrate into this harness.
+    #[cfg(e2e_test)]
+    Express,
+}
+
+/// A backend/bucket-kind pair a test runs against.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Target {
+    pub(crate) backend: Backend,
+    /// Read only on the real-S3 path to pick the bucket name.
+    #[cfg_attr(not(e2e_test), allow(dead_code))]
+    pub(crate) bucket_kind: BucketKind,
+}
+
+impl Target {
+    pub(crate) fn mock_gp() -> Self {
+        Self {
+            backend: Backend::Mock,
+            bucket_kind: BucketKind::GeneralPurpose,
+        }
+    }
+
+    /// Connect to the backend with the TM's default part size.
+    pub(crate) async fn connect(self) -> TmTestClient {
+        self.connect_with(None).await
+    }
+
+    /// Mock-only: connect with the S3 client's `ResponseChecksumValidation` set to
+    /// `WhenRequired`, so the SDK does NOT auto-enable `ChecksumMode` and an
+    /// unset-mode download resolves to validation disabled.
+    pub(crate) async fn connect_mock_when_required(self) -> TmTestClient {
+        assert_eq!(self.backend, Backend::Mock, "mock-only helper");
+        TmTestClient::connect_mock_with(
+            None,
+            Some(aws_sdk_s3::config::ResponseChecksumValidation::WhenRequired),
+        )
+        .await
+    }
+
+    /// Connect, optionally pinning an explicit part size. A pinned size applies
+    /// to both uploads and downloads, so multipart download ranges align to the
+    /// uploaded part boundaries (the precondition for per-part validation).
+    pub(crate) async fn connect_with(
+        self,
+        part_size: Option<aws_sdk_s3_transfer_manager::types::PartSize>,
+    ) -> TmTestClient {
+        match self.backend {
+            Backend::Mock => TmTestClient::connect_mock(part_size).await,
+            #[cfg(e2e_test)]
+            Backend::RealS3 => TmTestClient::connect_real(self.bucket_kind, part_size).await,
+        }
+    }
+}
+
+/// A transfer manager wired to a target, plus the bucket and (for mock targets)
+/// the server handle used for fault injection and direct inspection.
+pub(crate) struct TmTestClient {
+    tm: TmClient,
+    bucket: String,
+    /// Present for mock targets. Owns the server; held until `shutdown`.
+    mock: Option<MockBackend>,
+}
+
+struct MockBackend {
+    server: S3MockServer,
+    handle: s3_mock_server::ServerHandle,
+}
+
+impl TmTestClient {
+    async fn connect_mock(part_size: Option<aws_sdk_s3_transfer_manager::types::PartSize>) -> Self {
+        Self::connect_mock_with(part_size, None).await
+    }
+
+    /// Connect to the mock, optionally pinning a part size and overriding the S3
+    /// client's `ResponseChecksumValidation`. `None` validation leaves the SDK
+    /// default (`WhenSupported`), under which the SDK auto-enables `ChecksumMode`.
+    async fn connect_mock_with(
+        part_size: Option<aws_sdk_s3_transfer_manager::types::PartSize>,
+        response_checksum_validation: Option<aws_sdk_s3::config::ResponseChecksumValidation>,
+    ) -> Self {
+        let server = S3MockServer::builder()
+            .with_in_memory_store()
+            .build()
+            .expect("build mock server");
+        let handle = server.start().await.expect("start mock server");
+        let mut s3_client = handle.client().await;
+        if let Some(rcv) = response_checksum_validation {
+            let conf = s3_client
+                .config()
+                .to_builder()
+                .response_checksum_validation(rcv)
+                .build();
+            s3_client = aws_sdk_s3::Client::from_conf(conf);
+        }
+        s3_client
+            .create_bucket()
+            .bucket("test-bucket")
+            .send()
+            .await
+            .ok();
+        let mut builder = aws_sdk_s3_transfer_manager::Config::builder().client(s3_client);
+        if let Some(ps) = part_size {
+            builder = builder.part_size(ps);
+        }
+        Self {
+            tm: TmClient::new(builder.build()),
+            bucket: "test-bucket".to_string(),
+            mock: Some(MockBackend { server, handle }),
+        }
+    }
+
+    #[cfg(e2e_test)]
+    async fn connect_real(
+        kind: BucketKind,
+        part_size: Option<aws_sdk_s3_transfer_manager::types::PartSize>,
+    ) -> Self {
+        let bucket_name = option_env!("S3_TEST_BUCKET_NAME_RS")
+            .unwrap_or("aws-s3-transfer-manager-rs-test-bucket")
+            .to_owned();
+        let bucket = match kind {
+            BucketKind::GeneralPurpose => bucket_name,
+            BucketKind::Express => format!("{bucket_name}--usw2-az1--x-s3"),
+        };
+        let mut loader = aws_sdk_s3_transfer_manager::from_env();
+        if let Some(ps) = part_size {
+            loader = loader.part_size(ps);
+        }
+        Self {
+            tm: TmClient::new(loader.load().await),
+            bucket,
+            mock: None,
+        }
+    }
+
+    /// The bucket name to target.
+    pub(crate) fn bucket(&self) -> &str {
+        &self.bucket
+    }
+
+    /// The mock server, for fault injection and direct inspection. `None` on a
+    /// real-S3 target (faults cannot be injected into real S3).
+    pub(crate) fn mock(&self) -> Option<&S3MockServer> {
+        self.mock.as_ref().map(|m| &m.server)
+    }
+
+    /// Upload `data` under `key` with the given checksum strategy.
+    pub(crate) async fn put(
+        &self,
+        key: &str,
+        data: Vec<u8>,
+        strategy: aws_sdk_s3_transfer_manager::operation::upload::ChecksumStrategy,
+    ) {
+        self.tm
+            .upload()
+            .bucket(&self.bucket)
+            .key(key)
+            .checksum_strategy(strategy)
+            .body(aws_sdk_s3_transfer_manager::io::InputStream::from(data))
+            .initiate()
+            .expect("initiate upload")
+            .join()
+            .await
+            .expect("upload complete");
+    }
+
+    /// Download `key`, fully draining the body. Returns the bytes and the output
+    /// (carrying `integrity_checks()`). `checksum_mode` controls whether the
+    /// request asks S3 to return and the SDK to validate stored checksums.
+    pub(crate) async fn download(
+        &self,
+        key: &str,
+        checksum_mode: Option<aws_sdk_s3::types::ChecksumMode>,
+    ) -> Result<
+        (
+            Vec<u8>,
+            aws_sdk_s3_transfer_manager::operation::download::DownloadOutput,
+        ),
+        aws_sdk_s3_transfer_manager::error::Error,
+    > {
+        let mut builder = self.tm.download().bucket(&self.bucket).key(key);
+        if let Some(mode) = checksum_mode {
+            builder = builder.checksum_mode(mode);
+        }
+        let mut handle = builder.initiate().expect("initiate download");
+
+        let mut data = Vec::new();
+        while let Some(chunk) = handle.body_mut().next().await {
+            match chunk {
+                Ok(chunk) => data.extend_from_slice(&chunk.data.into_bytes()),
+                Err(e) => {
+                    // Drive the transfer to terminal so join() surfaces the real error.
+                    return Err(handle.join().await.err().unwrap_or(e));
+                }
+            }
+        }
+        let output = handle.join().await?;
+        Ok((data, output))
+    }
+
+    /// Download `key` to a file via the managed file-sink path (writes to a
+    /// `.s3tmp.` temp file, atomically renamed to `dest` on success; the temp is
+    /// removed and `dest` is never created on failure). This exercises the
+    /// validate-before-rename contract that the in-memory `download` path does
+    /// not. Returns the join result so callers can assert success or error.
+    pub(crate) async fn download_to_path(
+        &self,
+        key: &str,
+        dest: &std::path::Path,
+        checksum_mode: Option<aws_sdk_s3::types::ChecksumMode>,
+    ) -> Result<
+        aws_sdk_s3_transfer_manager::operation::download::DownloadOutput,
+        aws_sdk_s3_transfer_manager::error::Error,
+    > {
+        let mut builder = self.tm.download().bucket(&self.bucket).key(key);
+        if let Some(mode) = checksum_mode {
+            builder = builder.checksum_mode(mode);
+        }
+        builder.write_to_path(dest).await?.join().await
+    }
+
+    /// Release backend resources. Shuts the mock server down; a no-op for real S3.
+    pub(crate) async fn shutdown(self) {
+        if let Some(m) = self.mock {
+            m.handle.shutdown().await.expect("shutdown mock server");
+        }
+    }
+}

--- a/integration-tests/src/harness.rs
+++ b/integration-tests/src/harness.rs
@@ -31,10 +31,6 @@ pub(crate) enum Backend {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BucketKind {
     GeneralPurpose,
-    // TODO(vnext): add S3 Express coverage. The mock does not yet distinguish
-    // directory buckets, so an Express target against the mock would not exercise
-    // real Express behavior. Real-S3 Express is covered by the existing e2e tests
-    // until those migrate into this harness.
     #[cfg(e2e_test)]
     Express,
 }
@@ -53,6 +49,22 @@ impl Target {
         Self {
             backend: Backend::Mock,
             bucket_kind: BucketKind::GeneralPurpose,
+        }
+    }
+
+    #[cfg(e2e_test)]
+    pub(crate) fn real_gp() -> Self {
+        Self {
+            backend: Backend::RealS3,
+            bucket_kind: BucketKind::GeneralPurpose,
+        }
+    }
+
+    #[cfg(e2e_test)]
+    pub(crate) fn real_express() -> Self {
+        Self {
+            backend: Backend::RealS3,
+            bucket_kind: BucketKind::Express,
         }
     }
 
@@ -95,6 +107,9 @@ pub(crate) struct TmTestClient {
     bucket: String,
     /// Present for mock targets. Owns the server; held until `shutdown`.
     mock: Option<MockBackend>,
+    /// Present for real-S3 targets; used for direct SDK calls (e.g. HeadObject).
+    #[cfg(e2e_test)]
+    s3_client: Option<aws_sdk_s3::Client>,
 }
 
 struct MockBackend {
@@ -142,6 +157,8 @@ impl TmTestClient {
             tm: TmClient::new(builder.build()),
             bucket: "test-bucket".to_string(),
             mock: Some(MockBackend { server, handle }),
+            #[cfg(e2e_test)]
+            s3_client: None,
         }
     }
 
@@ -157,6 +174,10 @@ impl TmTestClient {
             BucketKind::GeneralPurpose => bucket_name,
             BucketKind::Express => format!("{bucket_name}--usw2-az1--x-s3"),
         };
+        let shared_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .load()
+            .await;
+        let s3_client = aws_sdk_s3::Client::new(&shared_config);
         let mut loader = aws_sdk_s3_transfer_manager::from_env();
         if let Some(ps) = part_size {
             loader = loader.part_size(ps);
@@ -165,6 +186,7 @@ impl TmTestClient {
             tm: TmClient::new(loader.load().await),
             bucket,
             mock: None,
+            s3_client: Some(s3_client),
         }
     }
 
@@ -177,6 +199,15 @@ impl TmTestClient {
     /// real-S3 target (faults cannot be injected into real S3).
     pub(crate) fn mock(&self) -> Option<&S3MockServer> {
         self.mock.as_ref().map(|m| &m.server)
+    }
+
+    /// The raw S3 client for direct SDK calls (e.g. HeadObject). Only available
+    /// on real-S3 targets.
+    #[cfg(e2e_test)]
+    pub(crate) fn s3(&self) -> &aws_sdk_s3::Client {
+        self.s3_client
+            .as_ref()
+            .expect("s3() requires a real-S3 target")
     }
 
     /// Upload `data` under `key` with the given checksum strategy.

--- a/integration-tests/src/integrity.rs
+++ b/integration-tests/src/integrity.rs
@@ -1,0 +1,509 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Object-integrity contract tests.
+//!
+//! These tests pin the integrity guarantee a caller gets for a given download,
+//! so it cannot change silently. They run the same body across [`Target`]s (see
+//! `harness`) against a real HTTP mock server.
+//!
+//! # How checksums work in the transfer manager
+//!
+//! Upload: the transfer manager never hashes object bytes. It selects an
+//! algorithm via `ChecksumStrategy` and the SDK computes the checksum while
+//! streaming. S3 verifies on receipt and stores the value.
+//!
+//! Download: the transfer manager downloads with ranged GETs. Validation of the
+//! delivered bytes is performed by the SDK's response body validator when a
+//! stored checksum covers exactly the bytes returned. A mismatch surfaces as an
+//! error from the body stream, which the transfer manager propagates as an `Err`
+//! from `join()`. A successful download therefore never carries unvalidated-but-
+//! corrupt bytes that a stored checksum could have caught.
+//!
+//! `DownloadOutput::integrity_checks()` reports two things:
+//!   * the object's checksum value members and type, surfaced only when the whole
+//!     object is covered by a single returned checksum (single-part objects); for
+//!     a larger multipart object the discovery chunk carries only part 1's
+//!     checksum, which is not the object checksum and is not surfaced.
+//!   * `ChecksumValidation`: `Validated{algorithm}` when the whole object was
+//!     validated, else `NotValidated{reason}`.
+//!
+//! Whole-object checksum types:
+//!   * Full object: one checksum over all bytes. Single-part objects always; a
+//!     multipart object when uploaded with a full-object type (CRC only).
+//!   * Composite (`<base64>-<parts>`): a checksum of the part checksums. Cannot be
+//!     validated against object bytes. SHA in a multipart upload is always
+//!     composite.
+//!
+//! A checksum value being present is not the same as the bytes being validated.
+//! The value records what S3 stored; validation records whether the delivered
+//! bytes were checked against it.
+//!
+//! ## Current limitation
+//!
+//! The Rust SDK does not yet expose a per-response validation outcome, so the
+//! transfer manager cannot currently confirm a positive result: the verdict is
+//! `NotValidated` whenever validation is requested, and `Disabled` when it is
+//! not. The integrity-critical negative guarantee (a tampered response fails the
+//! download) holds today and is tested here. Positive-result assertions are
+//! marked `TODO(vnext)` until the SDK reports the outcome.
+//!
+//! # Coverage
+//!
+//! | Object                        | checksum_mode | Asserts                                   |
+//! |-------------------------------|---------------|-------------------------------------------|
+//! | single-part                   | default       | round-trip; verdict Unavailable (on)      |
+//! | single-part (WhenRequired)    | default       | round-trip; verdict Disabled (off)        |
+//! | single-part                   | on            | round-trip; value shown; not Validated*   |
+//! | multipart full-object         | on            | round-trip; object value not from a part  |
+//! | multipart composite           | on            | round-trip; object value not from a part  |
+//! | single-part tampered          | on            | download errors (never Ok)                |
+//! | single-part tampered (file)   | on            | errors; temp cleaned, dest not created    |
+//! | multipart tampered (aligned)  | on            | download errors (never Ok)                |
+//! | multipart aligned             | on            | round-trip (download ranges align)        |
+//! | multipart unaligned, tampered | on            | NOT caught (no checksum on unaligned GET) |
+//!
+//! *not Validated until the SDK reports a per-response validation outcome
+//! (see the limitation above).
+//!
+//! Multipart download validation requires the download range to match a stored
+//! part boundary. The TM downloads with ranged GETs, so a test pins an explicit
+//! part size to align upload and download; the unaligned row pins the current
+//! default behavior (upload 8 MiB, download 5 MiB) where validation does not
+//! occur. See `harness::TmTestClient::connect_with`.
+//!
+//! Algorithm is a pass-through axis for the transfer manager (it forwards the
+//! choice and reads back whatever S3 returns), so per-algorithm value
+//! correctness is covered at the unit and mock-server layers, not multiplied
+//! through this matrix. Representative algorithms are used: CRC32 for full
+//! object, SHA-256 for the composite case.
+
+use crate::harness::Target;
+use aws_sdk_s3::types::ChecksumMode;
+use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
+use aws_sdk_s3_transfer_manager::operation::download::DownloadOutput;
+use aws_sdk_s3_transfer_manager::operation::upload::ChecksumStrategy;
+use aws_sdk_s3_transfer_manager::types::{ChecksumValidation, NotValidatedReason, PartSize};
+use s3_mock_server::{FaultType, Occurrence};
+
+/// A part size pinned equally for upload and download so multipart download
+/// ranges align to the uploaded part boundaries (the precondition for per-part
+/// download validation). The TM's default leaves upload (8 MiB) and download
+/// (5 MiB) unaligned; see the unaligned boundary test.
+const ALIGNED_PART_SIZE: PartSize = PartSize::Target(5 * 1024 * 1024);
+
+fn small() -> Vec<u8> {
+    b"hello world, integrity contract".to_vec()
+}
+
+/// Data larger than the default part size, forcing a multipart upload.
+fn multipart_data() -> Vec<u8> {
+    (0..20 * ByteUnit::Mebibyte.as_bytes_usize())
+        .map(|i| (i % 256) as u8)
+        .collect()
+}
+
+fn assert_not_validated(output: &DownloadOutput, expected: NotValidatedReason) {
+    match output.integrity_checks().checksum_validation() {
+        ChecksumValidation::NotValidated { reason } => assert_eq!(*reason, expected),
+        other => panic!("expected NotValidated{{{expected:?}}}, got {other:?}"),
+    }
+}
+
+/// Assert downloaded bytes match the source without dumping the buffers. A
+/// failed `assert_eq!` on multi-megabyte buffers prints both in full; this gates
+/// on real byte equality and, on mismatch, reports lengths and the first
+/// differing offset.
+fn assert_same_content(expected: &[u8], actual: &[u8]) {
+    if expected == actual {
+        return;
+    }
+    let first_diff = expected
+        .iter()
+        .zip(actual.iter())
+        .position(|(a, b)| a != b)
+        .unwrap_or(expected.len().min(actual.len()));
+    panic!(
+        "content mismatch: expected len={}, got len={}, first diff at byte {}",
+        expected.len(),
+        actual.len(),
+        first_diff
+    );
+}
+
+// single-part, default checksum_mode (unset) -----------------------------------
+//
+// Leaving checksum_mode unset does NOT mean validation is off: the SDK's
+// GetObject mutator auto-enables ChecksumMode when the client's
+// ResponseChecksumValidation resolves to WhenSupported (the default). So a
+// default download attempts validation; the verdict is Unavailable (not
+// Disabled) until the SDK reports a confirmed outcome (TODO(vnext) -> Validated).
+
+async fn single_part_mode_default(target: Target) {
+    let t = target.connect().await;
+    let data = small();
+    t.put(
+        "obj",
+        data.clone(),
+        ChecksumStrategy::with_calculated_crc32(),
+    )
+    .await;
+
+    let (bytes, output) = t.download("obj", None).await.expect("download");
+    assert_same_content(&data, &bytes);
+    // Default resolves to validation-attempted (SDK auto-enables ChecksumMode),
+    // so the verdict is Unavailable, NOT Disabled.
+    assert_not_validated(&output, NotValidatedReason::Unavailable);
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn single_part_mode_default_mock_gp() {
+    single_part_mode_default(Target::mock_gp()).await;
+}
+
+// single-part, client ResponseChecksumValidation=WhenRequired -------------------
+//
+// The only configuration under which an unset-mode download is genuinely not
+// validated: the SDK does not auto-enable ChecksumMode, so the verdict is
+// Disabled. Pins that Disabled means "validation will not happen," distinct from
+// the default (validation attempted) above.
+
+async fn single_part_when_required_disabled(target: Target) {
+    let t = target.connect_mock_when_required().await;
+    let data = small();
+    t.put(
+        "obj",
+        data.clone(),
+        ChecksumStrategy::with_calculated_crc32(),
+    )
+    .await;
+
+    let (bytes, output) = t.download("obj", None).await.expect("download");
+    assert_same_content(&data, &bytes);
+    assert_not_validated(&output, NotValidatedReason::Disabled);
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn single_part_when_required_disabled_mock_gp() {
+    single_part_when_required_disabled(Target::mock_gp()).await;
+}
+
+// single-part, checksum_mode on -------------------------------------------------
+
+async fn single_part_mode_on(target: Target) {
+    let t = target.connect().await;
+    let data = small();
+    t.put(
+        "obj",
+        data.clone(),
+        ChecksumStrategy::with_calculated_crc32(),
+    )
+    .await;
+
+    let (bytes, output) = t
+        .download("obj", Some(ChecksumMode::Enabled))
+        .await
+        .expect("download");
+    assert_same_content(&data, &bytes);
+    // Whole object in one chunk: the object's checksum is surfaced.
+    assert!(
+        output.integrity_checks().checksum_crc32().is_some(),
+        "whole-object checksum should be surfaced"
+    );
+    // TODO(vnext): assert Validated{Crc32} once the SDK reports the outcome.
+    assert!(
+        !matches!(
+            output.integrity_checks().checksum_validation(),
+            ChecksumValidation::Validated { .. }
+        ),
+        "must not report Validated without an SDK-confirmed outcome"
+    );
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn single_part_mode_on_mock_gp() {
+    single_part_mode_on(Target::mock_gp()).await;
+}
+
+// multipart full-object ---------------------------------------------------------
+
+async fn multipart_full_object(target: Target) {
+    let t = target.connect().await;
+    let data = multipart_data();
+    t.put(
+        "obj",
+        data.clone(),
+        ChecksumStrategy::with_calculated_crc32(),
+    )
+    .await;
+
+    let (bytes, output) = t
+        .download("obj", Some(ChecksumMode::Enabled))
+        .await
+        .expect("download");
+    assert_same_content(&data, &bytes);
+    // A part's checksum must not be surfaced as the object's checksum.
+    assert!(
+        output.integrity_checks().checksum_crc32().is_none(),
+        "must not surface a part checksum as the object checksum"
+    );
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn multipart_full_object_mock_gp() {
+    multipart_full_object(Target::mock_gp()).await;
+}
+
+// multipart composite -----------------------------------------------------------
+
+async fn multipart_composite(target: Target) {
+    let t = target.connect().await;
+    let data = multipart_data();
+    t.put(
+        "obj",
+        data.clone(),
+        ChecksumStrategy::with_calculated_sha256_composite_if_multipart(),
+    )
+    .await;
+
+    let (bytes, output) = t
+        .download("obj", Some(ChecksumMode::Enabled))
+        .await
+        .expect("download");
+    assert_same_content(&data, &bytes);
+    assert!(
+        output.integrity_checks().checksum_sha256().is_none(),
+        "must not surface a part checksum as the object checksum"
+    );
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn multipart_composite_mock_gp() {
+    multipart_composite(Target::mock_gp()).await;
+}
+
+// tamper -> error (the integrity-critical negative; mock only) -------------------
+
+async fn tampered_single_part_errors(target: Target) {
+    let t = target.connect().await;
+    let data = small();
+    t.put("obj", data, ChecksumStrategy::with_calculated_crc32())
+        .await;
+
+    let mock = t.mock().expect("tamper faults require the mock backend");
+    mock.insert_fault(
+        t.bucket(),
+        "obj",
+        FaultType::CorruptBody,
+        0,
+        Occurrence::Always,
+    );
+
+    let result = t.download("obj", Some(ChecksumMode::Enabled)).await;
+    assert!(result.is_err(), "tampered body must fail the download");
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn tampered_single_part_errors_mock_gp() {
+    tampered_single_part_errors(Target::mock_gp()).await;
+}
+
+// tamper -> error on the FILE path (validate before rename) ---------------------
+//
+// The in-memory tamper test above drains the body; this exercises the managed
+// file-sink path (slot buffer -> pwrite -> temp file -> rename), where the
+// integrity contract is "validate before rename": a checksum failure must error
+// AND leave no file at the destination (the temp is cleaned up). A corrupt body
+// landing at the destination would be silent on-disk corruption.
+
+async fn tampered_single_part_file_errors(target: Target) {
+    let t = target.connect().await;
+    let data = small();
+    t.put("obj", data, ChecksumStrategy::with_calculated_crc32())
+        .await;
+
+    let mock = t.mock().expect("tamper faults require the mock backend");
+    mock.insert_fault(
+        t.bucket(),
+        "obj",
+        FaultType::CorruptBody,
+        0,
+        Occurrence::Always,
+    );
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dest = dir.path().join("obj.bin");
+
+    let result = t
+        .download_to_path("obj", &dest, Some(ChecksumMode::Enabled))
+        .await;
+    assert!(result.is_err(), "tampered body must fail the file download");
+    assert!(
+        !dest.exists(),
+        "destination must not be created on a failed download"
+    );
+    // No leftover temp files (dest.s3tmp.*) in the directory.
+    let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+        .expect("read tempdir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.contains(".s3tmp."))
+        .collect();
+    assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn tampered_single_part_file_errors_mock_gp() {
+    tampered_single_part_file_errors(Target::mock_gp()).await;
+}
+
+// successful file download round-trips ------------------------------------------
+
+async fn file_download_round_trips(target: Target) {
+    let t = target.connect().await;
+    let data = small();
+    t.put(
+        "obj",
+        data.clone(),
+        ChecksumStrategy::with_calculated_crc32(),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let dest = dir.path().join("obj.bin");
+    t.download_to_path("obj", &dest, Some(ChecksumMode::Enabled))
+        .await
+        .expect("file download");
+
+    let on_disk = std::fs::read(&dest).expect("read destination");
+    assert_same_content(&data, &on_disk);
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn file_download_round_trips_mock_gp() {
+    file_download_round_trips(Target::mock_gp()).await;
+}
+
+async fn tampered_multipart_errors(target: Target) {
+    // Align download ranges to the uploaded part boundaries so each chunk carries
+    // a per-part checksum the SDK validates. Without alignment, S3 returns no
+    // checksum for the ranges and tampering cannot be caught (see the unaligned
+    // boundary test below).
+    let t = target.connect_with(Some(ALIGNED_PART_SIZE)).await;
+    let data = multipart_data();
+    t.put("obj", data, ChecksumStrategy::with_calculated_crc32())
+        .await;
+
+    let mock = t.mock().expect("tamper faults require the mock backend");
+    // Fail every chunk for a deterministic transfer outcome.
+    mock.insert_fault(
+        t.bucket(),
+        "obj",
+        FaultType::WrongStoredChecksum,
+        0,
+        Occurrence::Always,
+    );
+
+    let result = t.download("obj", Some(ChecksumMode::Enabled)).await;
+    assert!(result.is_err(), "tampered checksum must fail the download");
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn tampered_multipart_errors_mock_gp() {
+    tampered_multipart_errors(Target::mock_gp()).await;
+}
+
+// part-size alignment boundary --------------------------------------------------
+//
+// S3 returns a per-part checksum for a ranged GET only when the range matches a
+// stored part boundary (flexible-checksums SEP). The TM downloads with ranged
+// GETs, so multipart download validation depends on the download part size
+// matching the uploaded part size. These two tests pin both sides of that
+// boundary so the behavior cannot drift silently.
+//
+// TODO(vnext): the TM should align download ranges to the stored part size by
+// default (today upload defaults to 8 MiB, download to 5 MiB, so the default is
+// unaligned and not validated). When that lands, the unaligned case below stops
+// being the default; it remains reachable only with an explicit mismatched size.
+
+/// Aligned (upload part size == download part size): a non-tampered multipart
+/// download round-trips. Tampering on this path is caught (see
+/// `tampered_multipart_errors`).
+async fn multipart_aligned_round_trips(target: Target) {
+    let t = target.connect_with(Some(ALIGNED_PART_SIZE)).await;
+    let data = multipart_data();
+    t.put(
+        "obj",
+        data.clone(),
+        ChecksumStrategy::with_calculated_crc32(),
+    )
+    .await;
+
+    let (bytes, _output) = t
+        .download("obj", Some(ChecksumMode::Enabled))
+        .await
+        .expect("download");
+    assert_same_content(&data, &bytes);
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn multipart_aligned_round_trips_mock_gp() {
+    multipart_aligned_round_trips(Target::mock_gp()).await;
+}
+
+/// Unaligned (TM default: upload 8 MiB, download 5 MiB): the download still
+/// round-trips, but a tampered checksum is NOT caught, because S3 returns no
+/// checksum for the unaligned ranges. This pins the silent no-validation default
+/// so the alignment fix (TODO above) flips it deliberately.
+async fn multipart_unaligned_tamper_not_caught(target: Target) {
+    let t = target.connect().await; // default unaligned part sizes
+    let data = multipart_data();
+    t.put("obj", data, ChecksumStrategy::with_calculated_crc32())
+        .await;
+
+    let mock = t.mock().expect("requires the mock backend");
+    mock.insert_fault(
+        t.bucket(),
+        "obj",
+        FaultType::WrongStoredChecksum,
+        0,
+        Occurrence::Always,
+    );
+
+    // Unaligned ranges carry no checksum, so the tamper is invisible and the
+    // download succeeds. This is the gap the alignment fix closes.
+    let result = t.download("obj", Some(ChecksumMode::Enabled)).await;
+    assert!(
+        result.is_ok(),
+        "unaligned multipart download is not validated, so it currently succeeds"
+    );
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn multipart_unaligned_tamper_not_caught_mock_gp() {
+    multipart_unaligned_tamper_not_caught(Target::mock_gp()).await;
+}

--- a/integration-tests/src/integrity.rs
+++ b/integration-tests/src/integrity.rs
@@ -192,6 +192,48 @@ fn assert_same_content(expected: &[u8], actual: &[u8]) {
     );
 }
 
+/// Write `len` bytes of the deterministic `i % 256` pattern to `path` and return
+/// their CRC64NVME digest, in a single streaming pass (no full-file buffer). Used
+/// to stage a large upload source on disk without holding it in memory.
+fn write_pattern_file(path: &std::path::Path, len: usize) -> Vec<u8> {
+    use aws_smithy_checksums::ChecksumAlgorithm;
+    use std::io::Write;
+    let mut hasher = ChecksumAlgorithm::Crc64Nvme.into_impl();
+    let mut f = std::io::BufWriter::new(std::fs::File::create(path).expect("create source file"));
+    let mut buf = vec![0u8; 8 * 1024 * 1024];
+    let mut written = 0;
+    while written < len {
+        let n = buf.len().min(len - written);
+        for (j, b) in buf[..n].iter_mut().enumerate() {
+            *b = ((written + j) % 256) as u8;
+        }
+        f.write_all(&buf[..n]).expect("write source file");
+        hasher.update(&buf[..n]);
+        written += n;
+    }
+    f.flush().expect("flush source file");
+    hasher.finalize().to_vec()
+}
+
+/// CRC64NVME digest of a file, read in bounded chunks (no full-file buffer). Used
+/// to verify a downloaded large object matches the uploaded source independently
+/// of S3's own checksum.
+fn crc64nvme_file(path: &std::path::Path) -> Vec<u8> {
+    use aws_smithy_checksums::ChecksumAlgorithm;
+    use std::io::Read;
+    let mut hasher = ChecksumAlgorithm::Crc64Nvme.into_impl();
+    let mut f = std::fs::File::open(path).expect("open file");
+    let mut buf = vec![0u8; 8 * 1024 * 1024];
+    loop {
+        let n = f.read(&mut buf).expect("read file");
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    hasher.finalize().to_vec()
+}
+
 // single-part, default checksum_mode (unset) -----------------------------------
 //
 // Leaving checksum_mode unset does NOT mean validation is off: the SDK's
@@ -621,6 +663,173 @@ async fn file_download_round_trips_real_gp() {
 #[tokio::test]
 async fn file_download_round_trips_real_express() {
     file_download_round_trips(Target::real_express()).await;
+}
+
+// multi-chunk file-sink downloads ----------------------------------------------
+//
+// The file sink (SlotBuffer) coalesces contiguous filled slots and pwrites them,
+// then atomically renames the temp file to the destination on success. small()
+// is a single chunk; these drive ~64 parts at the aligned part size so the
+// multi-slot flush/coalesce path runs and, on tamper, a partially-written temp
+// must be discarded across many already-flushed chunks. Source and dest are
+// files (streamed, not buffered in memory).
+
+/// Number of aligned parts for the multi-chunk file tests. 64 * 5 MiB = 320 MiB,
+/// enough to coalesce and flush across dozens of slots.
+const MANY_PARTS: usize = 64;
+
+fn many_part_len() -> usize {
+    MANY_PARTS * 5 * ByteUnit::Mebibyte.as_bytes_usize()
+}
+
+/// A many-part object downloaded to a file round-trips on disk. Ranges align to
+/// the stored part size (explicit, matching the upload), so each chunk validates;
+/// the coalescing flush writes all parts and renames to the destination.
+async fn many_part_file_download_round_trips(target: Target) {
+    let t = target.connect_with(Some(ALIGNED_PART_SIZE)).await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("src.bin");
+    let dest = dir.path().join("dest.bin");
+    let len = many_part_len();
+    let src_digest = write_pattern_file(&src, len);
+
+    t.put_from_path("obj", &src, ChecksumStrategy::with_calculated_crc32())
+        .await;
+    t.download_to_path("obj", &dest, Some(ChecksumMode::Enabled))
+        .await
+        .expect("file download");
+
+    assert_eq!(
+        std::fs::metadata(&dest).expect("stat dest").len() as usize,
+        len,
+        "downloaded size mismatch"
+    );
+    assert_eq!(crc64nvme_file(&dest), src_digest, "content digest mismatch");
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn many_part_file_download_round_trips_mock_gp() {
+    many_part_file_download_round_trips(Target::mock_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn many_part_file_download_round_trips_real_gp() {
+    many_part_file_download_round_trips(Target::real_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn many_part_file_download_round_trips_real_express() {
+    many_part_file_download_round_trips(Target::real_express()).await;
+}
+
+/// A tampered chunk partway through a many-part file download is caught, and the
+/// destination is never created even though earlier chunks were already flushed
+/// to the temp file. The fault skips the first chunks so the failure lands after
+/// real bytes have been written: this exercises discarding a partially-written
+/// temp, not a fail-on-first-chunk. Ranged GETs are concurrent, so the moment of
+/// failure varies, but the outcome (transfer fails, dest absent, temp cleaned) is
+/// deterministic.
+async fn tampered_many_part_file_cleans_up(target: Target) {
+    let t = target.connect_with(Some(ALIGNED_PART_SIZE)).await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("src.bin");
+    let dest = dir.path().join("dest.bin");
+    let _ = write_pattern_file(&src, many_part_len());
+
+    t.put_from_path("obj", &src, ChecksumStrategy::with_calculated_crc32())
+        .await;
+
+    let mock = t.mock().expect("tamper faults require the mock backend");
+    // Skip the first 8 chunks so several parts flush to the temp before the
+    // corruption hits; then corrupt every subsequent body (checksum intact).
+    mock.insert_fault(
+        t.bucket(),
+        &t.key("obj"),
+        FaultType::CorruptBody,
+        8,
+        Occurrence::Always,
+    );
+
+    let result = t
+        .download_to_path("obj", &dest, Some(ChecksumMode::Enabled))
+        .await;
+    assert_chunk_failed(result);
+    assert!(
+        !dest.exists(),
+        "destination must not be created on a failed download"
+    );
+    let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+        .expect("read tempdir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.contains(".s3tmp."))
+        .collect();
+    assert!(leftovers.is_empty(), "leftover temp files: {leftovers:?}");
+
+    t.shutdown().await;
+}
+
+#[tokio::test]
+async fn tampered_many_part_file_cleans_up_mock_gp() {
+    tampered_many_part_file_cleans_up(Target::mock_gp()).await;
+}
+
+// large-object download (real S3 only) -----------------------------------------
+//
+// Sized past the 512-slot body buffer window (DEFAULT_BODY_SLOT_CAPACITY) so the
+// download crosses slot-index wraparound and exercises seq-window backpressure
+// against a real disk-bound file sink, also crossing the 5 GiB single-PUT /
+// multipart boundary. Real-S3 only: the data volume has no place in mock CI.
+// Source and dest are files; verification re-derives a CRC64NVME over the
+// downloaded file independently of S3.
+
+#[cfg(e2e_test)]
+async fn large_object_file_download_validates(target: Target) {
+    use aws_sdk_s3_transfer_manager::types::PartSize;
+
+    // 6 GiB at an 8 MiB part size = ~768 ranged GETs, past the 512-slot window.
+    let part = 8 * ByteUnit::Mebibyte.as_bytes_u64();
+    let t = target.connect_with(Some(PartSize::Target(part))).await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("src.bin");
+    let dest = dir.path().join("dest.bin");
+    let total = 6 * ByteUnit::Gibibyte.as_bytes_usize();
+    let src_digest = write_pattern_file(&src, total);
+
+    t.put_from_path(
+        "large-obj",
+        &src,
+        ChecksumStrategy::with_calculated_crc64_nvme(),
+    )
+    .await;
+    t.download_to_path("large-obj", &dest, Some(ChecksumMode::Enabled))
+        .await
+        .expect("large file download");
+
+    assert_eq!(
+        std::fs::metadata(&dest).expect("stat dest").len() as usize,
+        total,
+        "downloaded size mismatch"
+    );
+    assert_eq!(crc64nvme_file(&dest), src_digest, "content digest mismatch");
+
+    t.shutdown().await;
+}
+
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn large_object_file_download_validates_real_gp() {
+    large_object_file_download_validates(Target::real_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn large_object_file_download_validates_real_express() {
+    large_object_file_download_validates(Target::real_express()).await;
 }
 
 async fn tampered_multipart_errors(target: Target) {

--- a/integration-tests/src/integrity.rs
+++ b/integration-tests/src/integrity.rs
@@ -59,20 +59,32 @@
 //! | single-part                   | on            | round-trip; value shown; not Validated*   |
 //! | multipart full-object         | on            | round-trip; object value not from a part  |
 //! | multipart composite           | on            | round-trip; object value not from a part  |
-//! | single-part tampered          | on            | download errors (never Ok)                |
-//! | single-part tampered (file)   | on            | errors; temp cleaned, dest not created    |
-//! | multipart tampered (aligned)  | on            | download errors (never Ok)                |
-//! | multipart aligned             | on            | round-trip (download ranges align)        |
-//! | multipart unaligned, tampered | on            | NOT caught (no checksum on unaligned GET) |
+//! | single-part tampered          | on            | ChunkFailed (never Ok)                     |
+//! | single-part tampered (file)   | on            | ChunkFailed; temp cleaned, dest not created|
+//! | multipart tampered (explicit) | on            | ChunkFailed (explicit matched size)        |
+//! | multipart, default part size  | on            | round-trip (auto-aligned to stored parts) |
+//! | multipart tampered (default)  | on            | ChunkFailed (auto-aligned, caught)         |
+//! | single-PUT split, tampered    | on            | #[ignore] intent: must ChunkFailed (TODO)  |
+//!
+//! Tamper tests assert the specific `ErrorKind::ChunkFailed` (the kind a checksum
+//! mismatch surfaces as), not merely `is_err()`, so an unrelated failure cannot
+//! pass them.
+//!
+//! Multipart downloads are validated by default: when validating a multipart
+//! object with an Auto part size, the TM discovers the stored part size (a
+//! partNumber=1 GET reports part 1's exact length) and slices download ranges to
+//! it, so every range aligns to a stored part boundary and the SDK validates each
+//! part (including the ragged tail). An explicit user part size is respected as-is
+//! (no auto-align), so it validates only when it matches the uploaded part size.
+//!
+//! One `#[ignore]`d intent test states the remaining deferred goal (gated on wire
+//! checksum): `single_put_split_tamper_caught_mock_gp` — a large single-PUT
+//! object split into ranged GETs has no per-range checksum, so validating it needs
+//! a TM-computed whole-object hash. It verifiably FAILS today and is the executable
+//! statement of that goal.
 //!
 //! *not Validated until the SDK reports a per-response validation outcome
 //! (see the limitation above).
-//!
-//! Multipart download validation requires the download range to match a stored
-//! part boundary. The TM downloads with ranged GETs, so a test pins an explicit
-//! part size to align upload and download; the unaligned row pins the current
-//! default behavior (upload 8 MiB, download 5 MiB) where validation does not
-//! occur. See `harness::TmTestClient::connect_with`.
 //!
 //! Algorithm is a pass-through axis for the transfer manager (it forwards the
 //! choice and reads back whatever S3 returns), so per-algorithm value
@@ -82,16 +94,17 @@
 
 use crate::harness::Target;
 use aws_sdk_s3::types::ChecksumMode;
+use aws_sdk_s3_transfer_manager::error::{Error, ErrorKind};
 use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_sdk_s3_transfer_manager::operation::download::DownloadOutput;
 use aws_sdk_s3_transfer_manager::operation::upload::ChecksumStrategy;
 use aws_sdk_s3_transfer_manager::types::{ChecksumValidation, NotValidatedReason, PartSize};
 use s3_mock_server::{FaultType, Occurrence};
 
-/// A part size pinned equally for upload and download so multipart download
-/// ranges align to the uploaded part boundaries (the precondition for per-part
-/// download validation). The TM's default leaves upload (8 MiB) and download
-/// (5 MiB) unaligned; see the unaligned boundary test.
+/// A part size pinned equally for upload and download. Multipart downloads align
+/// automatically for an Auto part size; this pins an explicit size to cover the
+/// explicit-part-size path (where the user's size must match the upload to
+/// validate).
 const ALIGNED_PART_SIZE: PartSize = PartSize::Target(5 * 1024 * 1024);
 
 fn small() -> Vec<u8> {
@@ -105,10 +118,34 @@ fn multipart_data() -> Vec<u8> {
         .collect()
 }
 
+/// Data above the download part size (5 MiB) but below the multipart-upload
+/// threshold (16 MiB): uploaded as a SINGLE PUT (full-object checksum, no `-N`),
+/// but downloaded as multiple ranged GETs (split for throughput). S3 returns no
+/// per-range checksum for a single-stored-part object, so the SDK validates
+/// nothing on the split chunks.
+fn large_single_put() -> Vec<u8> {
+    (0..12 * ByteUnit::Mebibyte.as_bytes_usize())
+        .map(|i| (i % 256) as u8)
+        .collect()
+}
+
 fn assert_not_validated(output: &DownloadOutput, expected: NotValidatedReason) {
     match output.integrity_checks().checksum_validation() {
         ChecksumValidation::NotValidated { reason } => assert_eq!(*reason, expected),
         other => panic!("expected NotValidated{{{expected:?}}}, got {other:?}"),
+    }
+}
+
+/// Assert a download failed with a per-chunk failure (the kind a checksum
+/// mismatch surfaces as: the SDK body validator errors on a chunk, which the
+/// transfer manager reports as `ErrorKind::ChunkFailed`). Asserting the kind,
+/// not just `is_err()`, pins that the failure is integrity-related and not some
+/// unrelated error path.
+fn assert_chunk_failed<T>(result: Result<T, Error>) {
+    match result {
+        Err(e) if matches!(e.kind(), ErrorKind::ChunkFailed(_)) => {}
+        Err(e) => panic!("expected ErrorKind::ChunkFailed, got {:?}", e.kind()),
+        Ok(_) => panic!("expected the download to fail with ChunkFailed, but it succeeded"),
     }
 }
 
@@ -312,7 +349,7 @@ async fn tampered_single_part_errors(target: Target) {
     );
 
     let result = t.download("obj", Some(ChecksumMode::Enabled)).await;
-    assert!(result.is_err(), "tampered body must fail the download");
+    assert_chunk_failed(result);
 
     t.shutdown().await;
 }
@@ -351,7 +388,7 @@ async fn tampered_single_part_file_errors(target: Target) {
     let result = t
         .download_to_path("obj", &dest, Some(ChecksumMode::Enabled))
         .await;
-    assert!(result.is_err(), "tampered body must fail the file download");
+    assert_chunk_failed(result);
     assert!(
         !dest.exists(),
         "destination must not be created on a failed download"
@@ -403,10 +440,10 @@ async fn file_download_round_trips_mock_gp() {
 }
 
 async fn tampered_multipart_errors(target: Target) {
-    // Align download ranges to the uploaded part boundaries so each chunk carries
-    // a per-part checksum the SDK validates. Without alignment, S3 returns no
-    // checksum for the ranges and tampering cannot be caught (see the unaligned
-    // boundary test below).
+    // Explicit part size, applied to BOTH upload and download, so the download
+    // ranges match the uploaded part boundaries without relying on auto-alignment
+    // (auto-alignment only fires for an Auto part size). Each aligned chunk carries
+    // a per-part checksum the SDK validates, so a tampered checksum fails.
     let t = target.connect_with(Some(ALIGNED_PART_SIZE)).await;
     let data = multipart_data();
     t.put("obj", data, ChecksumStrategy::with_calculated_crc32())
@@ -423,7 +460,7 @@ async fn tampered_multipart_errors(target: Target) {
     );
 
     let result = t.download("obj", Some(ChecksumMode::Enabled)).await;
-    assert!(result.is_err(), "tampered checksum must fail the download");
+    assert_chunk_failed(result);
 
     t.shutdown().await;
 }
@@ -433,24 +470,19 @@ async fn tampered_multipart_errors_mock_gp() {
     tampered_multipart_errors(Target::mock_gp()).await;
 }
 
-// part-size alignment boundary --------------------------------------------------
+// multipart download is aligned to the stored part size by default ---------------
 //
 // S3 returns a per-part checksum for a ranged GET only when the range matches a
-// stored part boundary (flexible-checksums SEP). The TM downloads with ranged
-// GETs, so multipart download validation depends on the download part size
-// matching the uploaded part size. These two tests pin both sides of that
-// boundary so the behavior cannot drift silently.
-//
-// TODO(vnext): the TM should align download ranges to the stored part size by
-// default (today upload defaults to 8 MiB, download to 5 MiB, so the default is
-// unaligned and not validated). When that lands, the unaligned case below stops
-// being the default; it remains reachable only with an explicit mismatched size.
+// stored part boundary. The TM downloads with ranged
+// GETs and, when validating a multipart object with an Auto part size, discovers
+// the stored part size (via a partNumber=1 GET) and slices download ranges to it
+// so every chunk aligns to a stored boundary (including the ragged tail) and the
+// SDK validates each part. These tests pin that aligned-by-default behavior.
 
-/// Aligned (upload part size == download part size): a non-tampered multipart
-/// download round-trips. Tampering on this path is caught (see
-/// `tampered_multipart_errors`).
+/// Default part size (Auto): a non-tampered multipart download round-trips. The
+/// TM aligns ranges to the stored part size, so the SDK validates each part.
 async fn multipart_aligned_round_trips(target: Target) {
-    let t = target.connect_with(Some(ALIGNED_PART_SIZE)).await;
+    let t = target.connect().await;
     let data = multipart_data();
     t.put(
         "obj",
@@ -473,12 +505,12 @@ async fn multipart_aligned_round_trips_mock_gp() {
     multipart_aligned_round_trips(Target::mock_gp()).await;
 }
 
-/// Unaligned (TM default: upload 8 MiB, download 5 MiB): the download still
-/// round-trips, but a tampered checksum is NOT caught, because S3 returns no
-/// checksum for the unaligned ranges. This pins the silent no-validation default
-/// so the alignment fix (TODO above) flips it deliberately.
-async fn multipart_unaligned_tamper_not_caught(target: Target) {
-    let t = target.connect().await; // default unaligned part sizes
+/// Default part size (Auto): a tampered chunk of a multipart download IS caught.
+/// The TM aligns download ranges to the stored part boundaries, so each ranged
+/// GET carries a per-part checksum the SDK validates; a corrupted part fails the
+/// download. This is the integrity-critical guarantee for multipart downloads.
+async fn multipart_default_tamper_caught(target: Target) {
+    let t = target.connect().await; // default (Auto) part size -> auto-aligned
     let data = multipart_data();
     t.put("obj", data, ChecksumStrategy::with_calculated_crc32())
         .await;
@@ -492,18 +524,53 @@ async fn multipart_unaligned_tamper_not_caught(target: Target) {
         Occurrence::Always,
     );
 
-    // Unaligned ranges carry no checksum, so the tamper is invisible and the
-    // download succeeds. This is the gap the alignment fix closes.
     let result = t.download("obj", Some(ChecksumMode::Enabled)).await;
-    assert!(
-        result.is_ok(),
-        "unaligned multipart download is not validated, so it currently succeeds"
-    );
+    assert_chunk_failed(result);
 
     t.shutdown().await;
 }
 
 #[tokio::test]
-async fn multipart_unaligned_tamper_not_caught_mock_gp() {
-    multipart_unaligned_tamper_not_caught(Target::mock_gp()).await;
+async fn multipart_default_tamper_caught_mock_gp() {
+    multipart_default_tamper_caught(Target::mock_gp()).await;
+}
+
+// large single-PUT object split for throughput ---------------------------------
+//
+// An object uploaded as a SINGLE PUT (below the multipart-upload threshold) but
+// larger than the download part size is split into parallel ranged GETs for
+// throughput. The split already happens today (the slicer cuts by byte range,
+// not by stored part count). S3 stores ONE full-object checksum and returns NO
+// checksum for any sub-range of a single-stored-part object, so the SDK cannot
+// validate the split chunks. Closing this needs the transfer manager to compute
+// a whole-object checksum over the delivered bytes itself (HeadObject for the
+// expected value + an ordered hash at the slot-buffer consume point), or a wire
+// checksum from S3 over arbitrary response bytes.
+
+/// INTENT (not yet implemented): a tampered chunk of a split single-PUT download
+/// MUST fail the download. Ignored until the transfer manager validates this path
+/// itself; it currently succeeds (the chunks carry no checksum), so this FAILS
+/// today. The test states the desired behavior; the ignore reason states why it
+/// is not running yet.
+#[tokio::test]
+#[ignore = "TODO(vnext): wire checksums, or TM-computed whole-object checksum over the slot-buffer bytes, to validate split single-PUT downloads"]
+async fn single_put_split_tamper_caught_mock_gp() {
+    let t = Target::mock_gp().connect().await; // default part sizes; 12 MiB -> 3 ranged GETs
+    let data = large_single_put();
+    t.put("obj", data, ChecksumStrategy::with_calculated_crc32())
+        .await;
+
+    let mock = t.mock().expect("requires the mock backend");
+    mock.insert_fault(
+        t.bucket(),
+        "obj",
+        FaultType::CorruptBody,
+        0,
+        Occurrence::Always,
+    );
+
+    let result = t.download("obj", Some(ChecksumMode::Enabled)).await;
+    assert_chunk_failed(result);
+
+    t.shutdown().await;
 }

--- a/integration-tests/src/integrity.rs
+++ b/integration-tests/src/integrity.rs
@@ -52,19 +52,41 @@
 //!
 //! # Coverage
 //!
-//! | Object                        | checksum_mode | Asserts                                   |
-//! |-------------------------------|---------------|-------------------------------------------|
-//! | single-part                   | default       | round-trip; verdict Unavailable (on)      |
-//! | single-part (WhenRequired)    | default       | round-trip; verdict Disabled (off)        |
-//! | single-part                   | on            | round-trip; value shown; not Validated*   |
-//! | multipart full-object         | on            | round-trip; object value not from a part  |
-//! | multipart composite           | on            | round-trip; object value not from a part  |
-//! | single-part tampered          | on            | ChunkFailed (never Ok)                     |
-//! | single-part tampered (file)   | on            | ChunkFailed; temp cleaned, dest not created|
-//! | multipart tampered (explicit) | on            | ChunkFailed (explicit matched size)        |
-//! | multipart, default part size  | on            | round-trip (auto-aligned to stored parts) |
-//! | multipart tampered (default)  | on            | ChunkFailed (auto-aligned, caught)         |
-//! | single-PUT split, tampered    | on            | #[ignore] intent: must ChunkFailed (TODO)  |
+//! Two guarantees, each a table. "Request mode" is the download request's
+//! `checksum_mode` (whether the caller asks S3 to return a stored checksum for
+//! the SDK to validate against): ENABLED, or unset. "Client validation" is the
+//! S3 client's `ResponseChecksumValidation` (which decides whether an unset mode
+//! is auto-promoted to ENABLED): WhenSupported is the default. "Backend" is where
+//! the body runs: `mock` only, or `mock + real S3` (the same assertions gated
+//! under `--cfg e2e_test`, run against both GP and Express buckets). Tamper tests
+//! are `mock` only by design: fault injection cannot be done against real S3.
+//!
+//! ## Positive: a good download round-trips and reports an honest verdict
+//!
+//! | Object              | Request mode | Client validation | Verdict asserted                      | Backend     |
+//! |---------------------|--------------|-------------------|---------------------------------------|-------------|
+//! | single-part         | unset        | WhenSupported     | NotValidated{Unavailable}*            | mock + real |
+//! | single-part         | unset        | WhenRequired      | NotValidated{Disabled}                | mock        |
+//! | single-part         | ENABLED      | default           | object value surfaced; not Validated* | mock + real |
+//! | multipart full-obj  | ENABLED      | default           | object value is NOT a part checksum   | mock + real |
+//! | multipart composite | ENABLED      | default           | object value is NOT a part checksum   | mock + real |
+//! | multipart (Auto sz) | ENABLED      | default           | round-trip (ranges auto-aligned)      | mock + real |
+//! | single-part (file)  | ENABLED      | default           | round-trip on disk                    | mock + real |
+//! | composite MPU value | ENABLED      | default           | object value == composite_checksum    | real        |
+//!
+//! ## Negative: a tampered download MUST fail (mock only)
+//!
+//! | Object              | Request mode | Tamper injected     | Asserts                                |
+//! |---------------------|--------------|---------------------|----------------------------------------|
+//! | single-part         | ENABLED      | CorruptBody         | ChunkFailed                            |
+//! | single-part (file)  | ENABLED      | CorruptBody         | ChunkFailed; temp cleaned, dest absent |
+//! | multipart (matched) | ENABLED      | WrongStoredChecksum | ChunkFailed (explicit matched size)    |
+//! | multipart (Auto sz) | ENABLED      | WrongStoredChecksum | ChunkFailed (auto-aligned, caught)     |
+//! | single-PUT split    | ENABLED      | CorruptBody         | #[ignore] intent: must ChunkFailed — FAILS today (TODO) |
+//!
+//! * Verdict stays NotValidated even on success until the SDK exposes a
+//!   per-response validation outcome (see "Current limitation"). The negative
+//!   tables hold today regardless.
 //!
 //! Tamper tests assert the specific `ErrorKind::ChunkFailed` (the kind a checksum
 //! mismatch surfaces as), not merely `is_err()`, so an unrelated failure cannot
@@ -201,6 +223,16 @@ async fn single_part_mode_default(target: Target) {
 async fn single_part_mode_default_mock_gp() {
     single_part_mode_default(Target::mock_gp()).await;
 }
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn single_part_mode_default_real_gp() {
+    single_part_mode_default(Target::real_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn single_part_mode_default_real_express() {
+    single_part_mode_default(Target::real_express()).await;
+}
 
 // single-part, client ResponseChecksumValidation=WhenRequired -------------------
 //
@@ -269,6 +301,16 @@ async fn single_part_mode_on(target: Target) {
 async fn single_part_mode_on_mock_gp() {
     single_part_mode_on(Target::mock_gp()).await;
 }
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn single_part_mode_on_real_gp() {
+    single_part_mode_on(Target::real_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn single_part_mode_on_real_express() {
+    single_part_mode_on(Target::real_express()).await;
+}
 
 // multipart full-object ---------------------------------------------------------
 
@@ -300,6 +342,16 @@ async fn multipart_full_object(target: Target) {
 async fn multipart_full_object_mock_gp() {
     multipart_full_object(Target::mock_gp()).await;
 }
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn multipart_full_object_real_gp() {
+    multipart_full_object(Target::real_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn multipart_full_object_real_express() {
+    multipart_full_object(Target::real_express()).await;
+}
 
 // multipart composite -----------------------------------------------------------
 
@@ -329,6 +381,128 @@ async fn multipart_composite(target: Target) {
 #[tokio::test]
 async fn multipart_composite_mock_gp() {
     multipart_composite(Target::mock_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn multipart_composite_real_gp() {
+    multipart_composite(Target::real_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn multipart_composite_real_express() {
+    multipart_composite(Target::real_express()).await;
+}
+
+/// Real-S3 authority gate: assert that S3's composite checksum value for a
+/// multipart upload exactly equals our `s3_mock_server::composite_checksum`
+/// computation. Uses the raw SDK client to control per-part checksums.
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn mpu_composite_value_matches_expected_real_gp() {
+    use aws_sdk_s3::types::{
+        ChecksumAlgorithm, ChecksumMode, CompletedMultipartUpload, CompletedPart,
+    };
+    use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
+
+    let t = Target::real_gp().connect().await;
+    let s3 = t.s3();
+    let bucket = t.bucket();
+    let key = &format!("integrity-composite-gate-{}", uuid::Uuid::new_v4());
+
+    let algorithm = ChecksumAlgorithm::Crc32;
+
+    // Two parts, each >= 5 MiB (S3's minimum part size for MPU).
+    let part1: Vec<u8> = (0..5 * ByteUnit::Mebibyte.as_bytes_usize())
+        .map(|i| (i % 251) as u8)
+        .collect();
+    let part2: Vec<u8> = (0..5 * ByteUnit::Mebibyte.as_bytes_usize())
+        .map(|i| (i % 239) as u8)
+        .collect();
+
+    let create = s3
+        .create_multipart_upload()
+        .bucket(bucket)
+        .key(key)
+        .checksum_algorithm(algorithm.clone())
+        .send()
+        .await
+        .expect("create MPU");
+    let upload_id = create.upload_id().unwrap();
+
+    let r1 = s3
+        .upload_part()
+        .bucket(bucket)
+        .key(key)
+        .upload_id(upload_id)
+        .part_number(1)
+        .checksum_algorithm(algorithm.clone())
+        .body(aws_sdk_s3::primitives::ByteStream::from(part1))
+        .send()
+        .await
+        .expect("upload part 1");
+
+    let r2 = s3
+        .upload_part()
+        .bucket(bucket)
+        .key(key)
+        .upload_id(upload_id)
+        .part_number(2)
+        .checksum_algorithm(algorithm.clone())
+        .body(aws_sdk_s3::primitives::ByteStream::from(part2))
+        .send()
+        .await
+        .expect("upload part 2");
+
+    let c1 = r1.checksum_crc32().unwrap().to_owned();
+    let c2 = r2.checksum_crc32().unwrap().to_owned();
+
+    s3.complete_multipart_upload()
+        .bucket(bucket)
+        .key(key)
+        .upload_id(upload_id)
+        .multipart_upload(
+            CompletedMultipartUpload::builder()
+                .parts(
+                    CompletedPart::builder()
+                        .part_number(1)
+                        .e_tag(r1.e_tag().unwrap())
+                        .checksum_crc32(&c1)
+                        .build(),
+                )
+                .parts(
+                    CompletedPart::builder()
+                        .part_number(2)
+                        .e_tag(r2.e_tag().unwrap())
+                        .checksum_crc32(&c2)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await
+        .expect("complete MPU");
+
+    let head = s3
+        .head_object()
+        .bucket(bucket)
+        .key(key)
+        .checksum_mode(ChecksumMode::Enabled)
+        .send()
+        .await
+        .expect("head object");
+
+    let actual = head
+        .checksum_crc32()
+        .expect("expected composite CRC32 in HeadObject response");
+    let expected = s3_mock_server::composite_checksum(&[c1, c2], algorithm);
+    assert_eq!(
+        actual, expected,
+        "real S3 composite value must match our composite_checksum computation"
+    );
+
+    // Cleanup
+    s3.delete_object().bucket(bucket).key(key).send().await.ok();
+    t.shutdown().await;
 }
 
 // tamper -> error (the integrity-critical negative; mock only) -------------------
@@ -438,6 +612,16 @@ async fn file_download_round_trips(target: Target) {
 async fn file_download_round_trips_mock_gp() {
     file_download_round_trips(Target::mock_gp()).await;
 }
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn file_download_round_trips_real_gp() {
+    file_download_round_trips(Target::real_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn file_download_round_trips_real_express() {
+    file_download_round_trips(Target::real_express()).await;
+}
 
 async fn tampered_multipart_errors(target: Target) {
     // Explicit part size, applied to BOTH upload and download, so the download
@@ -503,6 +687,16 @@ async fn multipart_aligned_round_trips(target: Target) {
 #[tokio::test]
 async fn multipart_aligned_round_trips_mock_gp() {
     multipart_aligned_round_trips(Target::mock_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn multipart_aligned_round_trips_real_gp() {
+    multipart_aligned_round_trips(Target::real_gp()).await;
+}
+#[cfg(e2e_test)]
+#[tokio::test]
+async fn multipart_aligned_round_trips_real_express() {
+    multipart_aligned_round_trips(Target::real_express()).await;
 }
 
 /// Default part size (Auto): a tampered chunk of a multipart download IS caught.

--- a/integration-tests/src/integrity.rs
+++ b/integration-tests/src/integrity.rs
@@ -407,7 +407,7 @@ async fn mpu_composite_value_matches_expected_real_gp() {
     let t = Target::real_gp().connect().await;
     let s3 = t.s3();
     let bucket = t.bucket();
-    let key = &format!("integrity-composite-gate-{}", uuid::Uuid::new_v4());
+    let key = &format!("upload/mpu-composite-checksum-{}", uuid::Uuid::new_v4());
 
     let algorithm = ChecksumAlgorithm::Crc32;
 
@@ -516,7 +516,7 @@ async fn tampered_single_part_errors(target: Target) {
     let mock = t.mock().expect("tamper faults require the mock backend");
     mock.insert_fault(
         t.bucket(),
-        "obj",
+        &t.key("obj"),
         FaultType::CorruptBody,
         0,
         Occurrence::Always,
@@ -550,7 +550,7 @@ async fn tampered_single_part_file_errors(target: Target) {
     let mock = t.mock().expect("tamper faults require the mock backend");
     mock.insert_fault(
         t.bucket(),
-        "obj",
+        &t.key("obj"),
         FaultType::CorruptBody,
         0,
         Occurrence::Always,
@@ -637,7 +637,7 @@ async fn tampered_multipart_errors(target: Target) {
     // Fail every chunk for a deterministic transfer outcome.
     mock.insert_fault(
         t.bucket(),
-        "obj",
+        &t.key("obj"),
         FaultType::WrongStoredChecksum,
         0,
         Occurrence::Always,
@@ -712,7 +712,7 @@ async fn multipart_default_tamper_caught(target: Target) {
     let mock = t.mock().expect("requires the mock backend");
     mock.insert_fault(
         t.bucket(),
-        "obj",
+        &t.key("obj"),
         FaultType::WrongStoredChecksum,
         0,
         Occurrence::Always,
@@ -757,7 +757,7 @@ async fn single_put_split_tamper_caught_mock_gp() {
     let mock = t.mock().expect("requires the mock backend");
     mock.insert_fault(
         t.bucket(),
-        "obj",
+        &t.key("obj"),
         FaultType::CorruptBody,
         0,
         Occurrence::Always,

--- a/integration-tests/src/integrity.rs
+++ b/integration-tests/src/integrity.rs
@@ -153,7 +153,7 @@ fn large_single_put() -> Vec<u8> {
 
 fn assert_not_validated(output: &DownloadOutput, expected: NotValidatedReason) {
     match output.integrity_checks().checksum_validation() {
-        ChecksumValidation::NotValidated { reason } => assert_eq!(*reason, expected),
+        ChecksumValidation::NotValidated { reason, .. } => assert_eq!(*reason, expected),
         other => panic!("expected NotValidated{{{expected:?}}}, got {other:?}"),
     }
 }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -11,6 +11,10 @@
 #[cfg(test)]
 mod download;
 #[cfg(test)]
+mod harness;
+#[cfg(test)]
+mod integrity;
+#[cfg(test)]
 mod metrics;
 #[cfg(test)]
 mod upload;

--- a/s3-mock-server/src/faults.rs
+++ b/s3-mock-server/src/faults.rs
@@ -1,0 +1,218 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Deterministic, traceable fault injection for the mock server.
+//!
+//! Faults are registered per `(bucket, key)` as an ordered queue (a *script*
+//! consumed over successive matching requests). Targeting and timing are counted,
+//! never random, so a test's outcome is reproducible and every fired fault is
+//! logged with the request number that triggered it.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// What a fault does to a matching request. One effect per request.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaultType {
+    /// GET returns a valid-format but incorrect `x-amz-checksum-*` (first byte
+    /// XOR'd) — drives a download checksum mismatch.
+    WrongStoredChecksum,
+    /// GET returns tampered body bytes (byte 0 XOR'd) with the checksum left
+    /// intact — proves body-content validation, not just header comparison.
+    CorruptBody,
+}
+
+/// How many times an eligible fault fires before it is consumed.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Occurrence {
+    /// Fire once, then pop the entry.
+    Once,
+    /// Fire `n` times, then pop the entry.
+    NTimes(u32),
+    /// Fire forever (never popped) — terminal.
+    Always,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FaultEntry {
+    fault: FaultType,
+    /// Warm-up: matching requests before this entry becomes eligible, measured
+    /// against the monotonic per-key request counter (absolute).
+    skip: u32,
+    occurrence: Occurrence,
+    /// Remaining fires for `NTimes`; ignored for `Once`/`Always`.
+    remaining: u32,
+}
+
+#[derive(Debug, Default)]
+struct KeyState {
+    /// Monotonic count of matching requests seen for this key.
+    seen: u32,
+    queue: std::collections::VecDeque<FaultEntry>,
+}
+
+/// Key-scoped fault registry. Cheap to clone the `Arc` that holds it.
+#[derive(Debug, Default)]
+pub(crate) struct FaultRegistry {
+    keys: Mutex<HashMap<(String, String), KeyState>>,
+}
+
+impl FaultRegistry {
+    /// Append a fault to the `(bucket, key)` queue.
+    pub(crate) fn insert(
+        &self,
+        bucket: &str,
+        key: &str,
+        fault: FaultType,
+        skip: u32,
+        occurrence: Occurrence,
+    ) {
+        let remaining = match occurrence {
+            Occurrence::NTimes(n) => n,
+            _ => 0,
+        };
+        self.keys
+            .lock()
+            .unwrap()
+            .entry((bucket.to_string(), key.to_string()))
+            .or_default()
+            .queue
+            .push_back(FaultEntry {
+                fault,
+                skip,
+                occurrence,
+                remaining,
+            });
+    }
+
+    /// Drop the entire fault queue for `(bucket, key)`.
+    pub(crate) fn clear(&self, bucket: &str, key: &str) {
+        self.keys
+            .lock()
+            .unwrap()
+            .remove(&(bucket.to_string(), key.to_string()));
+    }
+
+    /// Record a matching request and return the fault to apply, if any.
+    ///
+    /// Increments the per-key request counter, then consults the head entry:
+    /// fires only once `seen > skip`; decrements/pops per occurrence. Emits a
+    /// `tracing` event on every fire for reproducibility.
+    pub(crate) fn next_fault(&self, bucket: &str, key: &str) -> Option<FaultType> {
+        let mut keys = self.keys.lock().unwrap();
+        let state = keys.get_mut(&(bucket.to_string(), key.to_string()))?;
+        state.seen += 1;
+        let seen = state.seen;
+        let entry = state.queue.front_mut()?;
+        if seen <= entry.skip {
+            return None;
+        }
+        let fault = entry.fault;
+        let occurrence = entry.occurrence;
+        let pop = match entry.occurrence {
+            Occurrence::Once => true,
+            Occurrence::NTimes(_) => {
+                entry.remaining = entry.remaining.saturating_sub(1);
+                entry.remaining == 0
+            }
+            Occurrence::Always => false,
+        };
+        if pop {
+            state.queue.pop_front();
+        }
+        tracing::warn!(
+            target: "s3_mock_server::fault",
+            %bucket, %key, request = seen, ?fault, ?occurrence,
+            "fault fired",
+        );
+        Some(fault)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reg() -> FaultRegistry {
+        FaultRegistry::default()
+    }
+
+    #[test]
+    fn always_fires_every_request() {
+        let r = reg();
+        r.insert("b", "k", FaultType::CorruptBody, 0, Occurrence::Always);
+        for _ in 0..5 {
+            assert_eq!(r.next_fault("b", "k"), Some(FaultType::CorruptBody));
+        }
+    }
+
+    #[test]
+    fn once_fires_exactly_once() {
+        let r = reg();
+        r.insert("b", "k", FaultType::CorruptBody, 0, Occurrence::Once);
+        assert_eq!(r.next_fault("b", "k"), Some(FaultType::CorruptBody));
+        assert_eq!(r.next_fault("b", "k"), None);
+    }
+
+    #[test]
+    fn ntimes_fires_n_then_stops() {
+        let r = reg();
+        r.insert("b", "k", FaultType::CorruptBody, 0, Occurrence::NTimes(2));
+        assert!(r.next_fault("b", "k").is_some());
+        assert!(r.next_fault("b", "k").is_some());
+        assert_eq!(r.next_fault("b", "k"), None);
+    }
+
+    #[test]
+    fn skip_warms_up_against_monotonic_counter() {
+        let r = reg();
+        r.insert(
+            "b",
+            "k",
+            FaultType::WrongStoredChecksum,
+            2,
+            Occurrence::Always,
+        );
+        assert_eq!(r.next_fault("b", "k"), None); // req 1
+        assert_eq!(r.next_fault("b", "k"), None); // req 2
+        assert!(r.next_fault("b", "k").is_some()); // req 3
+        assert!(r.next_fault("b", "k").is_some()); // req 4
+    }
+
+    #[test]
+    fn queue_consumed_in_order() {
+        let r = reg();
+        r.insert("b", "k", FaultType::CorruptBody, 0, Occurrence::Once);
+        r.insert(
+            "b",
+            "k",
+            FaultType::WrongStoredChecksum,
+            0,
+            Occurrence::Always,
+        );
+        assert_eq!(r.next_fault("b", "k"), Some(FaultType::CorruptBody));
+        assert_eq!(r.next_fault("b", "k"), Some(FaultType::WrongStoredChecksum));
+        assert_eq!(r.next_fault("b", "k"), Some(FaultType::WrongStoredChecksum));
+    }
+
+    #[test]
+    fn clear_drops_queue() {
+        let r = reg();
+        r.insert("b", "k", FaultType::CorruptBody, 0, Occurrence::Always);
+        assert!(r.next_fault("b", "k").is_some());
+        r.clear("b", "k");
+        assert_eq!(r.next_fault("b", "k"), None);
+    }
+
+    #[test]
+    fn faults_are_key_scoped() {
+        let r = reg();
+        r.insert("b", "k1", FaultType::CorruptBody, 0, Occurrence::Always);
+        assert_eq!(r.next_fault("b", "k2"), None);
+        assert!(r.next_fault("b", "k1").is_some());
+    }
+}

--- a/s3-mock-server/src/faults.rs
+++ b/s3-mock-server/src/faults.rs
@@ -18,10 +18,10 @@ use std::sync::Mutex;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FaultType {
     /// GET returns a valid-format but incorrect `x-amz-checksum-*` (first byte
-    /// XOR'd) — drives a download checksum mismatch.
+    /// XOR'd). Drives a download checksum mismatch.
     WrongStoredChecksum,
     /// GET returns tampered body bytes (byte 0 XOR'd) with the checksum left
-    /// intact — proves body-content validation, not just header comparison.
+    /// intact. Exercises body-content validation, not just header comparison.
     CorruptBody,
 }
 
@@ -33,7 +33,7 @@ pub enum Occurrence {
     Once,
     /// Fire `n` times, then pop the entry.
     NTimes(u32),
-    /// Fire forever (never popped) — terminal.
+    /// Fire forever; never popped.
     Always,
 }
 

--- a/s3-mock-server/src/lib.rs
+++ b/s3-mock-server/src/lib.rs
@@ -11,6 +11,7 @@
 //! concurrent operations, error handling, and performance characteristics.
 
 mod error;
+mod faults;
 mod s3s;
 mod server;
 mod storage;
@@ -19,6 +20,7 @@ mod types;
 
 pub use error::Error;
 pub use error::Result;
+pub use faults::{FaultType, Occurrence};
 pub use server::{
     AddObjectRequest, ObjectData, ObjectListEntry, S3MockServer, S3MockServerBuilder, ServerConfig,
     ServerHandle,

--- a/s3-mock-server/src/lib.rs
+++ b/s3-mock-server/src/lib.rs
@@ -25,3 +25,4 @@ pub use server::{
     AddObjectRequest, ObjectData, ObjectListEntry, S3MockServer, S3MockServerBuilder, ServerConfig,
     ServerHandle,
 };
+pub use types::composite_checksum;

--- a/s3-mock-server/src/s3s.rs
+++ b/s3-mock-server/src/s3s.rs
@@ -74,6 +74,30 @@ fn has_any_checksum_get(o: &s3s::dto::GetObjectOutput) -> bool {
         || o.checksum_sha256.is_some()
 }
 
+/// Deterministically corrupt the first checksum header present on a GET response:
+/// decode it, XOR its first byte with 0xFF, re-encode. The result is valid-format
+/// but guaranteed ≠ the real value, and is recomputable from the object.
+fn xor_first_byte_of_checksum(output: &mut s3s::dto::GetObjectOutput) {
+    for value in [
+        &mut output.checksum_crc32,
+        &mut output.checksum_crc32c,
+        &mut output.checksum_crc64nvme,
+        &mut output.checksum_sha1,
+        &mut output.checksum_sha256,
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if let Ok(mut raw) = base64::engine::general_purpose::STANDARD.decode(value.as_bytes()) {
+            if let Some(b) = raw.first_mut() {
+                *b ^= 0xFF;
+                *value = base64::engine::general_purpose::STANDARD.encode(&raw);
+                return;
+            }
+        }
+    }
+}
+
 /// Inner implementation of the s3s::S3 trait.
 ///
 /// This struct implements the s3s::S3 trait, delegating all operations to the storage backend.
@@ -82,12 +106,61 @@ fn has_any_checksum_get(o: &s3s::dto::GetObjectOutput) -> bool {
 pub(crate) struct Inner<S: StorageBackend + 'static> {
     /// The storage backend.
     storage: S,
+    /// Key-scoped fault injection registry.
+    faults: std::sync::Arc<crate::faults::FaultRegistry>,
 }
 
 impl<S: StorageBackend + 'static> Inner<S> {
-    /// Create a new Inner with the given storage backend.
+    /// Create a new Inner with the given storage backend (no faults).
+    #[cfg(test)]
     pub(crate) fn new(storage: S) -> Self {
-        Self { storage }
+        Self {
+            storage,
+            faults: std::sync::Arc::new(crate::faults::FaultRegistry::default()),
+        }
+    }
+
+    /// Create a new Inner sharing an external fault registry.
+    pub(crate) fn with_faults(
+        storage: S,
+        faults: std::sync::Arc<crate::faults::FaultRegistry>,
+    ) -> Self {
+        Self { storage, faults }
+    }
+
+    /// Apply a registered fault to a GET response, if one fires for this request.
+    /// Effects are deterministic transforms (XOR) so a faulted value is derivable.
+    async fn apply_get_fault(
+        &self,
+        bucket: &str,
+        key: &str,
+        output: &mut s3s::dto::GetObjectOutput,
+    ) -> S3Result<()> {
+        match self.faults.next_fault(bucket, key) {
+            Some(crate::faults::FaultType::WrongStoredChecksum) => {
+                xor_first_byte_of_checksum(output);
+            }
+            Some(crate::faults::FaultType::CorruptBody) => {
+                if let Some(body) = output.body.take() {
+                    let mut bytes = BytesMut::new();
+                    let mut stream = body;
+                    while let Some(chunk) = stream.next().await {
+                        let chunk =
+                            chunk.map_err(|e| Error::Internal(format!("Stream error: {}", e)))?;
+                        bytes.extend_from_slice(&chunk);
+                    }
+                    if let Some(b) = bytes.first_mut() {
+                        *b ^= 0xFF;
+                    }
+                    let bytes = bytes.freeze();
+                    output.body = Some(StreamingBlob::wrap(futures_util::stream::once(
+                        async move { Ok::<_, std::io::Error>(bytes) },
+                    )));
+                }
+            }
+            None => {}
+        }
+        Ok(())
     }
 }
 
@@ -185,6 +258,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         output.content_language = stream_metadata.content_language.map(|s| s.parse().unwrap());
 
         apply_response_defaults_get(&mut output);
+        self.apply_get_fault(bucket, key, &mut output).await?;
         Ok(S3Response::new(output))
     }
 

--- a/s3-mock-server/src/s3s.rs
+++ b/s3-mock-server/src/s3s.rs
@@ -182,7 +182,7 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         };
 
         // Convert s3s Range to std Range if present
-        let range = input
+        let mut range = input
             .range
             .as_ref()
             .map(|range_dto| {
@@ -191,6 +191,27 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
                     .map_err(|_| Error::InvalidRange)
             })
             .transpose()?;
+
+        // A partNumber GET returns exactly that stored part's bytes. Translate it
+        // to the part's byte range; the range path below then returns the part's
+        // data, Content-Range, and per-part checksum. parts_count is set on the
+        // response so callers learn the stored part count.
+        // For a non-multipart (single-PUT) object there are no stored parts:
+        // partNumber=1 returns the whole object, any higher number errors.
+        let parts_count = metadata.parts_count();
+        if let Some(pn) = input.part_number {
+            if parts_count == 0 {
+                if pn != 1 {
+                    return Err(Error::InvalidPart.into());
+                }
+                // pn == 1, single-PUT: leave range as-is (whole object).
+            } else {
+                match metadata.part_range(pn) {
+                    Some(r) => range = Some(r),
+                    None => return Err(Error::InvalidPart.into()),
+                }
+            }
+        }
 
         // Get object stream with validated range
         let request = crate::storage::GetObjectRequest {
@@ -247,6 +268,11 @@ impl<S: StorageBackend + 'static> s3s::S3 for Inner<S> {
         output.checksum_sha1 = stream_metadata.sha1;
         output.checksum_sha256 = stream_metadata.sha256;
         output.checksum_crc64nvme = stream_metadata.crc64nvme;
+
+        // A partNumber GET reports the object's stored part count.
+        if input.part_number.is_some() && parts_count > 1 {
+            output.parts_count = Some(parts_count as i32);
+        }
 
         // Return stored HTTP headers
         output.storage_class = stream_metadata.storage_class.map(|s| s.parse().unwrap());

--- a/s3-mock-server/src/server.rs
+++ b/s3-mock-server/src/server.rs
@@ -150,6 +150,7 @@ impl S3MockServerBuilder {
 
         Ok(S3MockServer {
             storage,
+            faults: Arc::new(crate::faults::FaultRegistry::default()),
             config: self.config,
         })
     }
@@ -222,6 +223,9 @@ pub struct S3MockServer {
     /// Storage backend.
     storage: Arc<dyn StorageBackend>,
 
+    /// Key-scoped fault injection registry (shared with the serving task).
+    faults: Arc<crate::faults::FaultRegistry>,
+
     /// Server configuration.
     config: ServerConfig,
 }
@@ -278,6 +282,27 @@ impl S3MockServer {
     /// Create a bucket in the mock server.
     pub async fn create_bucket(&self, bucket: &str) -> Result<()> {
         self.storage.create_bucket(bucket).await
+    }
+
+    /// Register a fault for `(bucket, key)`. Faults form an ordered queue
+    /// consumed over successive matching requests: `skip` matching requests pass
+    /// cleanly first, then the fault fires per `occurrence`. Deterministic and
+    /// traceable — every fire logs the request number under
+    /// `target: "s3_mock_server::fault"`.
+    pub fn insert_fault(
+        &self,
+        bucket: &str,
+        key: &str,
+        fault: crate::faults::FaultType,
+        skip: u32,
+        occurrence: crate::faults::Occurrence,
+    ) {
+        self.faults.insert(bucket, key, fault, skip, occurrence);
+    }
+
+    /// Drop the entire fault queue for `(bucket, key)`.
+    pub fn clear_fault(&self, bucket: &str, key: &str) {
+        self.faults.clear(bucket, key);
     }
 
     /// Check if an object exists.
@@ -368,11 +393,12 @@ impl S3MockServer {
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
 
         let storage = self.storage.clone();
+        let faults = self.faults.clone();
         let server_task = tokio::spawn(async move {
             let http_server = ConnBuilder::new(TokioExecutor::new());
             let graceful = hyper_util::server::graceful::GracefulShutdown::new();
 
-            let inner = Inner::new(storage);
+            let inner = Inner::with_faults(storage, faults);
             let service = {
                 let mut b = S3ServiceBuilder::new(inner);
                 b.set_auth(SimpleAuth::from_single(TEST_ACCESS_KEY, TEST_SECRET_KEY));

--- a/s3-mock-server/src/server.rs
+++ b/s3-mock-server/src/server.rs
@@ -285,9 +285,9 @@ impl S3MockServer {
     }
 
     /// Register a fault for `(bucket, key)`. Faults form an ordered queue
-    /// consumed over successive matching requests: `skip` matching requests pass
-    /// cleanly first, then the fault fires per `occurrence`. Deterministic and
-    /// traceable — every fire logs the request number under
+    /// consumed over successive matching requests: the first `skip` matching
+    /// requests pass cleanly, then the fault fires per `occurrence`. Firing is
+    /// deterministic; every fire logs the request number under
     /// `target: "s3_mock_server::fault"`.
     pub fn insert_fault(
         &self,

--- a/s3-mock-server/src/storage/filesystem.rs
+++ b/s3-mock-server/src/storage/filesystem.rs
@@ -21,7 +21,7 @@ use tokio::io::{AsyncSeekExt, AsyncWriteExt};
 use tokio_util::io::ReaderStream;
 
 use crate::error::{Error, Result};
-use crate::storage::models::{MultipartUploadMetadata, ObjectMetadata, PartMetadata};
+use crate::storage::models::{MultipartUploadMetadata, ObjectMetadata, ObjectPart, PartMetadata};
 use crate::storage::StorageBackend;
 use crate::types::StoredObjectMetadata;
 
@@ -294,6 +294,7 @@ impl StorageBackend for FilesystemStorage {
             content_encoding: request.content_encoding,
             content_disposition: request.content_disposition,
             content_language: request.content_language,
+            parts: Vec::new(),
         };
         let metadata_path = self.get_object_metadata_path(&request.bucket, &request.key);
         Self::save_metadata(&metadata_path, &metadata).await?;
@@ -350,10 +351,11 @@ impl StorageBackend for FilesystemStorage {
             Box::new(reader_stream)
         };
 
-        // Clear checksums for range requests since they apply to full object
+        // Range-aware checksums: an aligned range exposes the part's checksum,
+        // otherwise none apply (matches real S3).
         let mut response_metadata = metadata;
-        if request.range.is_some() {
-            response_metadata.clear_checksums();
+        if let Some(ref range) = request.range {
+            response_metadata.apply_range_checksums(range.start, range.end);
         }
 
         Ok(Some(crate::storage::GetObjectResponse {
@@ -584,7 +586,14 @@ impl StorageBackend for FilesystemStorage {
                 Some(aws_sdk_s3::types::ChecksumType::Composite) => {
                     if let Some(algorithm) = checksum_algorithm.as_ref() {
                         if let Some(part_checksum) = get_part_checksum(part_metadata, algorithm) {
-                            integrity_checks.update(part_checksum.as_bytes());
+                            // S3 computes the composite over the raw part-checksum
+                            // bytes, not their base64 text.
+                            if let Ok(raw) = base64::Engine::decode(
+                                &base64::engine::general_purpose::STANDARD,
+                                part_checksum,
+                            ) {
+                                integrity_checks.update(&raw);
+                            }
                         }
                     }
                 }
@@ -593,7 +602,14 @@ impl StorageBackend for FilesystemStorage {
                     // Future checksum types - default to composite behavior
                     if let Some(algorithm) = checksum_algorithm.as_ref() {
                         if let Some(part_checksum) = get_part_checksum(part_metadata, algorithm) {
-                            integrity_checks.update(part_checksum.as_bytes());
+                            // S3 computes the composite over the raw part-checksum
+                            // bytes, not their base64 text.
+                            if let Ok(raw) = base64::Engine::decode(
+                                &base64::engine::general_purpose::STANDARD,
+                                part_checksum,
+                            ) {
+                                integrity_checks.update(&raw);
+                            }
                         }
                     }
                 }
@@ -601,7 +617,26 @@ impl StorageBackend for FilesystemStorage {
         }
 
         // Finalize checksum calculation
-        let object_integrity = integrity_checks.finalize();
+        let mut object_integrity = integrity_checks.finalize();
+
+        // A composite checksum carries a `-<part_count>` suffix (e.g. `aB3..==-14`).
+        if matches!(
+            checksum_type,
+            Some(aws_sdk_s3::types::ChecksumType::Composite)
+        ) {
+            let n = part_metadata_list.len();
+            for v in [
+                &mut object_integrity.crc32,
+                &mut object_integrity.crc32c,
+                &mut object_integrity.sha1,
+                &mut object_integrity.sha256,
+            ]
+            .into_iter()
+            .flatten()
+            {
+                v.push_str(&format!("-{n}"));
+            }
+        }
 
         // Validate against client-provided checksum if present
         if let Some(client_checksums) = request.client_checksums {
@@ -615,6 +650,17 @@ impl StorageBackend for FilesystemStorage {
         final_metadata.content_length = total_size;
         final_metadata.etag = combined_etag.clone();
         final_metadata.last_modified = SystemTime::now();
+        final_metadata.parts = part_metadata_list
+            .iter()
+            .map(|(_, pm)| ObjectPart {
+                size: pm.size,
+                crc32: pm.crc32.clone(),
+                crc32c: pm.crc32c.clone(),
+                crc64nvme: pm.crc64nvme.clone(),
+                sha1: pm.sha1.clone(),
+                sha256: pm.sha256.clone(),
+            })
+            .collect();
 
         // Store calculated checksums in metadata
         final_metadata.crc32 = object_integrity.crc32.clone();

--- a/s3-mock-server/src/storage/in_memory.rs
+++ b/s3-mock-server/src/storage/in_memory.rs
@@ -15,7 +15,7 @@ use futures::{Stream, StreamExt};
 use tokio::sync::RwLock;
 
 use crate::error::{Error, Result};
-use crate::storage::models::{MultipartUploadMetadata, ObjectMetadata, PartMetadata};
+use crate::storage::models::{MultipartUploadMetadata, ObjectMetadata, ObjectPart, PartMetadata};
 use crate::storage::StorageBackend;
 use crate::streaming::{apply_range, VecByteStream};
 use crate::types::StoredObjectMetadata;
@@ -106,6 +106,7 @@ impl StorageBackend for InMemoryStorage {
             content_encoding: request.content_encoding,
             content_disposition: request.content_disposition,
             content_language: request.content_language,
+            parts: Vec::new(),
         };
 
         let mut buckets = self.buckets.write().await;
@@ -134,7 +135,7 @@ impl StorageBackend for InMemoryStorage {
             None => return Ok(None),
         };
 
-        let is_range_request = request.range.is_some();
+        let range_bounds = request.range.clone();
         let data = if let Some(range) = request.range {
             apply_range(data, range)
         } else {
@@ -147,8 +148,8 @@ impl StorageBackend for InMemoryStorage {
         > = Box::new(stream);
 
         let mut response_metadata = metadata.clone();
-        if is_range_request {
-            response_metadata.clear_checksums();
+        if let Some(range) = range_bounds {
+            response_metadata.apply_range_checksums(range.start, range.end);
         }
 
         Ok(Some(crate::storage::GetObjectResponse {
@@ -411,6 +412,14 @@ impl StorageBackend for InMemoryStorage {
                 combined.extend_from_slice(part_data);
                 etags.push(part_metadata.etag.clone());
                 total_size += part_metadata.size;
+                final_metadata.parts.push(ObjectPart {
+                    size: part_metadata.size,
+                    crc32: part_metadata.crc32.clone(),
+                    crc32c: part_metadata.crc32c.clone(),
+                    crc64nvme: part_metadata.crc64nvme.clone(),
+                    sha1: part_metadata.sha1.clone(),
+                    sha256: part_metadata.sha256.clone(),
+                });
             }
         }
 
@@ -459,7 +468,14 @@ impl StorageBackend for InMemoryStorage {
                             };
 
                             if let Some(checksum) = part_checksum {
-                                integrity_checks.update(checksum.as_bytes());
+                                // S3 computes the composite over the raw part-checksum
+                                // bytes, not their base64 text.
+                                if let Ok(raw) = base64::Engine::decode(
+                                    &base64::engine::general_purpose::STANDARD,
+                                    checksum,
+                                ) {
+                                    integrity_checks.update(&raw);
+                                }
                             }
                         }
                     }
@@ -488,7 +504,14 @@ impl StorageBackend for InMemoryStorage {
                             };
 
                             if let Some(checksum) = part_checksum {
-                                integrity_checks.update(checksum.as_bytes());
+                                // S3 computes the composite over the raw part-checksum
+                                // bytes, not their base64 text.
+                                if let Ok(raw) = base64::Engine::decode(
+                                    &base64::engine::general_purpose::STANDARD,
+                                    checksum,
+                                ) {
+                                    integrity_checks.update(&raw);
+                                }
                             }
                         }
                     }
@@ -496,7 +519,26 @@ impl StorageBackend for InMemoryStorage {
             }
         }
 
-        let object_integrity = integrity_checks.finalize();
+        let mut object_integrity = integrity_checks.finalize();
+
+        // A composite checksum carries a `-<part_count>` suffix (e.g. `aB3..==-14`).
+        if matches!(
+            checksum_type,
+            Some(aws_sdk_s3::types::ChecksumType::Composite)
+        ) {
+            let n = request.parts.len();
+            for v in [
+                &mut object_integrity.crc32,
+                &mut object_integrity.crc32c,
+                &mut object_integrity.sha1,
+                &mut object_integrity.sha256,
+            ]
+            .into_iter()
+            .flatten()
+            {
+                v.push_str(&format!("-{n}"));
+            }
+        }
 
         // Validate against client-provided checksum if present
         if let Some(client_checksums) = request.client_checksums {

--- a/s3-mock-server/src/storage/models.rs
+++ b/s3-mock-server/src/storage/models.rs
@@ -139,10 +139,18 @@ impl ObjectMetadata {
     }
 
     /// Resolve the checksum headers for a ranged GET, matching real S3:
-    /// if `[start, end)` exactly matches one part boundary, expose that part's
-    /// individual checksum (no `-N` suffix); otherwise no checksum applies.
+    /// a range covering the whole object keeps the object-level checksum; a range
+    /// matching one part boundary of a multipart object exposes that part's
+    /// individual checksum (no `-N` suffix); any other range has no checksum.
     /// `end` is exclusive.
     pub(crate) fn apply_range_checksums(&mut self, start: u64, end: u64) {
+        // A whole-object range keeps the object-level checksum. Covers single-PUT
+        // objects (no parts) and a multipart object's combined value. Verified
+        // against real S3: a ranged GET covering the whole object returns the
+        // full-object checksum.
+        if start == 0 && end == self.content_length {
+            return;
+        }
         let mut offset = 0u64;
         for part in &self.parts {
             if start == offset && end == offset + part.size {

--- a/s3-mock-server/src/storage/models.rs
+++ b/s3-mock-server/src/storage/models.rs
@@ -106,8 +106,26 @@ pub(crate) struct ObjectMetadata {
     pub server_side_encryption: Option<String>,
     pub cache_control: Option<String>,
     pub content_encoding: Option<String>,
-    pub content_disposition: Option<String>,
     pub content_language: Option<String>,
+    pub content_disposition: Option<String>,
+
+    /// Part boundaries + per-part checksums for a completed multipart object,
+    /// in part order. Empty for single-PUT objects. Enables range-aware checksum
+    /// responses: a GET whose range exactly matches a part boundary returns that
+    /// part's checksum (matching real S3).
+    #[serde(default)]
+    pub parts: Vec<ObjectPart>,
+}
+
+/// A completed multipart object's part: its size and per-algorithm checksum.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct ObjectPart {
+    pub size: u64,
+    pub crc32: Option<String>,
+    pub crc32c: Option<String>,
+    pub crc64nvme: Option<String>,
+    pub sha1: Option<String>,
+    pub sha256: Option<String>,
 }
 
 impl ObjectMetadata {
@@ -118,6 +136,26 @@ impl ObjectMetadata {
         self.crc64nvme = None;
         self.sha1 = None;
         self.sha256 = None;
+    }
+
+    /// Resolve the checksum headers for a ranged GET, matching real S3:
+    /// if `[start, end)` exactly matches one part boundary, expose that part's
+    /// individual checksum (no `-N` suffix); otherwise no checksum applies.
+    /// `end` is exclusive.
+    pub(crate) fn apply_range_checksums(&mut self, start: u64, end: u64) {
+        let mut offset = 0u64;
+        for part in &self.parts {
+            if start == offset && end == offset + part.size {
+                self.crc32 = part.crc32.clone();
+                self.crc32c = part.crc32c.clone();
+                self.crc64nvme = part.crc64nvme.clone();
+                self.sha1 = part.sha1.clone();
+                self.sha256 = part.sha256.clone();
+                return;
+            }
+            offset += part.size;
+        }
+        self.clear_checksums();
     }
 }
 
@@ -141,6 +179,7 @@ impl Default for ObjectMetadata {
             content_encoding: None,
             content_disposition: None,
             content_language: None,
+            parts: Vec::new(),
         }
     }
 }

--- a/s3-mock-server/src/storage/models.rs
+++ b/s3-mock-server/src/storage/models.rs
@@ -165,6 +165,28 @@ impl ObjectMetadata {
         }
         self.clear_checksums();
     }
+
+    /// Byte range `[start, end)` of the 1-based `part_number` for a completed
+    /// multipart object, from the stored part boundaries. `None` if the object
+    /// has no parts (single-PUT) or the part number is out of range. Matches S3's
+    /// `partNumber` GET, which returns exactly that part's bytes.
+    pub(crate) fn part_range(&self, part_number: i32) -> Option<std::ops::Range<u64>> {
+        if part_number < 1 {
+            return None;
+        }
+        let idx = (part_number - 1) as usize;
+        if idx >= self.parts.len() {
+            return None;
+        }
+        let start: u64 = self.parts[..idx].iter().map(|p| p.size).sum();
+        let end = start + self.parts[idx].size;
+        Some(start..end)
+    }
+
+    /// Number of stored parts for a completed multipart object (0 for single-PUT).
+    pub(crate) fn parts_count(&self) -> usize {
+        self.parts.len()
+    }
 }
 
 impl Default for ObjectMetadata {

--- a/s3-mock-server/src/types.rs
+++ b/s3-mock-server/src/types.rs
@@ -7,6 +7,7 @@
 
 use aws_smithy_checksums::ChecksumAlgorithm;
 use std::collections::HashMap;
+use std::str::FromStr;
 
 /// Client-provided checksums from S3 API requests
 #[derive(Debug, Clone)]
@@ -256,6 +257,33 @@ impl ObjectIntegrity {
 #[derive(Debug, Clone)]
 pub struct StoredObjectMetadata {
     pub object_integrity: ObjectIntegrity,
+}
+
+/// S3-faithful composite multipart checksum: hash the RAW (base64-decoded) per-part
+/// checksum bytes, base64-encode, and append `-<part_count>`. Verified against real S3.
+pub fn composite_checksum(
+    part_checksums: &[String],
+    algorithm: aws_sdk_s3::types::ChecksumAlgorithm,
+) -> String {
+    use base64::Engine;
+
+    let smithy_algorithm = aws_smithy_checksums::ChecksumAlgorithm::from_str(algorithm.as_str())
+        .expect("unsupported checksum algorithm");
+
+    let raw: Vec<u8> = part_checksums
+        .iter()
+        .flat_map(|c| {
+            base64::engine::general_purpose::STANDARD
+                .decode(c)
+                .expect("invalid base64 part checksum")
+        })
+        .collect();
+
+    let mut hasher = smithy_algorithm.into_impl();
+    hasher.update(&raw);
+    let digest = hasher.finalize();
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&digest);
+    format!("{}-{}", encoded, part_checksums.len())
 }
 
 #[cfg(test)]

--- a/s3-mock-server/tests/checksums.rs
+++ b/s3-mock-server/tests/checksums.rs
@@ -77,16 +77,7 @@ fn calculate_checksum(data: &[u8], algorithm: ChecksumAlgorithm) -> String {
 /// S3-faithful composite value: hash the RAW (decoded) part checksum bytes,
 /// base64-encode, and append `-<part_count>`.
 fn expected_composite(part_checksums: &[String], algorithm: ChecksumAlgorithm) -> String {
-    use base64::Engine;
-    let raw: Vec<u8> = part_checksums
-        .iter()
-        .flat_map(|c| base64::engine::general_purpose::STANDARD.decode(c).unwrap())
-        .collect();
-    format!(
-        "{}-{}",
-        calculate_checksum(&raw, algorithm),
-        part_checksums.len()
-    )
+    s3_mock_server::composite_checksum(part_checksums, algorithm)
 }
 
 // ============================================================================

--- a/s3-mock-server/tests/checksums.rs
+++ b/s3-mock-server/tests/checksums.rs
@@ -848,7 +848,6 @@ async fn run_multipart_composite_checksum(
     Ok(())
 }
 
-/// P4 — ranged-GET checksum fidelity (mirrors real-S3 verification 4).
 /// A composite MPU object: an aligned ranged GET returns that part's individual
 /// checksum (no `-N`); an unaligned range returns none; whole-object returns `-N`.
 async fn run_ranged_get_checksum_fidelity(storage_type: StorageType) -> Result<()> {
@@ -989,6 +988,145 @@ async fn test_ranged_get_checksum_fidelity_in_memory() -> Result<()> {
 #[tokio::test]
 async fn test_ranged_get_checksum_fidelity_filesystem() -> Result<()> {
     run_ranged_get_checksum_fidelity(StorageType::Filesystem).await
+}
+
+/// A `partNumber=N` GET returns exactly that stored part's bytes, the part's own
+/// checksum (no `-N`), `parts_count`, and a `Content-Range` with the total object
+/// size. This is the contract the TM's download range-alignment relies on; pin it
+/// so the mock cannot silently diverge from S3.
+async fn run_part_number_get_fidelity(storage_type: StorageType) -> Result<()> {
+    let (server, bucket) = create_server(storage_type).await?;
+    let handle = server.start().await?;
+    let s3 = handle.client().await;
+
+    let key = "test-part-number-fidelity.bin";
+    // Uniform interior + smaller tail (the ragged-tail case).
+    let part1 = vec![0x11u8; 4096];
+    let part2 = vec![0x22u8; 4096];
+    let part3 = vec![0x33u8; 1024];
+    let c1 = calculate_checksum(&part1, ChecksumAlgorithm::Crc32);
+    let c2 = calculate_checksum(&part2, ChecksumAlgorithm::Crc32);
+    let c3 = calculate_checksum(&part3, ChecksumAlgorithm::Crc32);
+    let total = (part1.len() + part2.len() + part3.len()) as u64;
+
+    let upload_id = s3
+        .create_multipart_upload()
+        .bucket(&bucket)
+        .key(key)
+        .checksum_algorithm(ChecksumAlgorithm::Crc32)
+        .send()
+        .await?
+        .upload_id()
+        .unwrap()
+        .to_string();
+
+    let mut etags = Vec::new();
+    for (i, (part, c)) in [(&part1, &c1), (&part2, &c2), (&part3, &c3)]
+        .iter()
+        .enumerate()
+    {
+        let etag = s3
+            .upload_part()
+            .bucket(&bucket)
+            .key(key)
+            .upload_id(&upload_id)
+            .part_number(i as i32 + 1)
+            .body(Bytes::from((*part).clone()).into())
+            .checksum_crc32((*c).clone())
+            .send()
+            .await?
+            .e_tag()
+            .unwrap()
+            .to_string();
+        etags.push(etag);
+    }
+
+    s3.complete_multipart_upload()
+        .bucket(&bucket)
+        .key(key)
+        .upload_id(&upload_id)
+        .multipart_upload(
+            CompletedMultipartUpload::builder()
+                .parts(
+                    CompletedPart::builder()
+                        .part_number(1)
+                        .e_tag(&etags[0])
+                        .checksum_crc32(&c1)
+                        .build(),
+                )
+                .parts(
+                    CompletedPart::builder()
+                        .part_number(2)
+                        .e_tag(&etags[1])
+                        .checksum_crc32(&c2)
+                        .build(),
+                )
+                .parts(
+                    CompletedPart::builder()
+                        .part_number(3)
+                        .e_tag(&etags[2])
+                        .checksum_crc32(&c3)
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await?;
+
+    // partNumber=1 → part 1's bytes + checksum + parts_count + Content-Range/total.
+    let r = s3
+        .get_object()
+        .bucket(&bucket)
+        .key(key)
+        .part_number(1)
+        .checksum_mode(aws_sdk_s3::types::ChecksumMode::Enabled)
+        .send()
+        .await?;
+    assert_eq!(r.checksum_crc32(), Some(c1.as_str()), "part1 checksum");
+    assert_eq!(r.parts_count(), Some(3), "parts_count");
+    assert_eq!(r.content_length(), Some(part1.len() as i64), "part1 length");
+    assert_eq!(
+        r.content_range(),
+        Some(format!("bytes 0-{}/{}", part1.len() - 1, total).as_str()),
+        "part1 content-range carries total size"
+    );
+
+    // partNumber=3 → the ragged tail's bytes + checksum.
+    let r = s3
+        .get_object()
+        .bucket(&bucket)
+        .key(key)
+        .part_number(3)
+        .checksum_mode(aws_sdk_s3::types::ChecksumMode::Enabled)
+        .send()
+        .await?;
+    assert_eq!(r.checksum_crc32(), Some(c3.as_str()), "tail part checksum");
+    assert_eq!(r.content_length(), Some(part3.len() as i64), "tail length");
+    let body = r.body.collect().await?.to_vec();
+    assert_eq!(body, part3, "tail part bytes");
+
+    // Out-of-range part number → error (not a panic, not wrong data).
+    let err = s3
+        .get_object()
+        .bucket(&bucket)
+        .key(key)
+        .part_number(99)
+        .send()
+        .await;
+    assert!(err.is_err(), "out-of-range partNumber must error");
+
+    handle.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_part_number_get_fidelity_in_memory() -> Result<()> {
+    run_part_number_get_fidelity(StorageType::InMemory).await
+}
+
+#[tokio::test]
+async fn test_part_number_get_fidelity_filesystem() -> Result<()> {
+    run_part_number_get_fidelity(StorageType::Filesystem).await
 }
 
 /// Test CompleteMultipartUpload with incorrect composite checksum (should fail with BadDigest)

--- a/s3-mock-server/tests/checksums.rs
+++ b/s3-mock-server/tests/checksums.rs
@@ -74,6 +74,21 @@ fn calculate_checksum(data: &[u8], algorithm: ChecksumAlgorithm) -> String {
     }
 }
 
+/// S3-faithful composite value: hash the RAW (decoded) part checksum bytes,
+/// base64-encode, and append `-<part_count>`.
+fn expected_composite(part_checksums: &[String], algorithm: ChecksumAlgorithm) -> String {
+    use base64::Engine;
+    let raw: Vec<u8> = part_checksums
+        .iter()
+        .flat_map(|c| base64::engine::general_purpose::STANDARD.decode(c).unwrap())
+        .collect();
+    format!(
+        "{}-{}",
+        calculate_checksum(&raw, algorithm),
+        part_checksums.len()
+    )
+}
+
 // ============================================================================
 // SINGLE PART UPLOAD TESTS
 // ============================================================================
@@ -770,16 +785,16 @@ async fn run_multipart_composite_checksum(
 
     match algorithm {
         ChecksumAlgorithm::Crc32 => {
-            part1_request = part1_request.checksum_crc32(part1_checksum);
-            part2_request = part2_request.checksum_crc32(part2_checksum);
+            part1_request = part1_request.checksum_crc32(part1_checksum.clone());
+            part2_request = part2_request.checksum_crc32(part2_checksum.clone());
         }
         ChecksumAlgorithm::Sha1 => {
-            part1_request = part1_request.checksum_sha1(part1_checksum);
-            part2_request = part2_request.checksum_sha1(part2_checksum);
+            part1_request = part1_request.checksum_sha1(part1_checksum.clone());
+            part2_request = part2_request.checksum_sha1(part2_checksum.clone());
         }
         ChecksumAlgorithm::Sha256 => {
-            part1_request = part1_request.checksum_sha256(part1_checksum);
-            part2_request = part2_request.checksum_sha256(part2_checksum);
+            part1_request = part1_request.checksum_sha256(part1_checksum.clone());
+            part2_request = part2_request.checksum_sha256(part2_checksum.clone());
         }
         _ => panic!("Unsupported algorithm for composite: {:?}", algorithm),
     }
@@ -815,22 +830,165 @@ async fn run_multipart_composite_checksum(
     // Should complete successfully with ETag
     assert!(response.e_tag().is_some());
 
-    // Should validate composite checksum and return it in response
-    match algorithm {
-        ChecksumAlgorithm::Crc32 => {
-            assert!(response.checksum_crc32().is_some());
-        }
-        ChecksumAlgorithm::Sha1 => {
-            assert!(response.checksum_sha1().is_some());
-        }
-        ChecksumAlgorithm::Sha256 => {
-            assert!(response.checksum_sha256().is_some());
-        }
+    // Should validate composite checksum and return the S3-faithful value:
+    // hash of the raw part-checksum bytes, with a `-<part_count>` suffix.
+    let expected = expected_composite(
+        &[part1_checksum.clone(), part2_checksum.clone()],
+        algorithm.clone(),
+    );
+    let actual = match algorithm {
+        ChecksumAlgorithm::Crc32 => response.checksum_crc32(),
+        ChecksumAlgorithm::Sha1 => response.checksum_sha1(),
+        ChecksumAlgorithm::Sha256 => response.checksum_sha256(),
         _ => panic!("Unsupported algorithm: {:?}", algorithm),
-    }
+    };
+    assert_eq!(actual, Some(expected.as_str()));
 
     handle.shutdown().await?;
     Ok(())
+}
+
+/// P4 — ranged-GET checksum fidelity (mirrors real-S3 verification 4).
+/// A composite MPU object: an aligned ranged GET returns that part's individual
+/// checksum (no `-N`); an unaligned range returns none; whole-object returns `-N`.
+async fn run_ranged_get_checksum_fidelity(storage_type: StorageType) -> Result<()> {
+    let (server, bucket) = create_server(storage_type).await?;
+    let handle = server.start().await?;
+    let s3 = handle.client().await;
+
+    let key = "test-ranged-get-fidelity.bin";
+    // Two distinct parts; sizes need not be >=5MiB (mock doesn't enforce it).
+    let part1 = vec![0xABu8; 4096];
+    let part2 = vec![0xCDu8; 2048];
+    let c1 = calculate_checksum(&part1, ChecksumAlgorithm::Crc32);
+    let c2 = calculate_checksum(&part2, ChecksumAlgorithm::Crc32);
+
+    let upload_id = s3
+        .create_multipart_upload()
+        .bucket(&bucket)
+        .key(key)
+        .checksum_algorithm(ChecksumAlgorithm::Crc32)
+        .send()
+        .await?
+        .upload_id()
+        .unwrap()
+        .to_string();
+
+    let e1 = s3
+        .upload_part()
+        .bucket(&bucket)
+        .key(key)
+        .upload_id(&upload_id)
+        .part_number(1)
+        .body(Bytes::from(part1.clone()).into())
+        .checksum_crc32(c1.clone())
+        .send()
+        .await?
+        .e_tag()
+        .unwrap()
+        .to_string();
+    let e2 = s3
+        .upload_part()
+        .bucket(&bucket)
+        .key(key)
+        .upload_id(&upload_id)
+        .part_number(2)
+        .body(Bytes::from(part2.clone()).into())
+        .checksum_crc32(c2.clone())
+        .send()
+        .await?
+        .e_tag()
+        .unwrap()
+        .to_string();
+
+    s3.complete_multipart_upload()
+        .bucket(&bucket)
+        .key(key)
+        .upload_id(&upload_id)
+        .multipart_upload(
+            CompletedMultipartUpload::builder()
+                .parts(
+                    CompletedPart::builder()
+                        .part_number(1)
+                        .e_tag(e1)
+                        .checksum_crc32(c1.clone())
+                        .build(),
+                )
+                .parts(
+                    CompletedPart::builder()
+                        .part_number(2)
+                        .e_tag(e2)
+                        .checksum_crc32(c2.clone())
+                        .build(),
+                )
+                .build(),
+        )
+        .send()
+        .await?;
+
+    let whole = expected_composite(&[c1.clone(), c2.clone()], ChecksumAlgorithm::Crc32);
+    let len1 = part1.len() as u64;
+    let len2 = part2.len() as u64;
+
+    // Aligned to part 1 → part1's own checksum, NO `-N`.
+    let r = s3
+        .get_object()
+        .bucket(&bucket)
+        .key(key)
+        .range(format!("bytes=0-{}", len1 - 1))
+        .checksum_mode(aws_sdk_s3::types::ChecksumMode::Enabled)
+        .send()
+        .await?;
+    assert_eq!(r.checksum_crc32(), Some(c1.as_str()), "aligned part1 range");
+
+    // Aligned to part 2 → part2's own checksum.
+    let r = s3
+        .get_object()
+        .bucket(&bucket)
+        .key(key)
+        .range(format!("bytes={}-{}", len1, len1 + len2 - 1))
+        .checksum_mode(aws_sdk_s3::types::ChecksumMode::Enabled)
+        .send()
+        .await?;
+    assert_eq!(r.checksum_crc32(), Some(c2.as_str()), "aligned part2 range");
+
+    // Unaligned range → no checksum.
+    let r = s3
+        .get_object()
+        .bucket(&bucket)
+        .key(key)
+        .range("bytes=10-100")
+        .checksum_mode(aws_sdk_s3::types::ChecksumMode::Enabled)
+        .send()
+        .await?;
+    assert_eq!(r.checksum_crc32(), None, "unaligned range");
+
+    // Whole-object GET → composite `-N` value.
+    let r = s3
+        .get_object()
+        .bucket(&bucket)
+        .key(key)
+        .checksum_mode(aws_sdk_s3::types::ChecksumMode::Enabled)
+        .send()
+        .await?;
+    assert_eq!(
+        r.checksum_crc32(),
+        Some(whole.as_str()),
+        "whole-object composite"
+    );
+
+    handle.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_ranged_get_checksum_fidelity_in_memory() -> Result<()> {
+    run_ranged_get_checksum_fidelity(StorageType::InMemory).await
+}
+
+#[tokio::test]
+async fn test_ranged_get_checksum_fidelity_filesystem() -> Result<()> {
+    run_ranged_get_checksum_fidelity(StorageType::Filesystem).await
 }
 
 /// Test CompleteMultipartUpload with incorrect composite checksum (should fail with BadDigest)

--- a/s3-mock-server/tests/faults.rs
+++ b/s3-mock-server/tests/faults.rs
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end fault-injection tests: a registered fault makes the validating
+//! SDK GET fail. Registry state-machine semantics (skip/occurrence/queue) are
+//! unit-tested in `src/faults.rs`; these assert the observable download outcome.
+
+use aws_sdk_s3::types::{ChecksumAlgorithm, ChecksumMode};
+use bytes::Bytes;
+use s3_mock_server::{FaultType, Occurrence, S3MockServer, ServerHandle};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
+
+const B: &str = "faults";
+const K: &str = "obj";
+const BODY: &[u8] = b"hello world, this is the body";
+
+async fn seed(handle: &ServerHandle) -> Result<()> {
+    let s3 = handle.client().await;
+    s3.create_bucket().bucket(B).send().await.ok();
+    s3.put_object()
+        .bucket(B)
+        .key(K)
+        .body(Bytes::copy_from_slice(BODY).into())
+        .checksum_algorithm(ChecksumAlgorithm::Crc32)
+        .send()
+        .await?;
+    Ok(())
+}
+
+/// A validating GET that fully reads the body. Ok(()) = validated clean,
+/// Err = the SDK rejected the (faulted) response.
+async fn validating_get(handle: &ServerHandle) -> Result<()> {
+    let s3 = handle.client().await;
+    let resp = s3
+        .get_object()
+        .bucket(B)
+        .key(K)
+        .checksum_mode(ChecksumMode::Enabled)
+        .send()
+        .await?;
+    let _ = resp.body.collect().await?; // checksum validated on full read
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_wrong_stored_checksum_fails_validating_get() -> Result<()> {
+    let server = S3MockServer::builder().with_in_memory_store().build()?;
+    let handle = server.start().await?;
+    seed(&handle).await?;
+
+    validating_get(&handle).await.expect("clean before fault");
+    server.insert_fault(B, K, FaultType::WrongStoredChecksum, 0, Occurrence::Always);
+    assert!(
+        validating_get(&handle).await.is_err(),
+        "wrong checksum must fail the GET"
+    );
+
+    handle.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_corrupt_body_fails_validating_get() -> Result<()> {
+    let server = S3MockServer::builder().with_in_memory_store().build()?;
+    let handle = server.start().await?;
+    seed(&handle).await?;
+
+    server.insert_fault(B, K, FaultType::CorruptBody, 0, Occurrence::Always);
+    // Body bytes are tampered but the checksum header is intact → validation
+    // catches the corruption (proves we validate content, not just compare headers).
+    assert!(
+        validating_get(&handle).await.is_err(),
+        "corrupt body must fail the GET"
+    );
+
+    handle.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_skip_warms_up_then_fails() -> Result<()> {
+    let server = S3MockServer::builder().with_in_memory_store().build()?;
+    let handle = server.start().await?;
+    seed(&handle).await?;
+
+    // Two clean GETs (warm-up), then fail.
+    server.insert_fault(B, K, FaultType::WrongStoredChecksum, 2, Occurrence::Always);
+    validating_get(&handle).await.expect("req 1 clean");
+    validating_get(&handle).await.expect("req 2 clean");
+    assert!(validating_get(&handle).await.is_err(), "req 3 faulted");
+
+    handle.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_once_then_recovers() -> Result<()> {
+    let server = S3MockServer::builder().with_in_memory_store().build()?;
+    let handle = server.start().await?;
+    seed(&handle).await?;
+
+    server.insert_fault(B, K, FaultType::WrongStoredChecksum, 0, Occurrence::Once);
+    assert!(validating_get(&handle).await.is_err(), "first GET faulted");
+    validating_get(&handle).await.expect("second GET recovers");
+
+    handle.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_clear_fault_recovers() -> Result<()> {
+    let server = S3MockServer::builder().with_in_memory_store().build()?;
+    let handle = server.start().await?;
+    seed(&handle).await?;
+
+    server.insert_fault(B, K, FaultType::WrongStoredChecksum, 0, Occurrence::Always);
+    assert!(validating_get(&handle).await.is_err());
+    server.clear_fault(B, K);
+    validating_get(&handle).await.expect("cleared → clean");
+
+    handle.shutdown().await?;
+    Ok(())
+}

--- a/s3-mock-server/tests/faults.rs
+++ b/s3-mock-server/tests/faults.rs
@@ -43,6 +43,37 @@ async fn validating_get(handle: &ServerHandle) -> Result<()> {
     Ok(())
 }
 
+/// Same but with a whole-object RANGE (bytes=0-(len-1)), like the TM's discovery GET.
+async fn validating_ranged_get(handle: &ServerHandle) -> Result<()> {
+    let s3 = handle.client().await;
+    let resp = s3
+        .get_object()
+        .bucket(B)
+        .key(K)
+        .range(format!("bytes=0-{}", BODY.len() - 1))
+        .checksum_mode(ChecksumMode::Enabled)
+        .send()
+        .await?;
+    let _ = resp.body.collect().await?;
+    Ok(())
+}
+
+/// A ranged whole-object GET (as the transfer manager issues for discovery) of a
+/// corrupted body must fail the SDK's checksum validation.
+#[tokio::test]
+async fn test_ranged_get_corrupt_body_fails_validation() -> Result<()> {
+    let server = S3MockServer::builder().with_in_memory_store().build()?;
+    let handle = server.start().await?;
+    seed(&handle).await?;
+    server.insert_fault(B, K, FaultType::CorruptBody, 0, Occurrence::Always);
+    assert!(
+        validating_ranged_get(&handle).await.is_err(),
+        "ranged GET corrupt body should fail validation"
+    );
+    handle.shutdown().await?;
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_wrong_stored_checksum_fails_validating_get() -> Result<()> {
     let server = S3MockServer::builder().with_in_memory_store().build()?;


### PR DESCRIPTION
## Summary

Make transfer manager downloads validate object checksums, report the result on the download output, and add the test infrastructure to keep it honest: a mock and real-S3 integrity contract suite, mock fault injection, and mock checksum fidelity fixes. Checksums are the largest remaining gap before merging `s3-tm-vnext` into `main`. Branches off `s3-tm-vnext` (`15ec23b`, after #148).

## Why

Download validation did not work. A download is sliced into ranged GETs at a fixed part size (Auto = 5 MiB) that ignores the object's stored layout. S3 returns a per-part checksum only when a ranged GET matches a stored part boundary, so an object uploaded multipart (Auto upload part = 8 MiB) and downloaded with defaults produced ranges that never aligned, and nothing was validated. The output also carried no checksum information, so a caller could not tell whether anything was checked.

Fixing this surfaced two latent bugs. First, `execute_get_range` hand-built each chunk GET with only bucket/key/range/if_match, dropping the other 17 fields the `From<DownloadInput>` conversion sets. Besides `checksum_mode` (the reason nothing validated), this dropped the SSE-C customer key (encrypted multipart range GETs would 400), `version_id` (a range chunk could read a different version than discovery pinned), `request_payer`, `expected_bucket_owner`, and the response-header overrides. Second, the error paths decremented the in-flight range count before transitioning to terminal, so a concurrent `poll_work` woken in between could observe `ranges_in_flight == 0` and `complete()` the transfer over a `ChecksumMismatch` on the last chunk, reporting success.

## How to review

Commit by commit. Each is self-contained and builds on the last.

1. [ensure inputs are propagated](https://github.com/awslabs/aws-s3-transfer-manager-rs/commit/1fa8674422db42596f331f2467a69e1feb8c01be) — range-GET field forwarding. `execute_get_range` builds from `From<DownloadInput>` then overrides range + etag, so every chunk carries the same fields as discovery. Smallest commit, independent of checksums; start here.
2. [improve checksum fidelity](https://github.com/awslabs/aws-s3-transfer-manager-rs/commit/4adc45dd472c0d23cdb09fc052d23e1d17585457) — mock-server composite and ranged-GET checksum behavior. Composite was hashing the base64 text of the part checksums (now decodes to raw bytes) and omitting the `-N` suffix; GET was range-blind (now returns the part checksum on an aligned range, none on an unaligned one, the object value on a whole-object GET). Mock only.
3. [bootstrap fault injection](https://github.com/awslabs/aws-s3-transfer-manager-rs/commit/284bb0d7e1617ff875c9547d9beba2d09844ef57) — `faults.rs`: a key-scoped ordered fault queue, `skip` warm-up orthogonal to `Occurrence` (Once/NTimes/Always), no RNG, every fire logged. Two checksum variants (`WrongStoredChecksum`, `CorruptBody`) applied in `get_object`. A general test primitive, not checksum-specific.
4. [define integrity checks](https://github.com/awslabs/aws-s3-transfer-manager-rs/commit/4c52f565f35a4924ec19ccc6ee369fab402e0167) — `IntegrityChecks` / `ChecksumValidation` / `NotValidatedReason` in `crate::types`, exposed via `DownloadOutput::integrity_checks()`, computed in `build_integrity_checks`. Read the type docs for the semantics.
5. [fix download terminal race](https://github.com/awslabs/aws-s3-transfer-manager-rs/commit/4962a411df4e36142c1d8cc2439494a6c9fcc334) — error paths go terminal under the lock before any wake. See the comments at `fail_range` and the two body-error sites.
6. [fill in integrity tests](https://github.com/awslabs/aws-s3-transfer-manager-rs/commit/59b391a7b5f4b5e7dcb83e2660c7227e6a613de3) — `harness.rs` (`Target = Backend × BucketKind`, one body per cell) and `integrity.rs` (assert outcomes: bytes round-trip; every guarantee has a paired tamper-must-error test).
7. [auto align multipart size](https://github.com/awslabs/aws-s3-transfer-manager-rs/commit/460b80ba3f78b0a1cb209db5a2602cec910166cd) — the validate-by-default mechanism. `discover_obj` re-issues discovery with `partNumber=1` to learn the stored part size and threads it through `effective_part_size` → `Transferring.part_size` → the range slicer. Also drops the now-dead `async-channel`/`blocking` deps.
8. [wire up express and prod s3 into harness](https://github.com/awslabs/aws-s3-transfer-manager-rs/commit/b7e80a015d44135ad4893ed30ad343218e7e6f0a) — real-S3 and S3 Express targets behind `--cfg e2e_test`, un-ignores `test_objects_transfer`, runs the suite in CI's e2e step.

## How it works

### Range alignment

When validation is on, there is no user range, the object is multipart (ETag carries `-N`), and the user has not pinned an explicit part size, `discover_obj` issues a second discovery GET with `partNumber=1`. Its `Content-Range` reports the exact first-part length, which is the stored part size. Total size and part count from a ranged response cannot give this: a multipart object's parts are (typically) uniform except a possibly-smaller last part, so `total / N` is ambiguous, and only a `partNumber` GET returns the stored size exactly. That size becomes `effective_part_size`, carried into `Transferring.part_size`, so every subsequent range aligns to a stored boundary (including the ragged tail) and S3 returns each part's checksum for the SDK to validate. It costs one extra headers-mostly request, only on this path. An explicit user part size is respected as set and validates only if it matches the upload.

### Integrity result

`DownloadOutput::integrity_checks()` returns the object's reported checksum values and a `ChecksumValidation` verdict. Values are surfaced only when the whole object arrived in the discovery chunk; a multipart object's discovery chunk carries part 1's checksum, not the object's, so its value members stay `None`. `Validated { algorithm }` means the entire delivered object was covered and matched; anything less is `NotValidated { reason }`. A checksum mismatch is not represented here, it is an `Err` from `join()`.

The verdict is currently conservative: `NotValidated { Unavailable }` when validation is enabled, `NotValidated { Disabled }` when it is not. Reporting `Validated` requires a per-response validation outcome from the SDK, which validates lazily as the body is consumed and records nothing observable at the operation boundary. The types are `#[non_exhaustive]` so adding the positive verdict later is not a breaking change. The negative guarantee holds regardless: a tampered or wrong-checksum download fails `join()`, and on the file-sink path it fails before the temp-to-final rename, so a corrupt object is never published.

### Mock fidelity

The mock is a dev-loop convenience, not an authority. The composite checksum value, ranged-GET checksum behavior (aligned / unaligned / whole-object / ragged tail), and single-PUT ranged behavior were each probed against real S3 first, and the mock changes encode the verified behavior. The contract suite runs against the mock in CI and against real S3 (general-purpose and Express) under `--cfg e2e_test`.

## Changes

### Transfer manager

- `execute_get_range` builds the chunk GET from `From<DownloadInput>` (was a four-field hand-built request).
- `discover_obj` takes `validation_enabled` and aligns multipart download ranges to the stored part size via a `partNumber=1` re-issue. Adds `discovery.effective_part_size`, `DownloadState::Transferring.part_size`, `parts_from_etag`.
- Error paths (`fail_range`, body read, flush) go terminal before any wake.
- New `IntegrityChecks` / `ChecksumValidation` / `NotValidatedReason` in `crate::types`; `DownloadOutput::integrity_checks()`.
- `Handle::user_set_part_size()`. Removed dead `target_part_size_bytes()`.
- Dropped `async-channel` and `blocking` (dead since the scheduler migration).
- Un-ignored `test_objects_transfer`; its stale FIXME (objects paths on the old scheduler) was resolved by #147/#148.

### s3-mock-server

- `faults.rs`: key-scoped fault registry with deterministic firing; `insert_fault` / `clear_fault` on `S3MockServer`; `WrongStoredChecksum` and `CorruptBody` in `get_object`.
- Composite checksum computed over raw decoded part bytes with the `-N` suffix (both backends).
- Range-aware GET checksums: per-part checksum on an aligned range, none on unaligned, object value on whole-object. Adds `ObjectMetadata.parts`, `part_range`, `parts_count`, and `partNumber` GET support.

### Tests and CI

- `integration-tests/harness.rs`: `Target = Backend × BucketKind`.
- `integration-tests/integrity.rs`: object-integrity contract suite (mock and real-S3 wrappers).
- `download_test.rs`: integrity-checks unit coverage.
- CI e2e step also runs `cargo test -p integration-tests` under `--cfg e2e_test`.

## What changed

```
operation/download/transfer.rs       - range-GET field forwarding, terminal-before-wake,
                                        build_integrity_checks, part_size in Transferring
operation/download/discovery.rs      - validation_enabled, partNumber=1 realignment,
                                        effective_part_size, parts_from_etag
operation/download/context.rs        - Transferring.part_size
operation/download/output.rs         - DownloadOutput::integrity_checks()
operation/download/handle.rs         - join() populates integrity_checks
types.rs                             - IntegrityChecks, ChecksumValidation, NotValidatedReason
client.rs                            - Handle::user_set_part_size()
tests/download_test.rs               - integrity-checks coverage
tests/e2e_transfer_test.rs           - un-ignore test_objects_transfer
Cargo.toml                           - drop async-channel, blocking
s3-mock-server/src/faults.rs         - New: fault registry (key-scoped, deterministic)
s3-mock-server/src/s3s.rs            - apply faults; partNumber GET; range-aware checksums
s3-mock-server/src/server.rs         - insert_fault/clear_fault, registry plumbing
s3-mock-server/src/storage/*.rs      - composite over raw bytes + -N; parts retained on MPU
s3-mock-server/src/types.rs          - Express bucket support
s3-mock-server/tests/{checksums,faults}.rs - fidelity + fault tests
integration-tests/src/harness.rs     - New: Target = Backend x BucketKind
integration-tests/src/integrity.rs   - New: object-integrity contract suite
.github/workflows/ci.yml             - run integration-tests in the e2e step
```

## Future

- Validate a large single-PUT object split into parallel ranges. S3 returns no checksum for a sub-range of a single stored part, so this needs a transfer-manager-computed whole-object checksum over the delivered bytes plus a HeadObject for the expected value. An `#[ignore]`d intent test states the goal.
- Report `Validated { algorithm }` once the SDK exposes a per-response validation outcome.
- A typed `ErrorKind::ChecksumMismatch` carrying algorithm and expected/computed, folded into the error-hierarchy work.
- Fold the legacy `e2e_transfer_test.rs` cases into the harness. S3 Express is real-S3-only until the mock models directory buckets.
