### PR TITLE
introduce memory budget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "jemallocator",
+ "libc",
  "loom",
  "md5",
  "nix",
@@ -317,6 +318,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4727,6 +4729,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/aws-sdk-s3-transfer-manager/Cargo.toml
+++ b/aws-sdk-s3-transfer-manager/Cargo.toml
@@ -45,7 +45,7 @@ dial9-tokio-telemetry = { version = "0.3", optional = true, features = ["cpu-pro
 dial9 = ["dep:dial9-tokio-telemetry"]
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", features = ["uio", "fs"] }
+nix = { version = "0.31", features = ["uio", "fs", "resource"] }
 
 [dev-dependencies]
 aws-sdk-s3 = { version = "1.128.0", features = ["behavior-version-latest", "test-util"] }

--- a/aws-sdk-s3-transfer-manager/Cargo.toml
+++ b/aws-sdk-s3-transfer-manager/Cargo.toml
@@ -47,6 +47,15 @@ dial9 = ["dep:dial9-tokio-telemetry"]
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["uio", "fs", "resource"] }
 
+# Total physical RAM via sysctl(hw.memsize).
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
+# Total physical RAM via GlobalMemoryStatusEx; descriptor limit is not low on
+# Windows, so the connection cap there is the absolute ceiling.
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_System_SystemInformation"] }
+
 [dev-dependencies]
 aws-sdk-s3 = { version = "1.128.0", features = ["behavior-version-latest", "test-util"] }
 aws-smithy-mocks = "0.2.6"

--- a/aws-sdk-s3-transfer-manager/examples/cp.rs
+++ b/aws-sdk-s3-transfer-manager/examples/cp.rs
@@ -6,7 +6,9 @@ use aws_sdk_s3_transfer_manager::io::InputStream;
 use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_sdk_s3_transfer_manager::metrics::Throughput;
 use aws_sdk_s3_transfer_manager::operation::download::Body;
-use aws_sdk_s3_transfer_manager::types::{ConcurrencyMode, PartSize, TargetThroughput};
+use aws_sdk_s3_transfer_manager::types::{
+    ConcurrencyMode, MemoryBudgetConfig, PartSize, TargetThroughput,
+};
 use aws_smithy_types::date_time::{DateTime, Format};
 use clap::{CommandFactory, Parser};
 use std::error::Error;
@@ -419,6 +421,17 @@ async fn run() -> Result<(), BoxError> {
     let mut config_loader = aws_sdk_s3_transfer_manager::from_env()
         .concurrency(args.concurrency.mode())
         .part_size(PartSize::Target(args.part_size));
+
+    // S3FIO_MEMORY_LIMIT=N caps the transfer manager's memory budget at N GiB
+    // (in-flight plus buffered transfer data; transfers backpressure at the cap).
+    if let Some(gib) = std::env::var("S3FIO_MEMORY_LIMIT")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+    {
+        let bytes = gib * ByteUnit::Gibibyte.as_bytes_usize();
+        tracing::info!(gib, "memory budget limit (S3FIO_MEMORY_LIMIT, GiB)");
+        config_loader = config_loader.memory_budget(MemoryBudgetConfig::Limit(bytes));
+    }
 
     #[cfg(feature = "dial9")]
     if let Some(guard) = telemetry_guard {

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -26,7 +26,9 @@ pub struct Client {
     pub(crate) handle: Arc<Handle>,
 }
 
-/// Whatever is needed to carry out operations, e.g. scheduler, budgets, config, env details, etc
+/// Shared state backing every transfer operation: configuration, the S3 client,
+/// the scheduler, the execution runtime, the concurrency controller, telemetry,
+/// and the memory budget.
 #[derive(Debug)]
 pub(crate) struct Handle {
     pub(crate) config: crate::Config,

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -15,7 +15,9 @@ use crate::Config;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::runtime::memory::{MemoryBudget, BUDGET_CHUNK_BYTES, DEFAULT_MEMORY_BUDGET_BYTES};
+#[cfg(test)]
+use crate::runtime::memory::DEFAULT_MEMORY_BUDGET_BYTES;
+use crate::runtime::memory::{MemoryBudget, BUDGET_CHUNK_BYTES};
 use crate::runtime::ExecutionRuntime;
 
 /// Transfer manager client for Amazon Simple Storage Service.
@@ -188,6 +190,9 @@ impl Client {
         #[cfg(feature = "dial9")]
         let telemetry_guard = config.take_telemetry_guard().map(std::sync::Arc::new);
 
+        // Resolve the budget once: it sizes the Handle's MemoryBudget.
+        let budget_capacity = config.memory_budget().resolve();
+
         let handle = Arc::new_cyclic(|weak_handle| {
             let scheduler = Scheduler::new(weak_handle.clone());
             let runtime: Arc<dyn ExecutionRuntime> = {
@@ -220,7 +225,7 @@ impl Client {
                 runtime,
                 controller,
                 telemetry,
-                memory_budget: MemoryBudget::new(DEFAULT_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
+                memory_budget: MemoryBudget::new(budget_capacity, BUDGET_CHUNK_BYTES),
             }
         });
         Client { handle }

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -15,6 +15,7 @@ use crate::Config;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::runtime::memory::{MemoryBudget, BUDGET_CHUNK_BYTES, DEFAULT_MEMORY_BUDGET_BYTES};
 use crate::runtime::ExecutionRuntime;
 
 /// Transfer manager client for Amazon Simple Storage Service.
@@ -32,6 +33,7 @@ pub(crate) struct Handle {
     pub(crate) runtime: Arc<dyn ExecutionRuntime>,
     pub(crate) controller: Arc<dyn ConcurrencyController>,
     pub(crate) telemetry: Arc<Telemetry>,
+    pub(crate) memory_budget: Arc<MemoryBudget>,
 }
 
 impl Handle {
@@ -88,6 +90,7 @@ impl Handle {
                 runtime,
                 controller: Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
                 telemetry: Arc::new(Telemetry::new(std::time::Duration::from_millis(500))),
+                memory_budget: MemoryBudget::new(DEFAULT_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
             }
         })
     }
@@ -146,6 +149,7 @@ impl Handle {
                 runtime,
                 controller: Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
                 telemetry: Arc::new(Telemetry::new(std::time::Duration::from_millis(500))),
+                memory_budget: MemoryBudget::new(DEFAULT_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
             }
         })
     }
@@ -216,6 +220,7 @@ impl Client {
                 runtime,
                 controller,
                 telemetry,
+                memory_budget: MemoryBudget::new(DEFAULT_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
             }
         });
         Client { handle }

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -238,6 +238,13 @@ impl Client {
         &self.handle.config
     }
 
+    /// Snapshot the global memory budget's resolved ceiling and current admission
+    /// state. For the configured intent (before resolution), see
+    /// [`config().memory_budget()`](Config::memory_budget).
+    pub fn memory_budget(&self) -> crate::types::MemoryBudgetSnapshot {
+        self.handle.memory_budget.stats()
+    }
+
     /// Upload a single object from S3.
     ///
     /// Constructs a fluent builder for the

--- a/aws-sdk-s3-transfer-manager/src/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/config.rs
@@ -7,7 +7,7 @@ use aws_runtime::user_agent::FrameworkMetadata;
 use std::cmp;
 
 use crate::metrics::unit::ByteUnit;
-use crate::types::{ConcurrencyMode, PartSize};
+use crate::types::{ConcurrencyMode, MemoryBudgetConfig, PartSize};
 
 pub(crate) mod loader;
 
@@ -70,6 +70,7 @@ pub struct Config {
     multipart_threshold: PartSize,
     target_part_size: PartSize,
     concurrency: ConcurrencyMode,
+    memory_budget: MemoryBudgetConfig,
     framework_metadata: Option<FrameworkMetadata>,
     s3_client_source: Option<S3ClientSource>,
     #[cfg(feature = "dial9")]
@@ -97,6 +98,11 @@ impl Config {
     /// This is the mode used for concurrent in-flight requests across _all_ operations.
     pub fn concurrency(&self) -> &ConcurrencyMode {
         &self.concurrency
+    }
+
+    /// Returns the memory budget configuration.
+    pub fn memory_budget(&self) -> &MemoryBudgetConfig {
+        &self.memory_budget
     }
 
     /// Returns the framework metadata setting when using transfer manager.
@@ -127,6 +133,7 @@ pub struct Builder {
     multipart_threshold_part_size: PartSize,
     target_part_size: PartSize,
     concurrency: ConcurrencyMode,
+    memory_budget: MemoryBudgetConfig,
     pub(crate) framework_metadata: Option<FrameworkMetadata>,
     client: Option<aws_sdk_s3::Client>,
     s3_client_config: Option<S3ClientConfig>,
@@ -198,6 +205,15 @@ impl Builder {
         self
     }
 
+    /// Set the memory budget: an upper bound on memory used for in-flight and
+    /// buffered transfer data. At the limit transfers backpressure rather than
+    /// fail. Default is [`MemoryBudgetConfig::Auto`] (a safe fraction of detected
+    /// RAM). Takes effect only when the transfer manager owns its runtime.
+    pub fn memory_budget(mut self, budget: MemoryBudgetConfig) -> Self {
+        self.memory_budget = budget;
+        self
+    }
+
     /// Sets the framework metadata for the transfer manager.
     ///
     /// This _optional_ name is used to identify the framework using transfer manager in the user agent that
@@ -252,6 +268,7 @@ impl Builder {
             multipart_threshold: self.multipart_threshold_part_size,
             target_part_size: self.target_part_size,
             concurrency: self.concurrency,
+            memory_budget: self.memory_budget,
             framework_metadata: self.framework_metadata,
             s3_client_source: Some(s3_client_source),
             #[cfg(feature = "dial9")]

--- a/aws-sdk-s3-transfer-manager/src/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/config.rs
@@ -208,7 +208,7 @@ impl Builder {
     /// Set the memory budget: an upper bound on memory used for in-flight and
     /// buffered transfer data. At the limit transfers backpressure rather than
     /// fail. Default is [`MemoryBudgetConfig::Auto`] (a safe fraction of detected
-    /// RAM). Takes effect only when the transfer manager owns its runtime.
+    /// RAM).
     pub fn memory_budget(mut self, budget: MemoryBudgetConfig) -> Self {
         self.memory_budget = budget;
         self

--- a/aws-sdk-s3-transfer-manager/src/config/loader.rs
+++ b/aws-sdk-s3-transfer-manager/src/config/loader.rs
@@ -10,7 +10,7 @@ use aws_sdk_s3::config::{Intercept, IntoShared};
 use aws_types::os_shim_internal::Env;
 
 use crate::config::{Builder, Config};
-use crate::types::{ConcurrencyMode, PartSize};
+use crate::types::{ConcurrencyMode, MemoryBudgetConfig, PartSize};
 
 #[derive(Debug)]
 struct S3TransferManagerInterceptor {
@@ -83,6 +83,14 @@ impl ConfigLoader {
     /// Default is [ConcurrencyMode::Auto].
     pub fn concurrency(mut self, mode: ConcurrencyMode) -> Self {
         self.builder = self.builder.concurrency(mode);
+        self
+    }
+
+    /// Set the memory budget: an upper bound on memory used for in-flight and
+    /// buffered transfer data. At the limit transfers backpressure rather than
+    /// fail. Default is [`MemoryBudgetConfig::Auto`].
+    pub fn memory_budget(mut self, budget: MemoryBudgetConfig) -> Self {
+        self.builder = self.builder.memory_budget(budget);
         self
     }
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -385,8 +385,6 @@ impl BodySlot {
     /// Attach a memory budget reservation to this slot. The reservation will
     /// move into ring storage on fill and drop when the chunk is consumed or
     /// flushed.
-    // TODO(budget): called by the download poll_work budget gate once wired in.
-    #[allow(dead_code)]
     pub(crate) fn attach_reservation(&mut self, reservation: Reservation) {
         self.reservation = Some(reservation);
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -1294,6 +1294,31 @@ mod tests {
     }
 
     #[test]
+    fn test_reservation_released_on_slot_drop_without_fill() {
+        // The abort path: a slot is claimed and its memory reserved, but the GET
+        // fails before the slot is filled. Dropping the slot must release the
+        // reservation rather than leaking the chunk.
+        let chunk_bytes = 1024;
+        let budget = MemoryBudget::new(chunk_bytes * 4, chunk_bytes);
+        let (writer, _consumer) = new_slot_body(4);
+
+        let mut slot = writer.try_claim().unwrap();
+        let reservation = budget
+            .try_reserve(chunk_bytes)
+            .expect("budget has capacity");
+        slot.attach_reservation(reservation);
+        assert_eq!(budget.in_use_chunks(), 1);
+
+        // Drop the claimed-but-never-filled slot.
+        drop(slot);
+        assert_eq!(
+            budget.in_use_chunks(),
+            0,
+            "dropping an unfilled slot releases its reservation"
+        );
+    }
+
+    #[test]
     fn test_no_reservation_is_harmless() {
         let (writer, consumer) = new_slot_body(4);
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::runtime::memory::Reservation;
 use crate::runtime::sync::cell::UnsafeCell;
 use crate::runtime::sync::sync::atomic::{
     AtomicBool, AtomicU64, AtomicU8, Ordering as AtomicOrdering,
@@ -105,14 +106,23 @@ struct SlotBuffer {
     sink: Option<Sink>,
 }
 
+/// A filled slot's payload: the chunk data and the optional memory budget
+/// reservation that accounts for this chunk's ring residency. The reservation
+/// lives here (not in `ChunkOutput`) so it drops when the chunk leaves the
+/// ring, not when the user drops the output.
+struct Filled {
+    chunk: ChunkOutput,
+    reservation: Option<Reservation>,
+}
+
 /// A single slot in the ring buffer.
 ///
-/// Holds an optional `ChunkOutput` behind `UnsafeCell`. Access is synchronized
+/// Holds an optional `Filled` behind `UnsafeCell`. Access is synchronized
 /// through the atomic `state` field: producers write data then store `FILLED`,
 /// the consumer reads data only after loading `FILLED`.
 struct Slot {
     state: AtomicU8,
-    data: UnsafeCell<Option<ChunkOutput>>,
+    data: UnsafeCell<Option<Filled>>,
 }
 
 // Safety: see SlotBuffer doc comment for the full invariant chain.
@@ -150,12 +160,12 @@ impl SlotBuffer {
     /// - `seq` must have been claimed via the `claimed` CAS (i.e. through
     ///   `BodyWriter::try_claim`). Filling an unclaimed seq is undefined behavior.
     /// - Each `seq` must be filled exactly once. Double-filling is undefined behavior.
-    fn fill(&self, seq: u64, chunk: ChunkOutput) {
+    fn fill(&self, seq: u64, chunk: ChunkOutput, reservation: Option<Reservation>) {
         let idx = (seq % self.capacity) as usize;
         // Safety: seq window guarantees exclusive access to this slot index.
         self.slots[idx]
             .data
-            .with_mut(|ptr| unsafe { *ptr = Some(chunk) });
+            .with_mut(|ptr| unsafe { *ptr = Some(Filled { chunk, reservation }) });
         self.slots[idx]
             .state
             .store(SLOT_FILLED, AtomicOrdering::Release);
@@ -226,15 +236,17 @@ impl SlotBuffer {
 
             // Start a new run with the first FILLED slot
             // Safety: state is FILLED and flush holds exclusive consumer access via CAS lock.
-            let first_chunk = self.slots[idx]
+            let filled = self.slots[idx]
                 .data
                 .with_mut(|ptr| unsafe { (*ptr).take().unwrap() });
-            let file_pos = first_chunk.offset - sink.object_range_start;
-            let mut run_end_offset = file_pos + first_chunk.data.remaining() as u64;
+            let file_pos = filled.chunk.offset - sink.object_range_start;
+            let mut run_end_offset = file_pos + filled.chunk.data.remaining() as u64;
             let mut combined = bytes_utils::SegmentedBuf::new();
-            for seg in first_chunk.data.0.into_inner() {
+            for seg in filled.chunk.data.0.into_inner() {
                 combined.push(seg);
             }
+            // Reservation drops here (filled consumed), releasing budget for this chunk.
+            drop(filled.reservation);
             self.slots[idx]
                 .state
                 .store(SLOT_FLUSHED, AtomicOrdering::Release);
@@ -247,22 +259,24 @@ impl SlotBuffer {
                     break;
                 }
                 // Safety: state is FILLED and flush holds exclusive consumer access via CAS lock.
-                let chunk = self.slots[jdx]
+                let filled = self.slots[jdx]
                     .data
                     .with_mut(|ptr| unsafe { (*ptr).take().unwrap() });
-                let chunk_file_pos = chunk.offset - sink.object_range_start;
+                let chunk_file_pos = filled.chunk.offset - sink.object_range_start;
                 if chunk_file_pos != run_end_offset {
                     // Not file-contiguous — put it back for the next iteration
                     // Safety: same CAS lock exclusion; no other thread accesses this slot.
                     self.slots[jdx]
                         .data
-                        .with_mut(|ptr| unsafe { *ptr = Some(chunk) });
+                        .with_mut(|ptr| unsafe { *ptr = Some(filled) });
                     break;
                 }
-                run_end_offset += chunk.data.remaining() as u64;
-                for seg in chunk.data.0.into_inner() {
+                run_end_offset += filled.chunk.data.remaining() as u64;
+                for seg in filled.chunk.data.0.into_inner() {
                     combined.push(seg);
                 }
+                // Reservation drops here (filled consumed), releasing budget.
+                drop(filled.reservation);
                 self.slots[jdx]
                     .state
                     .store(SLOT_FLUSHED, AtomicOrdering::Release);
@@ -309,14 +323,16 @@ impl SlotBuffer {
             return None;
         }
         // Safety: state is FILLED and only one consumer calls this.
-        let chunk = self.slots[idx]
+        let filled = self.slots[idx]
             .data
             .with_mut(|ptr| unsafe { (*ptr).take() });
         self.slots[idx]
             .state
             .store(SLOT_EMPTY, AtomicOrdering::Release);
         self.consumed.fetch_add(1, AtomicOrdering::Release);
-        chunk
+        // Reservation (if any) drops here when `filled` is destructured,
+        // releasing the budget as the chunk leaves the ring.
+        filled.map(|f| f.chunk)
     }
 }
 
@@ -343,10 +359,21 @@ pub(crate) struct BodyWriter {
 /// consumed by [`fill`](Self::fill). Cannot be constructed outside this module,
 /// preventing writes to unclaimed slots. Consuming `self` on fill prevents
 /// double-writes.
-#[derive(Debug)]
 pub(crate) struct BodySlot {
     seq: u64,
     buffer: Arc<SlotBuffer>,
+    /// Memory budget reservation held from claim until fill, then moved into
+    /// the slot's `Filled` storage. Drops when the chunk leaves the ring.
+    reservation: Option<Reservation>,
+}
+
+impl std::fmt::Debug for BodySlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BodySlot")
+            .field("seq", &self.seq)
+            .field("has_reservation", &self.reservation.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 impl BodySlot {
@@ -355,9 +382,19 @@ impl BodySlot {
         self.seq
     }
 
+    /// Attach a memory budget reservation to this slot. The reservation will
+    /// move into ring storage on fill and drop when the chunk is consumed or
+    /// flushed.
+    // TODO(budget): called by the download poll_work budget gate once wired in.
+    #[allow(dead_code)]
+    pub(crate) fn attach_reservation(&mut self, reservation: Reservation) {
+        self.reservation = Some(reservation);
+    }
+
     /// Write a completed chunk into this slot, consuming the claim.
-    pub(crate) fn fill(self, chunk: ChunkOutput) {
-        self.buffer.fill(self.seq, chunk);
+    pub(crate) fn fill(mut self, chunk: ChunkOutput) {
+        let reservation = self.reservation.take();
+        self.buffer.fill(self.seq, chunk, reservation);
     }
 }
 
@@ -397,6 +434,7 @@ impl BodyWriter {
                 return Some(BodySlot {
                     seq: claimed,
                     buffer: self.buffer.clone(),
+                    reservation: None,
                 });
             }
         }
@@ -1189,6 +1227,87 @@ mod tests {
                 "mismatch at seq {seq}"
             );
         }
+    }
+
+    // --- Reservation lifecycle tests ---
+
+    use crate::runtime::memory::MemoryBudget;
+
+    #[test]
+    fn test_reservation_released_on_consume() {
+        let chunk_bytes = 1024;
+        let budget = MemoryBudget::new(chunk_bytes * 4, chunk_bytes);
+        let (writer, consumer) = new_slot_body(4);
+
+        let mut slot = writer.try_claim().unwrap();
+        let reservation = budget
+            .try_reserve(chunk_bytes)
+            .expect("budget has capacity");
+        assert_eq!(budget.in_use_chunks(), 1);
+
+        slot.attach_reservation(reservation);
+        let mut seg = SegmentedBuf::new();
+        seg.push(Bytes::from("hello"));
+        slot.fill(chunk_resp(0, AggregatedBytes(seg)));
+
+        // Reservation still held while chunk is in the ring
+        assert_eq!(budget.in_use_chunks(), 1);
+
+        // Consume via streaming path
+        let chunk = consumer.try_take_next().unwrap();
+        assert_eq!(chunk.seq, 0);
+        assert_eq!(chunk.data.to_vec(), b"hello");
+
+        // Reservation released when chunk left the ring
+        assert_eq!(budget.in_use_chunks(), 0);
+    }
+
+    #[test]
+    fn test_reservation_released_on_flush() {
+        let chunk_bytes = 1024;
+        let budget = MemoryBudget::new(chunk_bytes * 4, chunk_bytes);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out");
+        let file = std::fs::File::create(&path).unwrap();
+        let (writer, _consumer) = new_slot_body_with_sink(16, file, 0, false);
+
+        let mut slot = writer.try_claim().unwrap();
+        let reservation = budget
+            .try_reserve(chunk_bytes)
+            .expect("budget has capacity");
+        assert_eq!(budget.in_use_chunks(), 1);
+
+        slot.attach_reservation(reservation);
+        slot.fill(chunk_at(0, 0, b"flushed"));
+
+        // Reservation still held before flush
+        assert_eq!(budget.in_use_chunks(), 1);
+
+        // Finalize flushes all filled slots to disk
+        writer.finalize().unwrap();
+
+        // Reservation released after flush
+        assert_eq!(budget.in_use_chunks(), 0);
+
+        // Data actually written
+        let contents = std::fs::read(&path).unwrap();
+        assert_eq!(&contents[..7], b"flushed");
+    }
+
+    #[test]
+    fn test_no_reservation_is_harmless() {
+        let (writer, consumer) = new_slot_body(4);
+
+        // Fill without any reservation (the default path)
+        let slot = writer.try_claim().unwrap();
+        let mut seg = SegmentedBuf::new();
+        seg.push(Bytes::from("no-budget"));
+        slot.fill(chunk_resp(0, AggregatedBytes(seg)));
+
+        let chunk = consumer.try_take_next().unwrap();
+        assert_eq!(chunk.seq, 0);
+        assert_eq!(chunk.data.to_vec(), b"no-budget");
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
@@ -3,6 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::operation::download::body::BodySlot;
+use crate::runtime::memory::WaitTicket;
+
+/// A claimed slot whose backing memory is not yet reserved. Held while a transfer
+/// is budget-blocked: `try_claim` already granted the slot (the prefetch window
+/// had room — the consumer is keeping up), but the slot cannot be filled until the
+/// budget grants `ticket`. Dropping it (on terminal) releases the slot and cancels
+/// the budget wait.
+#[derive(Debug)]
+pub(crate) struct PendingClaim {
+    pub(crate) slot: BodySlot,
+    pub(crate) ticket: WaitTicket,
+}
+
 /// Mutable state for tracking download work progress
 #[derive(Debug)]
 pub(crate) enum DownloadState {
@@ -25,6 +39,11 @@ pub(crate) enum DownloadState {
         /// object's stored part size so each range aligns to a stored part
         /// boundary (S3 returns a per-part checksum only for an aligned range).
         part_size: u64,
+        /// A claimed-but-unfilled slot whose memory reservation is still pending,
+        /// held only while budget-blocked. `Some` after the window granted a slot
+        /// but the budget queued the reservation; taken once the budget grants.
+        /// Dropping the state on terminal releases the slot and cancels the wait.
+        pending: Option<PendingClaim>,
     },
 
     /// Terminal state - transfer ended (success, failure, or cancelled)

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -8,6 +8,7 @@
 use std::cmp;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use bytes_utils::SegmentedBuf;
@@ -18,10 +19,11 @@ use crate::error::{self, ChunkRef, Error};
 use crate::io::AggregatedBytes;
 use crate::operation::download::body::{BodySlot, BodyWriter, ChunkOutput};
 use crate::operation::download::chunk_meta::ChunkMetadata;
-use crate::operation::download::context::DownloadState;
+use crate::operation::download::context::{DownloadState, PendingClaim};
 use crate::operation::download::discovery::{discover_obj, ObjectDiscovery};
 use crate::operation::download::object_meta::ObjectMetadata;
 use crate::operation::download::DownloadInput;
+use crate::runtime::memory::{NotifyFn, Reservation, Reserve};
 use crate::transfer::{IoRequest, PollWork, Transfer, TransferContext, TransferId, WorkOutcome};
 use crate::types::BucketType;
 
@@ -45,6 +47,29 @@ impl DownloadWork {
             DownloadWork::GetObjectRange { slot, .. } => slot.take(),
         }
     }
+}
+
+/// The next chunk's range (sliced from `remaining` at `part_size`) and its byte
+/// length. Peek only — does not advance `remaining`.
+fn next_chunk_range(
+    remaining: &std::ops::RangeInclusive<u64>,
+    part_size: u64,
+) -> (std::ops::RangeInclusive<u64>, usize) {
+    let start = *remaining.start();
+    let end = *remaining.end();
+    let chunk_end = cmp::min(start + part_size - 1, end);
+    (start..=chunk_end, (chunk_end - start + 1) as usize)
+}
+
+/// `remaining` after committing `chunk`: the leftover range, or `None` when
+/// `chunk` reached the end of `remaining`.
+fn next_remaining(
+    chunk: &std::ops::RangeInclusive<u64>,
+    remaining: &std::ops::RangeInclusive<u64>,
+) -> Option<std::ops::RangeInclusive<u64>> {
+    let chunk_end = *chunk.end();
+    let end = *remaining.end();
+    (chunk_end < end).then_some((chunk_end + 1)..=end)
 }
 
 /// Early return if transfer is terminal (failed/cancelled by another work item).
@@ -86,6 +111,25 @@ struct DownloadTransferInner {
     integrity_checks: std::sync::OnceLock<crate::types::IntegrityChecks>,
     /// Notified when discovery completes (success or failure)
     discovery_notify: tokio::sync::Notify,
+    /// Edge-tracked: whether this transfer is currently blocked on its prefetch
+    /// window (full of claimed-but-unconsumed parts, waiting on in-order
+    /// consumption). Drives the client `window_blocked_downloads` gauge; see
+    /// [`DownloadTransfer::set_window_blocked`].
+    window_blocked: AtomicBool,
+}
+
+impl Drop for DownloadTransferInner {
+    fn drop(&mut self) {
+        // Release the gauge if the transfer ended (cancel/fail) while blocked;
+        // normal completion unblocks via a successful claim before finishing.
+        if self.window_blocked.load(Ordering::Relaxed) {
+            self.ctx
+                .handle
+                .telemetry
+                .window_blocked_downloads
+                .fetch_sub(1, Ordering::Relaxed);
+        }
+    }
 }
 
 impl DownloadTransfer {
@@ -104,6 +148,7 @@ impl DownloadTransfer {
             object_meta: std::sync::OnceLock::new(),
             integrity_checks: std::sync::OnceLock::new(),
             discovery_notify: tokio::sync::Notify::new(),
+            window_blocked: AtomicBool::new(false),
         });
         Self { inner }
     }
@@ -121,6 +166,37 @@ impl DownloadTransfer {
     /// Body writer for backpressure control and chunk delivery.
     pub(crate) fn writer(&self) -> &BodyWriter {
         &self.inner.writer
+    }
+
+    /// Edge-track the prefetch-window-blocked vital sign: maintain the
+    /// client-level `window_blocked_downloads` gauge with exactly one increment
+    /// per block→unblock cycle, and emit an edge event. Blocked means the
+    /// transfer wanted to fetch another part but its window was full (waiting on
+    /// in-order consumption of a slow head part) — the head-of-line signal that
+    /// distinguishes a window-bound pipeline from a connection- or
+    /// work-generation-bound one. Idempotent: a no-op when already in `blocked`.
+    fn set_window_blocked(&self, blocked: bool) {
+        if self.inner.window_blocked.swap(blocked, Ordering::Relaxed) == blocked {
+            return;
+        }
+        let gauge = &self.inner.ctx.handle.telemetry.window_blocked_downloads;
+        if blocked {
+            let total = gauge.fetch_add(1, Ordering::Relaxed) + 1;
+            tracing::trace!(
+                target: crate::telemetry::TARGET_TRANSFER,
+                tid = %self.inner.ctx.id,
+                window_blocked_downloads = total,
+                "download blocked on prefetch window",
+            );
+        } else {
+            let total = gauge.fetch_sub(1, Ordering::Relaxed).saturating_sub(1);
+            tracing::trace!(
+                target: crate::telemetry::TARGET_TRANSFER,
+                tid = %self.inner.ctx.id,
+                window_blocked_downloads = total,
+                "download resumed (prefetch window opened)",
+            );
+        }
     }
 
     /// Object metadata from discovery.
@@ -180,58 +256,137 @@ impl DownloadTransfer {
                     data: Some(Box::new(DownloadWork::Discovery)),
                 })
             }
-            DownloadState::DiscoveryInFlight => {
-                self.inner.ctx.set_pending();
-                PollWork::Pending
-            }
+            DownloadState::DiscoveryInFlight => self.park(),
             DownloadState::Transferring {
                 remaining,
                 ranges_in_flight,
                 etag,
                 part_size,
-                ..
+                pending,
             } => {
-                // Check seq window before generating work
-                let Some(slot) = self.inner.writer.try_claim() else {
-                    self.inner.ctx.set_pending();
-                    return PollWork::Pending;
+                // Nothing left to fetch: drain in-flight, or finish once drained.
+                if remaining.is_none() {
+                    if *ranges_in_flight > 0 {
+                        return self.park();
+                    }
+                    self.complete(state);
+                    return PollWork::Done;
+                }
+
+                let (range, range_len) = next_chunk_range(remaining.as_ref().unwrap(), *part_size);
+
+                // Claim a slot (the prefetch-window gate — a grant means the
+                // consumer is keeping up), then reserve the memory backing it,
+                // resuming a budget-parked claim if one is held. `None` means
+                // parked; a waker is armed (consumer release or budget grant).
+                let Some(slot) = self.acquire_slot(range_len, pending) else {
+                    return self.park();
                 };
 
-                if let Some(range) = remaining.take() {
-                    // `part_size` is the stored part size for a validated multipart
-                    // object (so each range aligns to a stored part boundary and S3
-                    // returns the part's checksum for the SDK to validate), else the
-                    // configured download part size. Set at discovery.
-                    let part_size = *part_size;
-                    let start = *range.start();
-                    let end = *range.end();
-                    let chunk_end = cmp::min(start + part_size - 1, end);
-                    let chunk_range = start..=chunk_end;
-
-                    if chunk_end < end {
-                        *remaining = Some((chunk_end + 1)..=end);
-                    }
-
-                    *ranges_in_flight += 1;
-
-                    PollWork::Ready(IoRequest {
-                        data: Some(Box::new(DownloadWork::GetObjectRange {
-                            range: chunk_range,
-                            slot: Some(slot),
-                            etag: etag.clone(),
-                        })),
-                    })
-                } else if *ranges_in_flight > 0 {
-                    // All ranges generated, waiting for in-flight to complete
-                    self.inner.ctx.set_pending();
-                    PollWork::Pending
-                } else {
-                    // All done - success
-                    self.complete(state);
-                    PollWork::Done
-                }
+                // Commit the range and emit the ranged GET.
+                *remaining = next_remaining(&range, remaining.as_ref().unwrap());
+                *ranges_in_flight += 1;
+                PollWork::Ready(IoRequest {
+                    data: Some(Box::new(DownloadWork::GetObjectRange {
+                        range,
+                        slot: Some(slot),
+                        etag: etag.clone(),
+                    })),
+                })
             }
             DownloadState::Terminal => PollWork::Done,
+        }
+    }
+
+    /// Park the transfer: mark it pending so the scheduler stops polling it until
+    /// a waker re-readies it — the consumer on slot release (window), the budget
+    /// `NotifyFn` on grant, or a GET completion decrementing the in-flight count.
+    fn park(&self) -> PollWork {
+        self.inner.ctx.set_pending();
+        PollWork::Pending
+    }
+
+    /// Acquire a slot to fetch the next range into, with its memory reserved.
+    ///
+    /// Resumes a budget-parked claim if one is held; otherwise claims a fresh
+    /// slot (the prefetch-window gate) and reserves the backing memory. Returns
+    /// the slot with its reservation attached, or `None` when parked:
+    /// - window full (consumer lagging): `try_claim` returned `None`;
+    /// - budget exhausted: the reservation is queued and the claimed slot is
+    ///   stashed in `pending` until the budget grants it.
+    ///
+    /// Claiming before reserving makes the two states mutually exclusive — a
+    /// window-parked transfer holds nothing, a budget-parked one holds exactly
+    /// the slot it will fill — so there is no peek/claim race to handle.
+    fn acquire_slot(
+        &self,
+        range_len: usize,
+        pending: &mut Option<PendingClaim>,
+    ) -> Option<BodySlot> {
+        // Resume a budget-parked claim: the slot is already ours, just awaiting
+        // the reservation the budget queued.
+        if pending.is_some() {
+            self.set_window_blocked(false);
+            let granted = pending.as_mut().unwrap().ticket.take();
+            return match granted {
+                Some(reservation) => {
+                    let mut claim = pending.take().unwrap();
+                    claim.slot.attach_reservation(reservation);
+                    Some(claim.slot)
+                }
+                None => None, // not granted yet; the queued ticket is the waker
+            };
+        }
+
+        // Fresh: the window gate is the claim itself.
+        let Some(mut slot) = self.inner.writer.try_claim() else {
+            self.set_window_blocked(true);
+            return None;
+        };
+        self.set_window_blocked(false);
+
+        let notify: NotifyFn = {
+            let scheduler = self.inner.ctx.handle.scheduler.clone();
+            let tid = self.inner.ctx.id;
+            Arc::new(move || scheduler.wake(tid))
+        };
+        match self
+            .inner
+            .ctx
+            .handle
+            .memory_budget
+            .reserve(range_len, notify)
+        {
+            Reserve::Ready(reservation) => {
+                slot.attach_reservation(reservation);
+                Some(slot)
+            }
+            Reserve::Pending(ticket) => {
+                *pending = Some(PendingClaim { slot, ticket });
+                None
+            }
+        }
+    }
+
+    /// Reserve budget for a chunk of `len` bytes, awaiting a grant if the budget
+    /// is full. Used by the discovery path: discovery has already issued the GET
+    /// and must account its chunk's memory, but it runs inside an async `execute`
+    /// (not the re-pollable `poll_work`), so it backpressures by awaiting here —
+    /// holding the response stream undrained — rather than parking on the
+    /// scheduler. The head (seq 0) reserving before any read-ahead range keeps the
+    /// budget FIFO head-first, which guarantees forward progress under a tight cap.
+    async fn reserve_chunk(&self, len: usize) -> Reservation {
+        let notify = Arc::new(tokio::sync::Notify::new());
+        let waker = Arc::clone(&notify);
+        let notify_fn: NotifyFn = Arc::new(move || waker.notify_one());
+        match self.inner.ctx.handle.memory_budget.reserve(len, notify_fn) {
+            Reserve::Ready(reservation) => reservation,
+            Reserve::Pending(mut ticket) => loop {
+                notify.notified().await;
+                if let Some(reservation) = ticket.take() {
+                    return reservation;
+                }
+            },
         }
     }
 
@@ -313,11 +468,19 @@ impl DownloadTransfer {
         // Invariant: initial_chunk.is_some() == chunk_meta.is_some()
         let initial_work = match (initial_chunk, chunk_meta) {
             (Some(stream), Some(meta)) => {
-                let slot = self
+                let mut slot = self
                     .inner
                     .writer
                     .try_claim()
                     .expect("seq window should have capacity at start");
+                // Account the discovery chunk's memory before the transition wakes
+                // poll_work, so the head (seq 0) reserves before any read-ahead
+                // range. Awaiting here (the budget is non-binding at the default
+                // cap, so this is usually immediate) is correct backpressure: a
+                // full budget holds the discovery body undrained until a chunk
+                // frees.
+                let reservation = self.reserve_chunk(chunk_content_len as usize).await;
+                slot.attach_reservation(reservation);
                 Some((stream, meta, slot))
             }
             (None, _) => None,
@@ -333,6 +496,7 @@ impl DownloadTransfer {
                 ranges_in_flight: if initial_work.is_some() { 1 } else { 0 },
                 etag: etag.clone(),
                 part_size: effective_part_size,
+                pending: None,
             };
         }
 
@@ -1256,5 +1420,63 @@ mod tests {
     #[test]
     fn test_validate_content_range_missing() {
         assert!(validate_content_range("bytes=1024-2047", None).is_err());
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_budget_blocks_then_resumes() {
+        use crate::runtime::memory::BUDGET_CHUNK_BYTES;
+
+        // Object = 3 parts. Discovery fetches part 0 (seq 0) and reserves its
+        // chunk, so in_use == 1 after discovery; remaining covers parts 1+2.
+        let part_size = BUDGET_CHUNK_BYTES as u64;
+        let object_size = 3 * part_size;
+        let (transfer, consumer) = create_download_with_capacity(object_size, part_size, 8);
+
+        skip_discovery(&transfer).await;
+        let budget = &transfer.ctx().handle.memory_budget;
+        assert_eq!(budget.in_use_chunks(), 1, "discovery chunk is reserved");
+
+        // Tighten to 2 chunks: the discovery chunk plus room for exactly one range.
+        budget.set_limit(2 * BUDGET_CHUNK_BYTES);
+
+        // poll #1: part 1 fits (need 1, free 1) → Ready.
+        let _w1 = assert_ready(transfer.poll_work());
+        assert_eq!(budget.in_use_chunks(), 2);
+
+        // poll #2: part 2 does not fit (in_use 2, cap 2) → parked on the budget,
+        //          holding the claimed slot until a chunk frees.
+        assert_pending(transfer.poll_work());
+        {
+            let state = transfer.inner.state.lock().unwrap();
+            match &*state {
+                DownloadState::Transferring { pending, .. } => {
+                    assert!(pending.is_some(), "claim should be parked on the budget");
+                }
+                _ => panic!("expected Transferring"),
+            }
+        }
+
+        // Consume the discovery chunk (seq 0): its reservation drops, freeing a
+        // chunk that the budget immediately re-grants to the parked part-2 claim.
+        consumer.try_take_next().expect("discovery chunk is filled");
+        assert_eq!(
+            budget.in_use_chunks(),
+            2,
+            "freed chunk re-granted to the waiter"
+        );
+
+        // poll #3: the parked claim was granted → Ready, pending cleared.
+        let _w2 = assert_ready(transfer.poll_work());
+        {
+            let state = transfer.inner.state.lock().unwrap();
+            match &*state {
+                DownloadState::Transferring { pending, .. } => {
+                    assert!(pending.is_none(), "parked claim should be consumed");
+                }
+                _ => panic!("expected Transferring"),
+            }
+        }
+        assert_eq!(budget.in_use_chunks(), 2);
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -368,13 +368,12 @@ impl DownloadTransfer {
         }
     }
 
-    /// Reserve budget for a chunk of `len` bytes, awaiting a grant if the budget
-    /// is full. Used by the discovery path: discovery has already issued the GET
-    /// and must account its chunk's memory, but it runs inside an async `execute`
-    /// (not the re-pollable `poll_work`), so it backpressures by awaiting here —
-    /// holding the response stream undrained — rather than parking on the
-    /// scheduler. The head (seq 0) reserving before any read-ahead range keeps the
-    /// budget FIFO head-first, which guarantees forward progress under a tight cap.
+    /// Reserve budget for a chunk of `len` bytes, awaiting the grant if the budget
+    /// is full. Backpressures by holding the caller's async context — and the
+    /// undrained response stream — rather than parking on the scheduler, so it
+    /// suits a caller running inside `execute` rather than the re-pollable
+    /// `poll_work`. Reserving seq 0 before any read-ahead range keeps it at the
+    /// FIFO head, preserving forward progress under a tight cap.
     async fn reserve_chunk(&self, len: usize) -> Reservation {
         let notify = Arc::new(tokio::sync::Notify::new());
         let waker = Arc::clone(&notify);
@@ -475,10 +474,8 @@ impl DownloadTransfer {
                     .expect("seq window should have capacity at start");
                 // Account the discovery chunk's memory before the transition wakes
                 // poll_work, so the head (seq 0) reserves before any read-ahead
-                // range. Awaiting here (the budget is non-binding at the default
-                // cap, so this is usually immediate) is correct backpressure: a
-                // full budget holds the discovery body undrained until a chunk
-                // frees.
+                // range. Awaiting here backpressures: a full budget holds the
+                // discovery body undrained until a chunk frees.
                 let reservation = self.reserve_chunk(chunk_content_len as usize).await;
                 slot.attach_reservation(reservation);
                 Some((stream, meta, slot))
@@ -1467,7 +1464,7 @@ mod tests {
         );
 
         // poll #3: the parked claim was granted → Ready, pending cleared.
-        let _w2 = assert_ready(transfer.poll_work());
+        let mut w2 = assert_ready(transfer.poll_work());
         {
             let state = transfer.inner.state.lock().unwrap();
             match &*state {
@@ -1478,5 +1475,22 @@ mod tests {
             }
         }
         assert_eq!(budget.in_use_chunks(), 2);
+
+        // The resumed work carries the claimed slot with its reservation attached:
+        // it is a GetObjectRange holding a slot, and dropping the work releases the
+        // reservation (in_use falls), proving the grant rode the slot rather than
+        // being silently dropped at resume.
+        match w2.data_mut::<DownloadWork>() {
+            DownloadWork::GetObjectRange { slot, .. } => {
+                assert!(slot.is_some(), "resumed work should hold its claimed slot");
+            }
+            _ => panic!("expected GetObjectRange"),
+        }
+        drop(w2);
+        assert_eq!(
+            budget.in_use_chunks(),
+            1,
+            "dropping the resumed work releases its reservation"
+        );
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -1,0 +1,637 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Fungible global memory admission-control budget.
+//!
+//! `MemoryBudget` tracks how many fixed-size chunks of memory are logically
+//! reserved across all transfers. It grants reservations (RAII tickets whose drop
+//! returns chunks), parks callers when the budget is exhausted, and wakes them
+//! strictly FIFO as chunks are released.
+
+use std::collections::VecDeque;
+
+use crate::runtime::sync::sync::Arc;
+use crate::runtime::sync::Mutex;
+
+/// Closure the budget invokes to wake a parked reserver (= `scheduler.wake(tid)`).
+pub(crate) type NotifyFn = Arc<dyn Fn() + Send + Sync>;
+
+/// Fungible global memory budget. Accounts in fixed-size chunks; grants RAII
+/// `Reservation` tickets whose drop returns chunks and wakes parked waiters.
+pub(crate) struct MemoryBudget {
+    inner: Mutex<Inner>,
+    /// Fixed nominal accounting unit, in bytes (e.g. 8 MiB). NOT any transfer's
+    /// part size: a part of `n` bytes costs `ceil(n / chunk)` chunks, so a 16 MiB
+    /// part against an 8 MiB chunk costs 2. Bounds accounting error to within one
+    /// chunk per reservation while keeping the budget part-size-agnostic.
+    chunk: usize,
+}
+
+// Lock-ordering invariant (developer note).
+//
+// Two lock flavors exist: the budget lock (`MemoryBudget.inner`) and per-waiter
+// slot locks (`WaitSlot.state`). The orderings `budget → slot` (drain stores a
+// grant) and `slot → budget` (WaitTicket::drop acts on a waiter) must NEVER nest,
+// or they deadlock: drain holds budget and takes slot while a concurrent
+// WaitTicket::drop holds slot and takes budget. Enforced by:
+// - `drain`: takes a slot lock only briefly to store a grant; never drops a
+//   Reservation while holding a slot lock.
+// - `WaitTicket::take`: takes the slot lock only; never touches the budget lock.
+// - `WaitTicket::drop`: takes the slot lock, extracts the state, RELEASES the slot
+//   lock, THEN acts (dropping a granted Reservation re-locks budget; canceling a
+//   Waiting entry locks budget). Neither path holds slot while taking budget.
+
+/// Budget state behind the single budget lock.
+struct Inner {
+    /// Chunks currently reserved (granted and not yet released).
+    in_use: u64,
+    /// Chunk ceiling; resizable via `set_limit`.
+    capacity: u64,
+    /// Parked requests in strict arrival order; the front is served first.
+    waiters: VecDeque<Waiter>,
+}
+
+/// A parked reservation request: how many chunks it needs, the slot through which
+/// drain delivers its grant, and the closure to wake it once granted.
+struct Waiter {
+    need: u64,
+    slot: Arc<WaitSlot>,
+    notify: NotifyFn,
+}
+
+/// Per-waiter slot through which drain delivers a granted Reservation. Carries its
+/// own lock so a grant can be stored without holding the budget lock for long.
+struct WaitSlot {
+    state: Mutex<WaitState>,
+}
+
+/// Lifecycle of a parked request's slot.
+enum WaitState {
+    /// Enqueued, not yet granted.
+    Waiting,
+    /// drain has granted a reservation; awaiting `WaitTicket::take`.
+    Granted(Reservation),
+    /// The grant was taken (or the ticket dropped); terminal.
+    Taken,
+}
+
+/// Result of `MemoryBudget::reserve`: either an immediate grant or a ticket to
+/// poll later after the budget wakes the caller.
+pub(crate) enum Reserve {
+    /// The request fit immediately; chunks are reserved.
+    Ready(Reservation),
+    /// The request was enqueued; poll the ticket after the notify fires.
+    Pending(WaitTicket),
+}
+
+/// RAII ticket representing reserved chunks. Drop returns the chunks to the budget
+/// and drains parked waiters that now fit.
+pub(crate) struct Reservation {
+    budget: Arc<MemoryBudget>,
+    chunks: u64,
+}
+
+/// Opaque handle to a parked reservation request. The caller holds this until
+/// `take()` yields the granted `Reservation` (after the budget's notify fires).
+pub(crate) struct WaitTicket {
+    slot: Arc<WaitSlot>,
+    budget: Arc<MemoryBudget>,
+}
+
+// A request fits when the free chunks cover its need. The `in_use == 0` clause is
+// the forced grant: a request larger than the entire capacity can only ever proceed
+// when nothing else holds the budget, and strict FIFO guarantees that point is
+// eventually reached for the front waiter. This is the sole path by which a
+// `need > capacity` request makes progress (the upload / un-sliced-object backstop;
+// downloads slice to part_size so never hit it). Without it such a request would
+// park forever.
+fn can_grant(need: u64, in_use: u64, capacity: u64) -> bool {
+    need <= capacity.saturating_sub(in_use) || in_use == 0
+}
+
+/// Drain the wait queue strictly FIFO. Grants the front waiter if it fits, stops
+/// at the first that does not (no skip-ahead). Returns collected NotifyFns that
+/// callers MUST invoke AFTER releasing the budget lock.
+fn drain(budget: &Arc<MemoryBudget>, inner: &mut Inner) -> Vec<NotifyFn> {
+    let mut notifies = Vec::new();
+    while let Some(front) = inner.waiters.front() {
+        if !can_grant(front.need, inner.in_use, inner.capacity) {
+            break;
+        }
+        let waiter = inner.waiters.pop_front().unwrap();
+        inner.in_use += waiter.need;
+        let reservation = Reservation {
+            budget: budget.clone(),
+            chunks: waiter.need,
+        };
+        {
+            let mut slot_state = waiter.slot.state.lock();
+            *slot_state = WaitState::Granted(reservation);
+        }
+        notifies.push(waiter.notify);
+    }
+    notifies
+}
+
+impl MemoryBudget {
+    /// Create a new budget. `chunk_bytes` is the fixed accounting unit (must be > 0).
+    /// Capacity is `floor(capacity_bytes / chunk_bytes)` chunks.
+    pub(crate) fn new(capacity_bytes: usize, chunk_bytes: usize) -> Arc<Self> {
+        assert!(chunk_bytes > 0, "chunk_bytes must be > 0");
+        let capacity = (capacity_bytes / chunk_bytes) as u64;
+        Arc::new(Self {
+            inner: Mutex::new(Inner {
+                in_use: 0,
+                capacity,
+                waiters: VecDeque::new(),
+            }),
+            chunk: chunk_bytes,
+        })
+    }
+
+    /// Number of chunks required to hold `bytes` (ceiling division).
+    pub(crate) fn chunks_for(&self, bytes: usize) -> u64 {
+        if bytes == 0 {
+            return 0;
+        }
+        bytes.div_ceil(self.chunk) as u64
+    }
+
+    /// Attempt an immediate grant. Returns None if the queue is non-empty (no-barge)
+    /// or the request does not fit.
+    pub(crate) fn try_reserve(self: &Arc<Self>, bytes: usize) -> Option<Reservation> {
+        let need = self.chunks_for(bytes);
+        let mut inner = self.inner.lock();
+        // No-barge: a fresh request never jumps a queued waiter, even if it would fit.
+        // Combined with strict-FIFO drain (which stops at the first front that does not
+        // fit), this makes a front waiter see in_use only fall until its need is met, so it
+        // is never starved for need <= capacity. Bargeing would let a stream of small
+        // requests indefinitely starve a larger queued one. Cost: strict FIFO
+        // head-of-line-blocks smaller requests behind a large front waiter (the budget
+        // idles while it accumulates) — bounded, only under mixed part sizes; uniform part
+        // size never triggers it.
+        if !inner.waiters.is_empty() {
+            return None;
+        }
+        if can_grant(need, inner.in_use, inner.capacity) {
+            inner.in_use += need;
+            Some(Reservation {
+                budget: Arc::clone(self),
+                chunks: need,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Reserve chunks for `bytes`. Returns `Ready` with an immediate grant when the
+    /// queue is empty and the request fits, otherwise enqueues a waiter and returns
+    /// `Pending` with a `WaitTicket`.
+    pub(crate) fn reserve(self: &Arc<Self>, bytes: usize, notify: NotifyFn) -> Reserve {
+        let need = self.chunks_for(bytes);
+        let mut inner = self.inner.lock();
+        // No-barge: a fresh request never jumps a queued waiter, even if it would fit.
+        // Combined with strict-FIFO drain (which stops at the first front that does not
+        // fit), this makes a front waiter see in_use only fall until its need is met, so it
+        // is never starved for need <= capacity. Bargeing would let a stream of small
+        // requests indefinitely starve a larger queued one. Cost: strict FIFO
+        // head-of-line-blocks smaller requests behind a large front waiter (the budget
+        // idles while it accumulates) — bounded, only under mixed part sizes; uniform part
+        // size never triggers it.
+        if inner.waiters.is_empty() && can_grant(need, inner.in_use, inner.capacity) {
+            inner.in_use += need;
+            return Reserve::Ready(Reservation {
+                budget: Arc::clone(self),
+                chunks: need,
+            });
+        }
+        let slot = Arc::new(WaitSlot {
+            state: Mutex::new(WaitState::Waiting),
+        });
+        inner.waiters.push_back(Waiter {
+            need,
+            slot: Arc::clone(&slot),
+            notify,
+        });
+        Reserve::Pending(WaitTicket {
+            slot,
+            budget: Arc::clone(self),
+        })
+    }
+
+    /// Resize the capacity (in bytes). Growing may drain parked waiters. Shrinking
+    /// is soft: never revokes already-granted chunks, just tightens future grants.
+    pub(crate) fn set_limit(self: &Arc<Self>, capacity_bytes: usize) {
+        let new_capacity = (capacity_bytes / self.chunk) as u64;
+        let notifies = {
+            let mut inner = self.inner.lock();
+            inner.capacity = new_capacity;
+            drain(self, &mut inner)
+        };
+        for f in notifies {
+            f();
+        }
+    }
+
+    /// Chunks currently reserved (granted and not yet released).
+    pub(crate) fn in_use_chunks(&self) -> u64 {
+        self.inner.lock().in_use
+    }
+
+    /// Current capacity in chunks.
+    pub(crate) fn capacity_chunks(&self) -> u64 {
+        self.inner.lock().capacity
+    }
+
+    /// The fixed chunk size in bytes.
+    pub(crate) fn chunk_bytes(&self) -> usize {
+        self.chunk
+    }
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        let notifies = {
+            let mut inner = self.budget.inner.lock();
+            inner.in_use = inner.in_use.saturating_sub(self.chunks);
+            drain(&self.budget, &mut inner)
+        };
+        for f in notifies {
+            f();
+        }
+    }
+}
+
+impl WaitTicket {
+    /// If the budget has granted this ticket's reservation, take it out and return
+    /// it. Returns None if still waiting or already taken.
+    pub(crate) fn take(&mut self) -> Option<Reservation> {
+        let mut slot_state = self.slot.state.lock();
+        let state = std::mem::replace(&mut *slot_state, WaitState::Taken);
+        match state {
+            WaitState::Granted(res) => Some(res),
+            WaitState::Waiting => {
+                *slot_state = WaitState::Waiting;
+                None
+            }
+            WaitState::Taken => {
+                *slot_state = WaitState::Taken;
+                None
+            }
+        }
+    }
+}
+
+impl Drop for WaitTicket {
+    fn drop(&mut self) {
+        // Take the state out under the slot lock, then release it before acting.
+        let state = {
+            let mut slot_state = self.slot.state.lock();
+            std::mem::replace(&mut *slot_state, WaitState::Taken)
+        };
+        // Slot lock is released here. Now act on the extracted state.
+        match state {
+            WaitState::Granted(res) => {
+                // Granted but never taken: drop the reservation to return chunks.
+                // Safe: slot lock is released, so Reservation::drop can lock the budget.
+                drop(res);
+            }
+            WaitState::Waiting => {
+                // Cancel: remove this waiter from the queue.
+                let mut inner = self.budget.inner.lock();
+                inner.waiters.retain(|w| !Arc::ptr_eq(&w.slot, &self.slot));
+            }
+            WaitState::Taken => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+    fn notify_flag() -> (NotifyFn, Arc<AtomicBool>) {
+        let flag = Arc::new(AtomicBool::new(false));
+        let f = Arc::clone(&flag);
+        (Arc::new(move || f.store(true, Ordering::Release)), flag)
+    }
+
+    fn notify_counter() -> (NotifyFn, Arc<AtomicU64>) {
+        let counter = Arc::new(AtomicU64::new(0));
+        let c = Arc::clone(&counter);
+        (
+            Arc::new(move || {
+                c.fetch_add(1, Ordering::Release);
+            }),
+            counter,
+        )
+    }
+
+    #[test]
+    fn test_chunks_for_rounds_up() {
+        let budget = MemoryBudget::new(1024, 100);
+        assert_eq!(budget.chunks_for(0), 0);
+        assert_eq!(budget.chunks_for(1), 1);
+        assert_eq!(budget.chunks_for(100), 1);
+        assert_eq!(budget.chunks_for(101), 2);
+    }
+
+    #[test]
+    fn test_reserve_within_capacity_is_ready_and_tracks_in_use() {
+        let chunk = 8 * 1024 * 1024; // 8 MiB
+        let budget = MemoryBudget::new(chunk * 4, chunk);
+        let (notify, _flag) = notify_flag();
+
+        match budget.reserve(chunk * 2, notify) {
+            Reserve::Ready(_res) => {
+                assert_eq!(budget.in_use_chunks(), 2);
+            }
+            Reserve::Pending(_) => panic!("expected Ready"),
+        }
+    }
+
+    #[test]
+    fn test_drop_returns_chunks() {
+        let chunk = 8 * 1024 * 1024;
+        let budget = MemoryBudget::new(chunk * 4, chunk);
+        let (notify, _flag) = notify_flag();
+
+        let res = match budget.reserve(chunk * 2, notify) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+        assert_eq!(budget.in_use_chunks(), 2);
+        drop(res);
+        assert_eq!(budget.in_use_chunks(), 0);
+    }
+
+    #[test]
+    fn test_exhaustion_returns_pending_then_release_grants_waiter() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 2, chunk); // 2 chunks capacity
+        let (n1, _) = notify_flag();
+        let (n2, flag2) = notify_flag();
+        let (n2_counter, counter) = notify_counter();
+        // Use counter-based notify to check exactly-once
+        let _ = n2; // discard flag-based
+        let _ = flag2;
+
+        // Fill capacity
+        let res1 = match budget.reserve(chunk * 2, n1) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+        assert_eq!(budget.in_use_chunks(), 2);
+
+        // Next reserve exhausts budget -> Pending
+        let mut ticket = match budget.reserve(chunk, n2_counter) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // ticket.take() is None (still waiting)
+        assert!(ticket.take().is_none());
+
+        // Drop the first reservation -> should grant the waiter
+        drop(res1);
+
+        // Notify fired exactly once
+        assert_eq!(counter.load(Ordering::Acquire), 1);
+
+        // ticket.take() now returns Some
+        let res2 = ticket.take().expect("should be granted");
+        assert_eq!(budget.in_use_chunks(), 1);
+        drop(res2);
+        assert_eq!(budget.in_use_chunks(), 0);
+    }
+
+    #[test]
+    fn test_strict_fifo_two_waiters_granted_in_order() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk, chunk); // capacity = 1 chunk
+        let (n_hold, _) = notify_flag();
+        let (n_a, flag_a) = notify_flag();
+        let (n_b, flag_b) = notify_flag();
+
+        // Hold the single chunk
+        let holder = match budget.reserve(chunk, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Waiter A needs 1 chunk
+        let mut ticket_a = match budget.reserve(chunk, n_a) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Waiter B needs 1 chunk
+        let mut ticket_b = match budget.reserve(chunk, n_b) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Release holder -> A granted, B still waiting
+        drop(holder);
+        assert!(flag_a.load(Ordering::Acquire));
+        assert!(!flag_b.load(Ordering::Acquire));
+
+        let res_a = ticket_a.take().expect("A should be granted");
+        assert!(ticket_b.take().is_none());
+
+        // Release A -> B granted
+        drop(res_a);
+        assert!(flag_b.load(Ordering::Acquire));
+        let _res_b = ticket_b.take().expect("B should be granted");
+    }
+
+    #[test]
+    fn test_no_barge_small_request_does_not_jump_queued_large() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 4, chunk); // 4 chunks capacity
+        let (n_hold, _) = notify_flag();
+        let (n_large, flag_large) = notify_flag();
+
+        // Fill all 4 chunks
+        let holder = match budget.reserve(chunk * 4, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Queue a 4-chunk waiter
+        let mut ticket_large = match budget.reserve(chunk * 4, n_large) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // try_reserve of 1 chunk must return None (no-barge) even though 1 would
+        // fit if we freed 1 chunk.
+        assert!(budget.try_reserve(chunk).is_none());
+
+        // Release the holder -> the queued large waiter is served
+        drop(holder);
+        assert!(flag_large.load(Ordering::Acquire));
+        let _res_large = ticket_large.take().expect("large waiter should be granted");
+
+        // Now try_reserve works (queue is empty)
+        // But capacity is fully used by the large waiter, so it won't fit
+        assert!(budget.try_reserve(chunk).is_none());
+    }
+
+    #[test]
+    fn test_forced_grant_oversized_when_idle() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 2, chunk); // 2 chunks capacity
+
+        // try_reserve of 5 chunks while in_use == 0 -> Ready (forced grant)
+        let res = budget
+            .try_reserve(chunk * 5)
+            .expect("forced grant when idle");
+        assert_eq!(budget.in_use_chunks(), 5);
+        drop(res);
+
+        // Test forced grant via FIFO: hold 1 chunk, queue a 5-chunk waiter,
+        // then release -> waiter granted once in_use hits 0.
+        let (n_hold, _) = notify_flag();
+        let (n_big, flag_big) = notify_flag();
+
+        let holder = match budget.reserve(chunk, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        let mut ticket = match budget.reserve(chunk * 5, n_big) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Release holder -> in_use becomes 0 -> forced grant fires
+        drop(holder);
+        assert!(flag_big.load(Ordering::Acquire));
+        let res = ticket.take().expect("oversized waiter should be granted");
+        assert_eq!(budget.in_use_chunks(), 5);
+        drop(res);
+    }
+
+    #[test]
+    fn test_set_limit_grow_drains_waiters() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk, chunk); // 1 chunk capacity
+        let (n_hold, _) = notify_flag();
+        let (n_wait, flag_wait) = notify_flag();
+
+        // Fill capacity
+        let _holder = match budget.reserve(chunk, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Park a waiter needing 1 chunk
+        let mut ticket = match budget.reserve(chunk, n_wait) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Grow capacity to 2 -> waiter now fits
+        budget.set_limit(chunk * 2);
+        assert!(flag_wait.load(Ordering::Acquire));
+        let _res = ticket.take().expect("should be granted after grow");
+        assert_eq!(budget.in_use_chunks(), 2);
+    }
+
+    #[test]
+    fn test_set_limit_shrink_is_soft() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 4, chunk); // 4 chunks
+        let (n, _) = notify_flag();
+
+        // Reserve 3 chunks
+        let res = match budget.reserve(chunk * 3, n) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+        assert_eq!(budget.in_use_chunks(), 3);
+
+        // Shrink capacity below in_use: no panic, reservation still valid
+        budget.set_limit(chunk); // capacity now 1 chunk
+        assert_eq!(budget.capacity_chunks(), 1);
+        assert_eq!(budget.in_use_chunks(), 3); // unchanged
+
+        // New reserve is gated by lower capacity
+        let (n2, _) = notify_flag();
+        match budget.reserve(chunk, n2) {
+            Reserve::Pending(_) => {} // expected: 3 in_use > 1 capacity
+            Reserve::Ready(_) => panic!("expected Pending under shrunk capacity"),
+        }
+
+        drop(res);
+    }
+
+    #[test]
+    fn test_wait_ticket_drop_while_waiting_removes_from_queue() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk, chunk); // 1 chunk
+        let (n_hold, _) = notify_flag();
+        let (n_wait, flag_wait) = notify_flag();
+
+        // Fill capacity
+        let holder = match budget.reserve(chunk, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Park a waiter
+        let ticket = match budget.reserve(chunk, n_wait) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Drop the ticket (cancel the waiter)
+        drop(ticket);
+
+        // Release the holder — the dropped waiter must not be granted
+        drop(holder);
+        assert!(!flag_wait.load(Ordering::Acquire));
+        assert_eq!(budget.in_use_chunks(), 0);
+
+        // A subsequent waiter works correctly
+        let (n_new, flag_new) = notify_flag();
+        match budget.reserve(chunk, n_new) {
+            Reserve::Ready(_) => {} // queue is empty, fits
+            Reserve::Pending(_) => panic!("expected Ready after cancel"),
+        }
+        let _ = flag_new;
+    }
+
+    #[test]
+    fn test_wait_ticket_drop_after_granted_returns_chunks() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 2, chunk); // 2 chunks
+        let (n_hold, _) = notify_flag();
+        let (n_wait, flag_wait) = notify_flag();
+
+        // Reserve 2 chunks (fill capacity)
+        let holder = match budget.reserve(chunk * 2, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Park a 1-chunk waiter
+        let ticket = match budget.reserve(chunk, n_wait) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Release holder: drain grants the waiter (notify fires)
+        drop(holder);
+        assert!(flag_wait.load(Ordering::Acquire));
+        assert_eq!(budget.in_use_chunks(), 1); // 1 chunk granted to waiter
+
+        // Drop the ticket WITHOUT calling take() — granted-but-untaken chunks released
+        drop(ticket);
+        assert_eq!(budget.in_use_chunks(), 0);
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -12,6 +12,7 @@
 
 use std::collections::VecDeque;
 
+use crate::metrics::unit::ByteUnit;
 use crate::runtime::sync::sync::Arc;
 use crate::runtime::sync::Mutex;
 
@@ -27,6 +28,14 @@ pub(crate) struct MemoryBudget {
     /// part against an 8 MiB chunk costs 2. Bounds accounting error to within one
     /// chunk per reservation while keeping the budget part-size-agnostic.
     chunk: usize,
+}
+
+impl std::fmt::Debug for MemoryBudget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryBudget")
+            .field("chunk", &self.chunk)
+            .finish_non_exhaustive()
+    }
 }
 
 // Lock-ordering invariant (developer note).
@@ -99,6 +108,18 @@ pub(crate) struct WaitTicket {
     slot: Arc<WaitSlot>,
     budget: Arc<MemoryBudget>,
 }
+
+impl std::fmt::Debug for WaitTicket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WaitTicket").finish_non_exhaustive()
+    }
+}
+
+// TODO(budget): replaced by machine-aware sizing + MemoryBudgetConfig (later delegation).
+/// Nominal 8 MiB accounting unit for budget reservations.
+pub(crate) const BUDGET_CHUNK_BYTES: usize = 8 * ByteUnit::Mebibyte.as_bytes_usize();
+/// 8 GiB placeholder — large enough not to bind current tests.
+pub(crate) const DEFAULT_MEMORY_BUDGET_BYTES: usize = 8 * ByteUnit::Gibibyte.as_bytes_usize();
 
 // A request fits when the free chunks cover its need. The `in_use == 0` clause is
 // the forced grant: a request larger than the entire capacity can only ever proceed

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -64,6 +64,9 @@ struct Inner {
     capacity: u64,
     /// Parked requests in strict arrival order; the front is served first.
     waiters: VecDeque<Waiter>,
+    /// Cumulative count of requests that ever parked (returned `Pending`).
+    /// Monotonic; distinguishes a budget that has bound from one that never has.
+    total_parked: u64,
 }
 
 /// A parked reservation request: how many chunks it needs, the slot through which
@@ -170,11 +173,24 @@ impl MemoryBudget {
     pub(crate) fn new(capacity_bytes: usize, chunk_bytes: usize) -> Arc<Self> {
         assert!(chunk_bytes > 0, "chunk_bytes must be > 0");
         let capacity = (capacity_bytes / chunk_bytes).max(1) as u64;
+        if capacity_bytes < chunk_bytes {
+            tracing::debug!(
+                requested_bytes = capacity_bytes,
+                chunk_bytes,
+                "memory budget below one chunk; raised to a single chunk"
+            );
+        }
+        tracing::debug!(
+            capacity_chunks = capacity,
+            chunk_bytes,
+            "memory budget resolved"
+        );
         Arc::new(Self {
             inner: Mutex::new(Inner {
                 in_use: 0,
                 capacity,
                 waiters: VecDeque::new(),
+                total_parked: 0,
             }),
             chunk: chunk_bytes,
         })
@@ -246,6 +262,7 @@ impl MemoryBudget {
             slot: Arc::clone(&slot),
             notify,
         });
+        inner.total_parked += 1;
         Reserve::Pending(WaitTicket {
             slot,
             budget: Arc::clone(self),
@@ -283,6 +300,19 @@ impl MemoryBudget {
     #[allow(dead_code)]
     pub(crate) fn chunk_bytes(&self) -> usize {
         self.chunk
+    }
+
+    /// Snapshot the budget's admission state under a single lock. Chunk counts are
+    /// converted to bytes; `reserved_bytes` is admitted memory (a ceiling), not
+    /// resident memory.
+    pub(crate) fn stats(&self) -> crate::types::MemoryBudgetSnapshot {
+        let inner = self.inner.lock();
+        crate::types::MemoryBudgetSnapshot {
+            capacity_bytes: inner.capacity * self.chunk as u64,
+            reserved_bytes: inner.in_use * self.chunk as u64,
+            waiters: inner.waiters.len(),
+            total_parked: inner.total_parked,
+        }
     }
 }
 
@@ -386,6 +416,45 @@ mod tests {
         let first = budget.try_reserve(chunk);
         assert!(first.is_some());
         assert!(budget.try_reserve(chunk).is_none());
+    }
+
+    #[test]
+    fn test_stats_reports_bytes_and_park_counter() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 2, chunk); // capacity = 2 chunks
+
+        let s = budget.stats();
+        assert_eq!(s.capacity_bytes, (chunk * 2) as u64);
+        assert_eq!(s.reserved_bytes, 0);
+        assert_eq!(s.waiters, 0);
+        assert_eq!(s.total_parked, 0);
+
+        // Reserve both chunks: reserved tracks in bytes, still no parking.
+        let holder = match budget.reserve(chunk * 2, notify_flag().0) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+        let s = budget.stats();
+        assert_eq!(s.reserved_bytes, (chunk * 2) as u64);
+        assert_eq!(s.waiters, 0);
+        assert_eq!(s.total_parked, 0);
+
+        // Next request parks: waiters rises and the cumulative counter ticks.
+        let ticket = match budget.reserve(chunk, notify_flag().0) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+        let s = budget.stats();
+        assert_eq!(s.waiters, 1);
+        assert_eq!(s.total_parked, 1);
+
+        // Drop the waiter: waiters falls back, but total_parked is monotonic.
+        drop(ticket);
+        let s = budget.stats();
+        assert_eq!(s.waiters, 0);
+        assert_eq!(s.total_parked, 1, "park counter is cumulative");
+
+        drop(holder);
     }
 
     #[test]

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -115,10 +115,11 @@ impl std::fmt::Debug for WaitTicket {
     }
 }
 
-// TODO(budget): replaced by machine-aware sizing + MemoryBudgetConfig (later delegation).
-/// Nominal 8 MiB accounting unit for budget reservations.
+/// Nominal 8 MiB accounting unit for budget reservations. A part costs
+/// `ceil(part_size / chunk)` chunks, so non-uniform part sizes account correctly.
 pub(crate) const BUDGET_CHUNK_BYTES: usize = 8 * ByteUnit::Mebibyte.as_bytes_usize();
-/// 8 GiB placeholder — large enough not to bind current tests.
+/// Non-binding budget for test handles, which size objects far below it.
+#[cfg(test)]
 pub(crate) const DEFAULT_MEMORY_BUDGET_BYTES: usize = 8 * ByteUnit::Gibibyte.as_bytes_usize();
 
 // A request fits when the free chunks cover its need. The `in_use == 0` clause is

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -11,9 +11,13 @@
 //! strictly FIFO as chunks are released.
 
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use crate::metrics::unit::ByteUnit;
-use crate::runtime::sync::sync::Arc;
+// The compat-layer Mutex is loom-instrumented under `cfg(s3_tm_loom)`, which is
+// what exercises the budget/slot lock-ordering invariant. `Arc` stays `std`: the
+// budget is held as `std::sync::Arc` across the call graph, and loom tracks the
+// locks, not the refcount.
 use crate::runtime::sync::Mutex;
 
 /// Closure the budget invokes to wake a parked reserver (= `scheduler.wake(tid)`).
@@ -159,10 +163,13 @@ fn drain(budget: &Arc<MemoryBudget>, inner: &mut Inner) -> Vec<NotifyFn> {
 
 impl MemoryBudget {
     /// Create a new budget. `chunk_bytes` is the fixed accounting unit (must be > 0).
-    /// Capacity is `floor(capacity_bytes / chunk_bytes)` chunks.
+    /// Capacity is `floor(capacity_bytes / chunk_bytes)` chunks, with a floor of one
+    /// chunk: a capacity that rounds to zero would force every request through the
+    /// idle-only grant path, serializing all transfers, so a budget configured below
+    /// one chunk is raised to one rather than silently throttling to a single part.
     pub(crate) fn new(capacity_bytes: usize, chunk_bytes: usize) -> Arc<Self> {
         assert!(chunk_bytes > 0, "chunk_bytes must be > 0");
-        let capacity = (capacity_bytes / chunk_bytes) as u64;
+        let capacity = (capacity_bytes / chunk_bytes).max(1) as u64;
         Arc::new(Self {
             inner: Mutex::new(Inner {
                 in_use: 0,
@@ -181,10 +188,9 @@ impl MemoryBudget {
         bytes.div_ceil(self.chunk) as u64
     }
 
-    /// Attempt an immediate grant. Returns None if the queue is non-empty (no-barge)
-    /// or the request does not fit.
-    // Synchronous no-park reservation path; consumed by the upload-side budget
-    // integration (no scheduler waker to register there). Exercised by tests.
+    /// Attempt an immediate grant without parking. Returns None if the queue is
+    /// non-empty (no-barge) or the request does not fit. Unlike
+    /// [`reserve`](Self::reserve) it never enqueues a waiter and registers no waker.
     #[allow(dead_code)]
     pub(crate) fn try_reserve(self: &Arc<Self>, bytes: usize) -> Option<Reservation> {
         let need = self.chunks_for(bytes);
@@ -248,8 +254,6 @@ impl MemoryBudget {
 
     /// Resize the capacity (in bytes). Growing may drain parked waiters. Shrinking
     /// is soft: never revokes already-granted chunks, just tightens future grants.
-    // Consumed by the resize loop (Mountpoint read-window control + adaptive
-    // budget sizing). Exercised by the grow/shrink tests.
     #[allow(dead_code)]
     pub(crate) fn set_limit(self: &Arc<Self>, capacity_bytes: usize) {
         let new_capacity = (capacity_bytes / self.chunk) as u64;
@@ -263,9 +267,6 @@ impl MemoryBudget {
         }
     }
 
-    // Occupancy/introspection accessors, consumed by the per-NIC budget gauge in
-    // the backpressure-telemetry chunk (in_use/capacity render the occupancy
-    // line; chunk_bytes converts to bytes). Exercised by tests.
     /// Chunks currently reserved (granted and not yet released).
     #[allow(dead_code)]
     pub(crate) fn in_use_chunks(&self) -> u64 {
@@ -371,6 +372,20 @@ mod tests {
         assert_eq!(budget.chunks_for(1), 1);
         assert_eq!(budget.chunks_for(100), 1);
         assert_eq!(budget.chunks_for(101), 2);
+    }
+
+    #[test]
+    fn test_capacity_floored_at_one_chunk() {
+        // A budget configured below one chunk would otherwise round to zero
+        // capacity, forcing every request through the idle-only grant path and
+        // serializing transfers. It is raised to one chunk instead.
+        let chunk = 8 * 1024 * 1024;
+        let budget = MemoryBudget::new(chunk / 2, chunk);
+        assert_eq!(budget.capacity_chunks(), 1);
+        // The first request fits; a second parks rather than barging.
+        let first = budget.try_reserve(chunk);
+        assert!(first.is_some());
+        assert!(budget.try_reserve(chunk).is_none());
     }
 
     #[test]
@@ -489,30 +504,39 @@ mod tests {
         let (n_hold, _) = notify_flag();
         let (n_large, flag_large) = notify_flag();
 
-        // Fill all 4 chunks
-        let holder = match budget.reserve(chunk * 4, n_hold) {
+        // Hold 3 of 4 chunks, leaving 1 free.
+        let holder = match budget.reserve(chunk * 3, n_hold) {
             Reserve::Ready(r) => r,
             Reserve::Pending(_) => panic!("expected Ready"),
         };
 
-        // Queue a 4-chunk waiter
-        let mut ticket_large = match budget.reserve(chunk * 4, n_large) {
+        // Queue a 2-chunk waiter. It does not fit now (1 free < 2), so it parks.
+        let mut ticket_large = match budget.reserve(chunk * 2, n_large) {
             Reserve::Pending(t) => t,
             Reserve::Ready(_) => panic!("expected Pending"),
         };
 
-        // try_reserve of 1 chunk must return None (no-barge) even though 1 would
-        // fit if we freed 1 chunk.
-        assert!(budget.try_reserve(chunk).is_none());
+        // A 1-chunk request WOULD fit on capacity alone (1 chunk is free), so this
+        // isolates no-barge from exhaustion: it is rejected only because a waiter
+        // is queued ahead of it.
+        assert!(
+            budget.try_reserve(chunk).is_none(),
+            "no-barge: must not jump the queued waiter even though it fits"
+        );
 
-        // Release the holder -> the queued large waiter is served
+        // Drain the queue: releasing the holder frees 3 chunks; the parked 2-chunk
+        // waiter is granted, leaving in_use == 2.
         drop(holder);
         assert!(flag_large.load(Ordering::Acquire));
-        let _res_large = ticket_large.take().expect("large waiter should be granted");
+        let _res_large = ticket_large.take().expect("waiter should be granted");
+        assert_eq!(budget.in_use_chunks(), 2);
 
-        // Now try_reserve works (queue is empty)
-        // But capacity is fully used by the large waiter, so it won't fit
-        assert!(budget.try_reserve(chunk).is_none());
+        // Same 1-chunk request now succeeds: the queue is empty and 2 chunks are
+        // free, confirming the earlier rejection was no-barge, not exhaustion.
+        assert!(
+            budget.try_reserve(chunk).is_some(),
+            "with an empty queue and free capacity the request now fits"
+        );
     }
 
     #[test]
@@ -641,6 +665,55 @@ mod tests {
     }
 
     #[test]
+    fn test_cancel_middle_waiter_preserves_order_of_others() {
+        // Three waiters queued behind a holder; cancel the middle one. The
+        // remaining two must still be granted in arrival order — guarding against
+        // a cancel that removes the wrong entry (or all entries).
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk, chunk); // capacity = 1 chunk
+        let (n_hold, _) = notify_flag();
+        let (n_a, flag_a) = notify_flag();
+        let (n_b, flag_b) = notify_flag();
+        let (n_c, flag_c) = notify_flag();
+
+        let holder = match budget.reserve(chunk, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+        let mut ticket_a = match budget.reserve(chunk, n_a) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+        let ticket_b = match budget.reserve(chunk, n_b) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+        let mut ticket_c = match budget.reserve(chunk, n_c) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Cancel the middle waiter (B).
+        drop(ticket_b);
+
+        // Release the holder: A (front) is granted; B and C are not yet.
+        drop(holder);
+        assert!(flag_a.load(Ordering::Acquire), "A should be granted first");
+        assert!(!flag_b.load(Ordering::Acquire), "B was cancelled");
+        assert!(!flag_c.load(Ordering::Acquire), "C waits behind A");
+        let res_a = ticket_a.take().expect("A granted");
+
+        // Release A: C is now front (B was removed, not C) and is granted.
+        drop(res_a);
+        assert!(
+            flag_c.load(Ordering::Acquire),
+            "C should be granted after A"
+        );
+        let _res_c = ticket_c.take().expect("C granted");
+        assert_eq!(budget.in_use_chunks(), 1);
+    }
+
+    #[test]
     fn test_wait_ticket_drop_after_granted_returns_chunks() {
         let chunk = 1024;
         let budget = MemoryBudget::new(chunk * 2, chunk); // 2 chunks
@@ -667,5 +740,86 @@ mod tests {
         // Drop the ticket WITHOUT calling take() — granted-but-untaken chunks released
         drop(ticket);
         assert_eq!(budget.in_use_chunks(), 0);
+    }
+}
+
+// Concurrency models for the lock-ordering invariant: `drain` takes the budget
+// lock then a slot lock; `WaitTicket::drop` takes a slot lock then the budget
+// lock. The invariant is that these never nest (drain holds the slot lock only to
+// store a grant; WaitTicket::drop releases the slot lock before touching the
+// budget). Loom exhaustively explores the interleavings; a regression that nested
+// the locks would deadlock (loom reports it) and a regression in the accounting
+// would trip an assertion.
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use super::*;
+    use crate::runtime::sync::thread;
+
+    fn noop_notify() -> NotifyFn {
+        Arc::new(|| {})
+    }
+
+    #[test]
+    fn release_races_cancel() {
+        // One holder fills the budget, one waiter is parked. Releasing the holder
+        // (drain: budget -> slot) races dropping the waiter's ticket
+        // (cancel/return: slot -> budget). Whatever the interleaving, the holder's
+        // chunk is returned and the waiter ends with no chunk outstanding.
+        loom::model(|| {
+            let chunk = 1024;
+            let budget = MemoryBudget::new(chunk, chunk); // capacity = 1 chunk
+
+            let holder = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Ready(r) => r,
+                Reserve::Pending(_) => unreachable!("first reserve fits"),
+            };
+            let ticket = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Pending(t) => t,
+                Reserve::Ready(_) => unreachable!("budget is full"),
+            };
+
+            let h = thread::spawn(move || drop(holder));
+            drop(ticket);
+            h.join().unwrap();
+
+            // Reaching here means no deadlock. The waiter was either cancelled
+            // before its grant or granted then released by the ticket drop; either
+            // way nothing remains reserved.
+            assert_eq!(budget.in_use_chunks(), 0);
+        });
+    }
+
+    #[test]
+    fn release_races_take() {
+        // Releasing the holder (drain stores the grant) races the waiter taking it.
+        // After both complete the grant is delivered exactly once and accounting is
+        // consistent across release.
+        loom::model(|| {
+            let chunk = 1024;
+            let budget = MemoryBudget::new(chunk, chunk); // capacity = 1 chunk
+
+            let holder = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Ready(r) => r,
+                Reserve::Pending(_) => unreachable!("first reserve fits"),
+            };
+            let mut ticket = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Pending(t) => t,
+                Reserve::Ready(_) => unreachable!("budget is full"),
+            };
+
+            let h = thread::spawn(move || drop(holder));
+            let taken = ticket.take();
+            h.join().unwrap();
+
+            // The holder is gone, so the grant is available: take() either caught it
+            // or a second take() retrieves it now.
+            let granted = taken.or_else(|| ticket.take());
+            assert!(granted.is_some(), "waiter must be granted after release");
+            assert_eq!(budget.in_use_chunks(), 1);
+
+            drop(granted);
+            drop(ticket);
+            assert_eq!(budget.in_use_chunks(), 0);
+        });
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -183,6 +183,9 @@ impl MemoryBudget {
 
     /// Attempt an immediate grant. Returns None if the queue is non-empty (no-barge)
     /// or the request does not fit.
+    // Synchronous no-park reservation path; consumed by the upload-side budget
+    // integration (no scheduler waker to register there). Exercised by tests.
+    #[allow(dead_code)]
     pub(crate) fn try_reserve(self: &Arc<Self>, bytes: usize) -> Option<Reservation> {
         let need = self.chunks_for(bytes);
         let mut inner = self.inner.lock();
@@ -245,6 +248,9 @@ impl MemoryBudget {
 
     /// Resize the capacity (in bytes). Growing may drain parked waiters. Shrinking
     /// is soft: never revokes already-granted chunks, just tightens future grants.
+    // Consumed by the resize loop (Mountpoint read-window control + adaptive
+    // budget sizing). Exercised by the grow/shrink tests.
+    #[allow(dead_code)]
     pub(crate) fn set_limit(self: &Arc<Self>, capacity_bytes: usize) {
         let new_capacity = (capacity_bytes / self.chunk) as u64;
         let notifies = {
@@ -257,17 +263,23 @@ impl MemoryBudget {
         }
     }
 
+    // Occupancy/introspection accessors, consumed by the per-NIC budget gauge in
+    // the backpressure-telemetry chunk (in_use/capacity render the occupancy
+    // line; chunk_bytes converts to bytes). Exercised by tests.
     /// Chunks currently reserved (granted and not yet released).
+    #[allow(dead_code)]
     pub(crate) fn in_use_chunks(&self) -> u64 {
         self.inner.lock().in_use
     }
 
     /// Current capacity in chunks.
+    #[allow(dead_code)]
     pub(crate) fn capacity_chunks(&self) -> u64 {
         self.inner.lock().capacity
     }
 
     /// The fixed chunk size in bytes.
+    #[allow(dead_code)]
     pub(crate) fn chunk_bytes(&self) -> usize {
         self.chunk
     }

--- a/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
@@ -17,6 +17,8 @@ pub(crate) use managed::ManagedThreadRuntime;
 mod topology;
 pub(crate) use topology::Topology;
 
+#[allow(dead_code)] // TODO(budget): remove once wired into scheduler/download path
+pub(crate) mod memory;
 pub(crate) mod sync;
 
 use aws_smithy_runtime_api::client::http::SharedHttpClient;

--- a/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
@@ -19,7 +19,6 @@ pub(crate) use topology::Topology;
 
 pub(crate) mod platform;
 
-#[allow(dead_code)] // TODO(budget): remove once wired into scheduler/download path
 pub(crate) mod memory;
 pub(crate) mod sync;
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
@@ -17,6 +17,8 @@ pub(crate) use managed::ManagedThreadRuntime;
 mod topology;
 pub(crate) use topology::Topology;
 
+mod platform;
+
 #[allow(dead_code)] // TODO(budget): remove once wired into scheduler/download path
 pub(crate) mod memory;
 pub(crate) mod sync;

--- a/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use managed::ManagedThreadRuntime;
 mod topology;
 pub(crate) use topology::Topology;
 
-mod platform;
+pub(crate) mod platform;
 
 #[allow(dead_code)] // TODO(budget): remove once wired into scheduler/download path
 pub(crate) mod memory;

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -134,6 +134,12 @@ fn auto_budget(ram: Option<usize>) -> usize {
 /// capped — an explicit fraction is taken at the caller's word.
 /// `UNDETECTABLE_MEM_BYTES` when RAM is unknown.
 pub(crate) fn mem_for_fraction(fraction: f64) -> usize {
+    if !(fraction.is_finite() && fraction > 0.0) || fraction > 1.0 {
+        tracing::debug!(
+            requested = fraction,
+            "memory budget fraction outside (0.0, 1.0]; clamping"
+        );
+    }
     mem_for_fraction_from(available_ram(), fraction)
 }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Machine-resource detection for sizing the connection and memory budgets.
+//!
+//! Detection is best-effort: a failure yields a conservative cap, never an
+//! unbounded one.
+
+/// Fraction of the process file-descriptor limit the connection pool may use.
+/// The remainder is headroom for disk sinks, the directory walker, logging, and
+/// other descriptors the process holds.
+const POOL_FD_BUDGET_FRACTION: f64 = 0.5;
+
+/// Ceiling on pooled connections regardless of descriptor headroom. Bounds the
+/// request fan-out against a single S3 endpoint, and is the cap on platforms
+/// with no low descriptor limit.
+const ABSOLUTE_MAX_CONN: usize = 10_000;
+
+/// Floor so a low descriptor limit does not cap the pool below a usable count.
+const MIN_CONN: usize = 10;
+
+/// Global cap on pooled connections. Machine-derived and independent of the
+/// throughput target, so it bounds machine descriptor use and S3 request fan-out
+/// on its own. `clamp(POOL_FD_BUDGET_FRACTION x RLIMIT_NOFILE, MIN_CONN,
+/// ABSOLUTE_MAX_CONN)` on Unix; `ABSOLUTE_MAX_CONN` where there is no low
+/// descriptor limit or detection fails. Budget sizing later tightens this with
+/// the memory term `min(.., budget_capacity / chunk)`.
+pub(crate) fn connection_cap() -> usize {
+    cap_from_fd(fd_limit())
+}
+
+/// Apply the fraction and clamp to a detected descriptor limit. `None` falls
+/// back to the absolute ceiling.
+fn cap_from_fd(fd_limit: Option<usize>) -> usize {
+    fd_limit
+        .map(|n| (n as f64 * POOL_FD_BUDGET_FRACTION) as usize)
+        .unwrap_or(ABSOLUTE_MAX_CONN)
+        .clamp(MIN_CONN, ABSOLUTE_MAX_CONN)
+}
+
+/// Soft `RLIMIT_NOFILE` on Unix; `None` where there is no low descriptor limit
+/// or detection fails.
+#[cfg(unix)]
+fn fd_limit() -> Option<usize> {
+    use nix::sys::resource::{getrlimit, Resource};
+    match getrlimit(Resource::RLIMIT_NOFILE) {
+        Ok((soft, _hard)) if soft > 0 => usize::try_from(soft).ok(),
+        _ => None,
+    }
+}
+
+#[cfg(not(unix))]
+fn fd_limit() -> Option<usize> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cap_none_is_absolute_max() {
+        // No detection (non-Unix, or getrlimit failed) -> absolute ceiling.
+        assert_eq!(cap_from_fd(None), ABSOLUTE_MAX_CONN);
+    }
+
+    #[test]
+    fn test_cap_low_limit_floored() {
+        // 8 descriptors -> 4 by fraction -> floored to MIN_CONN.
+        assert_eq!(cap_from_fd(Some(8)), MIN_CONN);
+    }
+
+    #[test]
+    fn test_cap_mid_limit_is_fraction() {
+        assert_eq!(cap_from_fd(Some(1024)), 512);
+    }
+
+    #[test]
+    fn test_cap_high_limit_clamped() {
+        // 40k descriptors -> 20k by fraction -> clamped to the absolute ceiling.
+        assert_eq!(cap_from_fd(Some(40_000)), ABSOLUTE_MAX_CONN);
+    }
+
+    #[test]
+    fn test_cap_infinite_limit_saturates_to_absolute_max() {
+        // RLIM_INFINITY surfaces as usize::MAX; the fraction saturates, then clamps.
+        assert_eq!(cap_from_fd(Some(usize::MAX)), ABSOLUTE_MAX_CONN);
+    }
+
+    #[test]
+    fn test_connection_cap_within_bounds() {
+        assert!((MIN_CONN..=ABSOLUTE_MAX_CONN).contains(&connection_cap()));
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -11,12 +11,10 @@
 use crate::metrics::unit::ByteUnit;
 use std::path::{Path, PathBuf};
 
-// Connection-cap sizing from the descriptor limit and memory budget. Computed
-// here but not wired on this branch: the only consumer is the managed-runtime
-// `SharedPool` builder, which lands with the connection-pool workstream (the
-// `.max_connections()` wiring was held back in the memory-budget split). Hence
-// the `allow(dead_code)` on each item below; drop them when the pool wiring
-// lands. Tracked in bosun.md (`mem-budget` / `conn-pool`).
+// Connection-cap sizing from the descriptor limit and memory budget. The
+// consumer is the managed-runtime connection pool, which caps `max_connections`
+// from these. Each item below carries `#[allow(dead_code)]` until that wiring
+// exists.
 
 /// Fraction of the process file-descriptor limit the connection pool may use.
 /// The remainder is headroom for disk sinks, the directory walker, logging, and
@@ -86,37 +84,95 @@ fn fd_limit() -> Option<usize> {
     None
 }
 
-/// Fraction of detected RAM the memory budget may use under `Auto`. The
-/// remainder leaves room for the OS page cache (download-to-disk) and the rest
-/// of the process.
+/// Share of detected RAM the memory budget may take under `Auto`. The budget is
+/// a good-citizen ceiling: the remainder is left for the OS page cache
+/// (download-to-disk), the rest of this process, and any co-tenant on the box.
 const SAFE_MEM_FRACTION: f64 = 0.25;
 
-/// Floor on the resolved budget so a small or mis-detected machine still gets a
-/// workable amount.
-const MIN_USABLE_MEM_BYTES: usize = ByteUnit::Gibibyte.as_bytes_usize();
+/// Floor on the resolved budget. Funds a usable prefetch pipeline (64 chunks at
+/// the 8 MiB accounting unit) on a small or memory-constrained box.
+const MIN_BUDGET_BYTES: usize = 512 * ByteUnit::Mebibyte.as_bytes_usize();
+
+/// Ceiling on the resolved budget. Beyond this, more buffer does not raise
+/// sustained throughput, so a larger box gains nothing and its unclaimed share
+/// stays available to everything else. Caps the effective fraction on big boxes.
+const MAX_BUDGET_BYTES: usize = 32 * ByteUnit::Gibibyte.as_bytes_usize();
 
 /// Budget when RAM cannot be detected (non-Linux, or a read failure). Bounded,
-/// but large enough for one transfer's pipeline.
+/// large enough for one transfer's pipeline.
 const UNDETECTABLE_MEM_BYTES: usize = 2 * ByteUnit::Gibibyte.as_bytes_usize();
 
 /// Memory budget under `MemoryBudgetConfig::Auto`: `SAFE_MEM_FRACTION` of
-/// detected RAM, floored at `MIN_USABLE_MEM_BYTES`; `UNDETECTABLE_MEM_BYTES`
-/// when RAM is unknown.
+/// detected RAM, rounded to a power of two and clamped to
+/// `[MIN_BUDGET_BYTES, MAX_BUDGET_BYTES]`; `UNDETECTABLE_MEM_BYTES` when RAM is
+/// unknown.
+///
+/// The budget is a backstop, not the operating point: the concurrency
+/// controller settles at line rate well below it, and it binds only when a slow
+/// consumer backs parts up in the prefetch ring. RAM is an imprecise proxy for
+/// that ceiling — network bandwidth sets the real pipeline depth, and bandwidth
+/// is uncorrelated with RAM across instance families (m5.24xlarge and
+/// m5n.24xlarge share 384 GiB of RAM but differ 4x in bandwidth). The clamp
+/// keeps the estimate safe at both ends; NIC-aware sizing is a separate refinement.
 pub(crate) fn machine_safe_mem() -> usize {
-    mem_for_fraction(SAFE_MEM_FRACTION)
+    auto_budget(available_ram())
 }
 
-/// Memory budget for an explicit RAM fraction (`MemoryBudgetConfig::Fraction`),
-/// floored the same way; `UNDETECTABLE_MEM_BYTES` when RAM is unknown.
-pub(crate) fn mem_for_fraction(fraction: f64) -> usize {
-    mem_from_ram(available_ram(), fraction)
-}
-
-/// Apply a fraction to a detected RAM size and floor it.
-fn mem_from_ram(ram: Option<usize>, fraction: f64) -> usize {
+/// `Auto` policy as a pure function of detected RAM.
+fn auto_budget(ram: Option<usize>) -> usize {
     match ram {
-        Some(bytes) => ((bytes as f64 * fraction) as usize).max(MIN_USABLE_MEM_BYTES),
+        Some(bytes) => {
+            round_pow2(scale(bytes, SAFE_MEM_FRACTION)).clamp(MIN_BUDGET_BYTES, MAX_BUDGET_BYTES)
+        }
         None => UNDETECTABLE_MEM_BYTES,
+    }
+}
+
+/// Memory budget for an explicit `MemoryBudgetConfig::Fraction`. The fraction is
+/// clamped to `(0.0, 1.0]` (a non-finite or non-positive value falls back to
+/// `SAFE_MEM_FRACTION`); the result is floored at `MIN_BUDGET_BYTES` but not
+/// capped — an explicit fraction is taken at the caller's word.
+/// `UNDETECTABLE_MEM_BYTES` when RAM is unknown.
+pub(crate) fn mem_for_fraction(fraction: f64) -> usize {
+    mem_for_fraction_from(available_ram(), fraction)
+}
+
+/// `Fraction` policy as a pure function of detected RAM.
+fn mem_for_fraction_from(ram: Option<usize>, fraction: f64) -> usize {
+    let fraction = if fraction.is_finite() && fraction > 0.0 {
+        fraction.min(1.0)
+    } else {
+        SAFE_MEM_FRACTION
+    };
+    match ram {
+        Some(bytes) => scale(bytes, fraction).max(MIN_BUDGET_BYTES),
+        None => UNDETECTABLE_MEM_BYTES,
+    }
+}
+
+/// Apply a fraction to a byte count. The `f64` cast saturates rather than
+/// overflowing; callers validate the fraction first.
+fn scale(bytes: usize, fraction: f64) -> usize {
+    (bytes as f64 * fraction) as usize
+}
+
+/// Round to the nearer power of two; ties round up. `0` maps to `0`. Rounding to
+/// nearest (rather than `next_power_of_two`'s round-up) keeps the budget near the
+/// intended fraction instead of overshooting when the input sits just above a
+/// power of two.
+fn round_pow2(n: usize) -> usize {
+    match n.checked_next_power_of_two() {
+        Some(upper) if upper == n => n,
+        Some(upper) => {
+            let lower = upper >> 1;
+            if n - lower < upper - n {
+                lower
+            } else {
+                upper
+            }
+        }
+        // `n` exceeds the largest power of two: that power is the nearest.
+        None => 1usize << (usize::BITS - 1),
     }
 }
 
@@ -394,26 +450,85 @@ mod tests {
         assert!((MIN_CONN..=16).contains(&cap));
     }
 
+    const MIB: usize = 1024 * 1024;
+
     #[test]
-    fn test_mem_undetectable_fallback() {
-        assert_eq!(
-            mem_from_ram(None, SAFE_MEM_FRACTION),
-            UNDETECTABLE_MEM_BYTES
-        );
+    fn test_auto_budget_undetectable_fallback() {
+        assert_eq!(auto_budget(None), UNDETECTABLE_MEM_BYTES);
     }
 
     #[test]
-    fn test_mem_fraction_applied() {
-        assert_eq!(mem_from_ram(Some(64 * GIB), 0.25), 16 * GIB);
+    fn test_auto_budget_tiers() {
+        // Reported RAM runs a little under the marketed size (firmware/kernel
+        // reserve), so 0.25x lands just under a power of two; nearest-rounding
+        // recovers the intended tier. (marketed GiB, reported GiB, expected budget)
+        let cases = [
+            (1.0, 1.0, 512 * MIB),    // floor
+            (2.0, 1.8, 512 * MIB),    // 0.45 GiB -> 512 MiB
+            (4.0, 3.7, GIB),          // 0.93 GiB -> 1 GiB
+            (8.0, 7.7, 2 * GIB),      // 1.93 GiB -> 2 GiB
+            (16.0, 15.3, 4 * GIB),    // 3.83 GiB -> 4 GiB
+            (32.0, 30.6, 8 * GIB),    // 7.65 GiB -> 8 GiB
+            (64.0, 61.0, 16 * GIB),   // 15.25 GiB -> 16 GiB
+            (128.0, 123.0, 32 * GIB), // 30.75 GiB -> 32 GiB (cap)
+            (256.0, 250.0, 32 * GIB), // would be 62 GiB -> capped
+            (512.0, 504.0, 32 * GIB), // capped
+        ];
+        for (marketed, reported_gib, expected) in cases {
+            let ram = (reported_gib * GIB as f64) as usize;
+            assert_eq!(
+                auto_budget(Some(ram)),
+                expected,
+                "marketed {marketed} GiB (reported {reported_gib})"
+            );
+        }
     }
 
     #[test]
-    fn test_mem_floored() {
-        // 512 MiB x 0.25 = 128 MiB -> floored to MIN_USABLE_MEM_BYTES.
-        assert_eq!(
-            mem_from_ram(Some(512 * 1024 * 1024), 0.25),
-            MIN_USABLE_MEM_BYTES
-        );
+    fn test_auto_budget_floor_and_cap_bind() {
+        assert_eq!(auto_budget(Some(0)), MIN_BUDGET_BYTES);
+        assert_eq!(auto_budget(Some(usize::MAX)), MAX_BUDGET_BYTES);
+    }
+
+    #[test]
+    fn test_fraction_applied_uncapped() {
+        // An explicit fraction is taken at the caller's word: no power-of-two
+        // rounding, no ceiling.
+        assert_eq!(mem_for_fraction_from(Some(64 * GIB), 0.5), 32 * GIB);
+        assert_eq!(mem_for_fraction_from(Some(200 * GIB), 0.25), 50 * GIB);
+    }
+
+    #[test]
+    fn test_fraction_floored() {
+        // 1 GiB x 0.25 = 256 MiB -> floored.
+        assert_eq!(mem_for_fraction_from(Some(GIB), 0.25), MIN_BUDGET_BYTES);
+    }
+
+    #[test]
+    fn test_fraction_invalid_falls_back_to_safe() {
+        // Non-finite, non-positive, or >1.0 fall back / clamp rather than
+        // producing a zero or unbounded budget.
+        for bad in [f64::NAN, f64::INFINITY, -1.0, 0.0] {
+            assert_eq!(
+                mem_for_fraction_from(Some(64 * GIB), bad),
+                mem_for_fraction_from(Some(64 * GIB), SAFE_MEM_FRACTION),
+                "fraction {bad} should fall back to SAFE_MEM_FRACTION"
+            );
+        }
+        assert_eq!(mem_for_fraction_from(Some(64 * GIB), 2.0), 64 * GIB);
+    }
+
+    #[test]
+    fn test_round_pow2() {
+        assert_eq!(round_pow2(0), 0);
+        assert_eq!(round_pow2(1), 1);
+        assert_eq!(round_pow2(2), 2);
+        assert_eq!(round_pow2(3), 4); // tie-ish, closer to 4
+        assert_eq!(round_pow2(5), 4);
+        assert_eq!(round_pow2(6), 8); // tie rounds up
+        assert_eq!(round_pow2(7), 8);
+        assert_eq!(round_pow2(100), 128);
+        assert_eq!(round_pow2(usize::MAX), 1usize << (usize::BITS - 1));
     }
 
     #[test]

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -8,40 +8,69 @@
 //! Detection is best-effort: a failure yields a conservative cap, never an
 //! unbounded one.
 
+use crate::metrics::unit::ByteUnit;
+use std::path::{Path, PathBuf};
+
+// Connection-cap sizing from the descriptor limit and memory budget. Computed
+// here but not wired on this branch: the only consumer is the managed-runtime
+// `SharedPool` builder, which lands with the connection-pool workstream (the
+// `.max_connections()` wiring was held back in the memory-budget split). Hence
+// the `allow(dead_code)` on each item below; drop them when the pool wiring
+// lands. Tracked in bosun.md (`mem-budget` / `conn-pool`).
+
 /// Fraction of the process file-descriptor limit the connection pool may use.
 /// The remainder is headroom for disk sinks, the directory walker, logging, and
 /// other descriptors the process holds.
+#[allow(dead_code)]
 const POOL_FD_BUDGET_FRACTION: f64 = 0.5;
 
 /// Ceiling on pooled connections regardless of descriptor headroom. Bounds the
 /// request fan-out against a single S3 endpoint, and is the cap on platforms
 /// with no low descriptor limit.
+#[allow(dead_code)]
 const ABSOLUTE_MAX_CONN: usize = 10_000;
 
 /// Floor so a low descriptor limit does not cap the pool below a usable count.
+#[allow(dead_code)]
 const MIN_CONN: usize = 10;
 
-/// Global cap on pooled connections. Machine-derived and independent of the
-/// throughput target, so it bounds machine descriptor use and S3 request fan-out
-/// on its own. `clamp(POOL_FD_BUDGET_FRACTION x RLIMIT_NOFILE, MIN_CONN,
-/// ABSOLUTE_MAX_CONN)` on Unix; `ABSOLUTE_MAX_CONN` where there is no low
-/// descriptor limit or detection fails. Budget sizing later tightens this with
-/// the memory term `min(.., budget_capacity / chunk)`.
+/// Global cap on pooled connections from the descriptor limit alone, used where
+/// the memory budget is not yet known (the runtime-builder default). Machine-
+/// derived and independent of the throughput target. `clamp(POOL_FD_BUDGET_FRACTION
+/// x RLIMIT_NOFILE, MIN_CONN, ABSOLUTE_MAX_CONN)` on Unix; `ABSOLUTE_MAX_CONN`
+/// where there is no low descriptor limit or detection fails.
+#[allow(dead_code)]
 pub(crate) fn connection_cap() -> usize {
-    cap_from_fd(fd_limit())
+    cap(fd_limit(), usize::MAX)
 }
 
-/// Apply the fraction and clamp to a detected descriptor limit. `None` falls
-/// back to the absolute ceiling.
-fn cap_from_fd(fd_limit: Option<usize>) -> usize {
-    fd_limit
+/// Global connection cap including the memory term: a connection that can never
+/// hold a chunk is wasted, so the budget caps connections at the chunk count it
+/// can fund. `clamp(min(fd_budget, budget_capacity / chunk), MIN_CONN,
+/// ABSOLUTE_MAX_CONN)`.
+#[allow(dead_code)]
+pub(crate) fn connection_cap_with_memory(
+    budget_capacity_bytes: usize,
+    chunk_bytes: usize,
+) -> usize {
+    cap(fd_limit(), budget_capacity_bytes / chunk_bytes.max(1))
+}
+
+/// Apply the descriptor fraction, take the smaller of it and the memory-funded
+/// connection count, and clamp to `[MIN_CONN, ABSOLUTE_MAX_CONN]`.
+#[allow(dead_code)]
+fn cap(fd_limit: Option<usize>, mem_conns: usize) -> usize {
+    let fd_budget = fd_limit
         .map(|n| (n as f64 * POOL_FD_BUDGET_FRACTION) as usize)
-        .unwrap_or(ABSOLUTE_MAX_CONN)
-        .clamp(MIN_CONN, ABSOLUTE_MAX_CONN)
+        .unwrap_or(ABSOLUTE_MAX_CONN);
+    fd_budget.min(mem_conns).clamp(MIN_CONN, ABSOLUTE_MAX_CONN)
 }
 
 /// Soft `RLIMIT_NOFILE` on Unix; `None` where there is no low descriptor limit
 /// or detection fails.
+///
+/// Ref: getrlimit(2) <https://man7.org/linux/man-pages/man2/getrlimit.2.html>
+#[allow(dead_code)]
 #[cfg(unix)]
 fn fd_limit() -> Option<usize> {
     use nix::sys::resource::{getrlimit, Resource};
@@ -51,46 +80,427 @@ fn fd_limit() -> Option<usize> {
     }
 }
 
+#[allow(dead_code)]
 #[cfg(not(unix))]
 fn fd_limit() -> Option<usize> {
     None
+}
+
+/// Fraction of detected RAM the memory budget may use under `Auto`. The
+/// remainder leaves room for the OS page cache (download-to-disk) and the rest
+/// of the process.
+const SAFE_MEM_FRACTION: f64 = 0.25;
+
+/// Floor on the resolved budget so a small or mis-detected machine still gets a
+/// workable amount.
+const MIN_USABLE_MEM_BYTES: usize = ByteUnit::Gibibyte.as_bytes_usize();
+
+/// Budget when RAM cannot be detected (non-Linux, or a read failure). Bounded,
+/// but large enough for one transfer's pipeline.
+const UNDETECTABLE_MEM_BYTES: usize = 2 * ByteUnit::Gibibyte.as_bytes_usize();
+
+/// Memory budget under `MemoryBudgetConfig::Auto`: `SAFE_MEM_FRACTION` of
+/// detected RAM, floored at `MIN_USABLE_MEM_BYTES`; `UNDETECTABLE_MEM_BYTES`
+/// when RAM is unknown.
+pub(crate) fn machine_safe_mem() -> usize {
+    mem_for_fraction(SAFE_MEM_FRACTION)
+}
+
+/// Memory budget for an explicit RAM fraction (`MemoryBudgetConfig::Fraction`),
+/// floored the same way; `UNDETECTABLE_MEM_BYTES` when RAM is unknown.
+pub(crate) fn mem_for_fraction(fraction: f64) -> usize {
+    mem_from_ram(available_ram(), fraction)
+}
+
+/// Apply a fraction to a detected RAM size and floor it.
+fn mem_from_ram(ram: Option<usize>, fraction: f64) -> usize {
+    match ram {
+        Some(bytes) => ((bytes as f64 * fraction) as usize).max(MIN_USABLE_MEM_BYTES),
+        None => UNDETECTABLE_MEM_BYTES,
+    }
+}
+
+/// Usable RAM: the smaller of the cgroup memory limit and physical RAM. Linux
+/// only; `None` elsewhere or on a read failure, in which case the caller falls
+/// back to a conservative default.
+#[cfg(target_os = "linux")]
+fn available_ram() -> Option<usize> {
+    match (meminfo_total(), cgroup_mem_limit()) {
+        (Some(total), Some(cgroup)) => Some(total.min(cgroup)),
+        (total, None) => total,
+        (None, cgroup) => cgroup,
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn available_ram() -> Option<usize> {
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn available_ram() -> Option<usize> {
+    // hw.memsize is total physical memory in bytes; macOS has no cgroup.
+    // Ref: sysctl(3), hw.memsize key
+    // <https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sysctl.3.html>
+    let mut bytes: u64 = 0;
+    let mut len = std::mem::size_of::<u64>();
+    // SAFETY: sysctlbyname writes a u64 into `bytes`; `len` holds its size. The
+    // name is a valid nul-terminated string.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            c"hw.memsize".as_ptr(),
+            (&mut bytes as *mut u64).cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc == 0 && bytes > 0 {
+        usize::try_from(bytes).ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn available_ram() -> Option<usize> {
+    use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+    // ullTotalPhys is total physical memory in bytes.
+    // Ref: GlobalMemoryStatusEx / MEMORYSTATUSEX
+    // <https://learn.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-globalmemorystatusex>
+    // SAFETY: a zeroed MEMORYSTATUSEX with dwLength set is the documented input;
+    // GlobalMemoryStatusEx fills it and returns nonzero on success.
+    let mut status: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+    status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+    let ok = unsafe { GlobalMemoryStatusEx(&mut status) };
+    if ok != 0 && status.ullTotalPhys > 0 {
+        usize::try_from(status.ullTotalPhys).ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn meminfo_total() -> Option<usize> {
+    parse_meminfo_total(&std::fs::read_to_string("/proc/meminfo").ok()?)
+}
+
+/// Effective cgroup memory limit for this process, container-aware: resolve the
+/// process's cgroup path from /proc/self/cgroup, find the controller mount from
+/// /proc/self/mountinfo, and take the min of `memory.max` (v2) /
+/// `memory.limit_in_bytes` (v1) from the leaf cgroup up to the mount root (a
+/// parent cgroup may impose a tighter limit). Tries v2, then v1 (hybrid). `None`
+/// when no limit is set, then `available_ram` uses physical RAM.
+///
+/// Refs: cgroups(7) /proc/[pid]/cgroup <https://man7.org/linux/man-pages/man7/cgroups.7.html>;
+/// cgroup v2 memory.max <https://docs.kernel.org/admin-guide/cgroup-v2.html>;
+/// cgroup v1 memory.limit_in_bytes <https://docs.kernel.org/admin-guide/cgroup-v1/memory.html>
+#[cfg(target_os = "linux")]
+fn cgroup_mem_limit() -> Option<usize> {
+    let proc_cgroup = std::fs::read_to_string("/proc/self/cgroup").ok()?;
+    let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").unwrap_or_default();
+    min_limit(&cgroup_v2_files(&proc_cgroup, &mountinfo))
+        .or_else(|| min_limit(&cgroup_v1_files(&proc_cgroup, &mountinfo)))
+}
+
+/// Read each candidate limit file and return the smallest real limit; "max" and
+/// the v1 unlimited sentinel are ignored ("max" via `parse_cgroup_limit`, the
+/// sentinel via `min` with physical RAM in `available_ram`).
+#[cfg(target_os = "linux")]
+fn min_limit(files: &[PathBuf]) -> Option<usize> {
+    files
+        .iter()
+        .filter_map(|f| std::fs::read_to_string(f).ok())
+        .filter_map(|s| parse_cgroup_limit(&s))
+        .min()
+}
+
+/// Parse `MemTotal` (kB) from /proc/meminfo into bytes. The kernel always emits
+/// this value in kB.
+///
+/// Ref: proc_meminfo(5) <https://man7.org/linux/man-pages/man5/proc_meminfo.5.html>
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_meminfo_total(meminfo: &str) -> Option<usize> {
+    let line = meminfo.lines().find(|l| l.starts_with("MemTotal:"))?;
+    line.split_whitespace()
+        .nth(1)?
+        .parse::<usize>()
+        .ok()?
+        .checked_mul(1024)
+}
+
+/// Parse a cgroup memory-limit value into bytes. "max" (v2 unlimited) yields
+/// `None`. The v1 unlimited sentinel is a huge number that `available_ram`
+/// discards via `min` with physical RAM, so it needs no special case.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_cgroup_limit(raw: &str) -> Option<usize> {
+    let raw = raw.trim();
+    if raw == "max" {
+        return None;
+    }
+    raw.parse().ok()
+}
+
+/// `memory.max` candidate paths for the cgroup v2 unified hierarchy, leaf-first.
+/// Empty when this process has no v2 cgroup line.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn cgroup_v2_files(proc_cgroup: &str, mountinfo: &str) -> Vec<PathBuf> {
+    let Some(path) = cgroup_v2_path(proc_cgroup) else {
+        return Vec::new();
+    };
+    let mount =
+        mountinfo_mount(mountinfo, "cgroup2", None).unwrap_or_else(|| "/sys/fs/cgroup".to_string());
+    walk_paths(&mount, &path, "memory.max")
+}
+
+/// `memory.limit_in_bytes` candidate paths for the cgroup v1 memory controller,
+/// leaf-first. Empty when this process has no v1 memory cgroup line.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn cgroup_v1_files(proc_cgroup: &str, mountinfo: &str) -> Vec<PathBuf> {
+    let Some(path) = cgroup_v1_memory_path(proc_cgroup) else {
+        return Vec::new();
+    };
+    let mount = mountinfo_mount(mountinfo, "cgroup", Some("memory"))
+        .unwrap_or_else(|| "/sys/fs/cgroup/memory".to_string());
+    walk_paths(&mount, &path, "memory.limit_in_bytes")
+}
+
+/// The cgroup path from a v2 unified line (`0::<path>`).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn cgroup_v2_path(proc_cgroup: &str) -> Option<String> {
+    proc_cgroup.lines().find_map(|line| {
+        let mut fields = line.splitn(3, ':');
+        match (fields.next(), fields.next(), fields.next()) {
+            (Some("0"), Some(""), Some(path)) => Some(path.to_string()),
+            _ => None,
+        }
+    })
+}
+
+/// The cgroup path from the v1 line whose controllers include `memory`
+/// (`<id>:<controllers>:<path>`).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn cgroup_v1_memory_path(proc_cgroup: &str) -> Option<String> {
+    proc_cgroup.lines().find_map(|line| {
+        let mut fields = line.splitn(3, ':');
+        let (_id, controllers, path) = (fields.next()?, fields.next()?, fields.next()?);
+        controllers
+            .split(',')
+            .any(|c| c == "memory")
+            .then(|| path.to_string())
+    })
+}
+
+/// Mount point of the first /proc/self/mountinfo entry matching `fstype` and, if
+/// given, containing `super_opt` in its super options. mountinfo splits on " - "
+/// into `<...> mountpoint options [optional]` and `<fstype> <source> <superopts>`.
+///
+/// Ref: proc_pid_mountinfo(5) <https://man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html>
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn mountinfo_mount(mountinfo: &str, fstype: &str, super_opt: Option<&str>) -> Option<String> {
+    mountinfo.lines().find_map(|line| {
+        let (left, right) = line.split_once(" - ")?;
+        let mut right_fields = right.split_whitespace();
+        if right_fields.next()? != fstype {
+            return None;
+        }
+        if let Some(opt) = super_opt {
+            let superopts = right_fields.nth(1).unwrap_or("");
+            if !superopts.split(',').any(|o| o == opt) {
+                return None;
+            }
+        }
+        // mountpoint is the 5th field of the left part.
+        left.split_whitespace().nth(4).map(str::to_string)
+    })
+}
+
+/// Limit-file paths from `<mount><cgroup_path>` up to `<mount>`, leaf-first, so a
+/// tighter parent limit is included.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn walk_paths(mount: &str, cgroup_path: &str, filename: &str) -> Vec<PathBuf> {
+    let mount = Path::new(mount);
+    let rel = cgroup_path.trim_start_matches('/');
+    let mut dir = if rel.is_empty() {
+        mount.to_path_buf()
+    } else {
+        mount.join(rel)
+    };
+    let mut out = Vec::new();
+    loop {
+        out.push(dir.join(filename));
+        if dir == mount {
+            break;
+        }
+        match dir.parent() {
+            Some(parent) if parent.starts_with(mount) => dir = parent.to_path_buf(),
+            _ => break,
+        }
+    }
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const GIB: usize = 1024 * 1024 * 1024;
+
     #[test]
     fn test_cap_none_is_absolute_max() {
         // No detection (non-Unix, or getrlimit failed) -> absolute ceiling.
-        assert_eq!(cap_from_fd(None), ABSOLUTE_MAX_CONN);
+        assert_eq!(cap(None, usize::MAX), ABSOLUTE_MAX_CONN);
     }
 
     #[test]
-    fn test_cap_low_limit_floored() {
+    fn test_cap_low_fd_floored() {
         // 8 descriptors -> 4 by fraction -> floored to MIN_CONN.
-        assert_eq!(cap_from_fd(Some(8)), MIN_CONN);
+        assert_eq!(cap(Some(8), usize::MAX), MIN_CONN);
     }
 
     #[test]
-    fn test_cap_mid_limit_is_fraction() {
-        assert_eq!(cap_from_fd(Some(1024)), 512);
+    fn test_cap_mid_fd_is_fraction() {
+        assert_eq!(cap(Some(1024), usize::MAX), 512);
     }
 
     #[test]
-    fn test_cap_high_limit_clamped() {
+    fn test_cap_high_fd_clamped() {
         // 40k descriptors -> 20k by fraction -> clamped to the absolute ceiling.
-        assert_eq!(cap_from_fd(Some(40_000)), ABSOLUTE_MAX_CONN);
+        assert_eq!(cap(Some(40_000), usize::MAX), ABSOLUTE_MAX_CONN);
     }
 
     #[test]
-    fn test_cap_infinite_limit_saturates_to_absolute_max() {
+    fn test_cap_infinite_fd_saturates() {
         // RLIM_INFINITY surfaces as usize::MAX; the fraction saturates, then clamps.
-        assert_eq!(cap_from_fd(Some(usize::MAX)), ABSOLUTE_MAX_CONN);
+        assert_eq!(cap(Some(usize::MAX), usize::MAX), ABSOLUTE_MAX_CONN);
+    }
+
+    #[test]
+    fn test_cap_memory_term_binds() {
+        // FD allows 512 (1024 x 0.5) but the budget funds only 100 chunks.
+        assert_eq!(cap(Some(1024), 100), 100);
     }
 
     #[test]
     fn test_connection_cap_within_bounds() {
         assert!((MIN_CONN..=ABSOLUTE_MAX_CONN).contains(&connection_cap()));
+    }
+
+    #[test]
+    fn test_connection_cap_with_memory_is_bounded_by_chunks() {
+        // 16-chunk budget caps connections at 16 (or lower if descriptors are scarce).
+        let chunk = 8 * 1024 * 1024;
+        let cap = connection_cap_with_memory(16 * chunk, chunk);
+        assert!((MIN_CONN..=16).contains(&cap));
+    }
+
+    #[test]
+    fn test_mem_undetectable_fallback() {
+        assert_eq!(
+            mem_from_ram(None, SAFE_MEM_FRACTION),
+            UNDETECTABLE_MEM_BYTES
+        );
+    }
+
+    #[test]
+    fn test_mem_fraction_applied() {
+        assert_eq!(mem_from_ram(Some(64 * GIB), 0.25), 16 * GIB);
+    }
+
+    #[test]
+    fn test_mem_floored() {
+        // 512 MiB x 0.25 = 128 MiB -> floored to MIN_USABLE_MEM_BYTES.
+        assert_eq!(
+            mem_from_ram(Some(512 * 1024 * 1024), 0.25),
+            MIN_USABLE_MEM_BYTES
+        );
+    }
+
+    #[test]
+    fn test_parse_meminfo_total() {
+        let s = "MemFree: 100 kB\nMemTotal:    65536000 kB\nBuffers: 5 kB\n";
+        assert_eq!(parse_meminfo_total(s), Some(65536000 * 1024));
+    }
+
+    #[test]
+    fn test_parse_meminfo_missing() {
+        assert_eq!(parse_meminfo_total("Foo: 1 kB\n"), None);
+    }
+
+    #[test]
+    fn test_parse_cgroup_max_is_none() {
+        assert_eq!(parse_cgroup_limit("max\n"), None);
+    }
+
+    #[test]
+    fn test_parse_cgroup_value() {
+        assert_eq!(parse_cgroup_limit("4294967296\n"), Some(4_294_967_296));
+    }
+
+    #[test]
+    fn test_cgroup_v2_path() {
+        assert_eq!(
+            cgroup_v2_path("0::/foo/bar\n"),
+            Some("/foo/bar".to_string())
+        );
+        assert_eq!(cgroup_v2_path("0::/\n"), Some("/".to_string()));
+        // A pure-v1 file has no "0::" line.
+        assert_eq!(cgroup_v2_path("11:memory:/x\n"), None);
+    }
+
+    #[test]
+    fn test_cgroup_v1_memory_path() {
+        let f = "12:pids:/a\n4:cpu,cpuacct:/b\n3:memory:/foo/bar\n";
+        assert_eq!(cgroup_v1_memory_path(f), Some("/foo/bar".to_string()));
+        assert_eq!(cgroup_v1_memory_path("0::/unified\n"), None);
+    }
+
+    #[test]
+    fn test_mountinfo_mount_v2() {
+        let mi = "35 24 0:30 / /sys/fs/cgroup rw,nosuid - cgroup2 cgroup2 rw,nsdelegate\n";
+        assert_eq!(
+            mountinfo_mount(mi, "cgroup2", None),
+            Some("/sys/fs/cgroup".to_string())
+        );
+    }
+
+    #[test]
+    fn test_mountinfo_mount_v1_memory() {
+        let mi = "30 24 0:26 / /sys/fs/cgroup/cpu rw - cgroup cgroup rw,cpu\n\
+                  31 24 0:27 / /sys/fs/cgroup/memory rw - cgroup cgroup rw,memory\n";
+        assert_eq!(
+            mountinfo_mount(mi, "cgroup", Some("memory")),
+            Some("/sys/fs/cgroup/memory".to_string())
+        );
+        // The cpu controller is not the memory one.
+        assert_eq!(mountinfo_mount(mi, "cgroup", Some("hugetlb")), None);
+    }
+
+    #[test]
+    fn test_walk_paths_subcgroup() {
+        assert_eq!(
+            walk_paths("/sys/fs/cgroup", "/foo/bar", "memory.max"),
+            vec![
+                PathBuf::from("/sys/fs/cgroup/foo/bar/memory.max"),
+                PathBuf::from("/sys/fs/cgroup/foo/memory.max"),
+                PathBuf::from("/sys/fs/cgroup/memory.max"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_walk_paths_root() {
+        // A namespaced container sees its cgroup as "/": only the mount root.
+        assert_eq!(
+            walk_paths("/sys/fs/cgroup", "/", "memory.max"),
+            vec![PathBuf::from("/sys/fs/cgroup/memory.max")]
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn test_available_ram_detected_on_supported_platforms() {
+        // The detected machine has at least 1 GiB; guards the platform syscall.
+        assert!(available_ram().expect("RAM detected") >= GIB);
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/telemetry.rs
+++ b/aws-sdk-s3-transfer-manager/src/telemetry.rs
@@ -16,6 +16,7 @@
 
 use crate::metrics::latency::LatencyTracker;
 use crate::metrics::IOCounters;
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -42,6 +43,12 @@ pub(crate) struct Telemetry {
     pub(crate) recv_latencies: LatencyTracker,
     /// Throughput counters (network tx/rx, disk read/write).
     pub(crate) io_counters: Arc<IOCounters>,
+    /// Download transfers currently unable to fetch ahead because their prefetch
+    /// window is full (claimed-but-unconsumed parts at the window limit, blocked
+    /// on in-order consumption of a slow head part). A gauge: high values with
+    /// low in-flight indicate the pipeline is prefetch-window/head-of-line bound
+    /// rather than connection- or work-generation bound.
+    pub(crate) window_blocked_downloads: AtomicUsize,
 }
 
 impl Telemetry {
@@ -51,6 +58,7 @@ impl Telemetry {
             send_latencies: LatencyTracker::new(),
             recv_latencies: LatencyTracker::new(),
             io_counters: Arc::new(IOCounters::new(counter_window)),
+            window_blocked_downloads: AtomicUsize::new(0),
         }
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -24,15 +24,45 @@ pub enum PartSize {
 #[non_exhaustive]
 #[derive(Debug, Clone, Default)]
 pub enum MemoryBudgetConfig {
-    /// A safe fraction of detected RAM, cgroup-aware, leaving room for the OS
-    /// page cache and the rest of the process.
+    /// Size the budget from the machine, leaving headroom for the OS page cache
+    /// and the rest of the process. Derived from detected RAM (cgroup-aware) and
+    /// bounded so a small box stays usable and a large one does not over-reserve;
+    /// expect a budget on the order of a quarter of RAM, in the low gigabytes for
+    /// a typical box. The exact policy is intentionally unspecified and may change.
     #[default]
     Auto,
-    /// The given fraction of detected RAM, clamped to `(0.0, 1.0]`. A
-    /// non-finite or non-positive value falls back to the `Auto` fraction.
+    /// The given fraction of detected RAM, clamped to `(0.0, 1.0]`. A non-finite
+    /// or non-positive value falls back to the `Auto` fraction. The result is
+    /// floored at a minimum usable budget but, unlike `Auto`, is not capped.
     Fraction(f64),
-    /// An explicit byte limit, overriding detection.
+    /// An explicit byte limit. Bypasses detection, but is still floored at one
+    /// accounting chunk (8 MiB) — a smaller value would serialize transfers. Use
+    /// the [`ByteUnit`](crate::metrics::unit::ByteUnit) helpers to express it,
+    /// e.g. `Limit(2 * ByteUnit::Gibibyte.as_bytes_usize())`.
     Limit(usize),
+}
+
+/// Point-in-time view of the global memory budget's admission state.
+///
+/// Returned by [`Client::memory_budget`](crate::Client::memory_budget). Reports
+/// what the budget has admitted against its resolved ceiling and whether
+/// transfers are parked waiting on it. `reserved_bytes` is an upper bound — it
+/// counts reserved chunks, not bytes actually resident; per-transfer resident
+/// memory is reported separately.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub struct MemoryBudgetSnapshot {
+    /// The resolved ceiling in bytes (what [`MemoryBudgetConfig`] produced on this
+    /// machine).
+    pub capacity_bytes: u64,
+    /// Bytes currently reserved. Admission level, not resident memory.
+    pub reserved_bytes: u64,
+    /// Requests parked waiting for a grant right now. Zero means the budget is not
+    /// currently binding.
+    pub waiters: usize,
+    /// Cumulative count of requests that ever parked. Distinguishes a budget that
+    /// has bound at least once from one that never has.
+    pub total_parked: u64,
 }
 
 impl MemoryBudgetConfig {

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -21,9 +21,6 @@ pub enum PartSize {
 
 /// Upper bound on memory the transfer manager uses for in-flight and buffered
 /// transfer data. At the limit transfers backpressure rather than fail.
-///
-/// Only takes effect when the transfer manager owns its runtime; it does not
-/// apply when a fully built S3 client is supplied.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default)]
 pub enum MemoryBudgetConfig {
@@ -31,7 +28,8 @@ pub enum MemoryBudgetConfig {
     /// page cache and the rest of the process.
     #[default]
     Auto,
-    /// The given fraction (0.0 to 1.0) of detected RAM.
+    /// The given fraction of detected RAM, clamped to `(0.0, 1.0]`. A
+    /// non-finite or non-positive value falls back to the `Auto` fraction.
     Fraction(f64),
     /// An explicit byte limit, overriding detection.
     Limit(usize),

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -19,6 +19,35 @@ pub enum PartSize {
     Target(u64),
 }
 
+/// Upper bound on memory the transfer manager uses for in-flight and buffered
+/// transfer data. At the limit transfers backpressure rather than fail.
+///
+/// Only takes effect when the transfer manager owns its runtime; it does not
+/// apply when a fully built S3 client is supplied.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default)]
+pub enum MemoryBudgetConfig {
+    /// A safe fraction of detected RAM, cgroup-aware, leaving room for the OS
+    /// page cache and the rest of the process.
+    #[default]
+    Auto,
+    /// The given fraction (0.0 to 1.0) of detected RAM.
+    Fraction(f64),
+    /// An explicit byte limit, overriding detection.
+    Limit(usize),
+}
+
+impl MemoryBudgetConfig {
+    /// Resolve to the budget capacity in bytes.
+    pub(crate) fn resolve(&self) -> usize {
+        match self {
+            MemoryBudgetConfig::Auto => crate::runtime::platform::machine_safe_mem(),
+            MemoryBudgetConfig::Fraction(f) => crate::runtime::platform::mem_for_fraction(*f),
+            MemoryBudgetConfig::Limit(bytes) => *bytes,
+        }
+    }
+}
+
 /// The concurrency mode the client should use for executing requests.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
## Motivation

Download concurrency and resident memory are coupled: each in-flight ranged GET holds a slot buffer until the consumer drains it in order, so raising concurrency to fill a fast link raises peak memory without bound. The only per-transfer lever today is the prefetch window, which caps one transfer's outstanding parts but does not bound memory *across* transfers — N concurrent downloads each ride their own window, and the aggregate is unbounded. To push concurrency toward line rate without risking OOM, memory has to be admission-controlled globally and fungibly across all transfers, the way CRT bounds its buffer pool.

This adds the global memory budget: a fungible, chunk-accounted admission control that every download part reserves against before it fetches and releases when its chunk leaves the ring. It is sized from the machine — a bounded fraction of detected RAM, cgroup-aware — rather than a fixed placeholder, so the bound reflects the box the client runs on. This is the admission-control half of the eventual buffer pool; recycling the freed allocations is a separate, later change behind the same reservation API.

## How it works

### The budget primitive

`MemoryBudget` (`runtime/memory.rs`) tracks how many fixed-size chunks are reserved across all transfers, behind one lock. It is transfer-agnostic: it knows nothing about downloads, slots, or parts, only chunks. A request for `n` bytes costs `ceil(n / chunk)` chunks, so non-uniform part sizes account correctly against a single nominal unit (8 MiB) without the budget needing any transfer's part size.

```rust
pub(crate) enum Reserve {
    Ready(Reservation),   // fit immediately; chunks reserved
    Pending(WaitTicket),  // enqueued; poll the ticket after the notify fires
}
```

`reserve` grants immediately when the queue is empty and the request fits, otherwise it enqueues a waiter and hands back a `WaitTicket`. A granted `Reservation` is an RAII token: its `Drop` returns the chunks and drains any parked waiters that now fit. The budget never blocks a thread — a parked caller registers a `NotifyFn` (the scheduler waker) and is woken when its grant lands.

Two invariants keep it fair and deadlock-free. **Strict FIFO with no-barge**: a fresh request never jumps a queued waiter even if it would fit, and the drain stops at the first front waiter that does not fit (no skip-ahead). Together these guarantee a front waiter sees `in_use` only fall until its need is met, so it is never starved for `need <= capacity`. **Forced grant when idle**: a request larger than the entire capacity can proceed only when nothing else holds the budget, and FIFO guarantees that point is reached for the front waiter — the sole path by which an oversized request (the upload / un-sliced-object backstop) makes progress instead of parking forever. The lock-ordering rule between the budget lock and the per-waiter slot locks is documented inline; the two orderings never nest.

### Reserve at claim, release at consume

On the download path (`operation/download/{transfer,body}.rs`) the gate is claim-first: `poll_work` claims a ring slot (the prefetch-window gate — a grant means the consumer is keeping up), then reserves the chunk's memory for that held slot. Claiming before reserving makes the two park states mutually exclusive — a window-parked transfer holds nothing, a budget-parked one holds exactly the slot it will fill — so there is no peek/claim race. The reservation rides the slot from claim through fill, lives in the slot's `Filled` payload while the chunk sits in the ring, and drops exactly when the chunk leaves the ring (consumed by the reader or flushed to the sink). When the budget is exhausted the claimed slot and its wait ticket are stashed in the transfer's `pending` state and the transfer parks; the budget's notify re-drives it when a chunk frees.

Discovery is a special case: it has already issued the GET for part 0 and must account that chunk, but it runs inside an async `execute` rather than the re-pollable `poll_work`, so it backpressures by awaiting the reservation (holding the response stream undrained) rather than parking on the scheduler. Reserving the head before any read-ahead range keeps the budget FIFO head-first, preserving forward progress under a tight cap.

### Sizing from the machine

`runtime/platform.rs` detects usable RAM and resolves the public `MemoryBudgetConfig`. Detection is per-OS and best-effort — a failure yields a conservative default, never an unbounded budget: Linux reads `/proc/meminfo` and the process's cgroup memory limit (v2 `memory.max` / v1 `memory.limit_in_bytes`, container-aware via `/proc/self/cgroup` + `/proc/self/mountinfo`, walking leaf to root so a tighter parent limit wins, min'd with physical RAM); macOS reads `sysctl(hw.memsize)`; Windows reads `GlobalMemoryStatusEx`.

`Auto` resolves to `clamp(round_pow2(0.25 × RAM), 512 MiB, 32 GiB)`. The fraction is a good-citizen ceiling that leaves the rest of the box for the page cache, the process, and any co-tenant; the floor keeps a small or cgroup-constrained box usable; the cap stops a large box over-reserving past the point more buffer raises throughput, which also tapers the effective fraction on big boxes. The budget is a backstop, not the operating point — the concurrency controller settles at line rate well below it, and it binds only when a slow consumer backs parts up in the ring. RAM is an imprecise proxy for that bound: bandwidth, not memory, sets the real pipeline depth, and the two are uncorrelated across instance families (m5.24xlarge and m5n.24xlarge share 384 GiB but differ 4x in bandwidth). NIC-aware sizing is a later refinement; the clamp keeps the estimate safe at both ends meanwhile. `Fraction` takes an explicit RAM fraction (clamped to `(0.0, 1.0]`, floored, uncapped); `Limit` takes an explicit byte budget (floored at one chunk). `Client::new` resolves the config once to size the `Handle`'s budget.

### Observing the budget

`Client::memory_budget()` returns a `MemoryBudgetSnapshot` { `capacity_bytes`, `reserved_bytes`, `waiters`, `total_parked` }: the resolved ceiling and current admission state, taken under one lock. `reserved_bytes` is admitted memory — a ceiling on reserved chunks — not resident memory; `total_parked` is monotonic and answers whether the budget has ever bound. The configured intent stays on `Config::memory_budget()`; the snapshot reports what it resolved to and is doing.

### Scope

This carries only the budget and its machine sizing, extracted from the connection-pool / topology work it was developed alongside. The prefetch-window config surface, backpressure telemetry, NUMA topology, and the connection-pool wiring are separate follow-ons. `platform.rs` also computes a machine-derived connection cap (`connection_cap`, FD-limit-based, folded with the memory term) but does not yet wire it — the consumer is the managed-runtime connection pool, which lands with the connection-pool work, so those functions carry `#[allow(dead_code)]` with the consumer named. Only the download path reserves against the budget; upload is bounded by concurrency today and will reserve against the same budget when it gains read-ahead.

## How to review

Start with `runtime/memory.rs` — the primitive is self-contained and the doc comments state the FIFO / no-barge / forced-grant contract and the lock-ordering invariant. `can_grant` and `drain` are the whole policy. Then `operation/download/transfer.rs`: `acquire_slot` is the claim-first gate and the budget-park resume, and `reserve_chunk` is the discovery await-path. `operation/download/body.rs` shows the reservation riding the slot and dropping at the points a chunk leaves the ring. `runtime/platform.rs` splits into the sizing policy (`auto_budget` / `mem_for_fraction` and the `round_pow2` / clamp helpers) and detection (the per-OS `available_ram` arms, each syscall carrying a man-page / kernel-doc reference and a SAFETY note, plus the pure cgroup/meminfo parsers). The config surface (`types.rs`, `config.rs`, `config/loader.rs`) is the public `MemoryBudgetConfig` and `MemoryBudgetSnapshot`.

## Testing

`memory.rs` has unit tests covering the primitive directly: chunk rounding, ready/pending grants, drop-returns-chunks, exhaustion-then-release-grants-waiter (notify fires exactly once), strict-FIFO ordering, no-barge in isolation (a request that fits on capacity is rejected solely because a waiter is queued), forced grant of an oversized request when idle, grow-drains-waiters, soft shrink (never revokes granted chunks), `WaitTicket` drop in both the waiting and granted-but-untaken states, cancel of a middle waiter (the others still grant in order), the one-chunk capacity floor, and the `stats()` snapshot. Two loom models exercise the budget/slot lock-ordering invariant under concurrent release-vs-cancel and release-vs-take.

`platform.rs` has unit tests for the sizing math (the `Auto` clamp/floor/cap and power-of-two tiers across realistic under-reported RAM sizes, the undetectable fallback, and `Fraction` validation and fallback) and the detection parsers on realistic fixtures (`/proc/meminfo`, cgroup v2 `0::` and v1 `memory` path extraction, `mountinfo` controller matching, and the leaf-to-root walk including the namespaced-container case), so detection is deterministic and runs on every platform.

`test_budget_blocks_then_resumes` (`operation/download/transfer.rs`) drives the gate end to end against a tightened budget: discovery reserves its chunk, one range fits, the next parks holding its claimed slot, consuming the discovery chunk re-grants the parked claim, the next poll clears `pending` and yields work that still carries its slot and reservation, and dropping that work releases the reservation — asserting `in_use_chunks` at every step. Reservation-lifecycle tests in `body.rs` pin that the reservation releases on consume, on flush, and on an unfilled slot drop (the abort path).

TM lib 479, integration 80. `fmt` and `clippy -Dwarnings` clean; loom suite green.

## Changes

```
aws-sdk-s3-transfer-manager/
  src/
    runtime/
      memory.rs                       NEW — MemoryBudget primitive (reserve/release, FIFO, forced grant, resize, stats)
      platform.rs                     NEW — RAM/cgroup/FD detection; Auto/Fraction/Limit sizing
      mod.rs                          register memory + platform modules
    operation/download/
      transfer.rs                     claim-first budget gate, park/resume, discovery await-path
      body.rs                         reservation rides the slot; releases when the chunk leaves the ring
      context.rs                      budget handle plumbed to the transfer
    client.rs                         resolve MemoryBudgetConfig once; size the Handle's budget; memory_budget() snapshot
    config.rs, config/loader.rs       memory_budget() config surface
    types.rs                          public MemoryBudgetConfig { Auto, Fraction, Limit } and MemoryBudgetSnapshot
    telemetry.rs                      window_blocked_downloads gauge
    examples/cp.rs                    S3FIO_MEMORY_LIMIT -> Limit for on-instance sweeps
  Cargo.toml                          libc (macOS), windows-sys (Windows), nix resource feature (Unix FD limit)
```
