### PR TITLE
download: occupancy-bounded flow control over a paged receive buffer

### DIFF
--- a/aws-sdk-s3-transfer-manager/examples/cp.rs
+++ b/aws-sdk-s3-transfer-manager/examples/cp.rs
@@ -24,6 +24,37 @@ use jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
+// Compiled-in jemalloc runtime config. A saturated download frees and reallocates
+// part-sized (8 MiB) receive buffers at line rate; with the default config the
+// allocator returns those pages to the OS and refaults them on the next read, so
+// page-fault and purge cost dominates the receive path and resident size runs
+// several times the live working set. These options keep freed buffers mapped for
+// reuse, bounding both costs. Overridden by the _RJEM_MALLOC_CONF environment
+// variable (jemalloc config precedence).
+//
+//   background_thread:true  Run page purging on a dedicated thread instead of
+//                           inline on the freeing thread, where the madvise call
+//                           would block the receive path. pthread platforms only
+//                           (Linux); ignored with a startup warning elsewhere.
+//   narenas:32              Cap allocation arenas well below the default (~4x
+//                           CPUs). Fewer arenas concentrate freed buffers into a
+//                           shared dirty pool, so a free on one thread can satisfy
+//                           an allocation on another; the default scatters them
+//                           per-arena and forces a fresh mmap. Fixed count, not
+//                           machine-scaled (revisit per instance, or percpu_arena).
+//   dirty_decay_ms:1000     Hold a freed page mapped and reusable for 1s before
+//                           purging. This retention is the reuse window: a buffer
+//                           freed at delivery serves the next read without a fault.
+//                           0 disables reuse; larger values raise resident size.
+//   muzzy_decay_ms:0        Purge muzzy (already madvise(FREE)'d) pages immediately
+//                           rather than holding a second retention tier; the dirty
+//                           pool above provides the reuse.
+#[cfg(not(target_env = "msvc"))]
+#[allow(non_upper_case_globals)]
+#[export_name = "_rjem_malloc_conf"]
+pub static malloc_conf: &[u8] =
+    b"background_thread:true,narenas:32,dirty_decay_ms:1000,muzzy_decay_ms:0\0";
+
 #[derive(Debug, Clone, Default, clap::ValueEnum)]
 enum OutputFormat {
     #[default]

--- a/aws-sdk-s3-transfer-manager/examples/cp.rs
+++ b/aws-sdk-s3-transfer-manager/examples/cp.rs
@@ -40,8 +40,8 @@ static GLOBAL: Jemalloc = Jemalloc;
 //                           CPUs). Fewer arenas concentrate freed buffers into a
 //                           shared dirty pool, so a free on one thread can satisfy
 //                           an allocation on another; the default scatters them
-//                           per-arena and forces a fresh mmap. Fixed count, not
-//                           machine-scaled (revisit per instance, or percpu_arena).
+//                           per-arena and forces a fresh mmap. A fixed count rather
+//                           than machine-scaled or percpu_arena.
 //   dirty_decay_ms:1000     Hold a freed page mapped and reusable for 1s before
 //                           purging. This retention is the reuse window: a buffer
 //                           freed at delivery serves the next read without a fault.

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -60,6 +60,22 @@ impl Handle {
         }
     }
 
+    /// Resolve the read-ahead window in parts for a download, in precedence order:
+    /// the per-request [`ReadAhead`](crate::types::ReadAhead) override if set, else
+    /// the client default. `Auto` maps to [`DEFAULT_DOWNLOAD_READ_AHEAD_PARTS`] (the
+    /// fixed per-transfer cap; a future memory budget will size it). `Parts(n)` maps
+    /// to `n + 1`: `n` parts of speculation beyond the part the consumer is waiting
+    /// on, which is always admitted, so `Parts(0)` is demand paging.
+    pub(crate) fn download_read_ahead_window(
+        &self,
+        input: &crate::operation::download::DownloadInput,
+    ) -> u64 {
+        let mode = input
+            .read_ahead()
+            .unwrap_or_else(|| self.config.read_ahead());
+        crate::operation::download::read_ahead::window_parts_for(mode)
+    }
+
     /// Whether the user pinned an explicit part size (vs leaving it `Auto`).
     /// When `Auto`, the transfer manager owns part sizing and may override it
     /// (e.g. align download ranges to an object's stored part size for

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -60,22 +60,6 @@ impl Handle {
         }
     }
 
-    /// Resolve the read-ahead window in parts for a download, in precedence order:
-    /// the per-request [`ReadAhead`](crate::types::ReadAhead) override if set, else
-    /// the client default. `Auto` maps to the fixed per-transfer cap (a future memory
-    /// budget will size it); `Parts(n)` maps to `n + 1`: `n` parts of speculation
-    /// beyond the part the consumer is waiting on, which is always admitted, so
-    /// `Parts(0)` is demand paging. See `read_ahead::window_parts_for`.
-    pub(crate) fn download_read_ahead_window(
-        &self,
-        input: &crate::operation::download::DownloadInput,
-    ) -> u64 {
-        let mode = input
-            .read_ahead()
-            .unwrap_or_else(|| self.config.read_ahead());
-        crate::operation::download::read_ahead::window_parts_for(mode)
-    }
-
     /// Whether the user pinned an explicit part size (vs leaving it `Auto`).
     /// When `Auto`, the transfer manager owns part sizing and may override it
     /// (e.g. align download ranges to an object's stored part size for

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -62,10 +62,10 @@ impl Handle {
 
     /// Resolve the read-ahead window in parts for a download, in precedence order:
     /// the per-request [`ReadAhead`](crate::types::ReadAhead) override if set, else
-    /// the client default. `Auto` maps to [`DEFAULT_DOWNLOAD_READ_AHEAD_PARTS`] (the
-    /// fixed per-transfer cap; a future memory budget will size it). `Parts(n)` maps
-    /// to `n + 1`: `n` parts of speculation beyond the part the consumer is waiting
-    /// on, which is always admitted, so `Parts(0)` is demand paging.
+    /// the client default. `Auto` maps to the fixed per-transfer cap (a future memory
+    /// budget will size it); `Parts(n)` maps to `n + 1`: `n` parts of speculation
+    /// beyond the part the consumer is waiting on, which is always admitted, so
+    /// `Parts(0)` is demand paging. See `read_ahead::window_parts_for`.
     pub(crate) fn download_read_ahead_window(
         &self,
         input: &crate::operation::download::DownloadInput,

--- a/aws-sdk-s3-transfer-manager/src/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/config.rs
@@ -211,7 +211,9 @@ impl Builder {
     /// Set how far downloads may prefetch ahead of the consumer.
     ///
     /// This is the client default for all downloads; a request may override it via
-    /// [`DownloadInput`](crate::operation::download::DownloadInput).
+    /// [`DownloadInput`](crate::operation::download::DownloadInput), or a running
+    /// transfer may adjust it via
+    /// [`DownloadIoCtl`](crate::operation::download::DownloadIoCtl).
     /// Default is [ReadAhead::Auto].
     pub fn read_ahead(mut self, mode: ReadAhead) -> Self {
         self.read_ahead = mode;

--- a/aws-sdk-s3-transfer-manager/src/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/config.rs
@@ -7,7 +7,7 @@ use aws_runtime::user_agent::FrameworkMetadata;
 use std::cmp;
 
 use crate::metrics::unit::ByteUnit;
-use crate::types::{ConcurrencyMode, PartSize};
+use crate::types::{ConcurrencyMode, PartSize, ReadAhead};
 
 pub(crate) mod loader;
 
@@ -70,6 +70,7 @@ pub struct Config {
     multipart_threshold: PartSize,
     target_part_size: PartSize,
     concurrency: ConcurrencyMode,
+    read_ahead: ReadAhead,
     framework_metadata: Option<FrameworkMetadata>,
     s3_client_source: Option<S3ClientSource>,
     #[cfg(feature = "dial9")]
@@ -97,6 +98,14 @@ impl Config {
     /// This is the mode used for concurrent in-flight requests across _all_ operations.
     pub fn concurrency(&self) -> &ConcurrencyMode {
         &self.concurrency
+    }
+
+    /// Returns the read-ahead mode used for downloads.
+    ///
+    /// This is the client default; a download may override it per request via
+    /// [`DownloadInput`](crate::operation::download::DownloadInput).
+    pub fn read_ahead(&self) -> &ReadAhead {
+        &self.read_ahead
     }
 
     /// Returns the framework metadata setting when using transfer manager.
@@ -127,6 +136,7 @@ pub struct Builder {
     multipart_threshold_part_size: PartSize,
     target_part_size: PartSize,
     concurrency: ConcurrencyMode,
+    read_ahead: ReadAhead,
     pub(crate) framework_metadata: Option<FrameworkMetadata>,
     client: Option<aws_sdk_s3::Client>,
     s3_client_config: Option<S3ClientConfig>,
@@ -198,6 +208,16 @@ impl Builder {
         self
     }
 
+    /// Set how far downloads may prefetch ahead of the consumer.
+    ///
+    /// This is the client default for all downloads; a request may override it via
+    /// [`DownloadInput`](crate::operation::download::DownloadInput).
+    /// Default is [ReadAhead::Auto].
+    pub fn read_ahead(mut self, mode: ReadAhead) -> Self {
+        self.read_ahead = mode;
+        self
+    }
+
     /// Sets the framework metadata for the transfer manager.
     ///
     /// This _optional_ name is used to identify the framework using transfer manager in the user agent that
@@ -252,6 +272,7 @@ impl Builder {
             multipart_threshold: self.multipart_threshold_part_size,
             target_part_size: self.target_part_size,
             concurrency: self.concurrency,
+            read_ahead: self.read_ahead,
             framework_metadata: self.framework_metadata,
             s3_client_source: Some(s3_client_source),
             #[cfg(feature = "dial9")]

--- a/aws-sdk-s3-transfer-manager/src/operation/download.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download.rs
@@ -144,11 +144,8 @@ impl Download {
         let bucket_type =
             BucketType::from_bucket_name(input.bucket().expect("bucket is available"));
 
-        let (writer, _consumer) = body::new_recv_body_with_sink(
-            file,
-            object_range_start,
-            owns_file,
-        );
+        let (writer, _consumer) =
+            body::new_recv_body_with_sink(file, object_range_start, owns_file);
 
         let (ctx, completion_rx) = match parent_id {
             Some(pid) => TransferContext::new_child(handle.clone(), pid),

--- a/aws-sdk-s3-transfer-manager/src/operation/download.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download.rs
@@ -15,6 +15,15 @@ pub mod builders;
 mod body;
 pub use body::{Body, ChunkOutput};
 
+// In-order delivery buffer (out-of-order arrival → in-order stream). A generic,
+// self-contained data structure with its own loom models; `body.rs` will be rebuilt
+// on top of it.
+// TODO(flow-control): remove this allow once body.rs consumes PagedRecvBuffer — it
+// has no in-crate consumer yet, so its public surface reads as dead code. Tracked in
+// bosun.md flow-control workstream.
+#[allow(dead_code)]
+mod recv_buffer;
+
 mod context;
 
 pub(crate) mod discovery;

--- a/aws-sdk-s3-transfer-manager/src/operation/download.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download.rs
@@ -16,7 +16,6 @@ mod body;
 pub use body::{Body, ChunkOutput};
 
 /// In-order delivery buffer (out-of-order arrival → in-order stream).
-#[allow(dead_code)]
 pub(crate) mod recv_buffer;
 
 /// Read-ahead window — the occupancy bound on speculative issuance.
@@ -29,6 +28,7 @@ pub(crate) mod discovery;
 mod handle;
 pub use handle::DownloadHandle;
 pub(crate) use handle::DownloadHandleInner;
+pub use handle::DownloadIoCtl;
 pub use handle::ManagedDownloadHandle;
 
 mod output;
@@ -36,7 +36,6 @@ pub use output::DownloadOutput;
 
 pub(crate) mod transfer;
 pub(crate) use transfer::DownloadTransfer;
-pub use transfer::DownloadIoCtl;
 
 /// Provides metadata for each chunk during an object download.
 mod chunk_meta;
@@ -47,7 +46,7 @@ mod object_meta;
 pub use object_meta::ObjectMetadata;
 
 use crate::error;
-use crate::operation::download::body::new_slot_body;
+use crate::operation::download::body::new_recv_body;
 use crate::types::BucketType;
 use std::sync::Arc;
 
@@ -71,7 +70,7 @@ impl Download {
         let bucket_type =
             BucketType::from_bucket_name(input.bucket().expect("bucket is available"));
 
-        let (writer, consumer) = new_slot_body();
+        let (writer, consumer) = new_recv_body();
 
         let (ctx, completion_rx) = TransferContext::new(handle.clone());
 
@@ -145,7 +144,7 @@ impl Download {
         let bucket_type =
             BucketType::from_bucket_name(input.bucket().expect("bucket is available"));
 
-        let (writer, _consumer) = body::new_slot_body_with_sink(
+        let (writer, _consumer) = body::new_recv_body_with_sink(
             file,
             object_range_start,
             owns_file,

--- a/aws-sdk-s3-transfer-manager/src/operation/download.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download.rs
@@ -15,14 +15,12 @@ pub mod builders;
 mod body;
 pub use body::{Body, ChunkOutput};
 
-// In-order delivery buffer (out-of-order arrival → in-order stream). A generic,
-// self-contained data structure with its own loom models; `body.rs` will be rebuilt
-// on top of it.
-// TODO(flow-control): remove this allow once body.rs consumes PagedRecvBuffer — it
-// has no in-crate consumer yet, so its public surface reads as dead code. Tracked in
-// bosun.md flow-control workstream.
+/// In-order delivery buffer (out-of-order arrival → in-order stream).
 #[allow(dead_code)]
-mod recv_buffer;
+pub(crate) mod recv_buffer;
+
+/// Adaptive read-ahead window — paces speculative issuance to the consumer drain rate.
+mod read_ahead;
 
 mod context;
 
@@ -48,7 +46,7 @@ mod object_meta;
 pub use object_meta::ObjectMetadata;
 
 use crate::error;
-use crate::operation::download::body::{new_slot_body, DEFAULT_BODY_SLOT_CAPACITY};
+use crate::operation::download::body::new_slot_body;
 use crate::types::BucketType;
 use std::sync::Arc;
 
@@ -72,7 +70,7 @@ impl Download {
         let bucket_type =
             BucketType::from_bucket_name(input.bucket().expect("bucket is available"));
 
-        let (writer, consumer) = new_slot_body(DEFAULT_BODY_SLOT_CAPACITY);
+        let (writer, consumer) = new_slot_body();
 
         let (ctx, completion_rx) = TransferContext::new(handle.clone());
 
@@ -147,7 +145,6 @@ impl Download {
             BucketType::from_bucket_name(input.bucket().expect("bucket is available"));
 
         let (writer, _consumer) = body::new_slot_body_with_sink(
-            DEFAULT_BODY_SLOT_CAPACITY,
             file,
             object_range_start,
             owns_file,

--- a/aws-sdk-s3-transfer-manager/src/operation/download.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download.rs
@@ -19,8 +19,8 @@ pub use body::{Body, ChunkOutput};
 #[allow(dead_code)]
 pub(crate) mod recv_buffer;
 
-/// Adaptive read-ahead window — paces speculative issuance to the consumer drain rate.
-mod read_ahead;
+/// Read-ahead window — the occupancy bound on speculative issuance.
+pub(crate) mod read_ahead;
 
 mod context;
 
@@ -36,6 +36,7 @@ pub use output::DownloadOutput;
 
 pub(crate) mod transfer;
 pub(crate) use transfer::DownloadTransfer;
+pub use transfer::DownloadIoCtl;
 
 /// Provides metadata for each chunk during an object download.
 mod chunk_meta;

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -35,20 +35,55 @@ impl WakeNotify {
     async fn notified(&self) {}
 }
 
-/// File sink for download-to-file writes.
+/// Positioned-write target for download-to-file. Abstracts the file so the drain
+/// orchestration (run coalescing, offset translation) can be exercised against an
+/// in-memory capture, and so an alternative write strategy (e.g. O_DIRECT/io_uring)
+/// can replace the file write without touching the buffer or the drain logic.
 ///
-/// Positioned writes land at `chunk.offset - object_range_start` in the file.
-struct Sink {
+/// `write_all_at` writes the whole buffer at an absolute file position; `preallocate`
+/// is a best-effort size hint. Implementations are shared across the issuer and the
+/// drain task, hence `Send + Sync`.
+pub(crate) trait SinkWrite: Send + Sync + std::fmt::Debug {
+    /// Write the entire buffer at `pos` bytes into the target.
+    fn write_all_at(
+        &self,
+        buf: &mut bytes_utils::SegmentedBuf<bytes::Bytes>,
+        pos: u64,
+    ) -> std::io::Result<()>;
+
+    /// Best-effort preallocation of `len` bytes. Default no-op.
+    fn preallocate(&self, _len: u64) {}
+}
+
+/// File-backed [`SinkWrite`]: positioned writes via `pwritev`.
+struct FileSink {
     file: std::fs::File,
-    /// Start of the S3 byte range for this transfer.
-    object_range_start: u64,
-    /// Whether the transfer manager created this file (vs caller-provided).
+    /// Whether the transfer manager created this file (vs caller-provided). Only an
+    /// owned file is preallocated.
     owns_file: bool,
 }
 
-impl std::fmt::Debug for Sink {
+impl std::fmt::Debug for FileSink {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Sink").finish_non_exhaustive()
+        f.debug_struct("FileSink").finish_non_exhaustive()
+    }
+}
+
+impl SinkWrite for FileSink {
+    fn write_all_at(
+        &self,
+        buf: &mut bytes_utils::SegmentedBuf<bytes::Bytes>,
+        pos: u64,
+    ) -> std::io::Result<()> {
+        crate::io::fs::write_all_at(&self.file, buf, pos)
+    }
+
+    fn preallocate(&self, len: u64) {
+        if self.owns_file {
+            if let Err(e) = crate::io::fs::preallocate(&self.file, len) {
+                tracing::warn!(error = %e, "failed to preallocate file space");
+            }
+        }
     }
 }
 
@@ -56,7 +91,12 @@ impl std::fmt::Debug for Sink {
 #[derive(Debug)]
 enum Mode {
     Stream,
-    Disk(Sink),
+    /// Positioned writes land at `chunk.offset - object_range_start` in the sink.
+    Disk {
+        sink: Box<dyn SinkWrite>,
+        /// Start of the S3 byte range for this transfer.
+        object_range_start: u64,
+    },
 }
 
 /// Producer handle to the download body buffer. Held at `self.inner.writer`
@@ -121,7 +161,7 @@ impl Drop for BodySlot {
 
 impl BodyWriter {
     pub(crate) fn has_sink(&self) -> bool {
-        matches!(&*self.mode, Mode::Disk(_))
+        matches!(&*self.mode, Mode::Disk { .. })
     }
 
     /// Claim the next slot. The read-ahead gate lives in poll_work (tracks
@@ -141,32 +181,53 @@ impl BodyWriter {
         self.buffer.released()
     }
 
-    /// Disk mode: drain every sealed (FULL) segment to disk. Called on the
-    /// `SealedSegment` edge from execute tasks. Stream mode: no-op.
-    pub(crate) fn drain_sealed(&self) -> Result<(), std::io::Error> {
-        if let Mode::Disk(sink) = &*self.mode {
-            while let Some(sw) = self.buffer.take_completed_segment() {
-                write_segment(sink, &sw)?;
+    /// Disk mode: drain every batch-ready run to disk. Called on the `DrainReady`
+    /// edge from execute tasks. A non-terminal drain claims only runs that reach the
+    /// drain batch, coalescing each into one positioned write. Stream mode: no-op.
+    pub(crate) fn drain(&self, terminal: bool) -> Result<(), std::io::Error> {
+        if let Mode::Disk {
+            sink,
+            object_range_start,
+        } = &*self.mode
+        {
+            while let Some(sw) = self.buffer.take_drain_run(terminal) {
+                write_run(sink.as_ref(), *object_range_start, &sw)?;
                 sw.complete();
             }
         }
         Ok(())
     }
 
-    /// Terminal drain: sealed segments then the partial tail. Called once
-    /// from `complete()` / `on_terminal()`.
+    /// Terminal drain: flush every remaining filled run, including a partial final
+    /// segment below the drain batch. Called once from `complete()` / `on_terminal()`.
     pub(crate) fn finalize(&self) -> Result<(), std::io::Error> {
-        if let Mode::Disk(sink) = &*self.mode {
-            while let Some(sw) = self.buffer.take_completed_segment() {
-                write_segment(sink, &sw)?;
-                sw.complete();
-            }
-            while let Some(sw) = self.buffer.take_tail() {
-                write_segment(sink, &sw)?;
-                sw.complete();
-            }
+        if !matches!(&*self.mode, Mode::Disk { .. }) {
+            return Ok(());
         }
+        // Report the terminal flush: how many parts this last pass wrote (those left
+        // resident below the drain batch) and the total drained over the transfer.
+        // Fires once per disk transfer — the lifecycle marker that the tail actually
+        // reached disk; its absence on a hung transfer localizes the stall to the
+        // terminal drain.
+        let before = self.released();
+        self.drain(true)?;
+        let total = self.released();
+        tracing::debug!(
+            target: crate::telemetry::TARGET_TRANSFER,
+            terminal_parts = total - before,
+            parts_total = total,
+            "terminal drain complete; tail flushed to disk",
+        );
         Ok(())
+    }
+
+    /// Couple the drain batch to the read-ahead window: a window narrower than a
+    /// segment drains in smaller runs so the block surface never waits for a run it
+    /// cannot accumulate. Capped at the segment size (the coalescing target). Called
+    /// at construction and whenever the window changes.
+    pub(crate) fn sync_drain_batch(&self, window: u64) {
+        let batch = std::cmp::min(SEG_SIZE as u64, window.max(1)) as usize;
+        self.buffer.set_drain_batch(batch);
     }
 
     /// Wake the consumer (terminal transition).
@@ -176,20 +237,22 @@ impl BodyWriter {
 
     /// Best-effort pre-allocation of disk space.
     pub(crate) fn preallocate(&self, len: u64) {
-        if let Mode::Disk(sink) = &*self.mode {
-            if sink.owns_file {
-                if let Err(e) = crate::io::fs::preallocate(&sink.file, len) {
-                    tracing::warn!(error = %e, "failed to preallocate file space");
-                }
-            }
+        if let Mode::Disk { sink, .. } = &*self.mode {
+            sink.preallocate(len);
         }
     }
 }
 
-/// Gather a segment's filled payloads and write them to disk at the
-/// correct file positions. Reads payloads in place via `Slot::get()`;
-/// `complete()` (called by the caller after this returns) frees them.
-fn write_segment(sink: &Sink, sw: &SegmentWrite<ChunkOutput>) -> std::io::Result<()> {
+/// Gather a claimed run's filled payloads and write them to the sink at the correct
+/// positions, coalescing offset-contiguous payloads into one positioned write. A
+/// payload at object offset `o` lands at sink position `o - object_range_start`. Reads
+/// payloads in place via `Slot::get()`; `complete()` (called by the caller after this
+/// returns) frees them.
+fn write_run(
+    sink: &dyn SinkWrite,
+    object_range_start: u64,
+    sw: &SegmentWrite<ChunkOutput>,
+) -> std::io::Result<()> {
     let mut run_start_file_pos: Option<u64> = None;
     let mut run_end: u64 = 0;
     let mut combined = bytes_utils::SegmentedBuf::<bytes::Bytes>::new();
@@ -198,29 +261,20 @@ fn write_segment(sink: &Sink, sw: &SegmentWrite<ChunkOutput>) -> std::io::Result
         let Some(chunk) = slot.get() else {
             // Unfilled slot in a partial tail segment — flush accumulated run
             // and reset.
-            if run_start_file_pos.is_some() {
-                crate::io::fs::write_all_at(
-                    &sink.file,
-                    &mut combined,
-                    run_start_file_pos.unwrap(),
-                )?;
+            if let Some(pos) = run_start_file_pos.take() {
+                sink.write_all_at(&mut combined, pos)?;
                 combined = bytes_utils::SegmentedBuf::new();
-                run_start_file_pos = None;
             }
             continue;
         };
 
-        let file_pos = chunk.offset - sink.object_range_start;
+        let file_pos = chunk.offset - object_range_start;
         let chunk_len = chunk.data.remaining() as u64;
 
-        if let Some(_start) = run_start_file_pos {
+        if let Some(start) = run_start_file_pos {
             if file_pos != run_end {
                 // Gap: flush the accumulated run and start a new one.
-                crate::io::fs::write_all_at(
-                    &sink.file,
-                    &mut combined,
-                    run_start_file_pos.unwrap(),
-                )?;
+                sink.write_all_at(&mut combined, start)?;
                 combined = bytes_utils::SegmentedBuf::new();
                 run_start_file_pos = Some(file_pos);
                 run_end = file_pos + chunk_len;
@@ -240,7 +294,7 @@ fn write_segment(sink: &Sink, sw: &SegmentWrite<ChunkOutput>) -> std::io::Result
 
     // Flush any remaining accumulated run.
     if let Some(pos) = run_start_file_pos {
-        crate::io::fs::write_all_at(&sink.file, &mut combined, pos)?;
+        sink.write_all_at(&mut combined, pos)?;
     }
     Ok(())
 }
@@ -284,29 +338,37 @@ pub(crate) fn new_slot_body() -> (BodyWriter, SlotBodyConsumer) {
     (writer, slot_consumer)
 }
 
-/// Create a producer/consumer pair with a file sink for download-to-file.
+/// Create a producer/consumer pair writing to an arbitrary [`SinkWrite`] target.
+/// Positioned writes land at `chunk.offset - object_range_start` in the sink.
 ///
 /// Issuance backpressure is owned by the per-transfer [`ReadAhead`] controller.
 ///
 /// [`ReadAhead`]: super::read_ahead::ReadAhead
-pub(crate) fn new_slot_body_with_sink(
-    file: std::fs::File,
+fn new_slot_body_with_disk_mode(
+    sink: Box<dyn SinkWrite>,
     object_range_start: u64,
-    owns_file: bool,
 ) -> (BodyWriter, SlotBodyConsumer) {
     let (buffer, consumer) = PagedRecvBuffer::new_with_segment_size(SEG_SIZE);
     let notify = Arc::new(WakeNotify::new());
     let writer = BodyWriter {
         buffer,
         notify: notify.clone(),
-        mode: Arc::new(Mode::Disk(Sink {
-            file,
+        mode: Arc::new(Mode::Disk {
+            sink,
             object_range_start,
-            owns_file,
-        })),
+        }),
     };
     let slot_consumer = SlotBodyConsumer { consumer, notify };
     (writer, slot_consumer)
+}
+
+/// Create a producer/consumer pair with a file sink for download-to-file.
+pub(crate) fn new_slot_body_with_sink(
+    file: std::fs::File,
+    object_range_start: u64,
+    owns_file: bool,
+) -> (BodyWriter, SlotBodyConsumer) {
+    new_slot_body_with_disk_mode(Box::new(FileSink { file, owns_file }), object_range_start)
 }
 
 /// Stream of [ChunkOutput] representing an Amazon S3 Object's contents and metadata.
@@ -572,7 +634,13 @@ mod tests {
 
     // --- Disk driver tests ---
 
-    use super::new_slot_body_with_sink;
+    use super::{
+        new_slot_body_with_disk_mode, new_slot_body_with_sink, BodyWriter as Writer, SinkWrite,
+        SlotBodyConsumer,
+    };
+    use bytes::Buf as _;
+    use std::collections::BTreeMap;
+    use std::sync::Mutex as StdMutex;
 
     fn chunk_at(seq: u64, offset: u64, data: &[u8]) -> ChunkOutput {
         let mut seg = SegmentedBuf::new();
@@ -583,6 +651,66 @@ mod tests {
             data: AggregatedBytes(seg),
             metadata: Default::default(),
         }
+    }
+
+    /// In-memory [`SinkWrite`] that records every positioned write, for asserting the
+    /// drain orchestration (offset translation, run coalescing, ordering under
+    /// concurrency) without a real file. Reconstructs the destination by laying each
+    /// write down at its position, so overlapping or misordered writes surface as
+    /// wrong bytes.
+    #[derive(Debug, Default)]
+    struct CaptureSink {
+        // pos -> bytes written there (most recent wins, as a real file would).
+        writes: StdMutex<BTreeMap<u64, Vec<u8>>>,
+    }
+
+    impl CaptureSink {
+        /// Materialize the written bytes into a contiguous buffer, panicking on a gap
+        /// (an unwritten position below the high-water mark) so a missed write is loud.
+        fn assembled(&self) -> Vec<u8> {
+            let writes = self.writes.lock().unwrap();
+            let mut out = Vec::new();
+            for (&pos, bytes) in writes.iter() {
+                assert_eq!(pos as usize, out.len(), "gap or overlap at pos {pos}");
+                out.extend_from_slice(bytes);
+            }
+            out
+        }
+    }
+
+    impl SinkWrite for CaptureSink {
+        fn write_all_at(
+            &self,
+            buf: &mut bytes_utils::SegmentedBuf<bytes::Bytes>,
+            pos: u64,
+        ) -> std::io::Result<()> {
+            let mut bytes = vec![0u8; buf.remaining()];
+            buf.copy_to_slice(&mut bytes);
+            self.writes.lock().unwrap().insert(pos, bytes);
+            Ok(())
+        }
+    }
+
+    fn new_slot_body_with_capture(
+        object_range_start: u64,
+    ) -> (Writer, SlotBodyConsumer, Arc<CaptureSink>) {
+        let sink = Arc::new(CaptureSink::default());
+        // The Mode holds a Box<dyn SinkWrite>; share state via an Arc the test also
+        // holds. A thin forwarder lets the Box and the test handle point at one sink.
+        #[derive(Debug)]
+        struct Shared(Arc<CaptureSink>);
+        impl SinkWrite for Shared {
+            fn write_all_at(
+                &self,
+                buf: &mut bytes_utils::SegmentedBuf<bytes::Bytes>,
+                pos: u64,
+            ) -> std::io::Result<()> {
+                self.0.write_all_at(buf, pos)
+            }
+        }
+        let (writer, consumer) =
+            new_slot_body_with_disk_mode(Box::new(Shared(sink.clone())), object_range_start);
+        (writer, consumer, sink)
     }
 
     #[test]
@@ -602,7 +730,7 @@ mod tests {
         }
 
         // The last fill sealed the segment; drain it.
-        writer.drain_sealed().unwrap();
+        writer.drain(false).unwrap();
 
         let contents = std::fs::read(&path).unwrap();
         for i in 0..SEG_SIZE as u64 {
@@ -695,7 +823,7 @@ mod tests {
             slot.fill(chunk_at(i, offset, data.as_bytes()));
         }
 
-        writer.drain_sealed().unwrap();
+        writer.drain(false).unwrap();
 
         let contents = std::fs::read(&path).unwrap();
         for i in 0..n as u64 {
@@ -749,15 +877,15 @@ mod tests {
         }
     }
 
-    /// Draining sealed segments on the disk path must release read-ahead occupancy.
+    /// Draining runs on the disk path must release read-ahead occupancy.
     ///
-    /// The issuance gate bounds `issued - consumed()`. On the stream path `consumed()`
-    /// advances as the consumer pulls; on the disk path the consumer is
-    /// `drain_sealed`, which writes and frees whole segments. If draining does not
-    /// move the gate's occupancy, a download larger than the read-ahead window wedges:
-    /// the gate latches shut at the window and never reopens even though the buffer
-    /// has drained to empty. This drives that path directly — no network, no large
-    /// object — and asserts occupancy falls as segments drain.
+    /// The issuance gate bounds `issued - released()`. On the stream path `released`
+    /// advances as the consumer pulls; on the disk path the consumer is `drain`, which
+    /// writes and frees runs. If draining does not move the gate's occupancy, a
+    /// download larger than the read-ahead window wedges: the gate latches shut at the
+    /// window and never reopens even though the buffer has drained to empty. This
+    /// drives that path directly — no network, no large object — and asserts occupancy
+    /// falls as runs drain.
     #[test]
     fn disk_drain_releases_read_ahead_occupancy() {
         use super::SEG_SIZE;
@@ -766,14 +894,16 @@ mod tests {
         let file = std::fs::File::create(&path).unwrap();
         let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
 
-        // Fill and seal two full segments, draining after each seal — the disk path's
-        // steady-state loop. Bounded iteration, so a regression fails fast.
+        // Fill two full segments, draining on the DrainReady edge after each fill — the
+        // disk path's steady-state loop. Bounded iteration, so a regression fails fast.
         let total = (2 * SEG_SIZE) as u64;
         for i in 0..total {
             let slot = writer.claim();
-            slot.fill(chunk_at(i, i * 100, format!("d{i}").as_bytes()));
-            // Drain on the segment-seal boundary, as execute_get_range does.
-            writer.drain_sealed().unwrap();
+            let outcome = slot.fill(chunk_at(i, i * 100, format!("d{i}").as_bytes()));
+            // Drain on the batch edge, as execute_get_range does.
+            if outcome == super::FillOutcome::DrainReady {
+                writer.drain(false).unwrap();
+            }
         }
 
         // The gate measures resident occupancy as `issued - released()`. Every part
@@ -785,6 +915,97 @@ mod tests {
             occupancy, 0,
             "all {total} parts drained to disk, but the gate still counts {occupancy} \
              as resident (released={released}); issuance cannot reopen past the window"
+        );
+    }
+
+    /// Concurrent, out-of-order fills across several segments must drain to the correct
+    /// positions: many parts are claimed in order, then filled and drained from many
+    /// threads in a shuffled order, each thread mirroring the execute path (fill, then
+    /// drain on the `DrainReady` edge). A non-zero `object_range_start` also exercises
+    /// offset translation. The capture sink reconstructs the object; any misordered or
+    /// misplaced positioned write surfaces as wrong bytes or a gap.
+    ///
+    /// This is the property the disk path depends on but that an in-order producer
+    /// never exercises: parts arrive and drain out of order, yet positioned writes (no
+    /// recomputed checksum) must still reassemble the object byte-for-byte.
+    #[test]
+    fn disk_concurrent_out_of_order_drain_reassembles() {
+        use super::SEG_SIZE;
+
+        // Several segments' worth, with a partial final segment, so the run includes
+        // full-segment drains, cross-segment coalescing, and a terminal partial tail.
+        let parts = 3 * SEG_SIZE + 5;
+        let part_len = 64usize;
+        let range_start = 4096u64; // non-zero base: exercises offset translation
+
+        // Deterministic per-part bytes, so the assembled object is checkable.
+        let part_bytes = |seq: usize| -> Vec<u8> {
+            (0..part_len).map(|b| (seq as u8).wrapping_add(b as u8)).collect()
+        };
+        let mut expected = Vec::with_capacity(parts * part_len);
+        for seq in 0..parts {
+            expected.extend_from_slice(&part_bytes(seq));
+        }
+
+        let (writer, _consumer, sink) = new_slot_body_with_capture(range_start);
+
+        // Claim all slots up front (claim is serialized; seq assignment is in order).
+        let slots: Vec<_> = (0..parts).map(|_| writer.claim()).collect();
+
+        // A fixed shuffle of fill order (deterministic — no rng): odd indices first,
+        // then even, so later segments seal before earlier ones complete.
+        let mut order: Vec<usize> = (0..parts).filter(|i| i % 2 == 1).collect();
+        order.extend((0..parts).filter(|i| i % 2 == 0));
+
+        // Map seq -> slot, consumed as each thread fills.
+        let mut by_seq: std::collections::HashMap<usize, super::BodySlot> =
+            slots.into_iter().map(|s| (s.seq() as usize, s)).collect();
+
+        let writer = Arc::new(writer);
+        let n_threads = 4;
+        let chunks: Vec<Vec<usize>> = (0..n_threads)
+            .map(|t| {
+                order
+                    .iter()
+                    .copied()
+                    .skip(t)
+                    .step_by(n_threads)
+                    .collect()
+            })
+            .collect();
+
+        std::thread::scope(|scope| {
+            for thread_seqs in &chunks {
+                // Move this thread's slots in.
+                let mut my_slots = Vec::new();
+                for &seq in thread_seqs {
+                    my_slots.push((seq, by_seq.remove(&seq).expect("slot for seq")));
+                }
+                let writer = writer.clone();
+                scope.spawn(move || {
+                    for (seq, slot) in my_slots {
+                        let offset = range_start + (seq as u64) * (part_len as u64);
+                        let outcome = slot.fill(chunk_at(seq as u64, offset, &part_bytes(seq)));
+                        // Mirror execute_get_range: drain on the batch edge.
+                        if outcome == super::FillOutcome::DrainReady {
+                            writer.drain(false).unwrap();
+                        }
+                    }
+                });
+            }
+        });
+        assert!(by_seq.is_empty(), "every slot dispatched to a thread");
+
+        // Terminal drain flushes the partial final segment and any straggler runs.
+        writer.finalize().unwrap();
+
+        // Every part written and freed.
+        assert_eq!(writer.released(), parts as u64, "all parts drained");
+        // The positioned writes reassemble the object exactly.
+        assert_eq!(
+            sink.assembled(),
+            expected,
+            "out-of-order concurrent drain must reassemble the object byte-for-byte"
         );
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -633,8 +633,8 @@ mod tests {
     // --- Disk driver tests ---
 
     use super::{
-        new_recv_body_with_disk_mode, new_recv_body_with_sink, BodyWriter as Writer, SinkWrite,
-        RecvBodyConsumer,
+        new_recv_body_with_disk_mode, new_recv_body_with_sink, BodyWriter as Writer,
+        RecvBodyConsumer, SinkWrite,
     };
     use bytes::Buf as _;
     use std::collections::BTreeMap;
@@ -938,7 +938,9 @@ mod tests {
 
         // Deterministic per-part bytes, so the assembled object is checkable.
         let part_bytes = |seq: usize| -> Vec<u8> {
-            (0..part_len).map(|b| (seq as u8).wrapping_add(b as u8)).collect()
+            (0..part_len)
+                .map(|b| (seq as u8).wrapping_add(b as u8))
+                .collect()
         };
         let mut expected = Vec::with_capacity(parts * part_len);
         for seq in 0..parts {
@@ -962,14 +964,7 @@ mod tests {
         let writer = Arc::new(writer);
         let n_threads = 4;
         let chunks: Vec<Vec<usize>> = (0..n_threads)
-            .map(|t| {
-                order
-                    .iter()
-                    .copied()
-                    .skip(t)
-                    .step_by(n_threads)
-                    .collect()
-            })
+            .map(|t| order.iter().copied().skip(t).step_by(n_threads).collect())
             .collect();
 
         std::thread::scope(|scope| {

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -135,10 +135,10 @@ impl BodyWriter {
         }
     }
 
-    /// In-order delivery cursor. For the producer-side read-ahead gate:
-    /// `issued - consumed < W`.
-    pub(crate) fn consumed(&self) -> u64 {
-        self.buffer.consumed()
+    /// Parts whose memory the consumer has freed (stream delivery or disk drain) —
+    /// the read-ahead gate's denominator. See [`PagedRecvBuffer::released`].
+    pub(crate) fn released(&self) -> u64 {
+        self.buffer.released()
     }
 
     /// Disk mode: drain every sealed (FULL) segment to disk. Called on the
@@ -747,5 +747,44 @@ mod tests {
                 "mismatch at seq {seq}"
             );
         }
+    }
+
+    /// Draining sealed segments on the disk path must release read-ahead occupancy.
+    ///
+    /// The issuance gate bounds `issued - consumed()`. On the stream path `consumed()`
+    /// advances as the consumer pulls; on the disk path the consumer is
+    /// `drain_sealed`, which writes and frees whole segments. If draining does not
+    /// move the gate's occupancy, a download larger than the read-ahead window wedges:
+    /// the gate latches shut at the window and never reopens even though the buffer
+    /// has drained to empty. This drives that path directly — no network, no large
+    /// object — and asserts occupancy falls as segments drain.
+    #[test]
+    fn disk_drain_releases_read_ahead_occupancy() {
+        use super::SEG_SIZE;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out");
+        let file = std::fs::File::create(&path).unwrap();
+        let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
+
+        // Fill and seal two full segments, draining after each seal — the disk path's
+        // steady-state loop. Bounded iteration, so a regression fails fast.
+        let total = (2 * SEG_SIZE) as u64;
+        for i in 0..total {
+            let slot = writer.claim();
+            slot.fill(chunk_at(i, i * 100, format!("d{i}").as_bytes()));
+            // Drain on the segment-seal boundary, as execute_get_range does.
+            writer.drain_sealed().unwrap();
+        }
+
+        // The gate measures resident occupancy as `issued - released()`. Every part
+        // has been written to disk and its memory freed, so occupancy must be 0 —
+        // otherwise the gate would still count drained parts against the window.
+        let released = writer.released();
+        let occupancy = total - released;
+        assert_eq!(
+            occupancy, 0,
+            "all {total} parts drained to disk, but the gate still counts {occupancy} \
+             as resident (released={released}); issuance cannot reopen past the window"
+        );
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -206,9 +206,7 @@ impl BodyWriter {
         }
         // Report the terminal flush: how many parts this last pass wrote (those left
         // resident below the drain batch) and the total drained over the transfer.
-        // Fires once per disk transfer — the lifecycle marker that the tail actually
-        // reached disk; its absence on a hung transfer localizes the stall to the
-        // terminal drain.
+        // Logged once per disk transfer.
         let before = self.released();
         self.drain(true)?;
         let total = self.released();
@@ -301,18 +299,18 @@ fn write_run(
 
 /// Consumer wrapper carrying the notify handle alongside the buffer consumer.
 /// Handed from constructors to `Body::new`.
-pub(crate) struct SlotBodyConsumer {
+pub(crate) struct RecvBodyConsumer {
     consumer: RecvBufferConsumer<ChunkOutput>,
     notify: Arc<WakeNotify>,
 }
 
-impl std::fmt::Debug for SlotBodyConsumer {
+impl std::fmt::Debug for RecvBodyConsumer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SlotBodyConsumer").finish_non_exhaustive()
+        f.debug_struct("RecvBodyConsumer").finish_non_exhaustive()
     }
 }
 
-impl SlotBodyConsumer {
+impl RecvBodyConsumer {
     /// Try to take the next sequential chunk without waiting.
     #[cfg(test)]
     pub(crate) fn try_take_next(&mut self) -> Option<ChunkOutput> {
@@ -326,7 +324,7 @@ impl SlotBodyConsumer {
 /// by a fixed buffer capacity — the buffer grows as needed.
 ///
 /// [`ReadAhead`]: super::read_ahead::ReadAhead
-pub(crate) fn new_slot_body() -> (BodyWriter, SlotBodyConsumer) {
+pub(crate) fn new_recv_body() -> (BodyWriter, RecvBodyConsumer) {
     let (buffer, consumer) = PagedRecvBuffer::new_with_segment_size(SEG_SIZE);
     let notify = Arc::new(WakeNotify::new());
     let writer = BodyWriter {
@@ -334,7 +332,7 @@ pub(crate) fn new_slot_body() -> (BodyWriter, SlotBodyConsumer) {
         notify: notify.clone(),
         mode: Arc::new(Mode::Stream),
     };
-    let slot_consumer = SlotBodyConsumer { consumer, notify };
+    let slot_consumer = RecvBodyConsumer { consumer, notify };
     (writer, slot_consumer)
 }
 
@@ -344,10 +342,10 @@ pub(crate) fn new_slot_body() -> (BodyWriter, SlotBodyConsumer) {
 /// Issuance backpressure is owned by the per-transfer [`ReadAhead`] controller.
 ///
 /// [`ReadAhead`]: super::read_ahead::ReadAhead
-fn new_slot_body_with_disk_mode(
+fn new_recv_body_with_disk_mode(
     sink: Box<dyn SinkWrite>,
     object_range_start: u64,
-) -> (BodyWriter, SlotBodyConsumer) {
+) -> (BodyWriter, RecvBodyConsumer) {
     let (buffer, consumer) = PagedRecvBuffer::new_with_segment_size(SEG_SIZE);
     let notify = Arc::new(WakeNotify::new());
     let writer = BodyWriter {
@@ -358,17 +356,17 @@ fn new_slot_body_with_disk_mode(
             object_range_start,
         }),
     };
-    let slot_consumer = SlotBodyConsumer { consumer, notify };
+    let slot_consumer = RecvBodyConsumer { consumer, notify };
     (writer, slot_consumer)
 }
 
 /// Create a producer/consumer pair with a file sink for download-to-file.
-pub(crate) fn new_slot_body_with_sink(
+pub(crate) fn new_recv_body_with_sink(
     file: std::fs::File,
     object_range_start: u64,
     owns_file: bool,
-) -> (BodyWriter, SlotBodyConsumer) {
-    new_slot_body_with_disk_mode(Box::new(FileSink { file, owns_file }), object_range_start)
+) -> (BodyWriter, RecvBodyConsumer) {
+    new_recv_body_with_disk_mode(Box::new(FileSink { file, owns_file }), object_range_start)
 }
 
 /// Stream of [ChunkOutput] representing an Amazon S3 Object's contents and metadata.
@@ -416,7 +414,7 @@ impl std::fmt::Debug for ChunkOutput {
 }
 
 impl Body {
-    pub(crate) fn new(consumer: SlotBodyConsumer, transfer: DownloadTransfer) -> Self {
+    pub(crate) fn new(consumer: RecvBodyConsumer, transfer: DownloadTransfer) -> Self {
         Self {
             consumer: consumer.consumer,
             notify: consumer.notify,
@@ -485,7 +483,7 @@ mod tests {
     use bytes_utils::SegmentedBuf;
     use std::sync::Arc;
 
-    use super::{new_slot_body, AggregatedBytes, Body, BodyWriter};
+    use super::{new_recv_body, AggregatedBytes, Body, BodyWriter};
 
     fn chunk_resp(seq: u64, data: AggregatedBytes) -> ChunkOutput {
         ChunkOutput {
@@ -515,7 +513,7 @@ mod tests {
             .build()
             .unwrap();
         let (ctx, _) = TransferContext::new(tm.handle.clone());
-        let (writer, consumer) = new_slot_body();
+        let (writer, consumer) = new_recv_body();
         let transfer = DownloadTransfer::new(ctx, BucketType::Standard, input, writer.clone());
         (Body::new(consumer, transfer.clone()), transfer, writer)
     }
@@ -635,8 +633,8 @@ mod tests {
     // --- Disk driver tests ---
 
     use super::{
-        new_slot_body_with_disk_mode, new_slot_body_with_sink, BodyWriter as Writer, SinkWrite,
-        SlotBodyConsumer,
+        new_recv_body_with_disk_mode, new_recv_body_with_sink, BodyWriter as Writer, SinkWrite,
+        RecvBodyConsumer,
     };
     use bytes::Buf as _;
     use std::collections::BTreeMap;
@@ -691,9 +689,9 @@ mod tests {
         }
     }
 
-    fn new_slot_body_with_capture(
+    fn new_recv_body_with_capture(
         object_range_start: u64,
-    ) -> (Writer, SlotBodyConsumer, Arc<CaptureSink>) {
+    ) -> (Writer, RecvBodyConsumer, Arc<CaptureSink>) {
         let sink = Arc::new(CaptureSink::default());
         // The Mode holds a Box<dyn SinkWrite>; share state via an Arc the test also
         // holds. A thin forwarder lets the Box and the test handle point at one sink.
@@ -709,7 +707,7 @@ mod tests {
             }
         }
         let (writer, consumer) =
-            new_slot_body_with_disk_mode(Box::new(Shared(sink.clone())), object_range_start);
+            new_recv_body_with_disk_mode(Box::new(Shared(sink.clone())), object_range_start);
         (writer, consumer, sink)
     }
 
@@ -719,7 +717,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
+        let (writer, _consumer) = new_recv_body_with_sink(file, 0, false);
 
         // Fill a full segment's worth of slots
         for i in 0..SEG_SIZE as u64 {
@@ -750,7 +748,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
+        let (writer, _consumer) = new_recv_body_with_sink(file, 0, false);
 
         // Fill fewer than a segment's worth (partial)
         let partial = SEG_SIZE / 2;
@@ -782,7 +780,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
+        let (writer, _consumer) = new_recv_body_with_sink(file, 0, false);
 
         // Fill SEG_SIZE + 2 parts
         let total = SEG_SIZE + 2;
@@ -813,7 +811,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(file, 1000, false);
+        let (writer, _consumer) = new_recv_body_with_sink(file, 1000, false);
 
         let n = SEG_SIZE;
         for i in 0..n as u64 {
@@ -844,7 +842,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
+        let (writer, _consumer) = new_recv_body_with_sink(file, 0, false);
 
         let n = SEG_SIZE;
         let mut handles = Vec::new();
@@ -892,7 +890,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
+        let (writer, _consumer) = new_recv_body_with_sink(file, 0, false);
 
         // Fill two full segments, draining on the DrainReady edge after each fill — the
         // disk path's steady-state loop. Bounded iteration, so a regression fails fast.
@@ -947,7 +945,7 @@ mod tests {
             expected.extend_from_slice(&part_bytes(seq));
         }
 
-        let (writer, _consumer, sink) = new_slot_body_with_capture(range_start);
+        let (writer, _consumer, sink) = new_recv_body_with_capture(range_start);
 
         // Claim all slots up front (claim is serialized; seq assignment is in order).
         let slots: Vec<_> = (0..parts).map(|_| writer.claim()).collect();

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -175,16 +175,15 @@ impl BodyWriter {
         }
     }
 
-    /// Parts whose memory the consumer has freed (stream delivery or disk drain) —
-    /// the read-ahead gate's denominator. See [`PagedRecvBuffer::released`].
-    pub(crate) fn released(&self) -> u64 {
-        self.buffer.released()
-    }
-
     /// Disk mode: drain every batch-ready run to disk. Called on the `DrainReady`
     /// edge from execute tasks. A non-terminal drain claims only runs that reach the
     /// drain batch, coalescing each into one positioned write. Stream mode: no-op.
-    pub(crate) fn drain(&self, terminal: bool) -> Result<(), std::io::Error> {
+    ///
+    /// Returns the number of parts freed across the runs drained by this call — the
+    /// read-ahead occupancy the caller releases. The buffer does not track a running
+    /// total; the download layer accounts for the freed count under its state lock.
+    pub(crate) fn drain(&self, terminal: bool) -> Result<u64, std::io::Error> {
+        let mut freed = 0u64;
         if let Mode::Disk {
             sink,
             object_range_start,
@@ -192,31 +191,27 @@ impl BodyWriter {
         {
             while let Some(sw) = self.buffer.take_drain_run(terminal) {
                 write_run(sink.as_ref(), *object_range_start, &sw)?;
-                sw.complete();
+                freed += sw.complete();
             }
         }
-        Ok(())
+        Ok(freed)
     }
 
     /// Terminal drain: flush every remaining filled run, including a partial final
     /// segment below the drain batch. Called once from `complete()` / `on_terminal()`.
-    pub(crate) fn finalize(&self) -> Result<(), std::io::Error> {
+    /// Returns the parts freed by this terminal pass (the tail left resident below the
+    /// drain batch) so the caller can release the last of the read-ahead occupancy.
+    pub(crate) fn finalize(&self) -> Result<u64, std::io::Error> {
         if !matches!(&*self.mode, Mode::Disk { .. }) {
-            return Ok(());
+            return Ok(0);
         }
-        // Report the terminal flush: how many parts this last pass wrote (those left
-        // resident below the drain batch) and the total drained over the transfer.
-        // Logged once per disk transfer.
-        let before = self.released();
-        self.drain(true)?;
-        let total = self.released();
+        let terminal_parts = self.drain(true)?;
         tracing::debug!(
             target: crate::telemetry::TARGET_TRANSFER,
-            terminal_parts = total - before,
-            parts_total = total,
+            terminal_parts,
             "terminal drain complete; tail flushed to disk",
         );
-        Ok(())
+        Ok(terminal_parts)
     }
 
     /// Couple the drain batch to the read-ahead window: a window narrower than a
@@ -440,15 +435,16 @@ impl Body {
             // Register interest BEFORE checking state (lost-wake safety).
             let notified = self.notify.notified();
             if let Some(chunk) = self.consumer.poll_next() {
-                // Delivery advances `consumed`, freeing read-ahead occupancy; wake
-                // the issuer so the reopened window admits more work.
-                self.transfer.ctx().try_wake();
+                // Delivery freed one part's payload. Release that read-ahead occupancy
+                // and wake the issuer under the state lock, so the release is ordered
+                // against the gate's park (see `release_stream_occupancy`).
+                self.transfer.release_stream_occupancy();
                 return Some(Ok(chunk));
             }
             if !self.transfer.ctx().is_active() {
                 // Terminal: drain then report.
                 if let Some(chunk) = self.consumer.poll_next() {
-                    self.transfer.ctx().try_wake();
+                    self.transfer.release_stream_occupancy();
                     return Some(Ok(chunk));
                 }
                 return self.terminal_result();
@@ -875,15 +871,15 @@ mod tests {
         }
     }
 
-    /// Draining runs on the disk path must release read-ahead occupancy.
+    /// Draining runs on the disk path must report freed parts to release read-ahead
+    /// occupancy.
     ///
-    /// The issuance gate bounds `issued - released()`. On the stream path `released`
-    /// advances as the consumer pulls; on the disk path the consumer is `drain`, which
-    /// writes and frees runs. If draining does not move the gate's occupancy, a
-    /// download larger than the read-ahead window wedges: the gate latches shut at the
-    /// window and never reopens even though the buffer has drained to empty. This
-    /// drives that path directly — no network, no large object — and asserts occupancy
-    /// falls as runs drain.
+    /// The issuance gate bounds `issued - released`, where `released` is the sum of the
+    /// freed counts `drain` reports. On the disk path the consumer is `drain`, which
+    /// writes and frees runs. If draining does not report freed parts, a download larger
+    /// than the read-ahead window wedges: the gate latches shut at the window and never
+    /// reopens even though the buffer has drained to empty. This drives that path
+    /// directly — no network, no large object — and asserts every part is reported freed.
     #[test]
     fn disk_drain_releases_read_ahead_occupancy() {
         use super::SEG_SIZE;
@@ -895,24 +891,26 @@ mod tests {
         // Fill two full segments, draining on the DrainReady edge after each fill — the
         // disk path's steady-state loop. Bounded iteration, so a regression fails fast.
         let total = (2 * SEG_SIZE) as u64;
+        let mut freed_total = 0u64;
         for i in 0..total {
             let slot = writer.claim();
             let outcome = slot.fill(chunk_at(i, i * 100, format!("d{i}").as_bytes()));
             // Drain on the batch edge, as execute_get_range does.
             if outcome == super::FillOutcome::DrainReady {
-                writer.drain(false).unwrap();
+                freed_total += writer.drain(false).unwrap();
             }
         }
+        // A terminal drain flushes any sub-batch tail so the total accounts for every part.
+        freed_total += writer.finalize().unwrap();
 
-        // The gate measures resident occupancy as `issued - released()`. Every part
-        // has been written to disk and its memory freed, so occupancy must be 0 —
-        // otherwise the gate would still count drained parts against the window.
-        let released = writer.released();
-        let occupancy = total - released;
+        // Resident occupancy is `issued - released` = total - freed_total. Every part has
+        // been written to disk and its memory freed, so it must be 0 — otherwise the gate
+        // would still count drained parts against the window.
+        let occupancy = total - freed_total;
         assert_eq!(
             occupancy, 0,
-            "all {total} parts drained to disk, but the gate still counts {occupancy} \
-             as resident (released={released}); issuance cannot reopen past the window"
+            "all {total} parts drained to disk, but the drains reported only \
+             {freed_total} freed; issuance cannot reopen past the window"
         );
     }
 
@@ -962,6 +960,9 @@ mod tests {
             slots.into_iter().map(|s| (s.seq() as usize, s)).collect();
 
         let writer = Arc::new(writer);
+        // Sum every drain's freed count across threads, the way the download layer
+        // accumulates `released` under its state lock.
+        let freed_total = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let n_threads = 4;
         let chunks: Vec<Vec<usize>> = (0..n_threads)
             .map(|t| order.iter().copied().skip(t).step_by(n_threads).collect())
@@ -975,13 +976,15 @@ mod tests {
                     my_slots.push((seq, by_seq.remove(&seq).expect("slot for seq")));
                 }
                 let writer = writer.clone();
+                let freed_total = freed_total.clone();
                 scope.spawn(move || {
                     for (seq, slot) in my_slots {
                         let offset = range_start + (seq as u64) * (part_len as u64);
                         let outcome = slot.fill(chunk_at(seq as u64, offset, &part_bytes(seq)));
                         // Mirror execute_get_range: drain on the batch edge.
                         if outcome == super::FillOutcome::DrainReady {
-                            writer.drain(false).unwrap();
+                            let freed = writer.drain(false).unwrap();
+                            freed_total.fetch_add(freed, std::sync::atomic::Ordering::Relaxed);
                         }
                     }
                 });
@@ -990,10 +993,17 @@ mod tests {
         assert!(by_seq.is_empty(), "every slot dispatched to a thread");
 
         // Terminal drain flushes the partial final segment and any straggler runs.
-        writer.finalize().unwrap();
+        freed_total.fetch_add(
+            writer.finalize().unwrap(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
 
         // Every part written and freed.
-        assert_eq!(writer.released(), parts as u64, "all parts drained");
+        assert_eq!(
+            freed_total.load(std::sync::atomic::Ordering::Relaxed),
+            parts as u64,
+            "all parts drained"
+        );
         // The positioned writes reassemble the object exactly.
         assert_eq!(
             sink.assembled(),

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -3,21 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::runtime::sync::cell::UnsafeCell;
-use crate::runtime::sync::sync::atomic::{
-    AtomicBool, AtomicU64, AtomicU8, Ordering as AtomicOrdering,
-};
-use crate::runtime::sync::sync::Arc;
-
 use bytes::Buf;
 
 use crate::io::AggregatedBytes;
+use crate::runtime::sync::sync::Arc;
 
 use super::chunk_meta::ChunkMetadata;
-use super::transfer::DownloadTransfer;
+use super::recv_buffer::{
+    FillOutcome, PagedRecvBuffer, RecvBufferConsumer, SegmentWrite, SlotHandle,
+};
 
-/// Default slot buffer capacity for download body delivery.
-pub(crate) const DEFAULT_BODY_SLOT_CAPACITY: usize = 512;
+/// Segment size for the paged buffer. Re-exported from `recv_buffer` for test access.
+const SEG_SIZE: usize = super::recv_buffer::DEFAULT_SEG_SIZE;
+use super::transfer::DownloadTransfer;
 
 /// Wakeup signal wrapper. Under loom, tokio::sync::Notify is unavailable,
 /// but the Notify doesn't participate in safety invariants — it's just a
@@ -37,34 +35,15 @@ impl WakeNotify {
     async fn notified(&self) {}
 }
 
-/// Slot has no data and is available for reuse.
-const SLOT_EMPTY: u8 = 0;
-/// Slot contains a completed chunk awaiting consumption or flush.
-const SLOT_FILLED: u8 = 1;
-/// Data written to disk, awaiting consumed advancement. Sink path only.
-const SLOT_FLUSHED: u8 = 2;
-
-/// Number of fills between automatic flush attempts in the sink path.
-const FLUSH_INTERVAL: u64 = 1;
-
 /// File sink for download-to-file writes.
 ///
-/// When registered on a `SlotBuffer`, filled slots are batched and
-/// flushed to disk via positioned writes instead of being consumed
-/// through `Body::next()`.
+/// Positioned writes land at `chunk.offset - object_range_start` in the file.
 struct Sink {
     file: std::fs::File,
     /// Start of the S3 byte range for this transfer.
-    /// 0 for full object downloads, user's range start for ranged gets.
-    /// Each chunk's file position is `chunk.offset - object_range_start`.
     object_range_start: u64,
     /// Whether the transfer manager created this file (vs caller-provided).
-    /// Controls whether preallocate is allowed.
     owns_file: bool,
-    /// CAS lock for flush exclusion — only one thread flushes at a time.
-    flushing: AtomicBool,
-    /// Counts fills; flush triggered every `FLUSH_INTERVAL` fills.
-    fill_count: AtomicU64,
 }
 
 impl std::fmt::Debug for Sink {
@@ -73,378 +52,131 @@ impl std::fmt::Debug for Sink {
     }
 }
 
-/// Fixed-size ring buffer of slots for delivering download chunks.
-///
-/// Slots are indexed by `seq % capacity`. Each slot transitions through
-/// states: `Empty` → `Filled` (→ `Flushed` in sink path). The invariants
-/// that make `UnsafeCell` access safe are:
-///
-/// 1. **Exclusive producer access**: each sequence number is claimed exactly
-///    once via `claimed` CAS. The producer that claimed `seq` is the only
-///    writer to `slots[seq % capacity]`.
-/// 2. **State-gated consumer access**: the consumer only reads a slot's data
-///    after observing `FILLED` via acquire load. The release store in `fill()`
-///    ensures the data write is visible.
-/// 3. **No overlap between producer and consumer**: the seq window invariant
-///    (`claimed - consumed < capacity`) guarantees the producer never writes
-///    to a slot the consumer is currently reading.
-/// 4. **Flush exclusion**: in the sink path, the `flushing` CAS lock ensures
-///    only one thread reads FILLED slot data at a time.
-struct SlotBuffer {
-    slots: Box<[Slot]>,
-    capacity: u64,
-    /// Next seq to be consumed by the consumer. Only advanced by the consumer.
-    consumed: AtomicU64,
-    /// Next seq to be claimed by a producer. Advanced via CAS in `try_claim`.
-    claimed: AtomicU64,
-    /// Wakes the consumer when a producer fills a slot.
-    notify: WakeNotify,
-    /// Optional file sink. When present, filled slots are batched and
-    /// flushed to disk periodically instead of being consumed through
-    /// `Body::next()`.
-    sink: Option<Sink>,
-}
-
-/// A single slot in the ring buffer.
-///
-/// Holds an optional `ChunkOutput` behind `UnsafeCell`. Access is synchronized
-/// through the atomic `state` field: producers write data then store `FILLED`,
-/// the consumer reads data only after loading `FILLED`.
-struct Slot {
-    state: AtomicU8,
-    data: UnsafeCell<Option<ChunkOutput>>,
-}
-
-// Safety: see SlotBuffer doc comment for the full invariant chain.
-// In short: producers and consumer never access the same slot concurrently.
-// Producers have exclusive write access (unique seq via CAS), the consumer
-// has exclusive read access (sequential, state-gated), and the seq window
-// prevents overlap.
-unsafe impl Sync for SlotBuffer {}
-
-impl SlotBuffer {
-    fn new(capacity: usize) -> Self {
-        assert!(capacity > 0, "slot buffer capacity must be > 0");
-        let slots: Vec<Slot> = (0..capacity)
-            .map(|_| Slot {
-                state: AtomicU8::new(SLOT_EMPTY),
-                data: UnsafeCell::new(None),
-            })
-            .collect();
-        Self {
-            slots: slots.into_boxed_slice(),
-            capacity: capacity as u64,
-            consumed: AtomicU64::new(0),
-            claimed: AtomicU64::new(0),
-            notify: WakeNotify::new(),
-            sink: None,
-        }
-    }
-
-    /// Write a completed chunk into the slot for `seq`.
-    ///
-    /// Pure storage — no I/O, no counting, no flushing. In the sink path,
-    /// the caller is responsible for calling `try_flush()` afterward.
-    ///
-    /// # Requirements
-    /// - `seq` must have been claimed via the `claimed` CAS (i.e. through
-    ///   `BodyWriter::try_claim`). Filling an unclaimed seq is undefined behavior.
-    /// - Each `seq` must be filled exactly once. Double-filling is undefined behavior.
-    fn fill(&self, seq: u64, chunk: ChunkOutput) {
-        let idx = (seq % self.capacity) as usize;
-        // Safety: seq window guarantees exclusive access to this slot index.
-        self.slots[idx]
-            .data
-            .with_mut(|ptr| unsafe { *ptr = Some(chunk) });
-        self.slots[idx]
-            .state
-            .store(SLOT_FILLED, AtomicOrdering::Release);
-
-        if self.sink.is_none() {
-            self.notify.notify_one();
-        }
-    }
-
-    /// Interval-gated batched flush of FILLED slots to disk.
-    ///
-    /// Increments the fill counter and only performs I/O every `FLUSH_INTERVAL`
-    /// fills. Returns the first write error encountered, or `Ok(())`.
-    fn try_flush(&self) -> Result<(), std::io::Error> {
-        let sink = match &self.sink {
-            Some(s) => s,
-            None => return Ok(()),
-        };
-
-        let count = sink.fill_count.fetch_add(1, AtomicOrdering::Relaxed);
-        #[allow(clippy::modulo_one)] // FLUSH_INTERVAL is a tunable constant
-        if (count + 1) % FLUSH_INTERVAL != 0 {
-            return Ok(());
-        }
-
-        self.flush_all()
-    }
-
-    /// Flush all FILLED slots to disk unconditionally.
-    ///
-    /// Bypasses the interval counter. Used by `finalize()` for terminal drain
-    /// and by `try_flush()` when the interval fires.
-    fn flush_all(&self) -> Result<(), std::io::Error> {
-        let sink = match &self.sink {
-            Some(s) => s,
-            None => return Ok(()),
-        };
-
-        // Only one thread flushes at a time
-        if sink
-            .flushing
-            .compare_exchange(false, true, AtomicOrdering::AcqRel, AtomicOrdering::Acquire)
-            .is_err()
-        {
-            return Ok(());
-        }
-
-        let result = self.flush_locked(sink);
-
-        sink.flushing.store(false, AtomicOrdering::Release);
-        result
-    }
-
-    /// Core flush logic. Caller must hold the `flushing` CAS lock.
-    fn flush_locked(&self, sink: &Sink) -> Result<(), std::io::Error> {
-        let consumed = self.consumed.load(AtomicOrdering::Acquire);
-        let claimed = self.claimed.load(AtomicOrdering::Acquire);
-
-        // Phase 1: Write FILLED slots to disk, coalescing contiguous runs
-        let mut first_err: Option<std::io::Error> = None;
-        let mut i = consumed;
-        while i < claimed {
-            let idx = (i % self.capacity) as usize;
-            if self.slots[idx].state.load(AtomicOrdering::Acquire) != SLOT_FILLED {
-                i += 1;
-                continue;
-            }
-
-            // Start a new run with the first FILLED slot
-            // Safety: state is FILLED and flush holds exclusive consumer access via CAS lock.
-            let first_chunk = self.slots[idx]
-                .data
-                .with_mut(|ptr| unsafe { (*ptr).take().unwrap() });
-            let file_pos = first_chunk.offset - sink.object_range_start;
-            let mut run_end_offset = file_pos + first_chunk.data.remaining() as u64;
-            let mut combined = bytes_utils::SegmentedBuf::new();
-            for seg in first_chunk.data.0.into_inner() {
-                combined.push(seg);
-            }
-            self.slots[idx]
-                .state
-                .store(SLOT_FLUSHED, AtomicOrdering::Release);
-            i += 1;
-
-            // Extend with contiguous FILLED neighbors whose file offsets are adjacent
-            while i < claimed {
-                let jdx = (i % self.capacity) as usize;
-                if self.slots[jdx].state.load(AtomicOrdering::Acquire) != SLOT_FILLED {
-                    break;
-                }
-                // Safety: state is FILLED and flush holds exclusive consumer access via CAS lock.
-                let chunk = self.slots[jdx]
-                    .data
-                    .with_mut(|ptr| unsafe { (*ptr).take().unwrap() });
-                let chunk_file_pos = chunk.offset - sink.object_range_start;
-                if chunk_file_pos != run_end_offset {
-                    // Not file-contiguous — put it back for the next iteration
-                    // Safety: same CAS lock exclusion; no other thread accesses this slot.
-                    self.slots[jdx]
-                        .data
-                        .with_mut(|ptr| unsafe { *ptr = Some(chunk) });
-                    break;
-                }
-                run_end_offset += chunk.data.remaining() as u64;
-                for seg in chunk.data.0.into_inner() {
-                    combined.push(seg);
-                }
-                self.slots[jdx]
-                    .state
-                    .store(SLOT_FLUSHED, AtomicOrdering::Release);
-                i += 1;
-            }
-
-            if let Err(e) = crate::io::fs::write_all_at(&sink.file, &mut combined, file_pos) {
-                if first_err.is_none() {
-                    first_err = Some(e);
-                }
-            }
-        }
-
-        // Phase 2: Advance consumed past leading FLUSHED slots
-        let mut seq = consumed;
-        loop {
-            let idx = (seq % self.capacity) as usize;
-            if self.slots[idx].state.load(AtomicOrdering::Acquire) != SLOT_FLUSHED {
-                break;
-            }
-            self.slots[idx]
-                .state
-                .store(SLOT_EMPTY, AtomicOrdering::Release);
-            seq += 1;
-        }
-        if seq > consumed {
-            self.consumed.store(seq, AtomicOrdering::Release);
-        }
-
-        match first_err {
-            Some(e) => Err(e),
-            None => Ok(()),
-        }
-    }
-
-    /// Try to take the next sequential chunk. Returns `None` if not ready.
-    ///
-    /// Must only be called by a single consumer. Concurrent calls from
-    /// multiple threads are not safe.
-    fn try_take_next(&self) -> Option<ChunkOutput> {
-        let seq = self.consumed.load(AtomicOrdering::Acquire);
-        let idx = (seq % self.capacity) as usize;
-        if self.slots[idx].state.load(AtomicOrdering::Acquire) != SLOT_FILLED {
-            return None;
-        }
-        // Safety: state is FILLED and only one consumer calls this.
-        let chunk = self.slots[idx]
-            .data
-            .with_mut(|ptr| unsafe { (*ptr).take() });
-        self.slots[idx]
-            .state
-            .store(SLOT_EMPTY, AtomicOrdering::Release);
-        self.consumed.fetch_add(1, AtomicOrdering::Release);
-        chunk
-    }
-}
-
-impl std::fmt::Debug for SlotBuffer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SlotBuffer")
-            .field("capacity", &self.capacity)
-            .field("consumed", &self.consumed.load(AtomicOrdering::Relaxed))
-            .field("claimed", &self.claimed.load(AtomicOrdering::Relaxed))
-            .finish()
-    }
-}
-
-/// Producer side of the slot buffer. Held by the download transfer.
-///
-/// Provides seq window claiming and slot filling. The seq window
-/// and slot buffer share the same capacity, enforced by construction.
-#[derive(Debug, Clone)]
-pub(crate) struct BodyWriter {
-    buffer: Arc<SlotBuffer>,
-}
-
-/// A claimed slot in the body buffer. Produced by [`BodyWriter::try_claim`],
-/// consumed by [`fill`](Self::fill). Cannot be constructed outside this module,
-/// preventing writes to unclaimed slots. Consuming `self` on fill prevents
-/// double-writes.
+/// Stream vs disk discrimination. Mutually exclusive per transfer.
 #[derive(Debug)]
+enum Mode {
+    Stream,
+    Disk(Sink),
+}
+
+/// Producer handle to the download body buffer. Held at `self.inner.writer`
+/// in the transfer. Cheap to clone (all state behind Arc).
+#[derive(Clone)]
+pub(crate) struct BodyWriter {
+    buffer: PagedRecvBuffer<ChunkOutput>,
+    notify: Arc<WakeNotify>,
+    mode: Arc<Mode>,
+}
+
+impl std::fmt::Debug for BodyWriter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BodyWriter")
+            .field("mode", &self.mode)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A claimed slot in the body buffer, produced by [`BodyWriter::claim`].
+/// Consuming [`fill`](Self::fill) publishes the payload and notifies the
+/// consumer. Drop without fill still wakes the consumer (lost-wake safety).
 pub(crate) struct BodySlot {
-    seq: u64,
-    buffer: Arc<SlotBuffer>,
+    handle: Option<SlotHandle<ChunkOutput>>,
+    buffer: PagedRecvBuffer<ChunkOutput>,
+    notify: Arc<WakeNotify>,
+}
+
+impl std::fmt::Debug for BodySlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BodySlot")
+            .field("seq", &self.handle.as_ref().map(|h| h.seq()))
+            .finish_non_exhaustive()
+    }
 }
 
 impl BodySlot {
     /// The sequence number for this slot.
     pub(crate) fn seq(&self) -> u64 {
-        self.seq
+        self.handle.as_ref().expect("slot already consumed").seq()
     }
 
-    /// Write a completed chunk into this slot, consuming the claim.
-    pub(crate) fn fill(self, chunk: ChunkOutput) {
-        self.buffer.fill(self.seq, chunk);
+    /// Publish a completed chunk into this slot. Wakes the stream consumer
+    /// and returns the fill outcome (whether a segment was sealed).
+    pub(crate) fn fill(mut self, chunk: ChunkOutput) -> FillOutcome {
+        let handle = self.handle.take().expect("slot already consumed");
+        let outcome = self.buffer.fill(handle, chunk);
+        self.notify.notify_one();
+        outcome
     }
 }
 
 impl Drop for BodySlot {
     fn drop(&mut self) {
-        self.buffer.notify.notify_one();
+        // If the handle is still present the slot was never filled. Notify to
+        // prevent the consumer from sleeping forever waiting on this sequence.
+        if self.handle.is_some() {
+            self.notify.notify_one();
+        }
     }
 }
 
 impl BodyWriter {
     pub(crate) fn has_sink(&self) -> bool {
-        self.buffer.sink.is_some()
+        matches!(&*self.mode, Mode::Disk(_))
     }
 
-    /// Try to claim the next slot for work generation.
-    ///
-    /// Returns `None` if the seq window is exhausted
-    /// (`claimed - consumed >= capacity`).
-    pub(crate) fn try_claim(&self) -> Option<BodySlot> {
-        loop {
-            let consumed = self.buffer.consumed.load(AtomicOrdering::Acquire);
-            let claimed = self.buffer.claimed.load(AtomicOrdering::Acquire);
-            if claimed >= consumed + self.buffer.capacity {
-                return None;
-            }
-            if self
-                .buffer
-                .claimed
-                .compare_exchange_weak(
-                    claimed,
-                    claimed + 1,
-                    AtomicOrdering::AcqRel,
-                    AtomicOrdering::Acquire,
-                )
-                .is_ok()
-            {
-                return Some(BodySlot {
-                    seq: claimed,
-                    buffer: self.buffer.clone(),
-                });
-            }
+    /// Claim the next slot. The read-ahead gate lives in poll_work (tracks
+    /// `issued` under the state lock) — this is the unconditional claim.
+    pub(crate) fn claim(&self) -> BodySlot {
+        let handle = self.buffer.claim();
+        BodySlot {
+            handle: Some(handle),
+            buffer: self.buffer.clone(),
+            notify: self.notify.clone(),
         }
     }
 
-    /// Wake the consumer so it can observe a state change (e.g. terminal).
-    pub(crate) fn notify_consumer(&self) {
-        self.buffer.notify.notify_one();
+    /// In-order delivery cursor. For the producer-side read-ahead gate:
+    /// `issued - consumed < W`.
+    pub(crate) fn consumed(&self) -> u64 {
+        self.buffer.consumed()
     }
 
-    /// Attempt an interval-gated flush of filled slots to disk.
-    ///
-    /// Delegates to the slot buffer's `try_flush`, which increments the fill
-    /// counter and only performs I/O every `FLUSH_INTERVAL` fills.
-    pub(crate) fn try_flush(&self) -> Result<(), std::io::Error> {
-        self.buffer.try_flush()
-    }
-
-    /// Finalize the writer after the transfer reaches a terminal state.
-    ///
-    /// Flushes all remaining filled slots to disk when a sink is present.
-    /// Must be called before `notify_consumer` on terminal transitions —
-    /// no more fills will arrive after this point.
-    pub(crate) fn finalize(&self) -> Result<(), std::io::Error> {
-        if self.buffer.sink.is_none() {
-            return Ok(());
-        }
-        loop {
-            self.buffer.flush_all()?;
-            let consumed = self.buffer.consumed.load(AtomicOrdering::Acquire);
-            let claimed = self.buffer.claimed.load(AtomicOrdering::Acquire);
-            let any_filled = (consumed..claimed).any(|seq| {
-                let idx = (seq % self.buffer.capacity) as usize;
-                self.buffer.slots[idx].state.load(AtomicOrdering::Acquire) == SLOT_FILLED
-            });
-            if !any_filled {
-                break;
+    /// Disk mode: drain every sealed (FULL) segment to disk. Called on the
+    /// `SealedSegment` edge from execute tasks. Stream mode: no-op.
+    pub(crate) fn drain_sealed(&self) -> Result<(), std::io::Error> {
+        if let Mode::Disk(sink) = &*self.mode {
+            while let Some(sw) = self.buffer.take_completed_segment() {
+                write_segment(sink, &sw)?;
+                sw.complete();
             }
         }
         Ok(())
     }
 
-    /// Best-effort pre-allocation of disk space for the download file.
-    // TODO(vnext): should ENOSPC here fail the transfer immediately instead of
-    // continuing? Failing fast avoids wasting bandwidth downloading data we can't
-    // store. EOPNOTSUPP/ENOTSUP should remain non-fatal (filesystem doesn't support it).
+    /// Terminal drain: sealed segments then the partial tail. Called once
+    /// from `complete()` / `on_terminal()`.
+    pub(crate) fn finalize(&self) -> Result<(), std::io::Error> {
+        if let Mode::Disk(sink) = &*self.mode {
+            while let Some(sw) = self.buffer.take_completed_segment() {
+                write_segment(sink, &sw)?;
+                sw.complete();
+            }
+            while let Some(sw) = self.buffer.take_tail() {
+                write_segment(sink, &sw)?;
+                sw.complete();
+            }
+        }
+        Ok(())
+    }
+
+    /// Wake the consumer (terminal transition).
+    pub(crate) fn notify_consumer(&self) {
+        self.notify.notify_one();
+    }
+
+    /// Best-effort pre-allocation of disk space.
     pub(crate) fn preallocate(&self, len: u64) {
-        if let Some(sink) = &self.buffer.sink {
+        if let Mode::Disk(sink) = &*self.mode {
             if sink.owns_file {
                 if let Err(e) = crate::io::fs::preallocate(&sink.file, len) {
                     tracing::warn!(error = %e, "failed to preallocate file space");
@@ -454,90 +186,143 @@ impl BodyWriter {
     }
 }
 
-/// Consumer side of the slot buffer. Reads chunks sequentially.
-#[derive(Debug)]
-pub(crate) struct SlotBodyConsumer {
-    buffer: Arc<SlotBuffer>,
-}
+/// Gather a segment's filled payloads and write them to disk at the
+/// correct file positions. Reads payloads in place via `Slot::get()`;
+/// `complete()` (called by the caller after this returns) frees them.
+fn write_segment(sink: &Sink, sw: &SegmentWrite<ChunkOutput>) -> std::io::Result<()> {
+    let mut run_start_file_pos: Option<u64> = None;
+    let mut run_end: u64 = 0;
+    let mut combined = bytes_utils::SegmentedBuf::<bytes::Bytes>::new();
 
-impl SlotBodyConsumer {
-    /// Pull the next sequential chunk. Waits if not yet available.
-    ///
-    /// Returns `None` when the transfer is terminal and all filled slots are drained.
-    /// `is_terminal` should return `true` when the transfer has reached a terminal
-    /// state (success, failure, or cancellation). The caller must ensure
-    /// [`BodyWriter::notify_consumer`] is called when the transfer becomes terminal,
-    /// otherwise the consumer may wait indefinitely.
-    pub(crate) async fn next(&self, is_terminal: impl Fn() -> bool) -> Option<ChunkOutput> {
-        loop {
-            // Register interest before checking state
-            let notified = self.buffer.notify.notified();
-            if let Some(chunk) = self.buffer.try_take_next() {
-                return Some(chunk);
+    for slot in sw.payloads() {
+        let Some(chunk) = slot.get() else {
+            // Unfilled slot in a partial tail segment — flush accumulated run
+            // and reset.
+            if run_start_file_pos.is_some() {
+                crate::io::fs::write_all_at(
+                    &sink.file,
+                    &mut combined,
+                    run_start_file_pos.unwrap(),
+                )?;
+                combined = bytes_utils::SegmentedBuf::new();
+                run_start_file_pos = None;
             }
-            if is_terminal() {
-                return self.buffer.try_take_next();
+            continue;
+        };
+
+        let file_pos = chunk.offset - sink.object_range_start;
+        let chunk_len = chunk.data.remaining() as u64;
+
+        if let Some(_start) = run_start_file_pos {
+            if file_pos != run_end {
+                // Gap: flush the accumulated run and start a new one.
+                crate::io::fs::write_all_at(
+                    &sink.file,
+                    &mut combined,
+                    run_start_file_pos.unwrap(),
+                )?;
+                combined = bytes_utils::SegmentedBuf::new();
+                run_start_file_pos = Some(file_pos);
+                run_end = file_pos + chunk_len;
+            } else {
+                run_end += chunk_len;
             }
-            notified.await;
+        } else {
+            run_start_file_pos = Some(file_pos);
+            run_end = file_pos + chunk_len;
+        }
+
+        // Clone Bytes segments (refcount bump, zero data copy).
+        for seg in chunk.data.clone().into_segments() {
+            combined.push(seg);
         }
     }
 
-    /// Try to take the next sequential chunk without waiting.
-    /// Returns `None` if the next slot is not yet filled.
-    #[cfg(test)]
-    pub(crate) fn try_take_next(&self) -> Option<ChunkOutput> {
-        self.buffer.try_take_next()
+    // Flush any remaining accumulated run.
+    if let Some(pos) = run_start_file_pos {
+        crate::io::fs::write_all_at(&sink.file, &mut combined, pos)?;
+    }
+    Ok(())
+}
+
+/// Consumer wrapper carrying the notify handle alongside the buffer consumer.
+/// Handed from constructors to `Body::new`.
+pub(crate) struct SlotBodyConsumer {
+    consumer: RecvBufferConsumer<ChunkOutput>,
+    notify: Arc<WakeNotify>,
+}
+
+impl std::fmt::Debug for SlotBodyConsumer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SlotBodyConsumer").finish_non_exhaustive()
     }
 }
 
-/// Create a matched producer/consumer pair for download body delivery.
+impl SlotBodyConsumer {
+    /// Try to take the next sequential chunk without waiting.
+    #[cfg(test)]
+    pub(crate) fn try_take_next(&mut self) -> Option<ChunkOutput> {
+        self.consumer.poll_next()
+    }
+}
+
+/// Create a matched producer/consumer pair for download body delivery (stream mode).
 ///
-/// The capacity determines both the slot buffer size and the seq window gap.
-pub(crate) fn new_slot_body(capacity: usize) -> (BodyWriter, SlotBodyConsumer) {
-    let buffer = Arc::new(SlotBuffer::new(capacity));
-    (
-        BodyWriter {
-            buffer: buffer.clone(),
-        },
-        SlotBodyConsumer { buffer },
-    )
+/// Issuance backpressure is owned by the per-transfer [`ReadAhead`] controller, not
+/// by a fixed buffer capacity — the buffer grows as needed.
+///
+/// [`ReadAhead`]: super::read_ahead::ReadAhead
+pub(crate) fn new_slot_body() -> (BodyWriter, SlotBodyConsumer) {
+    let (buffer, consumer) = PagedRecvBuffer::new_with_segment_size(SEG_SIZE);
+    let notify = Arc::new(WakeNotify::new());
+    let writer = BodyWriter {
+        buffer,
+        notify: notify.clone(),
+        mode: Arc::new(Mode::Stream),
+    };
+    let slot_consumer = SlotBodyConsumer { consumer, notify };
+    (writer, slot_consumer)
 }
 
 /// Create a producer/consumer pair with a file sink for download-to-file.
 ///
-/// When a sink is registered, filled slots are batched and flushed to disk
-/// periodically (every `FLUSH_INTERVAL` fills) and at transfer completion.
+/// Issuance backpressure is owned by the per-transfer [`ReadAhead`] controller.
+///
+/// [`ReadAhead`]: super::read_ahead::ReadAhead
 pub(crate) fn new_slot_body_with_sink(
-    capacity: usize,
     file: std::fs::File,
     object_range_start: u64,
     owns_file: bool,
 ) -> (BodyWriter, SlotBodyConsumer) {
-    let mut buffer = SlotBuffer::new(capacity);
-    buffer.sink = Some(Sink {
-        file,
-        object_range_start,
-        owns_file,
-        flushing: AtomicBool::new(false),
-        fill_count: AtomicU64::new(0),
-    });
-    let buffer = Arc::new(buffer);
-    (
-        BodyWriter {
-            buffer: buffer.clone(),
-        },
-        SlotBodyConsumer { buffer },
-    )
+    let (buffer, consumer) = PagedRecvBuffer::new_with_segment_size(SEG_SIZE);
+    let notify = Arc::new(WakeNotify::new());
+    let writer = BodyWriter {
+        buffer,
+        notify: notify.clone(),
+        mode: Arc::new(Mode::Disk(Sink {
+            file,
+            object_range_start,
+            owns_file,
+        })),
+    };
+    let slot_consumer = SlotBodyConsumer { consumer, notify };
+    (writer, slot_consumer)
 }
 
 /// Stream of [ChunkOutput] representing an Amazon S3 Object's contents and metadata.
 ///
 /// Wraps potentially multiple streams of binary data into a single coherent stream.
 /// The data on this stream is sequenced into the correct order.
-#[derive(Debug)]
 pub struct Body {
-    consumer: SlotBodyConsumer,
+    consumer: RecvBufferConsumer<ChunkOutput>,
+    notify: Arc<WakeNotify>,
     transfer: DownloadTransfer,
+}
+
+impl std::fmt::Debug for Body {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Body").finish_non_exhaustive()
+    }
 }
 
 /// Contains body and metadata for each GetObject call made. This will be delivered sequentially
@@ -570,7 +355,11 @@ impl std::fmt::Debug for ChunkOutput {
 
 impl Body {
     pub(crate) fn new(consumer: SlotBodyConsumer, transfer: DownloadTransfer) -> Self {
-        Self { consumer, transfer }
+        Self {
+            consumer: consumer.consumer,
+            notify: consumer.notify,
+            transfer,
+        }
     }
 
     /// Close the body, signaling no more chunks will be consumed.
@@ -587,30 +376,41 @@ impl Body {
     /// On failure, returns `Some(Err(...))` with the error kind from the actual failure.
     /// Call `join()` on the handle to get the full error with source chain.
     pub async fn next(&mut self) -> Option<Result<ChunkOutput, crate::error::Error>> {
-        let transfer = &self.transfer;
-        let is_terminal = || !transfer.ctx().is_active();
-
-        match self.consumer.next(is_terminal).await {
-            Some(chunk) => {
-                // Wake the transfer so it can generate more work now that a slot freed up
-                transfer.ctx().try_wake();
-                Some(Ok(chunk))
+        loop {
+            // Register interest BEFORE checking state (lost-wake safety).
+            let notified = self.notify.notified();
+            if let Some(chunk) = self.consumer.poll_next() {
+                // Delivery advances `consumed`, freeing read-ahead occupancy; wake
+                // the issuer so the reopened window admits more work.
+                self.transfer.ctx().try_wake();
+                return Some(Ok(chunk));
             }
-            None => {
-                if transfer.ctx().is_cancelled() {
-                    Some(Err(crate::error::from_kind(
-                        crate::error::ErrorKind::OperationCancelled,
-                    )("download cancelled")))
-                } else if transfer.ctx().is_failed() {
-                    let kind = transfer
-                        .ctx()
-                        .error_kind()
-                        .unwrap_or(crate::error::ErrorKind::ChildOperationFailed);
-                    Some(Err(crate::error::from_kind(kind)("transfer failed")))
-                } else {
-                    None // normal completion
+            if !self.transfer.ctx().is_active() {
+                // Terminal: drain then report.
+                if let Some(chunk) = self.consumer.poll_next() {
+                    self.transfer.ctx().try_wake();
+                    return Some(Ok(chunk));
                 }
+                return self.terminal_result();
             }
+            notified.await;
+        }
+    }
+
+    fn terminal_result(&self) -> Option<Result<ChunkOutput, crate::error::Error>> {
+        if self.transfer.ctx().is_cancelled() {
+            Some(Err(crate::error::from_kind(
+                crate::error::ErrorKind::OperationCancelled,
+            )("download cancelled")))
+        } else if self.transfer.ctx().is_failed() {
+            let kind = self
+                .transfer
+                .ctx()
+                .error_kind()
+                .unwrap_or(crate::error::ErrorKind::ChildOperationFailed);
+            Some(Err(crate::error::from_kind(kind)("transfer failed")))
+        } else {
+            None // normal completion
         }
     }
 }
@@ -653,7 +453,7 @@ mod tests {
             .build()
             .unwrap();
         let (ctx, _) = TransferContext::new(tm.handle.clone());
-        let (writer, consumer) = new_slot_body(16);
+        let (writer, consumer) = new_slot_body();
         let transfer = DownloadTransfer::new(ctx, BucketType::Standard, input, writer.clone());
         (Body::new(consumer, transfer.clone()), transfer, writer)
     }
@@ -665,9 +465,9 @@ mod tests {
         let ctx_clone = transfer.clone();
         tokio::spawn(async move {
             // Claim 3 seqs, fill out of order
-            let s0 = writer.try_claim().unwrap();
-            let s1 = writer.try_claim().unwrap();
-            let s2 = writer.try_claim().unwrap();
+            let s0 = writer.claim();
+            let s1 = writer.claim();
+            let s2 = writer.claim();
 
             // Fill out of order: 2, 0, 1
             let mut seg2 = SegmentedBuf::new();
@@ -706,7 +506,7 @@ mod tests {
         let (mut body, transfer, writer) = test_body();
 
         // Fill one chunk
-        let s0 = writer.try_claim().unwrap();
+        let s0 = writer.claim();
         let mut seg = SegmentedBuf::new();
         seg.push(Bytes::from("chunk 0"));
         let seq0 = s0.seq();
@@ -770,239 +570,7 @@ mod tests {
         assert!(matches!(err.kind(), error::ErrorKind::OperationCancelled));
     }
 
-    // --- Slot buffer tests ---
-
-    #[test]
-    fn test_slot_buffer_fill_and_take() {
-        let (writer, consumer) = new_slot_body(4);
-
-        let s0 = writer.try_claim().unwrap();
-        assert_eq!(s0.seq(), 0);
-        s0.fill(chunk_resp(0, AggregatedBytes(SegmentedBuf::new())));
-
-        let taken = consumer.try_take_next();
-        assert!(taken.is_some());
-        assert_eq!(taken.unwrap().seq, 0);
-
-        assert!(consumer.try_take_next().is_none());
-    }
-
-    #[test]
-    fn test_slot_buffer_out_of_order_fill() {
-        let (writer, consumer) = new_slot_body(4);
-
-        let seq0 = writer.try_claim().unwrap();
-        let seq1 = writer.try_claim().unwrap();
-        let seq2 = writer.try_claim().unwrap();
-
-        // Fill out of order: 2, 0, 1
-        seq2.fill(chunk_resp(2, AggregatedBytes(SegmentedBuf::new())));
-        seq0.fill(chunk_resp(0, AggregatedBytes(SegmentedBuf::new())));
-        seq1.fill(chunk_resp(1, AggregatedBytes(SegmentedBuf::new())));
-
-        // Consumer reads in order
-        assert_eq!(consumer.try_take_next().unwrap().seq, 0);
-        assert_eq!(consumer.try_take_next().unwrap().seq, 1);
-        assert_eq!(consumer.try_take_next().unwrap().seq, 2);
-        assert!(consumer.try_take_next().is_none());
-    }
-
-    #[test]
-    fn test_slot_buffer_seq_window_exhaustion() {
-        let (writer, _consumer) = new_slot_body(3);
-
-        assert_eq!(writer.try_claim().unwrap().seq(), 0);
-        assert_eq!(writer.try_claim().unwrap().seq(), 1);
-        assert_eq!(writer.try_claim().unwrap().seq(), 2);
-        assert!(writer.try_claim().is_none());
-    }
-
-    #[test]
-    fn test_slot_buffer_consume_opens_window() {
-        let (writer, consumer) = new_slot_body(2);
-
-        let s0 = writer.try_claim().unwrap();
-        let s1 = writer.try_claim().unwrap();
-        assert!(writer.try_claim().is_none());
-
-        s0.fill(chunk_resp(0, AggregatedBytes(SegmentedBuf::new())));
-        s1.fill(chunk_resp(1, AggregatedBytes(SegmentedBuf::new())));
-        consumer.try_take_next(); // consume 0
-
-        // Window opens for seq 2
-        assert_eq!(writer.try_claim().unwrap().seq(), 2);
-    }
-
-    #[test]
-    fn test_slot_buffer_wraps_around() {
-        let (writer, consumer) = new_slot_body(2);
-
-        let s0 = writer.try_claim().unwrap();
-        let s1 = writer.try_claim().unwrap();
-        s0.fill(chunk_resp(0, AggregatedBytes(SegmentedBuf::new())));
-        s1.fill(chunk_resp(1, AggregatedBytes(SegmentedBuf::new())));
-
-        assert_eq!(consumer.try_take_next().unwrap().seq, 0);
-        assert_eq!(consumer.try_take_next().unwrap().seq, 1);
-
-        // Wraps around to slot indices 0, 1
-        let s2 = writer.try_claim().unwrap();
-        let s3 = writer.try_claim().unwrap();
-        s2.fill(chunk_resp(2, AggregatedBytes(SegmentedBuf::new())));
-        s3.fill(chunk_resp(3, AggregatedBytes(SegmentedBuf::new())));
-
-        assert_eq!(consumer.try_take_next().unwrap().seq, 2);
-        assert_eq!(consumer.try_take_next().unwrap().seq, 3);
-    }
-
-    #[cfg_attr(miri, ignore)]
-    #[tokio::test]
-    async fn test_slot_body_consumer_next() {
-        let (writer, consumer) = new_slot_body(4);
-
-        let s0 = writer.try_claim().unwrap();
-        s0.fill(chunk_resp(0, AggregatedBytes(SegmentedBuf::new())));
-
-        let chunk = consumer.next(|| false).await;
-        assert!(chunk.is_some());
-        assert_eq!(chunk.unwrap().seq, 0);
-    }
-
-    #[cfg_attr(miri, ignore)]
-    #[tokio::test]
-    async fn test_slot_body_consumer_returns_none_when_complete() {
-        let (_writer, consumer) = new_slot_body(4);
-
-        let chunk = consumer.next(|| true).await;
-        assert!(chunk.is_none());
-    }
-
-    #[cfg_attr(miri, ignore)]
-    #[tokio::test]
-    async fn test_slot_body_consumer_waits_for_producer() {
-        let (writer, consumer) = new_slot_body(4);
-
-        let s0 = writer.try_claim().unwrap();
-
-        tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            s0.fill(chunk_resp(0, AggregatedBytes(SegmentedBuf::new())));
-        });
-
-        let chunk = consumer.next(|| false).await;
-        assert!(chunk.is_some());
-        assert_eq!(chunk.unwrap().seq, 0);
-    }
-
-    #[test]
-    fn test_slot_buffer_batch_drain() {
-        let (writer, consumer) = new_slot_body(8);
-
-        for i in 0..5u64 {
-            let slot = writer.try_claim().unwrap();
-            slot.fill(chunk_resp(i, AggregatedBytes(SegmentedBuf::new())));
-        }
-
-        let mut batch = Vec::new();
-        while let Some(chunk) = consumer.try_take_next() {
-            batch.push(chunk);
-        }
-        assert_eq!(batch.len(), 5);
-        for (i, chunk) in batch.iter().enumerate() {
-            assert_eq!(chunk.seq, i as u64);
-        }
-    }
-
-    #[test]
-    fn test_slot_buffer_capacity_one() {
-        let (writer, consumer) = new_slot_body(1);
-
-        let s0 = writer.try_claim().unwrap();
-        assert!(writer.try_claim().is_none()); // only 1 slot
-
-        s0.fill(chunk_resp(0, AggregatedBytes(SegmentedBuf::new())));
-        assert_eq!(consumer.try_take_next().unwrap().seq, 0);
-
-        // Slot freed, can claim again
-        let s1 = writer.try_claim().unwrap();
-        assert_eq!(s1.seq(), 1);
-        s1.fill(chunk_resp(1, AggregatedBytes(SegmentedBuf::new())));
-        assert_eq!(consumer.try_take_next().unwrap().seq, 1);
-    }
-
-    #[test]
-    fn test_slot_buffer_fill_preserves_data() {
-        let (writer, consumer) = new_slot_body(4);
-
-        let s0 = writer.try_claim().unwrap();
-        let data = Bytes::from("hello world");
-        let mut seg = SegmentedBuf::new();
-        seg.push(data);
-        s0.fill(chunk_resp(0, AggregatedBytes(seg)));
-
-        let chunk = consumer.try_take_next().unwrap();
-        assert_eq!(chunk.seq, 0);
-        assert_eq!(chunk.data.to_vec(), b"hello world");
-    }
-
-    #[cfg_attr(miri, ignore)]
-    #[tokio::test]
-    async fn test_slot_buffer_concurrent_producers() {
-        let (writer, consumer) = new_slot_body(64);
-
-        // Claim 32 slots
-        let slots: Vec<_> = (0..32).map(|_| writer.try_claim().unwrap()).collect();
-
-        // Spawn producers that fill concurrently
-        let mut handles = Vec::new();
-        for slot in slots {
-            handles.push(tokio::spawn(async move {
-                // Small jitter to interleave
-                tokio::task::yield_now().await;
-                let seq = slot.seq();
-                let mut seg = SegmentedBuf::new();
-                seg.push(Bytes::from(format!("chunk-{seq}")));
-                slot.fill(chunk_resp(seq, AggregatedBytes(seg)));
-            }));
-        }
-
-        for h in handles {
-            h.await.unwrap();
-        }
-
-        // Consumer reads all 32 in order
-        for expected_seq in 0..32u64 {
-            let chunk = consumer.next(|| false).await.unwrap();
-            assert_eq!(chunk.seq, expected_seq);
-            assert_eq!(
-                chunk.data.to_vec(),
-                format!("chunk-{expected_seq}").as_bytes()
-            );
-        }
-    }
-
-    #[cfg_attr(miri, ignore)]
-    #[tokio::test]
-    async fn test_slot_body_consumer_completion_race() {
-        let (writer, consumer) = new_slot_body(4);
-
-        let s0 = writer.try_claim().unwrap();
-        s0.fill(chunk_resp(0, AggregatedBytes(SegmentedBuf::new())));
-
-        // is_complete returns true, but there's a filled slot
-        let chunk = consumer.next(|| true).await;
-        assert!(
-            chunk.is_some(),
-            "should drain filled slot even when complete"
-        );
-        assert_eq!(chunk.unwrap().seq, 0);
-
-        // Now truly empty and complete
-        let chunk = consumer.next(|| true).await;
-        assert!(chunk.is_none());
-    }
-
-    // --- File sink tests ---
+    // --- Disk driver tests ---
 
     use super::new_slot_body_with_sink;
 
@@ -1018,24 +586,26 @@ mod tests {
     }
 
     #[test]
-    fn test_sink_batched_flush() {
+    fn disk_writes_full_segment() {
+        use super::SEG_SIZE;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        // Capacity 16 so all 8 slots fit; FLUSH_INTERVAL=8 triggers flush on 8th try_flush
-        let (writer, _consumer) = new_slot_body_with_sink(16, file, 0, false);
+        let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
 
-        for i in 0..8u64 {
-            let slot = writer.try_claim().unwrap();
+        // Fill a full segment's worth of slots
+        for i in 0..SEG_SIZE as u64 {
+            let slot = writer.claim();
             let offset = i * 100;
             let data = format!("d{i}xx");
             slot.fill(chunk_at(i, offset, data.as_bytes()));
-            writer.try_flush().unwrap();
         }
 
-        // 8th try_flush triggers flush — all data on disk
+        // The last fill sealed the segment; drain it.
+        writer.drain_sealed().unwrap();
+
         let contents = std::fs::read(&path).unwrap();
-        for i in 0..8u64 {
+        for i in 0..SEG_SIZE as u64 {
             let offset = (i * 100) as usize;
             let expected = format!("d{i}xx");
             assert_eq!(
@@ -1047,29 +617,29 @@ mod tests {
     }
 
     #[test]
-    fn test_sink_out_of_order_fill() {
+    fn disk_eof_partial_tail() {
+        use super::SEG_SIZE;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(16, file, 0, false);
+        let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
 
-        // Claim 8 slots, fill out of order
-        let mut slots: Vec<Option<super::BodySlot>> =
-            (0..8).map(|_| Some(writer.try_claim().unwrap())).collect();
-
-        for &i in &[7usize, 3, 0, 5, 2, 6, 1, 4] {
-            let slot = slots[i].take().unwrap();
-            let offset = (i as u64) * 100;
-            let data = format!("s{i}");
-            slot.fill(chunk_at(i as u64, offset, data.as_bytes()));
-            writer.try_flush().unwrap();
+        // Fill fewer than a segment's worth (partial)
+        let partial = SEG_SIZE / 2;
+        for i in 0..partial as u64 {
+            let slot = writer.claim();
+            let offset = i * 100;
+            let data = format!("p{i}");
+            slot.fill(chunk_at(i, offset, data.as_bytes()));
         }
 
-        // 8th try_flush triggers flush; all 8 are FILLED so the entire run is contiguous
+        // finalize drains the partial tail
+        writer.finalize().unwrap();
+
         let contents = std::fs::read(&path).unwrap();
-        for i in 0..8u64 {
+        for i in 0..partial as u64 {
             let offset = (i * 100) as usize;
-            let expected = format!("s{i}");
+            let expected = format!("p{i}");
             assert_eq!(
                 &contents[offset..offset + expected.len()],
                 expected.as_bytes(),
@@ -1079,69 +649,56 @@ mod tests {
     }
 
     #[test]
-    fn test_sink_advances_consumed_after_flush() {
+    fn disk_finalize_drains_full_and_tail() {
+        use super::SEG_SIZE;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(16, file, 0, false);
+        let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
 
-        // Fill 8 slots and call try_flush after each to trigger a flush on the 8th
-        for i in 0..8u64 {
-            let slot = writer.try_claim().unwrap();
-            slot.fill(chunk_at(i, i * 10, b"xx"));
-            writer.try_flush().unwrap();
+        // Fill SEG_SIZE + 2 parts
+        let total = SEG_SIZE + 2;
+        for i in 0..total as u64 {
+            let slot = writer.claim();
+            let offset = i * 50;
+            let data = format!("x{i}");
+            slot.fill(chunk_at(i, offset, data.as_bytes()));
         }
 
-        // After flush, consumed advanced past all 8 flushed slots — new claims work
-        let s8 = writer.try_claim().unwrap();
-        assert_eq!(s8.seq(), 8);
-    }
-
-    #[test]
-    fn test_sink_terminal_flush_via_notify() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("out");
-        let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(16, file, 0, false);
-
-        // Fill fewer than FLUSH_INTERVAL slots — no automatic flush
-        let s0 = writer.try_claim().unwrap();
-        let s1 = writer.try_claim().unwrap();
-        s0.fill(chunk_at(0, 0, b"xxxx"));
-        s1.fill(chunk_at(1, 100, b"yyyy"));
-
-        // Data not yet on disk (no flush triggered)
-        let contents = std::fs::read(&path).unwrap();
-        assert!(contents.is_empty() || contents.iter().all(|&b| b == 0));
-
-        // Terminal flush via finalize writes remaining data
         writer.finalize().unwrap();
 
         let contents = std::fs::read(&path).unwrap();
-        assert!(contents.len() >= 104);
-        assert_eq!(&contents[0..4], b"xxxx");
-        assert_eq!(&contents[100..104], b"yyyy");
+        for i in 0..total as u64 {
+            let offset = (i * 50) as usize;
+            let expected = format!("x{i}");
+            assert_eq!(
+                &contents[offset..offset + expected.len()],
+                expected.as_bytes(),
+                "mismatch at seq {i}"
+            );
+        }
     }
 
     #[test]
-    fn test_sink_object_range_offset_translation() {
+    fn disk_offset_translation() {
+        use super::SEG_SIZE;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(16, file, 1000, false);
+        let (writer, _consumer) = new_slot_body_with_sink(file, 1000, false);
 
-        // Fill 8 slots and call try_flush after each, with object_range_start=1000
-        for i in 0..8u64 {
-            let slot = writer.try_claim().unwrap();
+        let n = SEG_SIZE;
+        for i in 0..n as u64 {
+            let slot = writer.claim();
             let offset = 1000 + i * 100;
             let data = format!("r{i}");
             slot.fill(chunk_at(i, offset, data.as_bytes()));
-            writer.try_flush().unwrap();
         }
 
+        writer.drain_sealed().unwrap();
+
         let contents = std::fs::read(&path).unwrap();
-        // File positions are chunk.offset - object_range_start
-        for i in 0..8u64 {
+        for i in 0..n as u64 {
             let file_pos = (i * 100) as usize;
             let expected = format!("r{i}");
             assert_eq!(
@@ -1154,15 +711,17 @@ mod tests {
 
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
-    async fn test_sink_concurrent_fill() {
+    async fn disk_concurrent_fill() {
+        use super::SEG_SIZE;
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out");
         let file = std::fs::File::create(&path).unwrap();
-        let (writer, _consumer) = new_slot_body_with_sink(16, file, 0, false);
+        let (writer, _consumer) = new_slot_body_with_sink(file, 0, false);
 
+        let n = SEG_SIZE;
         let mut handles = Vec::new();
-        for _ in 0..8 {
-            let slot = writer.try_claim().unwrap();
+        for _ in 0..n {
+            let slot = writer.claim();
             handles.push(tokio::spawn(async move {
                 tokio::task::yield_now().await;
                 let seq = slot.seq();
@@ -1176,11 +735,10 @@ mod tests {
             h.await.unwrap();
         }
 
-        // Terminal flush to ensure all data is on disk
         writer.finalize().unwrap();
 
         let contents = std::fs::read(&path).unwrap();
-        for seq in 0..8u64 {
+        for seq in 0..n as u64 {
             let offset = (seq * 100) as usize;
             let expected = format!("d{seq}");
             assert_eq!(
@@ -1189,200 +747,5 @@ mod tests {
                 "mismatch at seq {seq}"
             );
         }
-    }
-}
-
-#[cfg(all(test, s3_tm_loom))]
-mod loom_tests {
-    use super::*;
-    use crate::runtime::sync::thread;
-
-    fn dummy_chunk(seq: u64) -> ChunkOutput {
-        ChunkOutput {
-            seq,
-            offset: seq * 1024,
-            data: AggregatedBytes(bytes_utils::SegmentedBuf::new()),
-            metadata: Default::default(),
-        }
-    }
-
-    #[test]
-    fn two_producers_claim_unique_seqs() {
-        loom::model(|| {
-            let (writer, _consumer) = new_slot_body(4);
-            let writer2 = writer.clone();
-
-            let h = thread::spawn(move || {
-                if let Some(slot) = writer2.try_claim() {
-                    let seq = slot.seq();
-                    slot.fill(dummy_chunk(seq));
-                    seq
-                } else {
-                    u64::MAX
-                }
-            });
-
-            let seq1 = if let Some(slot) = writer.try_claim() {
-                let seq = slot.seq();
-                slot.fill(dummy_chunk(seq));
-                seq
-            } else {
-                u64::MAX
-            };
-
-            let seq2 = h.join().unwrap();
-
-            // Both should succeed and get different seqs
-            assert_ne!(seq1, seq2);
-            assert!(seq1 <= 1);
-            assert!(seq2 <= 1);
-        });
-    }
-
-    #[test]
-    fn fill_then_take() {
-        loom::model(|| {
-            let (writer, consumer) = new_slot_body(4);
-
-            let h = thread::spawn(move || {
-                let slot = writer.try_claim().unwrap();
-                slot.fill(dummy_chunk(0));
-            });
-
-            h.join().unwrap();
-
-            // Consumer should see the filled chunk
-            let chunk = consumer.try_take_next().unwrap();
-            assert_eq!(chunk.seq, 0);
-        });
-    }
-
-    #[test]
-    fn window_pressure() {
-        // capacity=1, so after one claim the window is full
-        loom::model(|| {
-            let (writer, _consumer) = new_slot_body(1);
-
-            let slot = writer.try_claim().unwrap();
-            // Window full — next claim should fail
-            assert!(writer.try_claim().is_none());
-
-            slot.fill(dummy_chunk(0));
-            // Still full until consumed
-            assert!(writer.try_claim().is_none());
-        });
-    }
-
-    #[test]
-    fn concurrent_claim_fill_take() {
-        loom::model(|| {
-            let (writer, consumer) = new_slot_body(2);
-            let writer2 = writer.clone();
-
-            // Producer 1
-            let h = thread::spawn(move || {
-                if let Some(slot) = writer2.try_claim() {
-                    let seq = slot.seq();
-                    slot.fill(dummy_chunk(seq));
-                }
-            });
-
-            // Producer 2
-            if let Some(slot) = writer.try_claim() {
-                let seq = slot.seq();
-                slot.fill(dummy_chunk(seq));
-            }
-
-            h.join().unwrap();
-
-            // Consumer takes in order
-            let mut taken = 0;
-            while let Some(_chunk) = consumer.try_take_next() {
-                taken += 1;
-            }
-            assert_eq!(taken, 2);
-        });
-    }
-
-    /// Producer fills while consumer concurrently polls try_take_next.
-    /// This is the core production pattern.
-    #[test]
-    fn concurrent_fill_and_take() {
-        loom::model(|| {
-            let (writer, consumer) = new_slot_body(2);
-
-            // Producer claims and fills on a separate thread
-            let h = thread::spawn(move || {
-                let slot = writer.try_claim().unwrap();
-                slot.fill(dummy_chunk(0));
-            });
-
-            // Consumer spins until it gets the chunk
-            // (producer must complete since we join)
-            h.join().unwrap();
-            let chunk = consumer.try_take_next().unwrap();
-            assert_eq!(chunk.seq, 0);
-        });
-    }
-
-    /// Fill, consume, then reclaim the same slot index — tests wrap-around.
-    #[test]
-    fn claim_fill_take_reclaim() {
-        loom::model(|| {
-            let (writer, consumer) = new_slot_body(1);
-
-            // Round 1: claim, fill, consume
-            let slot = writer.try_claim().unwrap();
-            assert_eq!(slot.seq(), 0);
-            slot.fill(dummy_chunk(0));
-            let chunk = consumer.try_take_next().unwrap();
-            assert_eq!(chunk.seq, 0);
-
-            // Round 2: same slot index (seq 1 % capacity 1 == 0)
-            let slot = writer.try_claim().unwrap();
-            assert_eq!(slot.seq(), 1);
-            slot.fill(dummy_chunk(1));
-            let chunk = consumer.try_take_next().unwrap();
-            assert_eq!(chunk.seq, 1);
-        });
-    }
-
-    /// Two producers + concurrent consumer — the full production pattern.
-    #[test]
-    fn two_producers_concurrent_consumer() {
-        loom::model(|| {
-            let (writer, consumer) = new_slot_body(4);
-            let writer2 = writer.clone();
-            use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
-            let taken = Arc::new(AtomicUsize::new(0));
-
-            let taken2 = Arc::clone(&taken);
-            // Consumer thread
-            let consumer_handle = thread::spawn(move || loop {
-                if let Some(_chunk) = consumer.try_take_next() {
-                    taken2.fetch_add(1, Ordering::Relaxed);
-                    if taken2.load(Ordering::Relaxed) == 2 {
-                        break;
-                    }
-                }
-                loom::thread::yield_now();
-            });
-
-            // Producer 1
-            let h = thread::spawn(move || {
-                let slot = writer2.try_claim().unwrap();
-                let seq = slot.seq();
-                slot.fill(dummy_chunk(seq));
-            });
-
-            // Producer 2
-            let slot = writer.try_claim().unwrap();
-            let seq = slot.seq();
-            slot.fill(dummy_chunk(seq));
-
-            h.join().unwrap();
-            consumer_handle.join().unwrap();
-            assert_eq!(taken.load(Ordering::Relaxed), 2);
-        });
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/builders.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/builders.rs
@@ -540,6 +540,23 @@ impl DownloadFluentBuilder {
     pub fn get_checksum_mode(&self) -> &Option<aws_sdk_s3::types::ChecksumMode> {
         self.inner.get_checksum_mode()
     }
+    /// Override how far this download prefetches ahead of the consumer, replacing the
+    /// client default for this request. Default defers to the client's
+    /// [`Config`](crate::config::Config).
+    pub fn read_ahead(mut self, input: crate::types::ReadAhead) -> Self {
+        self.inner = self.inner.read_ahead(input);
+        self
+    }
+    /// Override how far this download prefetches ahead of the consumer, replacing the
+    /// client default for this request.
+    pub fn set_read_ahead(mut self, input: Option<crate::types::ReadAhead>) -> Self {
+        self.inner = self.inner.set_read_ahead(input);
+        self
+    }
+    /// The read-ahead override set on this builder, if any.
+    pub fn get_read_ahead(&self) -> &Option<crate::types::ReadAhead> {
+        self.inner.get_read_ahead()
+    }
 }
 
 impl crate::operation::download::input::DownloadInputBuilder {

--- a/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
@@ -25,10 +25,9 @@ pub(crate) enum DownloadState {
         /// object's stored part size so each range aligns to a stored part
         /// boundary (S3 returns a per-part checksum only for an aligned range).
         part_size: u64,
-        /// Number of parts claimed for issuance. The read-ahead gate bounds
-        /// resident occupancy as `issued - released < window`, where `released`
-        /// is the count freed by either delivery surface (see `recv_buffer`).
-        issued: u64,
+        /// Read-ahead occupancy accounting. Bounds resident memory by gating
+        /// issuance on `issued - released < window`.
+        gate: OccupancyGate,
     },
 
     /// Terminal state - transfer ended (success, failure, or cancelled)
@@ -39,5 +38,123 @@ pub(crate) enum DownloadState {
 impl DownloadState {
     pub(crate) fn new() -> Self {
         DownloadState::PendingDiscovery
+    }
+}
+
+/// Read-ahead occupancy accounting: the numerator of the issuance gate.
+///
+/// Bounds resident memory by holding `issued - released < window`, where
+/// `issued` counts parts claimed for issuance and `released` counts parts whose
+/// payload memory has been freed by either delivery surface (stream `poll_next`
+/// or disk drain). `window` is *not* held here — it is the dynamically settable
+/// [`ReadAhead`](super::read_ahead::ReadAhead) knob, read as an input on each
+/// check — so this type owns exactly the two counters that must move together.
+///
+/// # Why this is plain (non-atomic) state
+///
+/// This struct lives inside [`DownloadState`], guarded by the transfer's `state`
+/// mutex, and is only ever reached through a `MutexGuard`. That is the entire
+/// lost-wake safety argument: `released` cannot be advanced, nor the gate read to
+/// arm the wake, except while holding the lock the gate is checked under. The
+/// issuer's park (read `issued - released`, then `set_pending`) and the
+/// consumer's release (advance `released`, then `try_wake`) are therefore always
+/// ordered by that lock — the mutator discipline `lock → mutate → unlock →
+/// try_wake` (see [`TransferContext::set_pending`](crate::transfer::TransferContext::set_pending)).
+/// There is no lock-free path to `released`, so the store-buffer interleaving
+/// that would lose a wake is unrepresentable rather than merely avoided.
+#[derive(Debug, Default)]
+pub(crate) struct OccupancyGate {
+    /// Parts claimed for issuance. Monotonic.
+    issued: u64,
+    /// Parts whose payload memory has been freed by a delivery surface.
+    released: u64,
+}
+
+impl OccupancyGate {
+    /// Create a gate that already counts `issued` parts as claimed (with none
+    /// released yet). Used at the discovery→transfer transition, where a
+    /// discovery chunk is one part already in flight.
+    pub(crate) fn with_issued(issued: u64) -> Self {
+        Self {
+            issued,
+            released: 0,
+        }
+    }
+
+    /// Issuer side: if the gate is open at `window`, count one part issued and
+    /// return `true`. Returns `false` (gate closed) without mutating, so the
+    /// caller parks. `window` is supplied by the read-ahead controller.
+    pub(crate) fn try_issue(&mut self, window: u64) -> bool {
+        if self.issued - self.released >= window {
+            false
+        } else {
+            self.issued += 1;
+            true
+        }
+    }
+
+    /// Consumer/drain side: record `n` parts freed, lowering resident occupancy.
+    ///
+    /// The caller wakes the issuer unconditionally after this returns (a wake is a
+    /// no-op unless the issuer parked), so this does not report whether the gate
+    /// reopened — it is a plain accumulator.
+    pub(crate) fn release(&mut self, n: u64) {
+        self.released += n;
+    }
+
+    /// Resident occupancy in parts: `issued - released`.
+    pub(crate) fn resident(&self) -> u64 {
+        self.issued - self.released
+    }
+
+    /// Parts issued so far (for tracing/tests).
+    pub(crate) fn issued(&self) -> u64 {
+        self.issued
+    }
+
+    /// Parts released so far (for tracing/tests).
+    pub(crate) fn released(&self) -> u64 {
+        self.released
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OccupancyGate;
+
+    #[test]
+    fn gate_closes_at_window() {
+        let mut g = OccupancyGate::default();
+        // Window 2: two issues succeed, the third is gated.
+        assert!(g.try_issue(2));
+        assert!(g.try_issue(2));
+        assert!(!g.try_issue(2), "gate must close once resident == window");
+        assert_eq!(g.resident(), 2);
+        assert_eq!(g.issued(), 2, "a gated try_issue must not bump issued");
+    }
+
+    #[test]
+    fn release_lowers_resident_and_reopens_the_gate() {
+        let mut g = OccupancyGate::default();
+        g.try_issue(2);
+        g.try_issue(2); // resident == window == 2, gate closed
+        assert!(!g.try_issue(2), "closed at the window");
+        g.release(1); // frees one part
+        assert_eq!(g.resident(), 1, "release lowers resident occupancy");
+        assert!(
+            g.try_issue(2),
+            "the freed part reopened the gate for one more"
+        );
+    }
+
+    #[test]
+    fn window_one_admits_exactly_one_resident_part() {
+        // Window 1 is the demand-paging regime (`Parts(0)` resolves to it): exactly
+        // one part in flight, the one the consumer is waiting on.
+        let mut g = OccupancyGate::default();
+        assert!(g.try_issue(1));
+        assert!(!g.try_issue(1), "window 1 admits exactly one resident part");
+        g.release(1);
+        assert!(g.try_issue(1), "gate reopened, next part may issue");
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
@@ -25,6 +25,9 @@ pub(crate) enum DownloadState {
         /// object's stored part size so each range aligns to a stored part
         /// boundary (S3 returns a per-part checksum only for an aligned range).
         part_size: u64,
+        /// Number of slots claimed (the W-gate numerator). Tracks the issuance
+        /// cursor for the read-ahead bound: `issued - consumed < W`.
+        issued: u64,
     },
 
     /// Terminal state - transfer ended (success, failure, or cancelled)

--- a/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
@@ -25,8 +25,9 @@ pub(crate) enum DownloadState {
         /// object's stored part size so each range aligns to a stored part
         /// boundary (S3 returns a per-part checksum only for an aligned range).
         part_size: u64,
-        /// Number of slots claimed (the W-gate numerator). Tracks the issuance
-        /// cursor for the read-ahead bound: `issued - consumed < W`.
+        /// Number of parts claimed for issuance. The read-ahead gate bounds
+        /// resident occupancy as `issued - released < window`, where `released`
+        /// is the count freed by either delivery surface (see `recv_buffer`).
         issued: u64,
     },
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/discovery.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/discovery.rs
@@ -336,7 +336,7 @@ mod tests {
         input: &DownloadInput,
     ) -> DownloadTransfer {
         use crate::operation::download::body;
-        let (writer, _consumer) = body::new_slot_body(body::DEFAULT_BODY_SLOT_CAPACITY);
+        let (writer, _consumer) = body::new_slot_body();
         let (ctx, _completion_rx) = TransferContext::new(handle);
         DownloadTransfer::new(ctx, BucketType::Standard, input.clone(), writer)
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/discovery.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/discovery.rs
@@ -336,7 +336,7 @@ mod tests {
         input: &DownloadInput,
     ) -> DownloadTransfer {
         use crate::operation::download::body;
-        let (writer, _consumer) = body::new_slot_body();
+        let (writer, _consumer) = body::new_recv_body();
         let (ctx, _completion_rx) = TransferContext::new(handle);
         DownloadTransfer::new(ctx, BucketType::Standard, input.clone(), writer)
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
@@ -120,6 +120,11 @@ impl DownloadHandleInner {
     pub(crate) fn scheduling(&self) -> crate::transfer::SchedulingCtl<'_> {
         self.transfer.ctx().scheduling()
     }
+
+    /// Get I/O controls for this transfer.
+    pub(crate) fn io_ctl(&self) -> super::transfer::DownloadIoCtl<'_> {
+        self.transfer.io_ctl()
+    }
 }
 
 /// Handle to an in-progress download operation.
@@ -257,6 +262,14 @@ impl DownloadHandle {
         self.inner.scheduling()
     }
 
+    /// Runtime I/O controls for this download.
+    ///
+    /// See [`DownloadIoCtl`](crate::operation::download::DownloadIoCtl) for available
+    /// controls (e.g. adjusting read-ahead on a running transfer).
+    pub fn io_ctl(&self) -> crate::operation::download::DownloadIoCtl<'_> {
+        self.inner.io_ctl()
+    }
+
     /// Current status of this transfer.
     pub fn status(&self) -> crate::types::TransferStatus {
         self.inner.transfer.ctx().transfer_status()
@@ -369,6 +382,14 @@ impl ManagedDownloadHandle {
     /// Get scheduling controls for this transfer.
     pub fn scheduling(&self) -> crate::transfer::SchedulingCtl<'_> {
         self.inner.scheduling()
+    }
+
+    /// Runtime I/O controls for this download.
+    ///
+    /// See [`DownloadIoCtl`](crate::operation::download::DownloadIoCtl) for available
+    /// controls (e.g. adjusting read-ahead on a running transfer).
+    pub fn io_ctl(&self) -> crate::operation::download::DownloadIoCtl<'_> {
+        self.inner.io_ctl()
     }
 
     /// Current status of this transfer.

--- a/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::error::{self, ErrorKind};
-use crate::operation::download::body::{Body, SlotBodyConsumer};
+use crate::operation::download::body::{Body, RecvBodyConsumer};
 use crate::operation::download::object_meta::ObjectMetadata;
 use crate::operation::download::output::DownloadOutput;
 use crate::operation::download::transfer::DownloadTransfer;
@@ -122,8 +122,38 @@ impl DownloadHandleInner {
     }
 
     /// Get I/O controls for this transfer.
-    pub(crate) fn io_ctl(&self) -> super::transfer::DownloadIoCtl<'_> {
-        self.transfer.io_ctl()
+    pub(crate) fn io_ctl(&self) -> DownloadIoCtl<'_> {
+        DownloadIoCtl {
+            transfer: &self.transfer,
+        }
+    }
+}
+
+/// Runtime I/O controls for a running download.
+///
+/// Adjusts how the transfer moves data, as opposed to how it is scheduled relative
+/// to other transfers (that is [`SchedulingCtl`](crate::transfer::SchedulingCtl)).
+/// Obtained via [`DownloadHandle::io_ctl()`].
+#[derive(Debug)]
+pub struct DownloadIoCtl<'a> {
+    transfer: &'a DownloadTransfer,
+}
+
+impl<'a> DownloadIoCtl<'a> {
+    /// Set how far this download prefetches ahead of the consumer, overriding the
+    /// value resolved at initiation. Takes effect on the next issuance decision.
+    ///
+    /// Lowering the window caps resident memory for a consumer that has fallen
+    /// behind; raising it restores prefetch depth once the consumer catches up.
+    pub fn set_read_ahead(&self, mode: crate::types::ReadAhead) {
+        self.transfer.set_read_ahead(&mode);
+    }
+
+    /// Construct directly from a transfer, for exercising the control surface in
+    /// transfer-level tests without a full handle.
+    #[cfg(test)]
+    pub(crate) fn for_test(transfer: &'a DownloadTransfer) -> Self {
+        Self { transfer }
     }
 }
 
@@ -194,7 +224,7 @@ pub struct DownloadHandle {
 impl DownloadHandle {
     pub(crate) fn new(
         transfer: DownloadTransfer,
-        consumer: SlotBodyConsumer,
+        consumer: RecvBodyConsumer,
         completion_rx: StateMachineTerminalReceiver,
     ) -> Self {
         let body = Body::new(consumer, transfer.clone());
@@ -439,7 +469,7 @@ impl Drop for ManagedDownloadHandle {
 mod tests {
     use super::{DownloadHandle, DownloadHandleInner, ManagedDownloadHandle};
     use crate::error::ErrorKind;
-    use crate::operation::download::body::{new_slot_body, SlotBodyConsumer};
+    use crate::operation::download::body::{new_recv_body, RecvBodyConsumer};
     use crate::operation::download::transfer::DownloadTransfer;
     use crate::operation::download::DownloadInput;
     use crate::transfer::TransferContext;
@@ -460,7 +490,7 @@ mod tests {
     /// a `Cancelled` terminal state. Callers assemble either a
     /// `DownloadHandle` or `ManagedDownloadHandle` around it to test the
     /// post-cancel `join()` contract.
-    fn make_cancelled_download_inner() -> (DownloadHandleInner, SlotBodyConsumer) {
+    fn make_cancelled_download_inner() -> (DownloadHandleInner, RecvBodyConsumer) {
         let handle = crate::client::Handle::test_handle_tokio(
             crate::Config::builder()
                 .client(aws_smithy_mocks::mock_client!(
@@ -475,7 +505,7 @@ mod tests {
             .key("test-key")
             .build()
             .unwrap();
-        let (writer, consumer) = new_slot_body();
+        let (writer, consumer) = new_recv_body();
         let (ctx, completion_rx) = TransferContext::new(handle);
         let transfer = DownloadTransfer::new(ctx.clone(), BucketType::Standard, input, writer);
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
@@ -418,9 +418,7 @@ impl Drop for ManagedDownloadHandle {
 mod tests {
     use super::{DownloadHandle, DownloadHandleInner, ManagedDownloadHandle};
     use crate::error::ErrorKind;
-    use crate::operation::download::body::{
-        new_slot_body, SlotBodyConsumer, DEFAULT_BODY_SLOT_CAPACITY,
-    };
+    use crate::operation::download::body::{new_slot_body, SlotBodyConsumer};
     use crate::operation::download::transfer::DownloadTransfer;
     use crate::operation::download::DownloadInput;
     use crate::transfer::TransferContext;
@@ -456,7 +454,7 @@ mod tests {
             .key("test-key")
             .build()
             .unwrap();
-        let (writer, consumer) = new_slot_body(DEFAULT_BODY_SLOT_CAPACITY);
+        let (writer, consumer) = new_slot_body();
         let (ctx, completion_rx) = TransferContext::new(handle);
         let transfer = DownloadTransfer::new(ctx.clone(), BucketType::Standard, input, writer);
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/input.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/input.rs
@@ -120,6 +120,10 @@ pub struct DownloadInput {
     pub expected_bucket_owner: Option<String>,
     /// <p>To retrieve the checksum, this mode must be enabled.</p>
     pub checksum_mode: Option<aws_sdk_s3::types::ChecksumMode>,
+    /// How far this download may prefetch ahead of the consumer. `None` uses the
+    /// client default from [`Config`](crate::config::Config); `Some` overrides it for
+    /// this request.
+    pub read_ahead: Option<crate::types::ReadAhead>,
 }
 impl DownloadInput {
     /// <p>The bucket name containing the object.</p>
@@ -271,6 +275,11 @@ impl DownloadInput {
     pub fn checksum_mode(&self) -> Option<&aws_sdk_s3::types::ChecksumMode> {
         self.checksum_mode.as_ref()
     }
+    /// How far this download may prefetch ahead of the consumer, if overridden for
+    /// this request. `None` uses the client default.
+    pub fn read_ahead(&self) -> Option<&crate::types::ReadAhead> {
+        self.read_ahead.as_ref()
+    }
 }
 
 impl fmt::Debug for DownloadInput {
@@ -300,6 +309,7 @@ impl fmt::Debug for DownloadInput {
         formatter.field("part_number", &self.part_number);
         formatter.field("expected_bucket_owner", &self.expected_bucket_owner);
         formatter.field("checksum_mode", &self.checksum_mode);
+        formatter.field("read_ahead", &self.read_ahead);
         formatter.finish()
     }
 }
@@ -336,6 +346,7 @@ pub struct DownloadInputBuilder {
     pub(crate) part_number: Option<i32>,
     pub(crate) expected_bucket_owner: Option<String>,
     pub(crate) checksum_mode: Option<aws_sdk_s3::types::ChecksumMode>,
+    pub(crate) read_ahead: Option<crate::types::ReadAhead>,
 }
 
 impl DownloadInputBuilder {
@@ -816,6 +827,22 @@ impl DownloadInputBuilder {
     pub fn get_checksum_mode(&self) -> &Option<aws_sdk_s3::types::ChecksumMode> {
         &self.checksum_mode
     }
+    /// Override how far this download prefetches ahead of the consumer, replacing the
+    /// client default for this request.
+    pub fn read_ahead(mut self, input: crate::types::ReadAhead) -> Self {
+        self.read_ahead = Option::Some(input);
+        self
+    }
+    /// Override how far this download prefetches ahead of the consumer, replacing the
+    /// client default for this request.
+    pub fn set_read_ahead(mut self, input: Option<crate::types::ReadAhead>) -> Self {
+        self.read_ahead = input;
+        self
+    }
+    /// The read-ahead override set on this builder, if any.
+    pub fn get_read_ahead(&self) -> &Option<crate::types::ReadAhead> {
+        &self.read_ahead
+    }
     /// Consumes the builder and constructs a [`DownloadInput`].
     pub fn build(self) -> Result<DownloadInput, ::aws_smithy_types::error::operation::BuildError> {
         if self.bucket.is_none() {
@@ -848,6 +875,7 @@ impl DownloadInputBuilder {
             part_number: self.part_number,
             expected_bucket_owner: self.expected_bucket_owner,
             checksum_mode: self.checksum_mode,
+            read_ahead: self.read_ahead,
         })
     }
 }
@@ -879,6 +907,7 @@ impl fmt::Debug for DownloadInputBuilder {
         formatter.field("part_number", &self.part_number);
         formatter.field("expected_bucket_owner", &self.expected_bucket_owner);
         formatter.field("checksum_mode", &self.checksum_mode);
+        formatter.field("read_ahead", &self.read_ahead);
         formatter.finish()
     }
 }
@@ -942,6 +971,7 @@ impl From<DownloadInput> for DownloadInputBuilder {
             part_number: value.part_number,
             expected_bucket_owner: value.expected_bucket_owner,
             checksum_mode: value.checksum_mode,
+            read_ahead: value.read_ahead,
         }
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/read_ahead.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/read_ahead.rs
@@ -1,0 +1,167 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Per-transfer read-ahead window — the **receive window** (rwnd) of the download.
+//!
+//! # The bound it owns
+//!
+//! Issuance of a speculative part requires `issued - consumed < window()`. The
+//! quantity `issued - consumed` is the transfer's **resident occupancy in parts**:
+//! parts claimed (issued) but not yet delivered in order to the consumer. So the
+//! gate is a pure occupancy bound — "do not run more than `window` parts ahead of
+//! the consumer" — and nothing more. It is one of three independent upper bounds
+//! on issuance (the others — total in-flight concurrency, and the aggregate memory
+//! budget — live elsewhere); issuance takes their min. This type owns only the
+//! read-ahead bound.
+//!
+//! # rwnd, not cwnd — and occupancy, not rate
+//!
+//! The window maps onto TCP's *receive window* (rwnd), which is advertised from
+//! the receiver's **free buffer space** — `capacity - unread`. It is not estimated
+//! and it does not decay: it is an exact subtraction recomputed as the buffer fills
+//! and drains. This is categorically different from the *congestion window* (cwnd),
+//! which probes toward the bandwidth-delay product `R̂·L̂`. The cwnd job — ramping
+//! to the throughput knee — belongs to the **concurrency controller** (global,
+//! separate), never here.
+//!
+//! An earlier version of this controller derived the operating window from a
+//! measured drain rate (`W* = R̂·L̂/part_size`, smoothed by an EWMA, decayed on
+//! idle). That is cwnd math on an rwnd, and it self-destructs: any gap in delivery
+//! — a consumer between bursts, or one blocked behind a not-yet-filled part —
+//! decays the rate estimate toward zero, collapsing the window to its floor and
+//! throttling issuance to a single outstanding part (a wedge). The window is
+//! occupancy-bounded; no rate is estimated.
+//!
+//! # The window today: a fixed ceiling
+//!
+//! The window is a **fixed constant** ([`DEFAULT_WINDOW_PARTS`]) — a per-transfer
+//! resident cap, so memory bounds the transfer rather than a control loop. The
+//! pacing behaviors fall out of the occupancy gate directly, with no adaptation:
+//!
+//! - **Fast consumer:** `consumed` keeps pace → `issued - consumed` stays small →
+//!   the gate never binds → the transfer runs at full speed, bounded by concurrency
+//!   and (later) the global budget, not by us.
+//! - **Slow consumer:** `consumed` lags → `issued - consumed` fills to the window →
+//!   the gate closes → issuance pauses until the consumer drains. Resident memory is
+//!   bounded at exactly `window` parts; we never pile up parts the consumer will not
+//!   read soon. This is the backpressure, and it is automatic.
+//! - **Blocked consumer (a stalled/missing part):** `consumed` cannot advance past
+//!   the hole → occupancy pins at the window → issuance stops at `window`, leaving a
+//!   full window of slack to make progress around the hole. It does not collapse to
+//!   one part.
+//!
+//! # What is deferred
+//!
+//! Two layers build on this and are **not** implemented here yet (see
+//! `flow-control-architecture.md` §7b, the backpressure ladder):
+//!
+//! 1. **Budget-pressure clamp (ladder rung 1).** When aggregate resident across all
+//!    transfers approaches the global budget, the budget layer pulls each transfer's
+//!    effective window down toward its demand. The fixed constant here becomes
+//!    `memory_budget / part_size`, arbitrated globally. This is what stops one slow
+//!    transfer from holding buffer space other transfers need.
+//! 2. **`Auto`-mode resident-size adaptation.** A fill-side signal — resident set
+//!    size ballooning relative to the window — clamps the window down ahead of the
+//!    buffer filling completely. Observed where parts are filled (not by polling the
+//!    consumer, which is the thing we are waiting on). Layered under the public
+//!    `ReadAhead::Auto` mode once the fixed model is proven.
+//!
+//! The window is stored in an [`AtomicU64`] (not a plain constant) precisely so
+//! those layers can lower it with a lock-free store; today nothing writes it after
+//! construction except the test helper.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Fixed read-ahead window, in parts. A per-transfer cap on resident occupancy:
+/// with an 8 MiB part this holds at most 8 GiB of buffer for one transfer, while
+/// staying well above the bandwidth-delay product of a 100 Gbps link (so the gate
+/// does not bind a consumer that keeps pace).
+///
+/// Provisional: when a global memory budget exists the window is sized from it
+/// (`memory_budget / part_size`) and arbitrated across transfers rather than fixed
+/// per transfer (see `flow-control-architecture.md` §7b, ladder rung 1).
+const DEFAULT_WINDOW_PARTS: u64 = 1024;
+
+/// Per-transfer read-ahead window — the receive-window (rwnd) bound on speculative
+/// issuance.
+///
+/// `window()` is the hot read (the issuance gate, per claim) and is lock-free.
+/// Today the value is fixed at construction; the [`AtomicU64`] exists so the
+/// deferred budget-clamp and `Auto` adaptation layers can lower it without a lock.
+/// Shared `&self` across the issuer and consumer tasks.
+pub(crate) struct ReadAhead {
+    /// Current window in parts. Read by the gate on every claim.
+    window: AtomicU64,
+}
+
+impl ReadAhead {
+    /// Create a controller with the interim fixed window. The window opens at
+    /// [`DEFAULT_WINDOW_PARTS`] and (today) stays there: memory bounds the transfer,
+    /// the occupancy gate paces a slow or blocked consumer for free.
+    pub(crate) fn new() -> Self {
+        Self {
+            window: AtomicU64::new(DEFAULT_WINDOW_PARTS),
+        }
+    }
+
+    /// The current read-ahead window, in parts. Lock-free; the issuance gate reads
+    /// this per claim (`issued - consumed < window()`).
+    pub(crate) fn window(&self) -> u64 {
+        self.window.load(Ordering::Relaxed)
+    }
+
+    /// Test-only: force the window to a fixed value, so transfer-level tests can
+    /// drive the issuance gate deterministically (e.g. exercise the closed-gate
+    /// path without claiming a thousand parts).
+    #[cfg(test)]
+    pub(crate) fn force_window(&self, w: u64) {
+        self.window.store(w, Ordering::Relaxed);
+    }
+}
+
+impl Default for ReadAhead {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for ReadAhead {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReadAhead")
+            .field("window", &self.window.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn window_opens_at_the_fixed_default() {
+        // rwnd: the window is the fixed per-transfer ceiling from construction. No
+        // warm-up, no slow-start, no estimate to wait on.
+        let ra = ReadAhead::new();
+        assert_eq!(ra.window(), DEFAULT_WINDOW_PARTS);
+    }
+
+    #[test]
+    fn window_is_constant_today() {
+        // Nothing in the controller decays or adapts the window — that is deferred
+        // to the budget clamp and Auto-mode layers. Repeated reads are stable.
+        let ra = ReadAhead::new();
+        let w = ra.window();
+        for _ in 0..1000 {
+            assert_eq!(ra.window(), w, "window must not drift");
+        }
+    }
+
+    #[test]
+    fn force_window_overrides_for_gate_tests() {
+        let ra = ReadAhead::new();
+        ra.force_window(3);
+        assert_eq!(ra.window(), 3);
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/operation/download/read_ahead.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/read_ahead.rs
@@ -3,74 +3,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Per-transfer read-ahead window — the **receive window** (rwnd) of the download.
+//! Per-transfer read-ahead window: the occupancy bound on speculative issuance.
 //!
-//! # The bound it owns
+//! Issuance of a speculative part requires `issued - released < window()`, where
+//! `issued` counts parts claimed for issuance and `released` counts parts freed by
+//! either delivery surface (stream pull or disk drain; see `recv_buffer`). The
+//! quantity `issued - released` is the transfer's resident occupancy in parts, so
+//! the gate bounds how far issuance runs ahead of consumption and nothing more.
+//! It is one of three independent upper bounds on issuance; the others — total
+//! in-flight concurrency and the aggregate memory budget — live elsewhere, and
+//! issuance takes their min.
 //!
-//! Issuance of a speculative part requires `issued - consumed < window()`. The
-//! quantity `issued - consumed` is the transfer's **resident occupancy in parts**:
-//! parts claimed (issued) but not yet delivered in order to the consumer. So the
-//! gate is a pure occupancy bound — "do not run more than `window` parts ahead of
-//! the consumer" — and nothing more. It is one of three independent upper bounds
-//! on issuance (the others — total in-flight concurrency, and the aggregate memory
-//! budget — live elsewhere); issuance takes their min. This type owns only the
-//! read-ahead bound.
+//! The window is free buffer space, `window - occupancy`, an exact subtraction
+//! recomputed as the buffer fills and drains. It is not estimated from a rate and
+//! it does not decay, so a gap in delivery does not shrink it: a consumer paused
+//! between bursts, or blocked behind a not-yet-filled part, still leaves a full
+//! window of slack to make progress.
 //!
-//! # rwnd, not cwnd — and occupancy, not rate
+//! # Pacing
 //!
-//! The window maps onto TCP's *receive window* (rwnd), which is advertised from
-//! the receiver's **free buffer space** — `capacity - unread`. It is not estimated
-//! and it does not decay: it is an exact subtraction recomputed as the buffer fills
-//! and drains. This is categorically different from the *congestion window* (cwnd),
-//! which probes toward the bandwidth-delay product `R̂·L̂`. The cwnd job — ramping
-//! to the throughput knee — belongs to the **concurrency controller** (global,
-//! separate), never here.
+//! The window is a fixed per-transfer cap ([`DEFAULT_WINDOW_PARTS`]). The pacing
+//! behaviors follow from the occupancy gate directly:
 //!
-//! An earlier version of this controller derived the operating window from a
-//! measured drain rate (`W* = R̂·L̂/part_size`, smoothed by an EWMA, decayed on
-//! idle). That is cwnd math on an rwnd, and it self-destructs: any gap in delivery
-//! — a consumer between bursts, or one blocked behind a not-yet-filled part —
-//! decays the rate estimate toward zero, collapsing the window to its floor and
-//! throttling issuance to a single outstanding part (a wedge). The window is
-//! occupancy-bounded; no rate is estimated.
+//! - Fast consumer: `released` keeps pace, `issued - released` stays small, the
+//!   gate does not bind, and the transfer runs at the concurrency limit.
+//! - Slow consumer: `released` lags, `issued - released` fills to the window, the
+//!   gate closes, and issuance pauses until the consumer drains. Resident memory is
+//!   bounded at `window` parts.
+//! - Blocked consumer (a stalled or missing part): `released` cannot advance past
+//!   the hole, occupancy pins at the window, and issuance stops at `window`, leaving
+//!   a full window of slack to make progress around the hole rather than collapsing
+//!   to one part.
 //!
-//! # The window today: a fixed ceiling
-//!
-//! The window is a **fixed constant** ([`DEFAULT_WINDOW_PARTS`]) — a per-transfer
-//! resident cap, so memory bounds the transfer rather than a control loop. The
-//! pacing behaviors fall out of the occupancy gate directly, with no adaptation:
-//!
-//! - **Fast consumer:** `consumed` keeps pace → `issued - consumed` stays small →
-//!   the gate never binds → the transfer runs at full speed, bounded by concurrency
-//!   and (later) the global budget, not by us.
-//! - **Slow consumer:** `consumed` lags → `issued - consumed` fills to the window →
-//!   the gate closes → issuance pauses until the consumer drains. Resident memory is
-//!   bounded at exactly `window` parts; we never pile up parts the consumer will not
-//!   read soon. This is the backpressure, and it is automatic.
-//! - **Blocked consumer (a stalled/missing part):** `consumed` cannot advance past
-//!   the hole → occupancy pins at the window → issuance stops at `window`, leaving a
-//!   full window of slack to make progress around the hole. It does not collapse to
-//!   one part.
-//!
-//! # What is deferred
-//!
-//! Two layers build on this and are **not** implemented here yet (see
-//! `flow-control-architecture.md` §7b, the backpressure ladder):
-//!
-//! 1. **Budget-pressure clamp (ladder rung 1).** When aggregate resident across all
-//!    transfers approaches the global budget, the budget layer pulls each transfer's
-//!    effective window down toward its demand. The fixed constant here becomes
-//!    `memory_budget / part_size`, arbitrated globally. This is what stops one slow
-//!    transfer from holding buffer space other transfers need.
-//! 2. **`Auto`-mode resident-size adaptation.** A fill-side signal — resident set
-//!    size ballooning relative to the window — clamps the window down ahead of the
-//!    buffer filling completely. Observed where parts are filled (not by polling the
-//!    consumer, which is the thing we are waiting on). Layered under the public
-//!    `ReadAhead::Auto` mode once the fixed model is proven.
-//!
-//! The window is stored in an [`AtomicU64`] (not a plain constant) precisely so
-//! those layers can lower it with a lock-free store; today nothing writes it after
-//! construction except the test helper.
+//! The window is stored in an [`AtomicU64`] so it can be lowered with a lock-free
+//! store while a transfer runs (see [`ReadAhead::set_window`]).
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -79,20 +45,25 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// staying well above the bandwidth-delay product of a 100 Gbps link (so the gate
 /// does not bind a consumer that keeps pace).
 ///
-/// Provisional: when a global memory budget exists the window is sized from it
-/// (`memory_budget / part_size`) and arbitrated across transfers rather than fixed
-/// per transfer (see `flow-control-architecture.md` §7b, ladder rung 1).
-///
 /// The default for the public [`ReadAhead::Auto`](crate::types::ReadAhead) mode;
-/// `Handle::download_read_ahead_window` resolves the knob to a window in parts.
+/// [`window_parts_for`] resolves the knob to a window in parts.
 pub(crate) const DEFAULT_WINDOW_PARTS: u64 = 1024;
 
+/// Resolve the effective read-ahead window in parts for a download, in precedence
+/// order: the per-request [`ReadAhead`](crate::types::ReadAhead) override if set,
+/// else the client default. See [`window_parts_for`] for the per-mode mapping.
+pub(crate) fn resolve_window(
+    request: Option<&crate::types::ReadAhead>,
+    client_default: &crate::types::ReadAhead,
+) -> u64 {
+    window_parts_for(request.unwrap_or(client_default))
+}
+
 /// Map the public [`ReadAhead`](crate::types::ReadAhead) knob to a window in parts.
-/// `Auto` is the fixed per-transfer cap (a future memory budget will size it);
-/// `Parts(n)` is `n + 1` — `n` parts of speculation beyond the part the consumer is
-/// waiting on, which is always admitted, so `Parts(0)` is demand paging. The single
-/// definition of the knob's meaning, used at transfer construction and by the
-/// dynamic control surface.
+/// `Auto` is the fixed per-transfer cap; `Parts(n)` is `n + 1` — `n` parts of
+/// speculation beyond the part the consumer is waiting on, which is always admitted,
+/// so `Parts(0)` is demand paging. The single definition of the knob's meaning, used
+/// at transfer construction and by the dynamic control surface.
 pub(crate) fn window_parts_for(mode: &crate::types::ReadAhead) -> u64 {
     match mode {
         crate::types::ReadAhead::Auto => DEFAULT_WINDOW_PARTS,
@@ -100,13 +71,12 @@ pub(crate) fn window_parts_for(mode: &crate::types::ReadAhead) -> u64 {
     }
 }
 
-/// Per-transfer read-ahead window — the receive-window (rwnd) bound on speculative
-/// issuance.
+/// Per-transfer read-ahead window: the occupancy bound on speculative issuance.
 ///
-/// `window()` is the hot read (the issuance gate, per claim) and is lock-free.
-/// Today the value is fixed at construction; the [`AtomicU64`] exists so the
-/// deferred budget-clamp and `Auto` adaptation layers can lower it without a lock.
-/// Shared `&self` across the issuer and consumer tasks.
+/// `window()` is the hot read (the issuance gate, per claim) and is lock-free. The
+/// value is fixed at construction; the [`AtomicU64`] allows it to be lowered with a
+/// lock-free store while the transfer runs. Shared `&self` across the issuer and
+/// consumer tasks.
 pub(crate) struct ReadAhead {
     /// Current window in parts. Read by the gate on every claim.
     window: AtomicU64,
@@ -127,7 +97,7 @@ impl ReadAhead {
     }
 
     /// The current read-ahead window, in parts. Lock-free; the issuance gate reads
-    /// this per claim (`issued - consumed < window()`).
+    /// this per claim (`issued - released < window()`).
     pub(crate) fn window(&self) -> u64 {
         self.window.load(Ordering::Relaxed)
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/read_ahead.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/read_ahead.rs
@@ -177,7 +177,11 @@ mod tests {
         // Auto -> the fixed default.
         assert_eq!(window_parts_for(&Knob::Auto), DEFAULT_WINDOW_PARTS);
         // Parts(n) -> n + 1: n speculative parts plus the always-admitted demand part.
-        assert_eq!(window_parts_for(&Knob::Parts(0)), 1, "Parts(0) is demand paging");
+        assert_eq!(
+            window_parts_for(&Knob::Parts(0)),
+            1,
+            "Parts(0) is demand paging"
+        );
         assert_eq!(window_parts_for(&Knob::Parts(1)), 2);
         assert_eq!(window_parts_for(&Knob::Parts(255)), 256);
         // The + 1 saturates rather than overflowing at the top of the range.

--- a/aws-sdk-s3-transfer-manager/src/operation/download/read_ahead.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/read_ahead.rs
@@ -82,7 +82,23 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// Provisional: when a global memory budget exists the window is sized from it
 /// (`memory_budget / part_size`) and arbitrated across transfers rather than fixed
 /// per transfer (see `flow-control-architecture.md` §7b, ladder rung 1).
-const DEFAULT_WINDOW_PARTS: u64 = 1024;
+///
+/// The default for the public [`ReadAhead::Auto`](crate::types::ReadAhead) mode;
+/// `Handle::download_read_ahead_window` resolves the knob to a window in parts.
+pub(crate) const DEFAULT_WINDOW_PARTS: u64 = 1024;
+
+/// Map the public [`ReadAhead`](crate::types::ReadAhead) knob to a window in parts.
+/// `Auto` is the fixed per-transfer cap (a future memory budget will size it);
+/// `Parts(n)` is `n + 1` — `n` parts of speculation beyond the part the consumer is
+/// waiting on, which is always admitted, so `Parts(0)` is demand paging. The single
+/// definition of the knob's meaning, used at transfer construction and by the
+/// dynamic control surface.
+pub(crate) fn window_parts_for(mode: &crate::types::ReadAhead) -> u64 {
+    match mode {
+        crate::types::ReadAhead::Auto => DEFAULT_WINDOW_PARTS,
+        crate::types::ReadAhead::Parts(n) => (*n as u64).saturating_add(1),
+    }
+}
 
 /// Per-transfer read-ahead window — the receive-window (rwnd) bound on speculative
 /// issuance.
@@ -97,12 +113,16 @@ pub(crate) struct ReadAhead {
 }
 
 impl ReadAhead {
-    /// Create a controller with the interim fixed window. The window opens at
-    /// [`DEFAULT_WINDOW_PARTS`] and (today) stays there: memory bounds the transfer,
-    /// the occupancy gate paces a slow or blocked consumer for free.
+    /// Create a controller with the default fixed window ([`DEFAULT_WINDOW_PARTS`]).
     pub(crate) fn new() -> Self {
+        Self::with_window(DEFAULT_WINDOW_PARTS)
+    }
+
+    /// Create a controller with an explicit window, in parts. The resolved value of
+    /// the public [`ReadAhead`](crate::types::ReadAhead) knob enters here.
+    pub(crate) fn with_window(parts: u64) -> Self {
         Self {
-            window: AtomicU64::new(DEFAULT_WINDOW_PARTS),
+            window: AtomicU64::new(parts),
         }
     }
 
@@ -112,12 +132,18 @@ impl ReadAhead {
         self.window.load(Ordering::Relaxed)
     }
 
+    /// Set the window, in parts. Lock-free. Used to apply a dynamic read-ahead
+    /// change to a running transfer; the next gate read observes the new value.
+    pub(crate) fn set_window(&self, parts: u64) {
+        self.window.store(parts, Ordering::Relaxed);
+    }
+
     /// Test-only: force the window to a fixed value, so transfer-level tests can
     /// drive the issuance gate deterministically (e.g. exercise the closed-gate
     /// path without claiming a thousand parts).
     #[cfg(test)]
     pub(crate) fn force_window(&self, w: u64) {
-        self.window.store(w, Ordering::Relaxed);
+        self.set_window(w);
     }
 }
 
@@ -148,9 +174,10 @@ mod tests {
     }
 
     #[test]
-    fn window_is_constant_today() {
-        // Nothing in the controller decays or adapts the window — that is deferred
-        // to the budget clamp and Auto-mode layers. Repeated reads are stable.
+    fn window_does_not_drift_on_its_own() {
+        // The controller never changes the window itself; only an explicit
+        // set_window (the budget clamp or the dynamic knob) moves it. Repeated reads
+        // with no writer are stable.
         let ra = ReadAhead::new();
         let w = ra.window();
         for _ in 0..1000 {
@@ -159,9 +186,34 @@ mod tests {
     }
 
     #[test]
+    fn set_window_updates_the_value() {
+        let ra = ReadAhead::new();
+        ra.set_window(7);
+        assert_eq!(ra.window(), 7);
+        ra.set_window(1);
+        assert_eq!(ra.window(), 1);
+    }
+
+    #[test]
     fn force_window_overrides_for_gate_tests() {
         let ra = ReadAhead::new();
         ra.force_window(3);
         assert_eq!(ra.window(), 3);
+    }
+
+    #[test]
+    fn window_parts_for_maps_the_knob() {
+        use crate::types::ReadAhead as Knob;
+        // Auto -> the fixed default.
+        assert_eq!(window_parts_for(&Knob::Auto), DEFAULT_WINDOW_PARTS);
+        // Parts(n) -> n + 1: n speculative parts plus the always-admitted demand part.
+        assert_eq!(window_parts_for(&Knob::Parts(0)), 1, "Parts(0) is demand paging");
+        assert_eq!(window_parts_for(&Knob::Parts(1)), 2);
+        assert_eq!(window_parts_for(&Knob::Parts(255)), 256);
+        // The + 1 saturates rather than overflowing at the top of the range.
+        assert_eq!(
+            window_parts_for(&Knob::Parts(usize::MAX)),
+            (usize::MAX as u64).saturating_add(1)
+        );
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -232,6 +232,24 @@ impl SegState {
             .is_ok()
     }
 
+    /// Terminal-only: claim a segment for draining regardless of whether it is full,
+    /// `{OPEN | FULL} → DRAINING`, exactly once. For [`PagedRecvBuffer::take_tail`],
+    /// which drains the partial final segment at end-of-stream. Returns `true` for the
+    /// single caller that wins. Already-`DRAINING`/`DRAINED` segments are skipped.
+    fn try_claim_for_drain_partial(&self) -> bool {
+        // Try the full→draining edge first, then the open→draining edge. Whichever the
+        // segment currently sits at, exactly one of these CASes can succeed (the other
+        // observes a state that is no longer OPEN/FULL). Safe only at end-of-stream,
+        // when no producer will fill this segment further (caller obligation).
+        self.0
+            .compare_exchange(SEG_FULL, SEG_DRAINING, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+            || self
+                .0
+                .compare_exchange(SEG_OPEN, SEG_DRAINING, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+    }
+
     /// Mark consumption complete: `DRAINING → DRAINED` (`Release`).
     fn set_drained(&self) {
         self.0.store(SEG_DRAINED, Ordering::Release);
@@ -515,6 +533,14 @@ fn reclaim_front<T>(inner: &Inner<T>) {
 unsafe impl<T: Send> Send for PagedRecvBuffer<T> {}
 unsafe impl<T: Send> Sync for PagedRecvBuffer<T> {}
 unsafe impl<T: Send> Send for RecvBufferConsumer<T> {}
+// Safety: all mutation goes through `poll_next(&mut self)`, so a shared `&consumer`
+// exposes only Arc/Copy state with no interior mutation — Sync is sound. Needed so a
+// holder of the consumer (e.g. the download `Body`) can itself be Sync.
+unsafe impl<T: Send> Sync for RecvBufferConsumer<T> {}
+// Safety: a SlotHandle is claimed on one thread and may be filled on another (the
+// download claims in poll_work, fills in the async execute task). It carries an
+// Arc<Segment<T>> and indices; moving it and filling moves a `T`, so T: Send suffices.
+unsafe impl<T: Send> Send for SlotHandle<T> {}
 unsafe impl<T: Send> Send for SegmentWrite<T> {}
 unsafe impl<T: Send> Sync for SegmentWrite<T> {}
 
@@ -601,6 +627,14 @@ impl<T> PagedRecvBuffer<T> {
         seg.slots[idx].state.publish_filled();
         let prev = seg.filled_count.fetch_add(1, Ordering::AcqRel);
         if prev + 1 == seg.slots.len() {
+            // The sealing fill (the one that brought the count to full) sets FULL.
+            // `set_full` (Release) is not ordered with a concurrent
+            // `take_completed_segment`, which reads `state` under the lock this path
+            // does not take: a taker racing the seal may observe the segment still
+            // OPEN and skip it. That is safe, not a lost segment — the sealing thread
+            // returns `SealedSegment`, and its caller drains via `drain_sealed`, which
+            // re-scans and finds the now-FULL segment. Per-slot payload visibility is
+            // independent, carried by the publish_filled/is_filled pair above.
             seg.state.set_full();
             FillOutcome::SealedSegment
         } else {
@@ -625,6 +659,44 @@ impl<T> PagedRecvBuffer<T> {
             }
         }
         None
+    }
+
+    /// Terminal-only: hand out the frontmost not-yet-drained segment as an owned
+    /// [`SegmentWrite`] *regardless of whether it is full* (claimed `{OPEN | FULL} →
+    /// DRAINING` via [`SegState::try_claim_for_drain_partial`]), or `None` when every
+    /// segment is already draining/drained.
+    ///
+    /// This drains the **partial final segment** at end-of-stream — the block surface's
+    /// [`take_completed_segment`](Self::take_completed_segment) only yields *full*
+    /// segments, so the last segment of a stream whose length is not a multiple of the
+    /// segment size would otherwise never be handed out. Looping `take_tail` drains that
+    /// tail plus any straggler full segments.
+    ///
+    /// # Caller obligation
+    /// Call only once issuance is complete and all outstanding fills have landed: a
+    /// partial segment claimed here must not receive further fills (a concurrent fill
+    /// would race the consumer reading the segment's slots). The consumer reads only
+    /// the `FILLED` slots (via [`Slot::get`]); unfilled slots are skipped.
+    pub(crate) fn take_tail(&self) -> Option<SegmentWrite<T>> {
+        let guard = self.inner.locked.lock();
+        for seg in guard.segments.iter() {
+            if seg.state.try_claim_for_drain_partial() {
+                return Some(SegmentWrite {
+                    seg: seg.clone(),
+                    inner: self.inner.clone(),
+                });
+            }
+        }
+        None
+    }
+
+    /// The in-order delivery cursor: the next sequence the consumer will deliver, i.e.
+    /// the count of sequences already delivered. Lock-free read of the shared cursor.
+    ///
+    /// For a producer-side read-ahead gate: the issuer bounds outstanding work by
+    /// `issued − consumed < W` (the caller tracks `issued`; this supplies `consumed`).
+    pub(crate) fn consumed(&self) -> u64 {
+        self.inner.consumed.load(Ordering::Acquire)
     }
 
     // ── Introspection (advisory) ─────────────────────────────────────────────────
@@ -815,6 +887,29 @@ impl<T> PagedRecvBuffer<T> {
 }
 
 #[cfg(test)]
+impl<T> PagedRecvBuffer<T> {
+    /// Test helper: fill the handle for sequence `slot`, taken out of a slice of
+    /// claimed handles by index. Lets a test drive fills in an arbitrary order
+    /// without consuming the whole slice up front. Each handle is filled at most
+    /// once; the cell is taken on use.
+    fn fill_at(&self, handles: &[SlotHandle<T>], slot: usize, value: T) {
+        // Fill by index without consuming the handle, so a test can drive an
+        // arbitrary fill order over a pre-claimed slice.
+        let h = &handles[slot];
+        let seg = h.seg.clone();
+        let idx = h.idx;
+        seg.slots[idx].data.with_mut(|p| unsafe {
+            *p = Some(value);
+        });
+        seg.slots[idx].state.publish_filled();
+        let prev = seg.filled_count.fetch_add(1, Ordering::AcqRel);
+        if prev + 1 == seg.slots.len() {
+            seg.state.set_full();
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -964,6 +1059,62 @@ mod tests {
             ring.fill(h, i as u64);
         }
         assert!(ring.take_completed_segment().is_none());
+    }
+
+    /// `take_tail` drains a partial final segment that `take_completed_segment` won't
+    /// (not full). Only the FILLED slots carry payloads; unfilled are skipped.
+    #[test]
+    fn take_tail_drains_partial_segment() {
+        let seg_size = 4;
+        let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+        // Fill only 2 of 4 slots — segment never goes FULL.
+        let handles: Vec<_> = (0..2).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, (i * 10) as u64);
+        }
+        // The full-only surface yields nothing.
+        assert!(ring.take_completed_segment().is_none());
+        // The terminal tail surface hands out the partial segment.
+        let sw = ring.take_tail().expect("partial tail segment");
+        assert_eq!(sw.base_seq(), 0);
+        let seen: Vec<Option<u64>> = sw.payloads().iter().map(|s| s.get().copied()).collect();
+        assert_eq!(seen, vec![Some(0), Some(10), None, None]);
+        sw.complete();
+        // Once drained, a second take_tail finds nothing more in this segment.
+        assert!(ring.take_tail().is_none());
+    }
+
+    /// `take_tail` also claims a FULL segment (it accepts OPEN or FULL), and only once.
+    #[test]
+    fn take_tail_claims_full_and_is_exclusive() {
+        let seg_size = 2;
+        let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+        let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, i as u64);
+        }
+        let sw = ring.take_tail().expect("full segment via take_tail");
+        assert_eq!(sw.base_seq(), 0);
+        // Already DRAINING → not handed out again by either take surface.
+        assert!(ring.take_tail().is_none());
+        assert!(ring.take_completed_segment().is_none());
+        sw.complete();
+    }
+
+    /// `consumed()` reports the in-order delivery cursor for the read-ahead gate.
+    #[test]
+    fn consumed_tracks_delivery_cursor() {
+        let seg_size = 2;
+        let (ring, mut consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        assert_eq!(ring.consumed(), 0);
+        let handles: Vec<_> = (0..3).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, i as u64);
+        }
+        assert_eq!(ring.consumed(), 0, "filling does not advance the cursor");
+        consumer.poll_next().unwrap();
+        consumer.poll_next().unwrap();
+        assert_eq!(ring.consumed(), 2, "two deliveries advance the cursor to 2");
     }
 
     /// Block surface reads payloads in place via `Slot::get`, then completes.
@@ -1134,7 +1285,7 @@ mod tests {
         );
         assert_eq!(snap.frontier, 5);
         assert_eq!(snap.outstanding(), 2);
-        assert_eq!(snap.arrived(), &[3..5]);
+        assert_eq!(snap.arrived(), std::slice::from_ref(&(3..5)));
         assert_eq!(
             snap.head_of_line(),
             None,
@@ -1247,7 +1398,7 @@ mod tests {
         assert_eq!(snap.frontier, 2);
         assert_eq!(snap.head_of_line(), Some(0));
         assert_eq!(snap.pending(), vec![0..1]);
-        assert_eq!(snap.arrived(), &[1..2]);
+        assert_eq!(snap.arrived(), std::slice::from_ref(&(1..2)));
 
         ring.fill(h0, 10u64);
     }
@@ -1266,7 +1417,7 @@ mod tests {
         assert_eq!(snap.outstanding(), 2);
         assert_eq!(snap.head_of_line(), None);
         assert!(snap.pending().is_empty());
-        assert_eq!(snap.arrived(), &[0..2]);
+        assert_eq!(snap.arrived(), std::slice::from_ref(&(0..2)));
     }
 
     #[test]
@@ -1328,36 +1479,20 @@ mod tests {
     }
 }
 
-#[cfg(test)]
-impl<T> PagedRecvBuffer<T> {
-    /// Test helper: fill the handle for sequence `slot`, taken out of a slice of
-    /// claimed handles by index. Lets a test drive fills in an arbitrary order
-    /// without consuming the whole slice up front. Each handle is filled at most
-    /// once; the cell is taken on use.
-    fn fill_at(&self, handles: &[SlotHandle<T>], slot: usize, value: T) {
-        // Fill by index without consuming the handle, so a test can drive an
-        // arbitrary fill order over a pre-claimed slice.
-        let h = &handles[slot];
-        let seg = h.seg.clone();
-        let idx = h.idx;
-        seg.slots[idx].data.with_mut(|p| unsafe {
-            *p = Some(value);
-        });
-        seg.slots[idx].state.publish_filled();
-        let prev = seg.filled_count.fetch_add(1, Ordering::AcqRel);
-        if prev + 1 == seg.slots.len() {
-            seg.state.set_full();
-        }
-    }
-}
-
 // Loom model-checks the real structure directly (no model of it): the compat layer
 // swaps in loom's atomics/Arc/Mutex under `cfg(s3_tm_loom)`. Segment size is set to
 // 2 per ring (via new_with_segment_size) so boundary-crossing interleavings stay
-// tractable; the algorithm is identical at any size. Six models cover the handoff,
-// the segment hop, reclaim vs an outstanding write (complete and drop paths),
-// multi-producer fill, and the block-take CAS. Run with:
-//   RUSTFLAGS="--cfg s3_tm_loom" cargo test --lib --release loom_tests -- --test-threads=1
+// tractable; the algorithm is identical at any size. Nine models cover the handoff
+// (1), the segment hop (2), reclaim vs an outstanding write — complete (3) and drop
+// (6) paths, multi-producer fill (4), the block-take CAS (5), out-of-order fill
+// across a hop (7), reclaim racing the consumer hop (8), and two takers over
+// distinct segments (9). Run with:
+//   LOOM_MAX_PREEMPTIONS=3 RUSTFLAGS="--cfg s3_tm_loom" \
+//     cargo test --lib --release loom_tests -- --test-threads=1
+// The preemption bound is required: unbounded exploration of the multi-producer and
+// hop-vs-reclaim models is exponential and does not terminate in practical time. A
+// bound of 3 explores all interleavings with at most three preemptions, which
+// exercises every published ordering edge here while keeping the suite to seconds.
 #[cfg(all(test, s3_tm_loom))]
 mod loom_tests {
     use super::*;
@@ -1587,6 +1722,136 @@ mod loom_tests {
 
             taker.join().unwrap();
             assert!(ring.segment_count() >= 1);
+        });
+    }
+
+    /// Model 7 — out-of-order fill across a segment boundary, with the consumer
+    /// hopping.
+    ///
+    /// Four seqs span two segments (seg0={0,1}, seg1={2,3}). One producer fills seq 3
+    /// (sealing seg1) before seq 0, while another fills 0,1,2; the consumer drains
+    /// across the seg0→seg1 hop concurrently. This combines what Model 2 (hop) and
+    /// Model 4 (out-of-order fill) cover separately: a later segment may seal before
+    /// an earlier one, yet in-order delivery and the hop's `Arc` reconstruction must
+    /// still yield 0,1,2,3 exactly once with no use-after-free. loom's `UnsafeCell`
+    /// and Arc registry catch a torn read, a lost/dup payload, or a freed-segment hop.
+    #[test]
+    fn out_of_order_fill_across_segment_hop() {
+        loom::model(|| {
+            let (ring, mut consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
+            // Claim all four up front (claim is serialized under the lock).
+            let handles: Vec<_> = (0..4).map(|_| ring.claim()).collect();
+
+            let ring_a = ring.clone();
+            let a = thread::spawn(move || {
+                // Seal seg1 before seg0 is touched: fill 3 then 2.
+                ring_a.fill_at(&handles, 3, 3);
+                ring_a.fill_at(&handles, 2, 2);
+                ring_a.fill_at(&handles, 1, 1);
+                ring_a.fill_at(&handles, 0, 0);
+            });
+
+            let mut got = Vec::new();
+            for _ in 0..8 {
+                if let Some(v) = consumer.poll_next() {
+                    got.push(v);
+                }
+                if got.len() == 4 {
+                    break;
+                }
+            }
+            a.join().unwrap();
+            while let Some(v) = consumer.poll_next() {
+                got.push(v);
+            }
+            assert_eq!(got, vec![0, 1, 2, 3], "in-order, exactly once, across the hop");
+        });
+    }
+
+    /// Model 8 — front-reclaim racing the consumer's hop.
+    ///
+    /// seg0 is filled and fully delivered (its slots emptied, `consumed` past its
+    /// end); the consumer is poised at the boundary about to hop to seg1. One thread
+    /// claims seq 2 (growing seg1) and then claims seq 3, whose `reclaim_locked` is
+    /// now eligible to pop the fully-consumed seg0 from the deque — concurrently with
+    /// the consumer loading `seg0.next` and reconstructing seg1's `Arc`. The hop holds
+    /// `self.current` (seg0) by strong ref until the reassignment, and seg1 cannot be
+    /// reclaimed while `consumed <= seg1.base`, so the reconstruction stays live.
+    /// loom's Arc registry catches a use-after-free if reclaim could free a segment
+    /// the hop still touches.
+    #[test]
+    fn reclaim_races_consumer_hop() {
+        loom::model(|| {
+            let (ring, mut consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
+            // Fill and drain seg0 fully so it is reclaim-eligible and the consumer is
+            // at the seg0→seg1 boundary.
+            let h0 = ring.claim();
+            let h1 = ring.claim();
+            ring.fill(h0, 0);
+            ring.fill(h1, 1);
+            assert_eq!(consumer.poll_next(), Some(0));
+            assert_eq!(consumer.poll_next(), Some(1));
+
+            let ring2 = ring.clone();
+            let issuer = thread::spawn(move || {
+                let h2 = ring2.claim(); // grows seg1
+                ring2.fill(h2, 2);
+                let h3 = ring2.claim(); // reclaim_locked may pop the drained seg0
+                ring2.fill(h3, 3);
+            });
+
+            // Hop into seg1 concurrently with the reclaim above.
+            let mut got = Vec::new();
+            for _ in 0..6 {
+                if let Some(v) = consumer.poll_next() {
+                    got.push(v);
+                }
+                if got.len() == 2 {
+                    break;
+                }
+            }
+            issuer.join().unwrap();
+            while let Some(v) = consumer.poll_next() {
+                got.push(v);
+            }
+            assert_eq!(got, vec![2, 3], "post-hop delivery in order, exactly once");
+        });
+    }
+
+    /// Model 9 — two block takers race two distinct full segments.
+    ///
+    /// seg0 and seg1 are both FULL, then two threads call `take_completed_segment`
+    /// concurrently. Each `FULL → DRAINING` CAS succeeds on a different segment, so
+    /// the two takers must come away with seg0 and seg1 — one each, no duplicate, no
+    /// segment skipped. Model 5 proves at-most-once on a *single* contended segment;
+    /// this proves the forward scan hands out *every* takeable segment exactly once
+    /// when takers race across segments.
+    #[test]
+    fn two_takers_distinct_segments() {
+        loom::model(|| {
+            let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
+            // Fill seg0 (0,1) and seg1 (2,3) both to FULL.
+            for i in 0..4u64 {
+                let h = ring.claim();
+                ring.fill(h, i);
+            }
+
+            let ring2 = ring.clone();
+            let t1 = thread::spawn(move || ring2.take_completed_segment().map(|sw| sw.base_seq()));
+            let t2 = thread::spawn(move || ring.take_completed_segment().map(|sw| sw.base_seq()));
+
+            let r1 = t1.join().unwrap();
+            let r2 = t2.join().unwrap();
+
+            // Both segments handed out, one per taker, no duplication. Order between
+            // the two threads is nondeterministic, so compare as a sorted set.
+            let mut bases: Vec<u64> = [r1, r2].into_iter().flatten().collect();
+            bases.sort_unstable();
+            assert_eq!(
+                bases,
+                vec![0, 2],
+                "both full segments handed out exactly once across racing takers"
+            );
         });
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -349,14 +349,6 @@ struct Inner<T> {
     /// In-order delivery cursor. Written only by the consumer, read by the issuer
     /// for reclaim, so it is atomic and padded off the lock's cache line.
     consumed: CachePadded<AtomicU64>,
-    /// Count of parts whose payload memory the consumer has freed, across both
-    /// surfaces: the stream surface frees one per in-order delivery, the block surface
-    /// frees a run's slots per drain (out of order; a segment may be several runs).
-    /// This is resident occupancy's complement — `issued - released` is the read-ahead
-    /// gate's denominator. Distinct from `consumed`, which is the in-order cursor
-    /// reclaim needs; on the stream path the two advance together, on the block path
-    /// only `released` moves.
-    released: CachePadded<AtomicU64>,
     /// Slots per segment for this instance. Fixed at construction; used to size
     /// the initial segment and every grown successor.
     seg_size: usize,
@@ -485,20 +477,27 @@ impl<T> SegmentWrite<T> {
     }
 
     /// Free the run's payloads, advance the segment's `drained_count`, and reclaim
-    /// drained front segments. Idempotent and shared by [`complete`](Self::complete)
-    /// and `Drop`, guarded on the token's `drained` flag so it runs exactly once per
-    /// token.
+    /// drained front segments. Returns the number of payloads freed **by this call**
+    /// (zero on a repeat, since the drain runs at most once per token). Idempotent and
+    /// shared by [`complete`](Self::complete) and `Drop`, guarded on the token's
+    /// `drained` flag.
+    ///
+    /// The freed count is the caller's read-ahead occupancy release: a claimed run is
+    /// entirely filled (`take_drain_run` scans only filled slots), so it equals the run
+    /// length, but counting the payloads actually taken keeps occupancy exact
+    /// regardless. The buffer does not track a running `released` total — it reports the
+    /// per-run count and lets the download layer account for it under its state lock.
     ///
     /// Dropping the payloads here — rather than at segment pop — releases the budget
     /// the bytes hold **eagerly and per-run**, decoupled from the in-order front-pop.
     /// A run written out of order (e.g. a later segment completed while an earlier one
     /// still writes) frees its memory immediately even though its shelf waits its turn
     /// at the front.
-    fn drain(&self) {
-        // Idempotency guard: complete() then drop, or a double drain, is a no-op the
+    fn drain(&self) -> u64 {
+        // Idempotency guard: complete() then drop, or a double drain, frees nothing the
         // second time. AcqRel so the freeing below happens once.
         if self.drained.swap(true, Ordering::AcqRel) {
-            return;
+            return 0;
         }
         let mut freed = 0u64;
         for slot in self.payloads() {
@@ -514,32 +513,33 @@ impl<T> SegmentWrite<T> {
                 }
             });
         }
-        // Release the read-ahead occupancy these parts held. A claimed run is entirely
-        // filled (`take_drain_run` scans only filled slots), so `freed == len`; counting
-        // the payloads actually taken keeps the occupancy exact regardless.
-        self.inner.released.fetch_add(freed, Ordering::AcqRel);
         // Publish this run as drained. `AcqRel` so a reclaimer that reads `== len`
         // (`Acquire`) has seen the payload frees above. Adds `len`, not the freed
         // count, because reclaim gates on every claimed slot being accounted for.
         self.seg.drained_count.fetch_add(self.len, Ordering::AcqRel);
         reclaim_front(&self.inner);
+        freed
     }
 
     /// Finish consuming the run: free its payloads now, advance `drained_count`, and
-    /// reclaim drained front segments. Equivalent to dropping the token, but explicit
-    /// at the call site.
-    pub(crate) fn complete(self) {
-        self.drain();
-        // `self` drops here; Drop sees the guard set and the drain is a no-op.
+    /// reclaim drained front segments. Returns the parts freed (the run length) so the
+    /// caller can release that much read-ahead occupancy. Equivalent to dropping the
+    /// token, but explicit at the call site and it hands back the freed count.
+    pub(crate) fn complete(self) -> u64 {
+        // `drain` runs the payload free + reclaim; `self` then drops here and its Drop
+        // sees the `drained` guard set, so the drop-time drain is a no-op.
+        self.drain()
     }
 }
 
 impl<T> Drop for SegmentWrite<T> {
     /// Safety net: a token dropped without [`complete`](SegmentWrite::complete) —
     /// an aborted or early-returning consumer — still drains, so the run's slots are
-    /// freed and counted toward `drained_count` and cannot stall front-reclaim.
+    /// freed and counted toward `drained_count` and cannot stall front-reclaim. The
+    /// freed count is discarded: a drop-without-complete is the IO-error/abort path,
+    /// where the transfer is heading terminal and read-ahead occupancy no longer gates.
     fn drop(&mut self) {
-        self.drain();
+        let _ = self.drain();
     }
 }
 
@@ -608,7 +608,6 @@ impl<T> PagedRecvBuffer<T> {
                 issued: 0,
             }),
             consumed: CachePadded::new(AtomicU64::new(0)),
-            released: CachePadded::new(AtomicU64::new(0)),
             seg_size,
             drain_batch: AtomicUsize::new(seg_size),
         });
@@ -779,24 +778,15 @@ impl<T> PagedRecvBuffer<T> {
     /// The in-order delivery cursor: the next sequence the consumer will deliver, i.e.
     /// the count of sequences already delivered. Lock-free read of the shared cursor.
     ///
-    /// This is the in-order reclaim threshold, not the read-ahead gate's denominator
-    /// (use [`released`](Self::released) for that): the block surface delivers to disk
-    /// without advancing this cursor.
+    /// This is the in-order reclaim threshold, not the read-ahead gate's denominator:
+    /// the block surface delivers to disk without advancing this cursor. Occupancy
+    /// accounting (`released`) is the caller's concern — the buffer reports parts freed
+    /// via the return value of [`poll_next`](RecvBufferConsumer::poll_next) (one) and
+    /// [`SegmentWrite::complete`](SegmentWrite::complete) (the run length) and does not
+    /// track a running total itself.
     #[cfg(test)]
     pub(crate) fn consumed(&self) -> u64 {
         self.inner.consumed.load(Ordering::Acquire)
-    }
-
-    /// Count of parts whose payload memory the consumer has freed, across both the
-    /// stream and block surfaces. Lock-free.
-    ///
-    /// This is the read-ahead gate's denominator: the issuer bounds resident
-    /// occupancy by `issued − released < window` (the caller tracks `issued`; this
-    /// supplies `released`). Unlike [`consumed`](Self::consumed), it advances on the
-    /// block (disk) surface too, so a download larger than the window keeps issuing as
-    /// segments drain instead of latching shut at the window.
-    pub(crate) fn released(&self) -> u64 {
-        self.inner.released.load(Ordering::Acquire)
     }
 
     // ── Introspection (advisory) ─────────────────────────────────────────────────
@@ -901,10 +891,10 @@ impl<T> RecvBufferConsumer<T> {
         self.current.slots[idx].state.set_empty();
         self.cursor += 1;
         self.inner.consumed.store(self.cursor, Ordering::Release);
-        // This delivery freed one part's payload; release its read-ahead occupancy.
-        // On the stream path `released` tracks `consumed` one-to-one.
-        self.inner.released.fetch_add(1, Ordering::AcqRel);
-
+        // This delivery freed exactly one part's payload. The caller releases that
+        // one part of read-ahead occupancy (under its state lock, ordered against the
+        // issuance gate) — the buffer does not track occupancy itself. A `Some` return
+        // is therefore also the signal "one part freed".
         Some(value)
     }
 }
@@ -1368,38 +1358,33 @@ mod tests {
             seg_size - batch,
             "residue is the sub-batch tail"
         );
-        r1.complete();
+        let freed = r1.complete();
         assert_eq!(
-            ring.released(),
-            seg_size as u64,
-            "every slot drained exactly once"
+            freed,
+            (seg_size - batch) as u64,
+            "residue run frees its tail"
         );
     }
 
-    /// The block surface advances `released` (the read-ahead gate's denominator) by a
-    /// run's filled count on each drain, while `consumed` (the in-order stream cursor)
-    /// never moves — the two counters are distinct on the block path. Two batches arrive
+    /// A block drain reports its run's filled count as `freed` (the read-ahead
+    /// occupancy the caller releases), while `consumed` (the in-order stream cursor)
+    /// never moves — the two are distinct on the block path. Two batches arrive
     /// separately (a drain between them), so the segment is claimed as two runs of 2;
     /// `take_drain_run` takes the whole contiguous filled run available, so batches must
     /// be separated to observe per-run accounting.
     #[test]
-    fn block_drain_advances_released_not_consumed() {
+    fn block_drain_reports_freed_not_consumed() {
         let seg_size = 4;
         let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
         ring.set_drain_batch(2);
         let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
-        assert_eq!(ring.released(), 0);
         assert_eq!(ring.consumed(), 0);
 
         // First batch of 2 arrives and drains as run [0,2).
         ring.fill_at(&handles, 0, 0);
         ring.fill_at(&handles, 1, 10);
-        ring.take_drain_run(false).expect("run [0,2)").complete();
-        assert_eq!(
-            ring.released(),
-            2,
-            "a block drain advances released by the run length"
-        );
+        let freed = ring.take_drain_run(false).expect("run [0,2)").complete();
+        assert_eq!(freed, 2, "a block drain frees the run length");
         assert_eq!(
             ring.consumed(),
             0,
@@ -1409,16 +1394,13 @@ mod tests {
         // Second batch of 2 arrives and drains as run [2,4).
         ring.fill_at(&handles, 2, 20);
         ring.fill_at(&handles, 3, 30);
-        ring.take_drain_run(false).expect("run [2,4)").complete();
-        assert_eq!(
-            ring.released(),
-            4,
-            "released tracks total drained across runs"
-        );
+        let freed = ring.take_drain_run(false).expect("run [2,4)").complete();
+        assert_eq!(freed, 2, "the second run frees its own length");
         assert_eq!(ring.consumed(), 0, "consumed stays put on the block path");
     }
 
-    /// `consumed()` reports the in-order delivery cursor for the read-ahead gate.
+    /// `consumed()` reports the in-order delivery cursor, distinct from occupancy
+    /// accounting (which the caller derives from per-call freed counts).
     #[test]
     fn consumed_tracks_delivery_cursor() {
         let seg_size = 2;
@@ -1468,8 +1450,10 @@ mod tests {
     }
 
     /// A `SegmentWrite` dropped without `complete()` still drains: its run's payloads
-    /// are freed, `released` advances, and the run is counted toward `drained_count` so
-    /// the segment reclaims and reclaim does not stall behind it.
+    /// are freed and the run is counted toward `drained_count` so the segment reclaims
+    /// and reclaim does not stall behind it. (Occupancy accounting is the caller's
+    /// concern via `complete()`'s return value; `Drop` discards the freed count, since a
+    /// drop-without-complete is the abort/error path where the gate no longer matters.)
     #[test]
     fn drop_without_complete_reclaims() {
         use std::sync::atomic::{AtomicUsize, Ordering as O};
@@ -1494,20 +1478,19 @@ mod tests {
         }
         let sw = ring.take_drain_run(false).expect("seg0 full");
         assert_eq!(sw.base_seq(), 0);
-        assert_eq!(ring.released(), 0, "nothing released until the run drains");
+        assert_eq!(
+            drops.load(O::SeqCst),
+            0,
+            "nothing freed until the run drains"
+        );
 
         // Drop WITHOUT complete(): the Drop safety net must free the run's payloads and
-        // advance both `released` (read-ahead occupancy) and `drained_count` (reclaim).
+        // advance `drained_count` so the segment reclaims.
         drop(sw);
         assert_eq!(
             drops.load(O::SeqCst),
             seg_size,
             "drop-without-complete must free every payload in the run"
-        );
-        assert_eq!(
-            ring.released(),
-            seg_size as u64,
-            "drop-without-complete must release the run's occupancy"
         );
 
         // `claim` runs reclaim before it grows, so the drained front pops on the
@@ -1833,19 +1816,25 @@ mod tests {
     fn fill_probe_does_not_underflow_under_concurrent_drain() {
         // Past the diminishing-returns knee for surfacing the race under native
         // scheduling, without the wall-clock cost of the original 2000.
+        use std::sync::atomic::{AtomicU64, Ordering as O};
         for _ in 0..200 {
             let seg_size = 16;
             let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
             ring.set_drain_batch(1);
             let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
             let ring = Arc::new(ring);
+            // Sum every run's freed count across all drainers. The buffer no longer
+            // tracks a running total, so the test accumulates the per-run `freed` the
+            // way the download layer does under its state lock.
+            let freed_total = Arc::new(AtomicU64::new(0));
             std::thread::scope(|s| {
                 for h in handles {
                     let ring = ring.clone();
+                    let freed_total = freed_total.clone();
                     s.spawn(move || {
                         if ring.fill(h, 0) == FillOutcome::DrainReady {
                             while let Some(sw) = ring.take_drain_run(false) {
-                                sw.complete();
+                                freed_total.fetch_add(sw.complete(), O::Relaxed);
                             }
                         }
                     });
@@ -1854,14 +1843,14 @@ mod tests {
             // Terminal sweep mops up any run a filler produced after its own drain
             // scan (the fill/drain interleaving can leave a slot claimed-but-untaken).
             while let Some(sw) = ring.take_drain_run(true) {
-                sw.complete();
+                freed_total.fetch_add(sw.complete(), O::Relaxed);
             }
             // Beyond the underflow (a bare subtraction panics here under overflow-checks),
-            // assert the outcome is correct: every slot drained exactly once, so occupancy
-            // returns to zero. Catches a double-take or a lost run that a panic-only check
-            // would miss.
+            // assert the outcome is correct: every slot drained exactly once, so the freed
+            // counts sum to the segment size. Catches a double-take or a lost run that a
+            // panic-only check would miss.
             assert_eq!(
-                ring.released(),
+                freed_total.load(O::Relaxed),
                 seg_size as u64,
                 "every slot must drain exactly once under concurrent fill+drain"
             );

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -1667,6 +1667,20 @@ mod tests {
                     });
                 }
             });
+            // Terminal sweep mops up any run a filler produced after its own drain
+            // scan (the fill/drain interleaving can leave a slot claimed-but-untaken).
+            while let Some(sw) = ring.take_drain_run(true) {
+                sw.complete();
+            }
+            // Beyond the underflow (a bare subtraction panics here under overflow-checks),
+            // assert the outcome is correct: every slot drained exactly once, so occupancy
+            // returns to zero. Catches a double-take or a lost run that a panic-only check
+            // would miss.
+            assert_eq!(
+                ring.released(),
+                seg_size as u64,
+                "every slot must drain exactly once under concurrent fill+drain"
+            );
         }
     }
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -356,6 +356,14 @@ struct Inner<T> {
     /// In-order delivery cursor. Written only by the consumer, read by the issuer
     /// for reclaim, so it is atomic and padded off the lock's cache line.
     consumed: CachePadded<AtomicU64>,
+    /// Count of parts whose payload memory the consumer has freed, across both
+    /// surfaces: the stream surface frees one per in-order delivery, the block
+    /// surface frees a whole segment's filled slots on drain (out of order). This is
+    /// resident occupancy's complement — `issued - released` is the read-ahead gate's
+    /// denominator. Distinct from `consumed`, which is the in-order cursor reclaim
+    /// needs; on the stream path the two advance together, on the block path only
+    /// `released` moves.
+    released: CachePadded<AtomicU64>,
     /// Slots per segment for this instance. Fixed at construction; used to size
     /// the initial segment and every grown successor.
     seg_size: usize,
@@ -472,6 +480,7 @@ impl<T> SegmentWrite<T> {
         if self.seg.state.is_drained() {
             return;
         }
+        let mut freed = 0u64;
         for slot in self.seg.slots.iter() {
             // SAFETY: winning the FULL → DRAINING CAS made this token the segment's
             // sole accessor, and the two consumption surfaces are mutually exclusive
@@ -479,9 +488,16 @@ impl<T> SegmentWrite<T> {
             // consumer touches these slots. Freeing the payload releases whatever it
             // carries (e.g. a memory reservation).
             slot.data.with_mut(|p| unsafe {
-                *p = None;
+                if (*p).take().is_some() {
+                    freed += 1;
+                }
             });
         }
+        // Release the read-ahead occupancy these parts held. Counts only slots that
+        // actually carried a payload (a partial tail segment has unfilled slots), so
+        // the count is exact. Out of order across segments is fine — it is a count,
+        // not a cursor.
+        self.inner.released.fetch_add(freed, Ordering::AcqRel);
         self.seg.state.set_drained();
         reclaim_front(&self.inner);
     }
@@ -565,6 +581,7 @@ impl<T> PagedRecvBuffer<T> {
                 issued: 0,
             }),
             consumed: CachePadded::new(AtomicU64::new(0)),
+            released: CachePadded::new(AtomicU64::new(0)),
             seg_size,
         });
         let consumer = RecvBufferConsumer {
@@ -693,10 +710,23 @@ impl<T> PagedRecvBuffer<T> {
     /// The in-order delivery cursor: the next sequence the consumer will deliver, i.e.
     /// the count of sequences already delivered. Lock-free read of the shared cursor.
     ///
-    /// For a producer-side read-ahead gate: the issuer bounds outstanding work by
-    /// `issued − consumed < W` (the caller tracks `issued`; this supplies `consumed`).
+    /// This is the in-order reclaim threshold, not the read-ahead gate's denominator
+    /// (use [`released`](Self::released) for that): the block surface delivers to disk
+    /// without advancing this cursor.
     pub(crate) fn consumed(&self) -> u64 {
         self.inner.consumed.load(Ordering::Acquire)
+    }
+
+    /// Count of parts whose payload memory the consumer has freed, across both the
+    /// stream and block surfaces. Lock-free.
+    ///
+    /// This is the read-ahead gate's denominator: the issuer bounds resident
+    /// occupancy by `issued − released < W` (the caller tracks `issued`; this
+    /// supplies `released`). Unlike [`consumed`](Self::consumed), it advances on the
+    /// block (disk) surface too, so a download larger than `W` keeps issuing as
+    /// segments drain instead of latching shut at the window.
+    pub(crate) fn released(&self) -> u64 {
+        self.inner.released.load(Ordering::Acquire)
     }
 
     // ── Introspection (advisory) ─────────────────────────────────────────────────
@@ -797,6 +827,9 @@ impl<T> RecvBufferConsumer<T> {
         self.current.slots[idx].state.set_empty();
         self.cursor += 1;
         self.inner.consumed.store(self.cursor, Ordering::Release);
+        // This delivery freed one part's payload; release its read-ahead occupancy.
+        // On the stream path `released` tracks `consumed` one-to-one.
+        self.inner.released.fetch_add(1, Ordering::AcqRel);
 
         Some(value)
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -26,8 +26,7 @@
 //!   │  │  seg 0  │─nx─▶│  seg 1  │─nx─▶│  seg 2  │          │
 //!   │  │ F F . . │     │ F F F F │     │ F . _ _ │          │
 //!   │  │ 0 1 2 3 │     │ 4 5 6 7 │     │ 8 9     │          │
-//!   │  │ base=0  │     │ base=4  │     │ base=8  │          │
-//!   │  │ [DRAIND]│     │ [FULL]  │     │ [OPEN]  │ issued=9 │
+//!   │  │ base=0  │     │ base=4  │     │ base=8  │ issued=9 │
 //!   │  └─────────┘     └────▲────┘     └─▲───────┘          │
 //!   └───────────────────────┼───────────┼──────────────────┘
 //!     consumed=6            cursor=5    fill (producers, any order, lock-free)
@@ -45,12 +44,20 @@
 //! growth. The only intrusive link is one `next` pointer per segment, by which the
 //! consumer reaches the successor segment without taking the lock.
 //!
+//! The stream surface (drawn above) tracks delivery with `consumed`. The block surface
+//! instead tracks two per-segment counters: `claim_cursor`, the number of leading
+//! slots claimed for draining, and `drained_count`, the number written and freed. A
+//! segment is reclaimable when either surface has finished it — `base + len <=
+//! consumed` for the stream, or `drained_count == len` for the block.
+//!
 //! # Locking
 //!
 //! One `Mutex` guards the segment deque and the `issued` counter. Only the issuer
-//! paths take it — `claim` (assign a sequence, maybe grow, opportunistic reclaim),
-//! `take_completed_segment` (find a full segment), and `complete`/drop reclaim. The
-//! two hot paths are lock-free: `fill` writes a claimed slot and publishes it with a
+//! and block paths take it — `claim` (assign a sequence, maybe grow, opportunistic
+//! reclaim), `take_drain_run` (scan a contiguous filled run and claim it by advancing
+//! `claim_cursor`), and `complete`/drop reclaim. Each is a short critical section: a
+//! cursor scan or a `pop_front` loop, never held across the disk write itself. The two
+//! hot paths are lock-free: `fill` writes a claimed slot and publishes it with a
 //! `Release` store; `poll_next` reads the cursor slot under `Acquire` and hops
 //! segments via the `next` pointer. The delivery cursor lives in `RecvBufferConsumer` and
 //! is mirrored to an atomic `consumed` so the issuer's reclaim can read it without
@@ -79,14 +86,15 @@
 //!   Taking `&mut self`, on a non-cloneable handle, makes "single consumer" a
 //!   type-level fact and lets the cursor and current-segment cache live in the
 //!   handle (so the hop needs no lock).
-//! - **block** (`PagedRecvBuffer`) — [`take_completed_segment`](PagedRecvBuffer::take_completed_segment)
-//!   hands out a whole `FULL` segment as an owned [`SegmentWrite`], for bulk
-//!   consumption that does not need in-order single-item delivery. Segments may be
-//!   taken and completed out of order and concurrently.
+//! - **block** (`PagedRecvBuffer`) — [`take_drain_run`](PagedRecvBuffer::take_drain_run)
+//!   hands out a contiguous filled *run* (a prefix of a segment, of at least the drain
+//!   batch) as an owned [`SegmentWrite`], for bulk consumption that does not need
+//!   in-order single-item delivery. Runs may be taken and completed out of order and
+//!   concurrently, and a single segment may be partitioned into several runs.
 //!
 //! An instance is driven through one consumption surface or the other, never both:
-//! the stream cursor empties slots as it passes; the block surface consumes whole
-//! segments. A block-only caller drops the `RecvBufferConsumer`. **This exclusion is a
+//! the stream cursor empties slots as it passes; the block surface reads runs in place
+//! and frees them. A block-only caller drops the `RecvBufferConsumer`. **This exclusion is a
 //! caller obligation, not type-enforced** — `PagedRecvBuffer` is `Clone` and exposes the
 //! block surface, so the type system does not prevent driving both at once. Doing so
 //! races the stream `take` against the block in-place read and is undefined; the
@@ -100,20 +108,40 @@
 //!
 //! `FILLED` is published with a `Release` store after the payload write; a reader
 //! observes it with an `Acquire` load before reading the payload. The block
-//! surface leaves slots `FILLED` and reclaims at segment granularity.
+//! surface leaves slots `FILLED` and frees them at run granularity.
 //!
-//! # Segment states
+//! # Segment progress (block surface)
+//!
+//! A segment carries three monotonic counts rather than a single state flag:
 //!
 //! ```text
-//!   OPEN ──last slot filled──▶ FULL ──taken──▶ DRAINING ──complete──▶ DRAINED
+//!   filled_count   slots a producer has filled (any positions)   — lock-free
+//!   claim_cursor   leading slots claimed for draining            — under the lock
+//!   drained_count  slots written to the sink and freed           — lock-free add
+//!
+//!   claim_cursor <= len, drained_count <= len
+//!   drained_count == len  ⇒  segment reclaimable
 //! ```
 //!
-//! The fill that fills a segment's last slot *seals* it: `OPEN → FULL`. Sealing is
-//! by a count (`filled_count`), not a high-water index, so out-of-order fills reach
-//! `FULL` correctly. The block surface claims `FULL → DRAINING` once (so a segment
-//! is handed out at most once) and `DRAINING → DRAINED` on completion, after which
-//! the segment is reclaimable. The stream surface ignores these states and reclaims
-//! by cursor position.
+//! `claim_cursor` and `filled_count` are *not* mutually ordered. A drainer claims a run
+//! by scanning per-slot `FILLED` state, not by reading `filled_count`, and a producer
+//! publishes a slot `FILLED` before bumping `filled_count` (the bump is a probe input,
+//! not the source of truth). So a drainer can advance `claim_cursor` past a slot whose
+//! `filled_count` increment a concurrent producer has not yet performed: from that
+//! producer's view, `claim_cursor > filled_count` transiently. Both are bounded by
+//! `len`, and the per-slot `FILLED` state — not their relative order — is what gates a
+//! safe read. The fill probe's `filled - claim_cursor` is therefore a saturating
+//! subtraction, never a bare one.
+//!
+//! A *drainable run* is the contiguous `FILLED` slice between `claim_cursor` and the
+//! first unfilled slot. [`take_drain_run`](PagedRecvBuffer::take_drain_run) claims such
+//! a run by advancing `claim_cursor` under the lock — so a run is handed out at most
+//! once, and a segment may be partitioned into several runs claimed by different
+//! drainers. A non-terminal claim waits until the run spans the drain batch; a terminal
+//! claim takes whatever contiguous prefix is filled. Completing a run frees its
+//! payloads and advances `drained_count`; when that reaches the segment length every
+//! claimed slot has been written, and the segment is reclaimable. The stream surface
+//! ignores these counts and reclaims by `consumed`.
 //!
 //! # Memory ordering and safety
 //!
@@ -140,8 +168,17 @@
 //!    only; emptying a *slot's* payload (delivery, or future demand reclaim) leaves
 //!    the segment in place and does not bear on the hop.
 //! 5. **Outstanding block pin.** A live [`SegmentWrite`] holds an
-//!    `Arc<Segment<T>>`, so a segment being consumed by the block surface cannot
-//!    be reclaimed until that token completes.
+//!    `Arc<Segment<T>>`, so a segment with a run still being consumed by the block
+//!    surface stays alive until that token drains, even if front-reclaim pops it from
+//!    the deque first.
+//! 6. **Drain claim and reclaim handoff.** `claim_cursor` is advanced only under the
+//!    deque lock, so a run is claimed at most once and concurrent drainers take
+//!    disjoint runs; the fill probe's lock-free `Acquire` read of it is advisory only.
+//!    `drained_count` is advanced with `AcqRel` after a run's payloads are freed and
+//!    read with `Acquire` by front-reclaim, so a reclaimer observing `drained_count ==
+//!    len` has seen those frees. The per-slot `is_filled` `Acquire` (rule 2) is what
+//!    makes a claimed run's payloads safe to read; the lock orders drainers against
+//!    each other and against grow/reclaim, not against the lock-free fills.
 //!
 //! # Caller obligations
 //!
@@ -152,7 +189,9 @@
 use crossbeam_utils::CachePadded;
 
 use crate::runtime::sync::cell::UnsafeCell;
-use crate::runtime::sync::sync::atomic::{AtomicPtr, AtomicU64, AtomicU8, AtomicUsize, Ordering};
+use crate::runtime::sync::sync::atomic::{
+    AtomicBool, AtomicPtr, AtomicU64, AtomicU8, AtomicUsize, Ordering,
+};
 use crate::runtime::sync::sync::{Arc, Mutex};
 
 /// Default slots per segment for [`PagedRecvBuffer::new`].
@@ -197,67 +236,6 @@ impl SlotState {
     /// Mark the slot empty after its payload has been taken.
     fn set_empty(&self) {
         self.0.store(SLOT_EMPTY, Ordering::Release);
-    }
-}
-
-/// Segment open: accepting fills; not all slots filled yet.
-const SEG_OPEN: u8 = 0;
-/// Segment full: every slot filled, eligible to be taken by the block surface.
-const SEG_FULL: u8 = 1;
-/// Segment draining: claimed by a block consumer, pinned by a live [`SegmentWrite`],
-/// not yet reclaimable.
-const SEG_DRAINING: u8 = 2;
-/// Segment drained: block consumption complete, payloads freed, reclaimable.
-const SEG_DRAINED: u8 = 3;
-
-/// Segment lifecycle over an `AtomicU8`. The `FULL → DRAINING` transition is a CAS
-/// so a full segment is handed to the block surface at most once.
-struct SegState(AtomicU8);
-
-impl SegState {
-    fn new() -> Self {
-        Self(AtomicU8::new(SEG_OPEN))
-    }
-
-    /// Mark the segment full when its last slot fills: `OPEN → FULL` (`Release`).
-    fn set_full(&self) {
-        self.0.store(SEG_FULL, Ordering::Release);
-    }
-
-    /// Claim a full segment for block consumption exactly once: `FULL → DRAINING`.
-    /// Returns `true` for the single caller that wins the CAS.
-    fn try_claim_for_drain(&self) -> bool {
-        self.0
-            .compare_exchange(SEG_FULL, SEG_DRAINING, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
-    }
-
-    /// Terminal-only: claim a segment for draining regardless of whether it is full,
-    /// `{OPEN | FULL} → DRAINING`, exactly once. For [`PagedRecvBuffer::take_tail`],
-    /// which drains the partial final segment at end-of-stream. Returns `true` for the
-    /// single caller that wins. Already-`DRAINING`/`DRAINED` segments are skipped.
-    fn try_claim_for_drain_partial(&self) -> bool {
-        // Try the full→draining edge first, then the open→draining edge. Whichever the
-        // segment currently sits at, exactly one of these CASes can succeed (the other
-        // observes a state that is no longer OPEN/FULL). Safe only at end-of-stream,
-        // when no producer will fill this segment further (caller obligation).
-        self.0
-            .compare_exchange(SEG_FULL, SEG_DRAINING, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
-            || self
-                .0
-                .compare_exchange(SEG_OPEN, SEG_DRAINING, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
-    }
-
-    /// Mark consumption complete: `DRAINING → DRAINED` (`Release`).
-    fn set_drained(&self) {
-        self.0.store(SEG_DRAINED, Ordering::Release);
-    }
-
-    /// Whether the segment has been fully drained (`Acquire`).
-    fn is_drained(&self) -> bool {
-        self.0.load(Ordering::Acquire) == SEG_DRAINED
     }
 }
 
@@ -312,11 +290,19 @@ struct Segment<T> {
     /// consumer may reconstruct an `Arc` from this pointer.
     next: AtomicPtr<Segment<T>>,
     /// Number of filled slots. Contended across this segment's producers, hence
-    /// padded off the header's read-mostly fields. The fill that brings it to
-    /// `slots.len()` seals the segment (`OPEN → FULL`).
+    /// padded off the header's read-mostly fields. The fill probe compares it against
+    /// `claim_cursor` and the drain batch to raise the [`FillOutcome::DrainReady`] edge.
     filled_count: CachePadded<AtomicUsize>,
-    /// Block-surface lifecycle: `OPEN → FULL → DRAINING → DRAINED`.
-    state: SegState,
+    /// Number of leading slots claimed for draining by the block surface, contiguous
+    /// from slot 0. Advanced only under the deque lock (in `take_drain_run`), so the
+    /// claim of a run is exclusive; read lock-free by the fill probe as an advisory
+    /// lower bound. Not contended (single writer under the lock), so unpadded.
+    claim_cursor: AtomicUsize,
+    /// Number of slots whose payload the block surface has written and freed. Reaches
+    /// `slots.len()` once every claimed run has completed, at which point the segment
+    /// is reclaimable. Written `AcqRel` by a draining [`SegmentWrite`]; read `Acquire`
+    /// by front-reclaim, so a reclaimer observing `== len` has seen the freed payloads.
+    drained_count: AtomicUsize,
 }
 
 impl<T> Segment<T> {
@@ -330,7 +316,8 @@ impl<T> Segment<T> {
             slots,
             next: AtomicPtr::new(std::ptr::null_mut()),
             filled_count: CachePadded::new(AtomicUsize::new(0)),
-            state: SegState::new(),
+            claim_cursor: AtomicUsize::new(0),
+            drained_count: AtomicUsize::new(0),
         }
     }
 
@@ -367,6 +354,14 @@ struct Inner<T> {
     /// Slots per segment for this instance. Fixed at construction; used to size
     /// the initial segment and every grown successor.
     seg_size: usize,
+    /// Drain batch, in slots: the minimum contiguous filled run the block surface
+    /// coalesces into one drain, and the threshold the fill probe raises
+    /// [`FillOutcome::DrainReady`] at. Defaults to `seg_size` (drain whole segments);
+    /// lowered toward 1 (drain on arrival) when the caller's resident-occupancy bound
+    /// is smaller than a segment, so the block surface never waits for a run it cannot
+    /// accumulate. Read lock-free by the fill probe (`Relaxed`) and under the lock by
+    /// `take_drain_run`.
+    drain_batch: AtomicUsize,
 }
 
 /// Producer + block handle to an in-order delivery buffer. Cloneable; share across
@@ -417,76 +412,94 @@ impl<T> SlotHandle<T> {
 
 /// The result of a [`fill`](PagedRecvBuffer::fill).
 ///
-/// `SealedSegment` is an edge signal: this fill was the one that filled a segment's
-/// last slot, so a block-surface consumer should drain via
-/// [`take_completed_segment`](PagedRecvBuffer::take_completed_segment). It carries no
-/// sequence — the consumer locates the full segment itself — so the only
-/// information is *that* a segment became drainable, not which. A stream-surface
-/// consumer ignores the outcome entirely.
+/// `DrainReady` is an advisory edge signal: after this fill, the count of filled
+/// slots in the segment reached the drain batch ahead of the slots already claimed
+/// for draining, so a block-surface consumer should attempt a drain via
+/// [`take_drain_run`](PagedRecvBuffer::take_drain_run). It carries no sequence and is
+/// not authoritative — the filled slots may not form a contiguous run yet (an earlier
+/// slot in the batch is still in flight), in which case `take_drain_run` claims
+/// nothing and the fill that later closes the gap re-raises the edge. The
+/// authoritative check is `take_drain_run` under the lock. A stream-surface consumer
+/// ignores the outcome entirely.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum FillOutcome {
-    /// Payload stored; this fill did not fill a segment's last slot.
+    /// Payload stored; the filled count has not reached the drain batch beyond what is
+    /// already claimed for draining.
     Stored,
-    /// This fill filled a segment's last slot; a block consumer should drain.
-    SealedSegment,
+    /// Payload stored and the filled count reached the drain batch; a block consumer
+    /// should attempt [`take_drain_run`](PagedRecvBuffer::take_drain_run).
+    DrainReady,
 }
 
-/// An owned token granting consumption of one `FULL` segment's payloads.
+/// An owned token granting consumption of one claimed run of a segment's payloads.
 ///
-/// Holds an `Arc<Segment<T>>`, pinning the segment until [`complete`](Self::complete),
-/// and a strong `Arc<Inner<T>>` so completion can free memory and reclaim the
-/// shelf independent of issuance. It is owned rather than borrowed so it can outlive
-/// the call that produced it: a synchronous consumer completes it immediately, an
+/// A run is the contiguous slice `[start, start + len)` of a segment's slots, claimed
+/// by [`take_drain_run`](PagedRecvBuffer::take_drain_run). The token holds an
+/// `Arc<Segment<T>>`, pinning the segment until [`complete`](Self::complete), and a
+/// strong `Arc<Inner<T>>` so completion can free memory and reclaim the shelf
+/// independent of issuance. It is owned rather than borrowed so it can outlive the
+/// call that produced it: a synchronous consumer completes it immediately, an
 /// asynchronous one parks it and completes it on a later event.
 ///
 /// The strong ring reference keeps the buffer accounting alive for exactly the
 /// outstanding-write window — the correct lifetime, since a write may be reading a
-/// segment's bytes when every other handle has dropped. It is bounded (released at
+/// run's bytes when every other handle has dropped. It is bounded (released at
 /// `complete` or drop) and forms no cycle (segments do not point back at `Inner`).
 ///
 /// Dropping the token without calling [`complete`](Self::complete) is safe: `Drop`
-/// runs the same drain, so an aborted or short-circuited consumer cannot wedge
-/// reclaim by leaving the segment stuck `DRAINING`.
-#[must_use = "a taken segment must be completed (or dropped) to free its payloads and unblock reclaim"]
+/// runs the same drain, so an aborted or short-circuited consumer still frees the
+/// run's payloads and advances `drained_count`, and cannot stall front-reclaim by
+/// leaving the run's slots accounted-for-but-unfreed.
+#[must_use = "a claimed run must be completed (or dropped) to free its payloads and unblock reclaim"]
 pub(crate) struct SegmentWrite<T> {
     seg: Arc<Segment<T>>,
     inner: Arc<Inner<T>>,
+    /// First slot of the claimed run within `seg.slots`.
+    start: usize,
+    /// Number of slots in the claimed run.
+    len: usize,
+    /// Exactly-once guard for [`drain`](Self::drain), shared by `complete` and `Drop`.
+    /// Per-token (not per-segment): a segment may have several outstanding runs, each
+    /// of which must free its own slots exactly once.
+    drained: AtomicBool,
 }
 
 impl<T> SegmentWrite<T> {
-    /// Sequence number of the segment's first slot.
+    /// Sequence number of the run's first slot.
     pub(crate) fn base_seq(&self) -> u64 {
-        self.seg.base
+        self.seg.base + self.start as u64
     }
 
-    /// The segment's payloads in sequence order, all `FILLED`. Borrowed for the
-    /// duration of consumption; payloads are read in place, never moved out.
+    /// The run's payloads in sequence order, all `FILLED`. Borrowed for the duration
+    /// of consumption; payloads are read in place, never moved out.
     pub(crate) fn payloads(&self) -> &[Slot<T>] {
-        &self.seg.slots
+        &self.seg.slots[self.start..self.start + self.len]
     }
 
-    /// Free the segment's payloads, mark it `DRAINED`, and reclaim drained front
-    /// segments. Idempotent and shared by [`complete`](Self::complete) and `Drop`,
-    /// guarded on the `DRAINED` state so it runs exactly once per token.
+    /// Free the run's payloads, advance the segment's `drained_count`, and reclaim
+    /// drained front segments. Idempotent and shared by [`complete`](Self::complete)
+    /// and `Drop`, guarded on the token's `drained` flag so it runs exactly once per
+    /// token.
     ///
     /// Dropping the payloads here — rather than at segment pop — releases the budget
-    /// the bytes hold **eagerly and per-segment**, decoupled from the in-order
-    /// front-pop. A segment written out of order (e.g. seg 2 done while seg 0 still
-    /// writes) frees its memory immediately even though its empty shelf waits its
-    /// turn at the front.
+    /// the bytes hold **eagerly and per-run**, decoupled from the in-order front-pop.
+    /// A run written out of order (e.g. a later segment completed while an earlier one
+    /// still writes) frees its memory immediately even though its shelf waits its turn
+    /// at the front.
     fn drain(&self) {
         // Idempotency guard: complete() then drop, or a double drain, is a no-op the
-        // second time. Acquire pairs with the set_drained Release below.
-        if self.seg.state.is_drained() {
+        // second time. AcqRel so the freeing below happens once.
+        if self.drained.swap(true, Ordering::AcqRel) {
             return;
         }
         let mut freed = 0u64;
-        for slot in self.seg.slots.iter() {
-            // SAFETY: winning the FULL → DRAINING CAS made this token the segment's
-            // sole accessor, and the two consumption surfaces are mutually exclusive
-            // per instance (ordering rule 5, plus the surface contract), so no stream
-            // consumer touches these slots. Freeing the payload releases whatever it
-            // carries (e.g. a memory reservation).
+        for slot in self.payloads() {
+            // SAFETY: advancing `claim_cursor` under the lock in `take_drain_run` made
+            // this token the sole accessor of `[start, start + len)`, and the two
+            // consumption surfaces are mutually exclusive per instance (ordering rule
+            // 5, plus the surface contract), so no other drainer or stream consumer
+            // touches these slots. Freeing the payload releases whatever it carries
+            // (e.g. a memory reservation).
             slot.data.with_mut(|p| unsafe {
                 if (*p).take().is_some() {
                     freed += 1;
@@ -494,40 +507,45 @@ impl<T> SegmentWrite<T> {
             });
         }
         // Release the read-ahead occupancy these parts held. Counts only slots that
-        // actually carried a payload (a partial tail segment has unfilled slots), so
-        // the count is exact. Out of order across segments is fine — it is a count,
-        // not a cursor.
+        // actually carried a payload (a terminal run may include unfilled trailing
+        // slots if claimed loosely), so the count is exact.
         self.inner.released.fetch_add(freed, Ordering::AcqRel);
-        self.seg.state.set_drained();
+        // Publish this run as drained. `AcqRel` so a reclaimer that reads `== len`
+        // (`Acquire`) has seen the payload frees above. Adds `len`, not the freed
+        // count, because reclaim gates on every claimed slot being accounted for.
+        self.seg.drained_count.fetch_add(self.len, Ordering::AcqRel);
         reclaim_front(&self.inner);
     }
 
-    /// Finish consuming the segment: free its payloads now, mark it drained, and
-    /// reclaim drained front segments. Equivalent to dropping the token, but
-    /// explicit at the call site.
+    /// Finish consuming the run: free its payloads now, advance `drained_count`, and
+    /// reclaim drained front segments. Equivalent to dropping the token, but explicit
+    /// at the call site.
     pub(crate) fn complete(self) {
         self.drain();
-        // `self` drops here; Drop sees DRAINED and the drain is a no-op.
+        // `self` drops here; Drop sees the guard set and the drain is a no-op.
     }
 }
 
 impl<T> Drop for SegmentWrite<T> {
     /// Safety net: a token dropped without [`complete`](SegmentWrite::complete) —
-    /// an aborted or early-returning consumer — still drains, so the segment cannot
-    /// linger in `DRAINING` and stall front-reclaim behind it.
+    /// an aborted or early-returning consumer — still drains, so the run's slots are
+    /// freed and counted toward `drained_count` and cannot stall front-reclaim.
     fn drop(&mut self) {
         self.drain();
     }
 }
 
-/// Pop reclaimable segments from the front of the deque. A segment is
-/// reclaimable if fully consumed (`base + len <= consumed`) or drained
-/// by the block surface. Never pops the last segment so the deque is never empty.
+/// Pop reclaimable segments from the front of the deque. A segment is reclaimable if
+/// fully consumed by the stream surface (`base + len <= consumed`) or fully drained by
+/// the block surface (every claimed slot written and freed, `drained_count == len`).
+/// Never pops the last segment so the deque is never empty.
 fn reclaim_locked<T>(guard: &mut Locked<T>, consumed: u64) {
     while guard.segments.len() > 1 {
         let front = guard.segments.front().unwrap();
         let fully_consumed = front.base + front.len() <= consumed;
-        let drained = front.state.is_drained();
+        // `Acquire` pairs with the draining token's `AcqRel` add: observing the full
+        // count here means the freed payloads are visible.
+        let drained = front.drained_count.load(Ordering::Acquire) == front.slots.len();
         if fully_consumed || drained {
             guard.segments.pop_front();
         } else {
@@ -583,6 +601,7 @@ impl<T> PagedRecvBuffer<T> {
             consumed: CachePadded::new(AtomicU64::new(0)),
             released: CachePadded::new(AtomicU64::new(0)),
             seg_size,
+            drain_batch: AtomicUsize::new(seg_size),
         });
         let consumer = RecvBufferConsumer {
             inner: inner.clone(),
@@ -633,8 +652,9 @@ impl<T> PagedRecvBuffer<T> {
 
     /// Publish a payload into its claimed slot, consuming the handle. Lock-free:
     /// writes the slot's `data`, publishes filled via [`SlotState::publish_filled`],
-    /// increments the segment's `filled_count`. Returns [`FillOutcome::SealedSegment`]
-    /// when this fill brings the count to the segment's slot count.
+    /// increments the segment's `filled_count`. Returns [`FillOutcome::DrainReady`]
+    /// when the filled count reaches the drain batch beyond the slots already claimed
+    /// for draining.
     pub(crate) fn fill(&self, handle: SlotHandle<T>, value: T) -> FillOutcome {
         let SlotHandle { seg, idx, .. } = handle;
         // Sole writer for this sequence number.
@@ -642,65 +662,104 @@ impl<T> PagedRecvBuffer<T> {
             *p = Some(value);
         });
         seg.slots[idx].state.publish_filled();
-        let prev = seg.filled_count.fetch_add(1, Ordering::AcqRel);
-        if prev + 1 == seg.slots.len() {
-            // The sealing fill (the one that brought the count to full) sets FULL.
-            // `set_full` (Release) is not ordered with a concurrent
-            // `take_completed_segment`, which reads `state` under the lock this path
-            // does not take: a taker racing the seal may observe the segment still
-            // OPEN and skip it. That is safe, not a lost segment — the sealing thread
-            // returns `SealedSegment`, and its caller drains via `drain_sealed`, which
-            // re-scans and finds the now-FULL segment. Per-slot payload visibility is
-            // independent, carried by the publish_filled/is_filled pair above.
-            seg.state.set_full();
-            FillOutcome::SealedSegment
+        let filled = seg.filled_count.fetch_add(1, Ordering::AcqRel) + 1;
+
+        // Advisory drain probe. Both inputs race a concurrent `take_drain_run` (which
+        // advances `claim_cursor` under the lock) and the other producers' fills, so the
+        // result is only a hint to attempt a drain. `claim_cursor` is read lock-free and
+        // may either lag the cursor (under-read) or run ahead of *this* fill's local
+        // `filled` snapshot — another producer's later fill can let a drainer claim a run
+        // past this thread's count, so `claimed > filled` is reachable; the run length is
+        // therefore `saturating_sub`, never a bare subtraction. The probe can over-signal
+        // — `filled` counts slots anywhere in the segment, but `take_drain_run` claims
+        // only a contiguous run from the cursor, so a gap (an earlier slot still in
+        // flight) yields nothing until the fill that closes it raises the edge again. It
+        // cannot under-signal a drainable run: the fill that makes a run of `batch`
+        // contiguous brings `filled` to at least `claimed + batch`. Authority rests
+        // entirely with `take_drain_run`.
+        //
+        // The second term (`filled == len`) handles the segment's final residue. When
+        // the drain batch does not divide the segment size, the slots past the last
+        // batch-aligned boundary form a run shorter than the batch; no further fill can
+        // extend it (the segment is full), so the batch edge would never fire for it
+        // and it would wait for terminal drain — pinning occupancy and wedging a window
+        // smaller than a segment. The fill that completes the segment raises the edge so
+        // that residue drains. It is the only fill that observes `filled == len`.
+        let claimed = seg.claim_cursor.load(Ordering::Acquire);
+        let batch = self.inner.drain_batch.load(Ordering::Relaxed);
+        if filled == seg.slots.len() || filled.saturating_sub(claimed) >= batch {
+            FillOutcome::DrainReady
         } else {
             FillOutcome::Stored
         }
     }
 
-    // ── Block surface (out-of-order, segment-granular) ───────────────────────────
-
-    /// Hand out the frontmost full, not-yet-taken segment exactly once as an owned
-    /// [`SegmentWrite`] (claimed `FULL → DRAINING` via
-    /// [`SegState::try_claim_for_drain`]), or `None` if no segment is full. Segments
-    /// may be outstanding concurrently.
-    pub(crate) fn take_completed_segment(&self) -> Option<SegmentWrite<T>> {
-        let guard = self.inner.locked.lock();
-        for seg in guard.segments.iter() {
-            if seg.state.try_claim_for_drain() {
-                return Some(SegmentWrite {
-                    seg: seg.clone(),
-                    inner: self.inner.clone(),
-                });
-            }
-        }
-        None
+    /// Set the drain batch, in slots, clamped to at least 1. The block surface
+    /// coalesces a contiguous filled run of at least this many slots into one drain,
+    /// and the fill probe raises [`FillOutcome::DrainReady`] at this threshold. A value
+    /// of 1 drains each slot as it arrives; the default is the segment size (drain
+    /// whole segments). Lock-free; the next fill probe and `take_drain_run` observe it.
+    pub(crate) fn set_drain_batch(&self, batch: usize) {
+        self.inner
+            .drain_batch
+            .store(batch.max(1), Ordering::Relaxed);
     }
 
-    /// Terminal-only: hand out the frontmost not-yet-drained segment as an owned
-    /// [`SegmentWrite`] *regardless of whether it is full* (claimed `{OPEN | FULL} →
-    /// DRAINING` via [`SegState::try_claim_for_drain_partial`]), or `None` when every
-    /// segment is already draining/drained.
+    // ── Block surface (out-of-order, segment-granular) ───────────────────────────
+
+    /// Claim the frontmost drainable run as an owned [`SegmentWrite`], or `None`.
     ///
-    /// This drains the **partial final segment** at end-of-stream — the block surface's
-    /// [`take_completed_segment`](Self::take_completed_segment) only yields *full*
-    /// segments, so the last segment of a stream whose length is not a multiple of the
-    /// segment size would otherwise never be handed out. Looping `take_tail` drains that
-    /// tail plus any straggler full segments.
+    /// Walks segments front to back under the lock. For each segment, scans the
+    /// contiguous `FILLED` run beyond its `claim_cursor`. A non-terminal call claims
+    /// that run only if it spans at least the drain batch, and then claims the whole
+    /// run (coalescing greedily, bounded by the segment). A terminal call claims
+    /// whatever contiguous filled run exists, however short — this is what drains the
+    /// partial final segment at end-of-stream, which a non-terminal call would leave
+    /// below the batch forever. The run is `[claim_cursor, claim_cursor + len)`.
     ///
-    /// # Caller obligation
-    /// Call only once issuance is complete and all outstanding fills have landed: a
-    /// partial segment claimed here must not receive further fills (a concurrent fill
-    /// would race the consumer reading the segment's slots). The consumer reads only
-    /// the `FILLED` slots (via [`Slot::get`]); unfilled slots are skipped.
-    pub(crate) fn take_tail(&self) -> Option<SegmentWrite<T>> {
+    /// Advancing `claim_cursor` under the lock makes a run claimed at most once: a
+    /// second caller, racing or sequential, observes the advanced cursor and scans
+    /// beyond it, so concurrent drainers partition a segment into disjoint runs. The
+    /// per-slot `is_filled` check is an `Acquire` load pairing with the producer's
+    /// `publish_filled` `Release` — the same handoff [`poll_next`](RecvBufferConsumer::poll_next)
+    /// relies on — so the claimed run's payloads are safe to read.
+    ///
+    /// # Terminal caller obligation
+    /// Pass `terminal` only once issuance is complete and all outstanding fills have
+    /// landed: a slot claimed here must not receive a later fill (it would race the
+    /// block consumer reading the run). Unfilled trailing slots are simply not claimed.
+    pub(crate) fn take_drain_run(&self, terminal: bool) -> Option<SegmentWrite<T>> {
         let guard = self.inner.locked.lock();
+        let batch = self.inner.drain_batch.load(Ordering::Relaxed);
         for seg in guard.segments.iter() {
-            if seg.state.try_claim_for_drain_partial() {
+            let start = seg.claim_cursor.load(Ordering::Relaxed);
+            // Scan the contiguous filled run beyond what is already claimed.
+            let mut end = start;
+            while end < seg.slots.len() && seg.slots[end].state.is_filled() {
+                end += 1;
+            }
+            let avail = end - start;
+            // A non-terminal claim takes the run when it reaches the batch, or when it
+            // reaches the end of a full segment (no further fill can extend it, so a
+            // sub-batch residue at the segment tail must still drain — otherwise a
+            // window smaller than a segment would pin that residue forever). A terminal
+            // claim takes whatever contiguous filled prefix exists.
+            let at_segment_end = end == seg.slots.len();
+            let take = if terminal || avail >= batch || (avail > 0 && at_segment_end) {
+                avail
+            } else {
+                0
+            };
+            if take > 0 {
+                // Claim the run under the lock: the next scanner sees the advanced
+                // cursor and cannot re-claim these slots.
+                seg.claim_cursor.store(start + take, Ordering::Relaxed);
                 return Some(SegmentWrite {
                     seg: seg.clone(),
                     inner: self.inner.clone(),
+                    start,
+                    len: take,
+                    drained: AtomicBool::new(false),
                 });
             }
         }
@@ -935,10 +994,7 @@ impl<T> PagedRecvBuffer<T> {
             *p = Some(value);
         });
         seg.slots[idx].state.publish_filled();
-        let prev = seg.filled_count.fetch_add(1, Ordering::AcqRel);
-        if prev + 1 == seg.slots.len() {
-            seg.state.set_full();
-        }
+        seg.filled_count.fetch_add(1, Ordering::AcqRel);
     }
 }
 
@@ -1029,8 +1085,11 @@ mod tests {
         assert_eq!(consumer.poll_next(), None);
     }
 
+    /// With the default batch (the segment size) the probe raises `DrainReady` exactly
+    /// on the fill that completes the segment — the same edge the prior full-segment
+    /// seal produced.
     #[test]
-    fn fill_outcome_sealed_on_last_fill() {
+    fn fill_outcome_drain_ready_on_last_fill() {
         let seg_size = 8;
         let (ring, _consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
         let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
@@ -1041,13 +1100,15 @@ mod tests {
             } else {
                 assert_eq!(
                     outcome,
-                    FillOutcome::SealedSegment,
-                    "expected SealedSegment on last fill"
+                    FillOutcome::DrainReady,
+                    "expected DrainReady on the segment-completing fill"
                 );
             }
         }
     }
 
+    /// At the default batch (the segment size), `take_drain_run(false)` yields a whole
+    /// segment as one run, exactly once, and the next segment after completion.
     #[test]
     fn block_path_take_and_complete() {
         let seg_size = 4;
@@ -1058,14 +1119,15 @@ mod tests {
             ring.fill(h, i as u64);
         }
 
-        // Take the completed segment.
+        // Claim the full segment as one run.
         let sw = ring
-            .take_completed_segment()
+            .take_drain_run(false)
             .expect("should have a full segment");
         assert_eq!(sw.base_seq(), 0);
+        assert_eq!(sw.payloads().len(), seg_size);
 
-        // Second immediate take returns None (already claimed).
-        assert!(ring.take_completed_segment().is_none());
+        // Second immediate take returns None (whole segment already claimed).
+        assert!(ring.take_drain_run(false).is_none());
 
         // Complete it.
         sw.complete();
@@ -1076,62 +1138,150 @@ mod tests {
             ring.fill(h, (seg_size + i) as u64);
         }
         let sw2 = ring
-            .take_completed_segment()
+            .take_drain_run(false)
             .expect("second full segment should be takeable");
         assert_eq!(sw2.base_seq(), seg_size as u64);
         sw2.complete();
     }
 
+    /// A non-terminal claim waits for a full batch: a segment filled below its size
+    /// (the default batch) yields nothing.
     #[test]
-    fn take_returns_none_when_partial() {
+    fn take_returns_none_when_below_batch() {
         let seg_size = 4;
         let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
-        // Fill only some slots.
+        // Fill only some slots — below the default batch (== seg_size).
         let handles: Vec<_> = (0..seg_size - 1).map(|_| ring.claim()).collect();
         for (i, h) in handles.into_iter().enumerate() {
             ring.fill(h, i as u64);
         }
-        assert!(ring.take_completed_segment().is_none());
+        assert!(ring.take_drain_run(false).is_none());
     }
 
-    /// `take_tail` drains a partial final segment that `take_completed_segment` won't
-    /// (not full). Only the FILLED slots carry payloads; unfilled are skipped.
+    /// A relief-regime batch below the segment size drains a segment in disjoint runs
+    /// as fills arrive incrementally: a batch's worth lands and drains, then the next.
+    /// (A claim is greedy — it takes the whole contiguous filled run, bounded by what
+    /// has arrived — so partition follows arrival, not a fixed slice size.)
     #[test]
-    fn take_tail_drains_partial_segment() {
+    fn drain_runs_partition_segment_at_small_batch() {
+        let seg_size = 4;
+        let (ring, _consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        ring.set_drain_batch(2);
+        let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+
+        // First batch arrives: slots 0,1.
+        ring.fill_at(&handles, 0, 0);
+        ring.fill_at(&handles, 1, 10);
+        let r0 = ring.take_drain_run(false).expect("first run");
+        assert_eq!(r0.base_seq(), 0);
+        let seen0: Vec<u64> = r0.payloads().iter().map(|s| *s.get().unwrap()).collect();
+        assert_eq!(seen0, vec![0, 10]);
+        // Nothing more until the next batch arrives.
+        assert!(ring.take_drain_run(false).is_none());
+
+        // Second batch arrives: slots 2,3.
+        ring.fill_at(&handles, 2, 20);
+        ring.fill_at(&handles, 3, 30);
+        let r1 = ring.take_drain_run(false).expect("second run");
+        assert_eq!(r1.base_seq(), 2);
+        let seen1: Vec<u64> = r1.payloads().iter().map(|s| *s.get().unwrap()).collect();
+        assert_eq!(seen1, vec![20, 30]);
+
+        assert!(ring.take_drain_run(false).is_none(), "segment exhausted");
+        r0.complete();
+        r1.complete();
+    }
+
+    /// A gap (an unfilled slot inside the segment) stops a run at the gap. A claim
+    /// takes the contiguous prefix before it, yields nothing more until the gap fills,
+    /// then takes the rest.
+    #[test]
+    fn drain_run_stops_at_gap() {
         let seg_size = 4;
         let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
-        // Fill only 2 of 4 slots — segment never goes FULL.
+        ring.set_drain_batch(2);
+        let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+        // Fill slots 0, 1, 3 — gap at slot 2.
+        ring.fill_at(&handles, 0, 0);
+        ring.fill_at(&handles, 1, 10);
+        ring.fill_at(&handles, 3, 30);
+
+        // The contiguous run from 0 is [0,2); slot 2 blocks the rest.
+        let r0 = ring.take_drain_run(false).expect("prefix before the gap");
+        assert_eq!(r0.base_seq(), 0);
+        assert_eq!(r0.payloads().len(), 2);
+        // Nothing more: the run beyond the cursor starts at the unfilled slot 2.
+        assert!(ring.take_drain_run(false).is_none());
+
+        // Fill the gap; now [2,4) is a contiguous run of the batch size.
+        ring.fill_at(&handles, 2, 20);
+        let r1 = ring.take_drain_run(false).expect("run after the gap fills");
+        assert_eq!(r1.base_seq(), 2);
+        let seen: Vec<u64> = r1.payloads().iter().map(|s| *s.get().unwrap()).collect();
+        assert_eq!(seen, vec![20, 30]);
+        r0.complete();
+        r1.complete();
+    }
+
+    /// A terminal claim takes a partial prefix below the batch that a non-terminal
+    /// claim leaves untouched.
+    #[test]
+    fn terminal_drains_partial_below_batch() {
+        let seg_size = 4;
+        let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+        // Default batch == seg_size. Fill only 2 of 4.
         let handles: Vec<_> = (0..2).map(|_| ring.claim()).collect();
         for (i, h) in handles.into_iter().enumerate() {
             ring.fill(h, (i * 10) as u64);
         }
-        // The full-only surface yields nothing.
-        assert!(ring.take_completed_segment().is_none());
-        // The terminal tail surface hands out the partial segment.
-        let sw = ring.take_tail().expect("partial tail segment");
+        // Non-terminal: below batch, nothing.
+        assert!(ring.take_drain_run(false).is_none());
+        // Terminal: take the filled prefix.
+        let sw = ring.take_drain_run(true).expect("partial tail run");
         assert_eq!(sw.base_seq(), 0);
-        let seen: Vec<Option<u64>> = sw.payloads().iter().map(|s| s.get().copied()).collect();
-        assert_eq!(seen, vec![Some(0), Some(10), None, None]);
+        let seen: Vec<u64> = sw.payloads().iter().map(|s| *s.get().unwrap()).collect();
+        assert_eq!(seen, vec![0, 10]);
         sw.complete();
-        // Once drained, a second take_tail finds nothing more in this segment.
-        assert!(ring.take_tail().is_none());
+        // Once claimed, a second terminal call finds nothing more here.
+        assert!(ring.take_drain_run(true).is_none());
     }
 
-    /// `take_tail` also claims a FULL segment (it accepts OPEN or FULL), and only once.
+    /// Reclaim gates on every claimed slot being drained: a segment split into two runs
+    /// reclaims only after both runs complete.
     #[test]
-    fn take_tail_claims_full_and_is_exclusive() {
-        let seg_size = 2;
-        let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+    fn reclaim_waits_for_all_runs_of_a_segment() {
+        let seg_size = 4;
+        let (ring, _consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        ring.set_drain_batch(2);
         let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
-        for (i, h) in handles.into_iter().enumerate() {
-            ring.fill(h, i as u64);
-        }
-        let sw = ring.take_tail().expect("full segment via take_tail");
-        assert_eq!(sw.base_seq(), 0);
-        // Already DRAINING → not handed out again by either take surface.
-        assert!(ring.take_tail().is_none());
-        assert!(ring.take_completed_segment().is_none());
-        sw.complete();
+        // Two batches arrive separately, so each is claimed as its own run.
+        ring.fill_at(&handles, 0, 0);
+        ring.fill_at(&handles, 1, 1);
+        let r0 = ring.take_drain_run(false).expect("run [0,2)");
+        ring.fill_at(&handles, 2, 2);
+        ring.fill_at(&handles, 3, 3);
+        let r1 = ring.take_drain_run(false).expect("run [2,4)");
+
+        // Complete only the first run, then grow + reclaim. seg0 is not fully drained
+        // (drained_count == 2 < 4), so it must not be reclaimed.
+        r0.complete();
+        let h = ring.claim(); // seq 4 → grows seg1, runs reclaim_locked
+        ring.fill(h, 4);
+        assert_eq!(
+            ring.segment_count(),
+            2,
+            "seg0 has an outstanding run; must not reclaim yet"
+        );
+
+        // Complete the second run; now drained_count == len, and `complete`'s own
+        // front-reclaim pops seg0 (a second segment exists, so the deque-non-empty
+        // floor does not block it).
+        r1.complete();
+        assert_eq!(
+            ring.segment_count(),
+            1,
+            "seg0 reclaims once every claimed run completed"
+        );
     }
 
     /// `consumed()` reports the in-order delivery cursor for the read-ahead gate.
@@ -1159,15 +1309,15 @@ mod tests {
         for (i, h) in handles.into_iter().enumerate() {
             ring.fill(h, (i * 10) as u64);
         }
-        let sw = ring.take_completed_segment().expect("full segment");
+        let sw = ring.take_drain_run(false).expect("full segment");
         let seen: Vec<u64> = sw.payloads().iter().map(|s| *s.get().unwrap()).collect();
         assert_eq!(seen, vec![0, 10, 20, 30]);
         sw.complete();
     }
 
     /// `Slot::get` returns the payload for a filled slot. (The empty-slot `None`
-    /// branch is not reachable through the public block surface, which hands out only
-    /// FULL segments — every slot filled.)
+    /// branch is not reachable through a non-terminal claim, whose run is filled by
+    /// construction — every slot of the run is filled.)
     #[test]
     fn slot_get_returns_filled_payload() {
         let seg_size = 4;
@@ -1176,32 +1326,34 @@ mod tests {
         for (i, h) in handles.into_iter().enumerate() {
             ring.fill(h, (i * 7) as u64);
         }
-        let sw = ring.take_completed_segment().expect("full segment");
+        let sw = ring.take_drain_run(false).expect("full segment");
         for (i, slot) in sw.payloads().iter().enumerate() {
             assert_eq!(*slot.get().expect("filled"), (i * 7) as u64);
         }
         sw.complete();
     }
 
-    /// A `SegmentWrite` dropped without `complete()` still drains: the segment is
-    /// reclaimed (not left stuck DRAINING), so reclaim does not wedge behind it.
+    /// A `SegmentWrite` dropped without `complete()` still drains: its run is freed and
+    /// counted toward `drained_count`, so the segment reclaims and reclaim does not
+    /// stall behind it.
     #[test]
     fn drop_without_complete_reclaims() {
         let seg_size = 2;
         let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
-        // Fill seg0 full and take it.
+        // Fill seg0 full and take it as one run.
         for i in 0..seg_size {
             let h = ring.claim();
             ring.fill(h, i as u64);
         }
-        let sw = ring.take_completed_segment().expect("seg0 full");
+        let sw = ring.take_drain_run(false).expect("seg0 full");
         assert_eq!(sw.base_seq(), 0);
-        // Drop WITHOUT complete(): the Drop safety net marks seg0 DRAINED.
+        // Drop WITHOUT complete(): the Drop safety net frees the run and advances
+        // drained_count to the segment length.
         drop(sw);
         // `claim` runs reclaim before it grows, so the drained front pops on the
         // claim *after* seg1 exists. Two claims: the first grows seg1, the second
-        // observes seg0 drained and reclaims it. A segment stuck DRAINING would
-        // never pop and the count would climb without bound.
+        // observes seg0 fully drained and reclaims it. A run left unaccounted would
+        // never reach drained_count == len and the count would climb without bound.
         for i in 0..2 {
             let h = ring.claim();
             ring.fill(h, 99 + i);
@@ -1209,12 +1361,12 @@ mod tests {
         assert_eq!(
             ring.segment_count(),
             1,
-            "dropped-without-complete segment must drain and reclaim, not wedge"
+            "dropped-without-complete run must drain and reclaim, not wedge"
         );
     }
 
     /// `complete()` and `Drop` are exactly-once: payloads are freed once, never twice
-    /// (the DRAINED state guard makes the second drain a no-op).
+    /// (the token's `drained` guard makes the second drain a no-op).
     #[test]
     fn complete_then_drop_frees_exactly_once() {
         use std::sync::atomic::{AtomicUsize, Ordering as O};
@@ -1235,7 +1387,7 @@ mod tests {
             let h = ring.claim();
             ring.fill(h, DropCounter(drops.clone()));
         }
-        let sw = ring.take_completed_segment().expect("full");
+        let sw = ring.take_drain_run(false).expect("full");
         // complete() frees both payloads.
         sw.complete();
         assert_eq!(
@@ -1279,12 +1431,13 @@ mod tests {
         let h3 = it.next().unwrap();
         ring.fill(h2, DropCounter(drops.clone()));
         ring.fill(h3, DropCounter(drops.clone()));
-        // seg1 is now FULL while seg0 is still OPEN. Take and complete seg1.
-        let sw = ring.take_completed_segment().expect("seg1 is full");
+        // seg1 is now full while seg0 has no contiguous filled run. take_drain_run
+        // skips seg0 (its run from the cursor is empty) and claims seg1.
+        let sw = ring.take_drain_run(false).expect("seg1 is full");
         assert_eq!(
             sw.base_seq(),
             seg_size as u64,
-            "frontmost full segment is seg1"
+            "frontmost drainable run is in seg1"
         );
         sw.complete();
         // seg1's two payloads freed immediately, even though seg0 sits ahead unfilled.
@@ -1483,6 +1636,40 @@ mod tests {
         );
     }
 
+    /// The fill probe's run-length (`filled - claim_cursor`) must not underflow when a
+    /// concurrent drainer advances `claim_cursor` past *this* fill's local `filled`
+    /// snapshot. `filled` is captured at this thread's `fetch_add`; `claim_cursor` is
+    /// read lock-free afterward, and another producer's later fill can let a drainer
+    /// claim a run beyond this thread's count, so `claim_cursor > filled` is reachable.
+    /// A bare subtraction wraps in release but panics under overflow-checks (the default
+    /// for debug and `cargo test`), crashing the fill path. Reproduces only under real
+    /// concurrency — single-threaded, `claim_cursor <= filled` always holds — so this is
+    /// a multi-thread stress test at batch 1 (the disk relief regime) over a wide
+    /// segment, looped to make the race near-certain. It can only fail on a regression;
+    /// it never false-positives.
+    #[test]
+    fn fill_probe_does_not_underflow_under_concurrent_drain() {
+        for _ in 0..2_000 {
+            let seg_size = 16;
+            let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+            ring.set_drain_batch(1);
+            let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+            let ring = Arc::new(ring);
+            std::thread::scope(|s| {
+                for h in handles {
+                    let ring = ring.clone();
+                    s.spawn(move || {
+                        if ring.fill(h, 0) == FillOutcome::DrainReady {
+                            while let Some(sw) = ring.take_drain_run(false) {
+                                sw.complete();
+                            }
+                        }
+                    });
+                }
+            });
+        }
+    }
+
     #[test]
     fn concurrent_producer_consumer() {
         let seg_size = 4;
@@ -1515,11 +1702,12 @@ mod tests {
 // Loom model-checks the real structure directly (no model of it): the compat layer
 // swaps in loom's atomics/Arc/Mutex under `cfg(s3_tm_loom)`. Segment size is set to
 // 2 per ring (via new_with_segment_size) so boundary-crossing interleavings stay
-// tractable; the algorithm is identical at any size. Nine models cover the handoff
-// (1), the segment hop (2), reclaim vs an outstanding write — complete (3) and drop
-// (6) paths, multi-producer fill (4), the block-take CAS (5), out-of-order fill
-// across a hop (7), reclaim racing the consumer hop (8), and two takers over
-// distinct segments (9). Run with:
+// tractable; the algorithm is identical at any size. Ten models cover the handoff
+// (1), the segment hop (2), reclaim vs an outstanding run — complete (3) and drop
+// (6) paths, multi-producer fill (4), one full segment claimed by racing drainers
+// (5), out-of-order fill across a hop (7), reclaim racing the consumer hop (8), two
+// drainers over distinct segments (9), and two drainers partitioning one segment into
+// disjoint runs at batch 1 (10). Run with:
 //   LOOM_MAX_PREEMPTIONS=3 RUSTFLAGS="--cfg s3_tm_loom" \
 //     cargo test --lib --release loom_tests -- --test-threads=1
 // The preemption bound is required: unbounded exploration of the multi-producer and
@@ -1608,10 +1796,10 @@ mod loom_tests {
         });
     }
 
-    /// Model 3 — segment reclaim vs an outstanding write pin.
+    /// Model 3 — segment reclaim vs an outstanding run pin.
     ///
-    /// Fill seg0 full (seqs 0,1) so it is takeable on the block surface. One thread
-    /// takes it and `complete`s it (frees payloads, marks DRAINED, reclaims drained
+    /// Fill seg0 full (seqs 0,1) so a run is drainable. One thread claims the run and
+    /// `complete`s it (frees payloads, advances `drained_count`, reclaims drained
     /// front segments); concurrently the other thread `claim`s seq 2 (which grows
     /// seg1 and runs front-reclaim). The `SegmentWrite` pins seg0 via its `Arc`
     /// until `complete`, so the segment must not be freed while the token is alive,
@@ -1621,7 +1809,8 @@ mod loom_tests {
     fn reclaim_vs_outstanding_write() {
         loom::model(|| {
             let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
-            // Fill seg0 (seqs 0,1) to FULL.
+            // Fill seg0 (seqs 0,1) full; the default batch (== seg_size) makes it one
+            // drainable run.
             for i in 0..2 {
                 let h = ring.claim();
                 ring.fill(h, i as u64);
@@ -1630,10 +1819,10 @@ mod loom_tests {
             let ring2 = ring.clone();
             let taker = thread::spawn(move || {
                 let sw = ring2
-                    .take_completed_segment()
-                    .expect("seg0 is full and takeable");
+                    .take_drain_run(false)
+                    .expect("seg0 is full and drainable");
                 assert_eq!(sw.base_seq(), 0);
-                sw.complete(); // frees payloads, DRAINED, reclaim_front
+                sw.complete(); // frees payloads, drained_count += len, reclaim_front
             });
 
             // Concurrently grow + reclaim from the issuer side.
@@ -1690,12 +1879,13 @@ mod loom_tests {
         });
     }
 
-    /// Model 5 — two block takers race one full segment.
+    /// Model 5 — two drainers race one full segment at the default batch.
     ///
-    /// seg0 is filled FULL, then two threads call `take_completed_segment`
-    /// concurrently. The `FULL → DRAINING` CAS must hand the segment to exactly one:
-    /// one thread gets `Some(SegmentWrite)`, the other `None`. This proves the
-    /// at-most-once handout invariant under contention, which the single-threaded
+    /// seg0 is filled full, then two threads call `take_drain_run(false)` concurrently
+    /// with the batch equal to the segment size, so the only drainable run is the whole
+    /// segment. Advancing `claim_cursor` under the lock must hand that run to exactly
+    /// one: one thread gets `Some(SegmentWrite)` based at 0, the other `None`. This
+    /// proves the at-most-once handout under contention, which the single-threaded
     /// "second take returns None" test cannot.
     #[test]
     fn two_takers_race_one_segment() {
@@ -1707,28 +1897,28 @@ mod loom_tests {
             }
 
             let ring2 = ring.clone();
-            let t1 = thread::spawn(move || ring2.take_completed_segment().map(|sw| sw.base_seq()));
-            let t2 = thread::spawn(move || ring.take_completed_segment().map(|sw| sw.base_seq()));
+            let t1 = thread::spawn(move || ring2.take_drain_run(false).map(|sw| sw.base_seq()));
+            let t2 = thread::spawn(move || ring.take_drain_run(false).map(|sw| sw.base_seq()));
 
             let r1 = t1.join().unwrap();
             let r2 = t2.join().unwrap();
 
-            // Exactly one winner, and it got seg0.
+            // Exactly one winner, and it got the run based at seq 0.
             let winners: Vec<u64> = [r1, r2].into_iter().flatten().collect();
             assert_eq!(
                 winners,
                 vec![0],
-                "exactly one taker wins the FULL→DRAINING CAS"
+                "exactly one drainer claims the full-segment run"
             );
         });
     }
 
-    /// Model 6 — segment drop (no complete) vs concurrent reclaim.
+    /// Model 6 — run drop (no complete) vs concurrent reclaim.
     ///
-    /// Same shape as Model 3, but the taker **drops** the `SegmentWrite` instead of
-    /// calling `complete()`. The `Drop` safety net runs the same drain (free
-    /// payloads, set DRAINED, reclaim_front) concurrently with the issuer's `claim`
-    /// reclaim. The drain's idempotency guard and the `Arc` pin must still give
+    /// Same shape as Model 3, but the drainer **drops** the `SegmentWrite` instead of
+    /// calling `complete()`. The `Drop` safety net runs the same drain (free payloads,
+    /// advance `drained_count`, reclaim_front) concurrently with the issuer's `claim`
+    /// reclaim. The token's idempotency guard and the `Arc` pin must still give
     /// exactly-once teardown across the drop path and claim's reclaim — loom's Arc
     /// registry catches a double-free or use-after-free.
     #[test]
@@ -1743,8 +1933,8 @@ mod loom_tests {
             let ring2 = ring.clone();
             let taker = thread::spawn(move || {
                 let sw = ring2
-                    .take_completed_segment()
-                    .expect("seg0 is full and takeable");
+                    .take_drain_run(false)
+                    .expect("seg0 is full and drainable");
                 assert_eq!(sw.base_seq(), 0);
                 // Drop without complete(): Drop must drain and reclaim safely.
                 drop(sw);
@@ -1851,39 +2041,110 @@ mod loom_tests {
         });
     }
 
-    /// Model 9 — two block takers race two distinct full segments.
+    /// Model 9 — two drainers race two distinct full segments.
     ///
-    /// seg0 and seg1 are both FULL, then two threads call `take_completed_segment`
-    /// concurrently. Each `FULL → DRAINING` CAS succeeds on a different segment, so
-    /// the two takers must come away with seg0 and seg1 — one each, no duplicate, no
-    /// segment skipped. Model 5 proves at-most-once on a *single* contended segment;
-    /// this proves the forward scan hands out *every* takeable segment exactly once
-    /// when takers race across segments.
+    /// seg0 and seg1 are both full, then two threads call `take_drain_run(false)`
+    /// concurrently at the default batch (so each segment is one run). The forward
+    /// scan plus the `claim_cursor` advance must hand the two segments' runs to the two
+    /// drainers — one each, no duplicate, no segment skipped. Model 5 proves
+    /// at-most-once on a *single* contended segment; this proves the forward scan hands
+    /// out *every* drainable run exactly once when drainers race across segments.
     #[test]
     fn two_takers_distinct_segments() {
         loom::model(|| {
             let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
-            // Fill seg0 (0,1) and seg1 (2,3) both to FULL.
+            // Fill seg0 (0,1) and seg1 (2,3) both full.
             for i in 0..4u64 {
                 let h = ring.claim();
                 ring.fill(h, i);
             }
 
             let ring2 = ring.clone();
-            let t1 = thread::spawn(move || ring2.take_completed_segment().map(|sw| sw.base_seq()));
-            let t2 = thread::spawn(move || ring.take_completed_segment().map(|sw| sw.base_seq()));
+            let t1 = thread::spawn(move || ring2.take_drain_run(false).map(|sw| sw.base_seq()));
+            let t2 = thread::spawn(move || ring.take_drain_run(false).map(|sw| sw.base_seq()));
 
             let r1 = t1.join().unwrap();
             let r2 = t2.join().unwrap();
 
-            // Both segments handed out, one per taker, no duplication. Order between
+            // Both segments handed out, one per drainer, no duplication. Order between
             // the two threads is nondeterministic, so compare as a sorted set.
             let mut bases: Vec<u64> = [r1, r2].into_iter().flatten().collect();
             bases.sort_unstable();
             assert_eq!(
                 bases,
                 vec![0, 2],
-                "both full segments handed out exactly once across racing takers"
+                "both full segments handed out exactly once across racing drainers"
+            );
+        });
+    }
+
+    /// Model 10 — two drainers partition one segment into disjoint runs at batch 1.
+    ///
+    /// One segment of size 2, batch lowered to 1 so each slot is individually
+    /// drainable. Each thread fills its own slot then drains, the realistic disk path
+    /// where a completing part probes and drains. The fills and drains interleave: a
+    /// drainer may find only its own slot filled and claim a single-slot run, or find
+    /// both and claim the pair — but advancing `claim_cursor` under the lock means the
+    /// two drainers' runs are always disjoint, so no slot is read by both. A terminal
+    /// sweep after the join mops up any slot whose filler had not reached its own drain
+    /// scan. A `DropCounter` payload proves every slot is freed exactly once: a run
+    /// overlap would either double-free (count > 2) or trip loom's `UnsafeCell` on the
+    /// concurrent in-place reads. This is the sub-segment partition the cursor
+    /// introduces, which a whole-segment handout could not race.
+    #[test]
+    fn two_drainers_partition_one_segment() {
+        loom::model(|| {
+            // Count drops through a loom `Arc<AtomicUsize>` (the compat re-export under
+            // loom cfg) so the model tracks every payload free. `Clone` is required by
+            // `PagedRecvBuffer<T>: Clone`'s `T: Clone` bound; cloning shares the same
+            // counter, and each instance still drops exactly once.
+            #[derive(Clone)]
+            struct DropCounter(Arc<AtomicUsize>);
+            impl Drop for DropCounter {
+                fn drop(&mut self) {
+                    self.0.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+
+            let drops = Arc::new(AtomicUsize::new(0));
+            let (ring, _consumer) = PagedRecvBuffer::<DropCounter>::new_with_segment_size(2);
+            ring.set_drain_batch(1);
+            // Claim both slots up front (claim is serialized under the lock).
+            let h0 = ring.claim();
+            let h1 = ring.claim();
+
+            let ring_a = ring.clone();
+            let da = drops.clone();
+            let a = thread::spawn(move || {
+                ring_a.fill(h0, DropCounter(da));
+                if let Some(sw) = ring_a.take_drain_run(false) {
+                    sw.complete();
+                }
+            });
+            let ring_b = ring.clone();
+            let db = drops.clone();
+            let b = thread::spawn(move || {
+                ring_b.fill(h1, DropCounter(db));
+                if let Some(sw) = ring_b.take_drain_run(false) {
+                    sw.complete();
+                }
+            });
+
+            a.join().unwrap();
+            b.join().unwrap();
+
+            // Mop up any slot a drainer's scan missed (its sibling filled after the
+            // scan). Single-threaded here, so no race; terminal takes a lone slot.
+            while let Some(sw) = ring.take_drain_run(true) {
+                sw.complete();
+            }
+
+            // Every payload freed exactly once. Overlapping runs would double-free
+            // (count > 2) or be caught earlier by loom's UnsafeCell.
+            assert_eq!(
+                drops.load(Ordering::SeqCst),
+                2,
+                "each slot's payload freed exactly once across partitioned runs"
             );
         });
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -1,0 +1,1592 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! In-order delivery over out-of-order arrival.
+//!
+//! `PagedRecvBuffer<T>` assigns each payload a sequence number at claim time, accepts
+//! completed payloads into their slots in any order from many producers, and
+//! delivers them to a single consumer in sequence order. It grows to absorb
+//! head-of-line backlog and shrinks as delivery advances; its resident footprint
+//! tracks the gap between the oldest undelivered and newest claimed sequence,
+//! not the total sequence count.
+//!
+//! # Structure
+//!
+//! Two levels. The primary level is a `VecDeque<Arc<Segment<T>>>` guarded by one
+//! `Mutex`; each segment holds a fixed run of `seg_size` slots covering a contiguous
+//! span of sequence numbers. The deque grows at the tail and is reclaimed from the
+//! front, so only the segments spanning the live window are resident.
+//!
+//! ```text
+//!         reclaim ◀── front                    tail ──▶ grow
+//!   ┌───────────── Mutex<{ segments, issued }> ─────────────┐
+//!   │  ┌─────────┐     ┌─────────┐     ┌─────────┐          │
+//!   │  │  seg 0  │─nx─▶│  seg 1  │─nx─▶│  seg 2  │          │
+//!   │  │ F F . . │     │ F F F F │     │ F . _ _ │          │
+//!   │  │ 0 1 2 3 │     │ 4 5 6 7 │     │ 8 9     │          │
+//!   │  │ base=0  │     │ base=4  │     │ base=8  │          │
+//!   │  │ [DRAIND]│     │ [FULL]  │     │ [OPEN]  │ issued=9 │
+//!   │  └─────────┘     └────▲────┘     └─▲───────┘          │
+//!   └───────────────────────┼───────────┼──────────────────┘
+//!     consumed=6            cursor=5    fill (producers, any order, lock-free)
+//!     (RecvBufferConsumer.current ─┘
+//!      hops seg→seg via `nx`, lock-free)
+//!
+//!   F = FILLED slot   _ = EMPTY slot   . = delivered/consumed   nx = next pointer
+//! ```
+//!
+//! In this picture the consumer has delivered seqs 0–4 (cursor at 5, the head of
+//! `seg 1`), producers have filled 5–8 out of order, seq 9 is still in flight, and
+//! `seg 0` is fully consumed (eligible for front-reclaim on the next claim). A
+//! `VecDeque` reallocation moves only the `Arc` pointers; the segments are
+//! heap-stable behind `Arc`, so no producer or consumer reference is invalidated by
+//! growth. The only intrusive link is one `next` pointer per segment, by which the
+//! consumer reaches the successor segment without taking the lock.
+//!
+//! # Locking
+//!
+//! One `Mutex` guards the segment deque and the `issued` counter. Only the issuer
+//! paths take it — `claim` (assign a sequence, maybe grow, opportunistic reclaim),
+//! `take_completed_segment` (find a full segment), and `complete`/drop reclaim. The
+//! two hot paths are lock-free: `fill` writes a claimed slot and publishes it with a
+//! `Release` store; `poll_next` reads the cursor slot under `Acquire` and hops
+//! segments via the `next` pointer. The delivery cursor lives in `RecvBufferConsumer` and
+//! is mirrored to an atomic `consumed` so the issuer's reclaim can read it without
+//! synchronizing with the consumer.
+//!
+//! # Roles
+//!
+//! - **issuer** — assigns sequence numbers and grows and reclaims segments. The
+//!   only writer to the deque; the one internal lock serializes issuers. Off the
+//!   hot path (producers fill lock-free), and claims are infrequent relative to
+//!   fills, so lock contention is incidental.
+//! - **producers** — each writes the single slot it claimed. Concurrent and
+//!   lock-free, touching disjoint memory.
+//! - **consumer** — reads slots in sequence order. Single and lock-free.
+//!
+//! # Surfaces
+//!
+//! [`PagedRecvBuffer::new`] returns a `(PagedRecvBuffer<T>, RecvBufferConsumer<T>)` pair, channel-style.
+//! The `PagedRecvBuffer` is cloneable and carries the producer and block surfaces; the
+//! `RecvBufferConsumer` is unique (not cloneable) and carries the stream surface.
+//!
+//! - **producer** (`PagedRecvBuffer`) — [`claim`](PagedRecvBuffer::claim) then
+//!   [`fill`](PagedRecvBuffer::fill).
+//! - **stream** (`RecvBufferConsumer`) — [`poll_next`](RecvBufferConsumer::poll_next) delivers
+//!   one payload at a time in strict sequence order, advancing a single cursor.
+//!   Taking `&mut self`, on a non-cloneable handle, makes "single consumer" a
+//!   type-level fact and lets the cursor and current-segment cache live in the
+//!   handle (so the hop needs no lock).
+//! - **block** (`PagedRecvBuffer`) — [`take_completed_segment`](PagedRecvBuffer::take_completed_segment)
+//!   hands out a whole `FULL` segment as an owned [`SegmentWrite`], for bulk
+//!   consumption that does not need in-order single-item delivery. Segments may be
+//!   taken and completed out of order and concurrently.
+//!
+//! An instance is driven through one consumption surface or the other, never both:
+//! the stream cursor empties slots as it passes; the block surface consumes whole
+//! segments. A block-only caller drops the `RecvBufferConsumer`. **This exclusion is a
+//! caller obligation, not type-enforced** — `PagedRecvBuffer` is `Clone` and exposes the
+//! block surface, so the type system does not prevent driving both at once. Doing so
+//! races the stream `take` against the block in-place read and is undefined; the
+//! `unsafe` in both paths relies on the caller honoring this.
+//!
+//! # Slot states
+//!
+//! ```text
+//!   EMPTY ──claim, then fill──▶ FILLED ──stream take──▶ EMPTY
+//! ```
+//!
+//! `FILLED` is published with a `Release` store after the payload write; a reader
+//! observes it with an `Acquire` load before reading the payload. The block
+//! surface leaves slots `FILLED` and reclaims at segment granularity.
+//!
+//! # Segment states
+//!
+//! ```text
+//!   OPEN ──last slot filled──▶ FULL ──taken──▶ DRAINING ──complete──▶ DRAINED
+//! ```
+//!
+//! The fill that fills a segment's last slot *seals* it: `OPEN → FULL`. Sealing is
+//! by a count (`filled_count`), not a high-water index, so out-of-order fills reach
+//! `FULL` correctly. The block surface claims `FULL → DRAINING` once (so a segment
+//! is handed out at most once) and `DRAINING → DRAINED` on completion, after which
+//! the segment is reclaimable. The stream surface ignores these states and reclaims
+//! by cursor position.
+//!
+//! # Memory ordering and safety
+//!
+//! 1. **Exclusive producer write.** Each sequence number is claimed once (the
+//!    issuer advances `issued` monotonically), so the producer holding a
+//!    [`SlotHandle`] is the sole writer of that slot.
+//! 2. **State-gated read.** A reader touches a slot's payload only after observing
+//!    `FILLED` via an `Acquire` load (`SlotState::is_filled`); the producer's
+//!    `Release` store of `FILLED` (`SlotState::publish_filled`) publishes the
+//!    preceding payload write. The two form the happens-before edge of the handoff:
+//!    payload write → `Release` `FILLED` → `Acquire` `FILLED` → payload read.
+//! 3. **No slot aliasing.** Sequence numbers are assigned monotonically and each
+//!    maps to exactly one slot in one segment for that segment's whole lifetime;
+//!    segments are allocated fresh on growth and freed on reclaim, never recycled.
+//!    So a slot is never the live target of two sequences — there is no reuse window
+//!    to race. (The window the caller must bound is *resident memory*, not aliasing:
+//!    see Caller obligations.)
+//! 4. **Segment-reclaim safety (the hop).** A segment is removed from the deque
+//!    (`pop_front`, front-only) only once `base + len <= consumed`, and only the
+//!    consumer advances `consumed`. So when the consumer hops, the successor it is
+//!    about to enter (base `== consumed`) cannot be popped, and stays strong-
+//!    referenced by the deque — which is what lets the consumer reconstruct an `Arc`
+//!    from the `next` pointer without the lock. This concerns *segment* removal
+//!    only; emptying a *slot's* payload (delivery, or future demand reclaim) leaves
+//!    the segment in place and does not bear on the hop.
+//! 5. **Outstanding block pin.** A live [`SegmentWrite`] holds an
+//!    `Arc<Segment<T>>`, so a segment being consumed by the block surface cannot
+//!    be reclaimed until that token completes.
+//!
+//! # Caller obligations
+//!
+//! The ring does not bound its own growth: it allocates a segment whenever a claim
+//! reaches a sequence past the current tail. The caller must bound outstanding
+//! (claimed-but-undelivered) sequences, or resident memory grows without limit.
+
+use crossbeam_utils::CachePadded;
+
+use crate::runtime::sync::cell::UnsafeCell;
+use crate::runtime::sync::sync::atomic::{AtomicPtr, AtomicU64, AtomicU8, AtomicUsize, Ordering};
+use crate::runtime::sync::sync::{Arc, Mutex};
+
+/// Default slots per segment for [`PagedRecvBuffer::new`].
+///
+/// Slots per segment is the unit of allocation and front-reclaim. A larger value
+/// amortizes allocation and deque churn over more sequences but holds more memory
+/// resident per shelf and coarsens reclaim (a segment is freed only once fully
+/// delivered or drained). It is fixed for an instance at construction; tests pick
+/// other sizes via [`PagedRecvBuffer::new_with_segment_size`].
+pub(crate) const DEFAULT_SEG_SIZE: usize = 16;
+
+/// Slot empty: initial state, and the state after the stream surface takes a payload.
+const SLOT_EMPTY: u8 = 0;
+/// Slot filled: a producer has published a payload. Readers observe this with an
+/// `Acquire` load (the reader's side of the handoff), pairing with the producer's
+/// `Release` store.
+const SLOT_FILLED: u8 = 1;
+
+/// Occupancy of one slot, over an `AtomicU8` so transitions read as named state
+/// changes with explicit orderings rather than raw atomic ops (cf.
+/// `StateMachineStatus` in `transfer.rs`).
+struct SlotState(AtomicU8);
+
+impl SlotState {
+    fn new() -> Self {
+        Self(AtomicU8::new(SLOT_EMPTY))
+    }
+
+    /// Publish a completed fill. `Release`: the payload write happens-before this,
+    /// so a reader that observes the slot filled via [`is_filled`](Self::is_filled)
+    /// sees the payload.
+    fn publish_filled(&self) {
+        self.0.store(SLOT_FILLED, Ordering::Release);
+    }
+
+    /// Whether the slot is filled, `Acquire` to pair with
+    /// [`publish_filled`](Self::publish_filled) before reading the payload.
+    fn is_filled(&self) -> bool {
+        self.0.load(Ordering::Acquire) == SLOT_FILLED
+    }
+
+    /// Mark the slot empty after its payload has been taken.
+    fn set_empty(&self) {
+        self.0.store(SLOT_EMPTY, Ordering::Release);
+    }
+}
+
+/// Segment open: accepting fills; not all slots filled yet.
+const SEG_OPEN: u8 = 0;
+/// Segment full: every slot filled, eligible to be taken by the block surface.
+const SEG_FULL: u8 = 1;
+/// Segment draining: claimed by a block consumer, pinned by a live [`SegmentWrite`],
+/// not yet reclaimable.
+const SEG_DRAINING: u8 = 2;
+/// Segment drained: block consumption complete, payloads freed, reclaimable.
+const SEG_DRAINED: u8 = 3;
+
+/// Segment lifecycle over an `AtomicU8`. The `FULL → DRAINING` transition is a CAS
+/// so a full segment is handed to the block surface at most once.
+struct SegState(AtomicU8);
+
+impl SegState {
+    fn new() -> Self {
+        Self(AtomicU8::new(SEG_OPEN))
+    }
+
+    /// Mark the segment full when its last slot fills: `OPEN → FULL` (`Release`).
+    fn set_full(&self) {
+        self.0.store(SEG_FULL, Ordering::Release);
+    }
+
+    /// Claim a full segment for block consumption exactly once: `FULL → DRAINING`.
+    /// Returns `true` for the single caller that wins the CAS.
+    fn try_claim_for_drain(&self) -> bool {
+        self.0
+            .compare_exchange(SEG_FULL, SEG_DRAINING, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    /// Mark consumption complete: `DRAINING → DRAINED` (`Release`).
+    fn set_drained(&self) {
+        self.0.store(SEG_DRAINED, Ordering::Release);
+    }
+
+    /// Whether the segment has been fully drained (`Acquire`).
+    fn is_drained(&self) -> bool {
+        self.0.load(Ordering::Acquire) == SEG_DRAINED
+    }
+}
+
+/// One slot: a single payload behind state-gated interior mutability.
+///
+/// `data` is written by the producer that claimed the slot and read by the
+/// consumer (or the block surface) after `state` is observed filled.
+pub(crate) struct Slot<T> {
+    state: SlotState,
+    data: UnsafeCell<Option<T>>,
+}
+
+impl<T> Slot<T> {
+    fn new() -> Self {
+        Self {
+            state: SlotState::new(),
+            data: UnsafeCell::new(None),
+        }
+    }
+
+    /// Borrow the payload of a filled slot. For the block surface, which reads
+    /// payloads in place from a [`SegmentWrite`] (every slot of a full segment is
+    /// filled). Returns `None` for an empty slot.
+    ///
+    /// # Safety contract
+    /// The two consumption surfaces are mutually exclusive per instance (module
+    /// docs), so no stream consumer races this in-place read.
+    pub(crate) fn get(&self) -> Option<&T> {
+        if !self.state.is_filled() {
+            return None;
+        }
+        // SAFETY: the slot is filled (Acquire above pairs with the producer's
+        // Release), and the surfaces are mutually exclusive per instance, so no
+        // stream consumer mutates this slot concurrently.
+        self.data.with(|p| unsafe { (*p).as_ref() })
+    }
+}
+
+/// A fixed run of `slots.len()` slots covering sequences `[base, base + slots.len())`.
+///
+/// Heap-stable behind `Arc`. `next` chains to the successor for the consumer's
+/// lock-free hop. The slot count is fixed at construction and is read from
+/// `slots.len()` wherever the segment's sequence span is needed.
+struct Segment<T> {
+    /// Sequence number of slot 0. Immutable after construction.
+    base: u64,
+    /// The slots, boxed so segment size is a runtime value rather than a const.
+    slots: Box<[Slot<T>]>,
+    /// Successor segment, or null. Published `Release` by the issuer when it grows
+    /// past this segment; loaded `Acquire` by the consumer at a segment boundary.
+    /// The pointee stays alive via the deque's `Arc` (ordering rule 4), so the
+    /// consumer may reconstruct an `Arc` from this pointer.
+    next: AtomicPtr<Segment<T>>,
+    /// Number of filled slots. Contended across this segment's producers, hence
+    /// padded off the header's read-mostly fields. The fill that brings it to
+    /// `slots.len()` seals the segment (`OPEN → FULL`).
+    filled_count: CachePadded<AtomicUsize>,
+    /// Block-surface lifecycle: `OPEN → FULL → DRAINING → DRAINED`.
+    state: SegState,
+}
+
+impl<T> Segment<T> {
+    fn new(base: u64, seg_size: usize) -> Self {
+        let slots = (0..seg_size)
+            .map(|_| Slot::new())
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            base,
+            slots,
+            next: AtomicPtr::new(std::ptr::null_mut()),
+            filled_count: CachePadded::new(AtomicUsize::new(0)),
+            state: SegState::new(),
+        }
+    }
+
+    /// Number of slots, i.e. the span of sequence numbers this segment covers.
+    fn len(&self) -> u64 {
+        self.slots.len() as u64
+    }
+}
+
+/// State behind the single internal lock (issuer only).
+struct Locked<T> {
+    /// Primary level: segments spanning the live window, front = oldest.
+    segments: std::collections::VecDeque<Arc<Segment<T>>>,
+    /// Next sequence number to hand out.
+    issued: u64,
+}
+
+/// Shared interior, held by `Arc` from every `PagedRecvBuffer`/`RecvBufferConsumer` handle and
+/// from every outstanding [`SegmentWrite`] token.
+struct Inner<T> {
+    /// The one lock — guards the segment deque and `issued`. Off the hot paths.
+    locked: Mutex<Locked<T>>,
+    /// In-order delivery cursor. Written only by the consumer, read by the issuer
+    /// for reclaim, so it is atomic and padded off the lock's cache line.
+    consumed: CachePadded<AtomicU64>,
+    /// Slots per segment for this instance. Fixed at construction; used to size
+    /// the initial segment and every grown successor.
+    seg_size: usize,
+}
+
+/// Producer + block handle to an in-order delivery buffer. Cloneable; share across
+/// the issuer, producers, and block-surface consumer. The stream surface is the
+/// separate [`RecvBufferConsumer`]. See module docs.
+#[derive(Clone)]
+pub(crate) struct PagedRecvBuffer<T> {
+    inner: Arc<Inner<T>>,
+}
+
+/// Unique stream-surface handle: in-order single-payload delivery via
+/// [`poll_next`](Self::poll_next). Not cloneable — its existence is the
+/// single-consumer guarantee. Caches the current segment and cursor so delivery
+/// and the segment hop are lock-free.
+pub(crate) struct RecvBufferConsumer<T> {
+    inner: Arc<Inner<T>>,
+    /// The segment holding `cursor`. Kept as a strong ref so the consumer can read
+    /// it lock-free; the deque also holds it (the unpoppable invariant).
+    current: Arc<Segment<T>>,
+    /// Local copy of the delivery cursor, mirrored to `inner.consumed` on advance.
+    cursor: u64,
+}
+
+/// A producer's exclusive claim on one slot — the only means to fill a slot, and
+/// consumed by [`fill`](PagedRecvBuffer::fill) so a slot cannot be written twice.
+///
+/// Resolves its slot at claim time and holds an `Arc<Segment<T>>`, so `fill` is
+/// lock-free and the segment cannot be reclaimed while an unfilled claim remains.
+///
+/// A claimed-but-never-filled sequence blocks in-order delivery at that point (the
+/// consumer waits on it) and holds its segment resident. The producer is obliged to
+/// fill every claim; the `#[must_use]` guards against discarding a claim outright,
+/// though it cannot catch a handle bound and then dropped.
+#[must_use = "a claimed slot must be filled, or in-order delivery blocks at its sequence"]
+pub(crate) struct SlotHandle<T> {
+    seq: u64,
+    seg: Arc<Segment<T>>,
+    /// Index within `seg.slots` (`seq - seg.base`).
+    idx: usize,
+}
+
+impl<T> SlotHandle<T> {
+    /// The sequence number assigned to this slot.
+    pub(crate) fn seq(&self) -> u64 {
+        self.seq
+    }
+}
+
+/// The result of a [`fill`](PagedRecvBuffer::fill).
+///
+/// `SealedSegment` is an edge signal: this fill was the one that filled a segment's
+/// last slot, so a block-surface consumer should drain via
+/// [`take_completed_segment`](PagedRecvBuffer::take_completed_segment). It carries no
+/// sequence — the consumer locates the full segment itself — so the only
+/// information is *that* a segment became drainable, not which. A stream-surface
+/// consumer ignores the outcome entirely.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum FillOutcome {
+    /// Payload stored; this fill did not fill a segment's last slot.
+    Stored,
+    /// This fill filled a segment's last slot; a block consumer should drain.
+    SealedSegment,
+}
+
+/// An owned token granting consumption of one `FULL` segment's payloads.
+///
+/// Holds an `Arc<Segment<T>>`, pinning the segment until [`complete`](Self::complete),
+/// and a strong `Arc<Inner<T>>` so completion can free memory and reclaim the
+/// shelf independent of issuance. It is owned rather than borrowed so it can outlive
+/// the call that produced it: a synchronous consumer completes it immediately, an
+/// asynchronous one parks it and completes it on a later event.
+///
+/// The strong ring reference keeps the buffer accounting alive for exactly the
+/// outstanding-write window — the correct lifetime, since a write may be reading a
+/// segment's bytes when every other handle has dropped. It is bounded (released at
+/// `complete` or drop) and forms no cycle (segments do not point back at `Inner`).
+///
+/// Dropping the token without calling [`complete`](Self::complete) is safe: `Drop`
+/// runs the same drain, so an aborted or short-circuited consumer cannot wedge
+/// reclaim by leaving the segment stuck `DRAINING`.
+#[must_use = "a taken segment must be completed (or dropped) to free its payloads and unblock reclaim"]
+pub(crate) struct SegmentWrite<T> {
+    seg: Arc<Segment<T>>,
+    inner: Arc<Inner<T>>,
+}
+
+impl<T> SegmentWrite<T> {
+    /// Sequence number of the segment's first slot.
+    pub(crate) fn base_seq(&self) -> u64 {
+        self.seg.base
+    }
+
+    /// The segment's payloads in sequence order, all `FILLED`. Borrowed for the
+    /// duration of consumption; payloads are read in place, never moved out.
+    pub(crate) fn payloads(&self) -> &[Slot<T>] {
+        &self.seg.slots
+    }
+
+    /// Free the segment's payloads, mark it `DRAINED`, and reclaim drained front
+    /// segments. Idempotent and shared by [`complete`](Self::complete) and `Drop`,
+    /// guarded on the `DRAINED` state so it runs exactly once per token.
+    ///
+    /// Dropping the payloads here — rather than at segment pop — releases the budget
+    /// the bytes hold **eagerly and per-segment**, decoupled from the in-order
+    /// front-pop. A segment written out of order (e.g. seg 2 done while seg 0 still
+    /// writes) frees its memory immediately even though its empty shelf waits its
+    /// turn at the front.
+    fn drain(&self) {
+        // Idempotency guard: complete() then drop, or a double drain, is a no-op the
+        // second time. Acquire pairs with the set_drained Release below.
+        if self.seg.state.is_drained() {
+            return;
+        }
+        for slot in self.seg.slots.iter() {
+            // SAFETY: winning the FULL → DRAINING CAS made this token the segment's
+            // sole accessor, and the two consumption surfaces are mutually exclusive
+            // per instance (ordering rule 5, plus the surface contract), so no stream
+            // consumer touches these slots. Freeing the payload releases whatever it
+            // carries (e.g. a memory reservation).
+            slot.data.with_mut(|p| unsafe {
+                *p = None;
+            });
+        }
+        self.seg.state.set_drained();
+        reclaim_front(&self.inner);
+    }
+
+    /// Finish consuming the segment: free its payloads now, mark it drained, and
+    /// reclaim drained front segments. Equivalent to dropping the token, but
+    /// explicit at the call site.
+    pub(crate) fn complete(self) {
+        self.drain();
+        // `self` drops here; Drop sees DRAINED and the drain is a no-op.
+    }
+}
+
+impl<T> Drop for SegmentWrite<T> {
+    /// Safety net: a token dropped without [`complete`](SegmentWrite::complete) —
+    /// an aborted or early-returning consumer — still drains, so the segment cannot
+    /// linger in `DRAINING` and stall front-reclaim behind it.
+    fn drop(&mut self) {
+        self.drain();
+    }
+}
+
+/// Pop reclaimable segments from the front of the deque. A segment is
+/// reclaimable if fully consumed (`base + len <= consumed`) or drained
+/// by the block surface. Never pops the last segment so the deque is never empty.
+fn reclaim_locked<T>(guard: &mut Locked<T>, consumed: u64) {
+    while guard.segments.len() > 1 {
+        let front = guard.segments.front().unwrap();
+        let fully_consumed = front.base + front.len() <= consumed;
+        let drained = front.state.is_drained();
+        if fully_consumed || drained {
+            guard.segments.pop_front();
+        } else {
+            break;
+        }
+    }
+}
+
+/// Take the lock and run front-reclaim.
+fn reclaim_front<T>(inner: &Inner<T>) {
+    let mut guard = inner.locked.lock();
+    let consumed = inner.consumed.load(Ordering::Acquire);
+    reclaim_locked(&mut guard, consumed);
+}
+
+// Safety: producers write to distinct slots (claimed via monotonic seq assignment
+// under the lock). The consumer reads only after observing FILLED. T: Send is
+// required because items cross thread boundaries.
+unsafe impl<T: Send> Send for PagedRecvBuffer<T> {}
+unsafe impl<T: Send> Sync for PagedRecvBuffer<T> {}
+unsafe impl<T: Send> Send for RecvBufferConsumer<T> {}
+unsafe impl<T: Send> Send for SegmentWrite<T> {}
+unsafe impl<T: Send> Sync for SegmentWrite<T> {}
+
+impl<T> PagedRecvBuffer<T> {
+    /// Create an empty ring with the default segment size ([`DEFAULT_SEG_SIZE`]),
+    /// returning the producer/block handle and the unique stream [`RecvBufferConsumer`].
+    pub(crate) fn new() -> (Self, RecvBufferConsumer<T>) {
+        Self::new_with_segment_size(DEFAULT_SEG_SIZE)
+    }
+
+    /// Create an empty ring whose segments hold `seg_size` slots each. One segment
+    /// based at sequence 0 exists initially, shared by the producer/block handle and
+    /// the consumer's `current`. Panics if `seg_size == 0`.
+    pub(crate) fn new_with_segment_size(seg_size: usize) -> (Self, RecvBufferConsumer<T>) {
+        assert!(seg_size > 0, "segment size must be non-zero");
+        let seg0 = Arc::new(Segment::new(0, seg_size));
+        let mut segments = std::collections::VecDeque::new();
+        segments.push_back(seg0.clone());
+        let inner = Arc::new(Inner {
+            locked: Mutex::new(Locked {
+                segments,
+                issued: 0,
+            }),
+            consumed: CachePadded::new(AtomicU64::new(0)),
+            seg_size,
+        });
+        let consumer = RecvBufferConsumer {
+            inner: inner.clone(),
+            current: seg0,
+            cursor: 0,
+        };
+        (PagedRecvBuffer { inner }, consumer)
+    }
+
+    // ── Producer surface ───────────────────────────────────────────────────────
+
+    /// Assign the next sequence number and resolve its slot, growing a tail segment
+    /// if the sequence reached a new one. Takes the lock.
+    pub(crate) fn claim(&self) -> SlotHandle<T> {
+        let mut guard = self.inner.locked.lock();
+
+        // Opportunistic front-reclaim: we already hold the lock, so drop any front
+        // segments the consumer has passed before assigning the next sequence.
+        let consumed = self.inner.consumed.load(Ordering::Acquire);
+        reclaim_locked(&mut guard, consumed);
+
+        let seq = guard.issued;
+        guard.issued += 1;
+
+        let tail = guard.segments.back().unwrap().clone();
+        // The sequence space is u64; exhausting it (2^64 claims) is unreachable in
+        // any real run, so this guards the invariant in debug rather than paying for
+        // checked arithmetic on the hot path.
+        debug_assert!(
+            tail.base.checked_add(tail.len()).is_some(),
+            "sequence space exhausted"
+        );
+        let seg = if seq >= tail.base + tail.len() {
+            // Grow: allocate a successor segment of the same size.
+            let new = Arc::new(Segment::new(tail.base + tail.len(), self.inner.seg_size));
+            tail.next
+                .store(Arc::as_ptr(&new) as *mut _, Ordering::Release);
+            guard.segments.push_back(new.clone());
+            debug_assert!(seq < new.base + new.len());
+            new
+        } else {
+            tail
+        };
+
+        let idx = (seq - seg.base) as usize;
+        SlotHandle { seq, seg, idx }
+    }
+
+    /// Publish a payload into its claimed slot, consuming the handle. Lock-free:
+    /// writes the slot's `data`, publishes filled via [`SlotState::publish_filled`],
+    /// increments the segment's `filled_count`. Returns [`FillOutcome::SealedSegment`]
+    /// when this fill brings the count to the segment's slot count.
+    pub(crate) fn fill(&self, handle: SlotHandle<T>, value: T) -> FillOutcome {
+        let SlotHandle { seg, idx, .. } = handle;
+        // Sole writer for this sequence number.
+        seg.slots[idx].data.with_mut(|p| unsafe {
+            *p = Some(value);
+        });
+        seg.slots[idx].state.publish_filled();
+        let prev = seg.filled_count.fetch_add(1, Ordering::AcqRel);
+        if prev + 1 == seg.slots.len() {
+            seg.state.set_full();
+            FillOutcome::SealedSegment
+        } else {
+            FillOutcome::Stored
+        }
+    }
+
+    // ── Block surface (out-of-order, segment-granular) ───────────────────────────
+
+    /// Hand out the frontmost full, not-yet-taken segment exactly once as an owned
+    /// [`SegmentWrite`] (claimed `FULL → DRAINING` via
+    /// [`SegState::try_claim_for_drain`]), or `None` if no segment is full. Segments
+    /// may be outstanding concurrently.
+    pub(crate) fn take_completed_segment(&self) -> Option<SegmentWrite<T>> {
+        let guard = self.inner.locked.lock();
+        for seg in guard.segments.iter() {
+            if seg.state.try_claim_for_drain() {
+                return Some(SegmentWrite {
+                    seg: seg.clone(),
+                    inner: self.inner.clone(),
+                });
+            }
+        }
+        None
+    }
+
+    // ── Introspection (advisory) ─────────────────────────────────────────────────
+
+    /// Advisory point-in-time skeleton in sequence space. Takes the lock (so the
+    /// issuer cannot grow or reclaim mid-walk and segments cannot vanish); slot
+    /// states still race under the lock-free producers and consumer, so the result
+    /// is advisory and never a correctness input. Cold path.
+    ///
+    /// Callers that need byte offsets translate sequence numbers themselves; the
+    /// ring has no notion of payload size.
+    pub(crate) fn snapshot(&self) -> RecvBufferSnapshot {
+        let guard = self.inner.locked.lock();
+        let cursor = self.inner.consumed.load(Ordering::Acquire);
+        let frontier = guard.issued;
+
+        let mut arrived = Vec::new();
+        let mut run_start: Option<u64> = None;
+
+        for seq in cursor..frontier {
+            // Locate the segment containing `seq`.
+            let seg = guard
+                .segments
+                .iter()
+                .find(|s| seq >= s.base && seq < s.base + s.len());
+            let filled = match seg {
+                Some(s) => {
+                    let idx = (seq - s.base) as usize;
+                    s.slots[idx].state.is_filled()
+                }
+                None => false,
+            };
+
+            if filled {
+                if run_start.is_none() {
+                    run_start = Some(seq);
+                }
+            } else if let Some(start) = run_start.take() {
+                arrived.push(start..seq);
+            }
+        }
+        if let Some(start) = run_start {
+            arrived.push(start..frontier);
+        }
+
+        RecvBufferSnapshot {
+            cursor,
+            frontier,
+            arrived,
+        }
+    }
+}
+
+impl<T> RecvBufferConsumer<T> {
+    /// Take the next in-order payload if it has arrived, else `None`. Lock-free.
+    ///
+    /// Checks the slot at the cursor with [`SlotState::is_filled`]; on a hit takes
+    /// the owned payload, empties the slot, advances the cursor (mirrored to
+    /// `inner.consumed` with `Release`), and at a segment boundary hops `current`
+    /// to the successor via the segment's `next` pointer.
+    ///
+    /// The cursor advances by one and no segment is reclaimed ahead of it, so a
+    /// single call crosses **at most one** segment boundary — hence a single `if`,
+    /// not a loop: a multi-segment skip cannot occur.
+    pub(crate) fn poll_next(&mut self) -> Option<T> {
+        // Hop: if the cursor reached the end of the current segment, advance to the
+        // successor before reading. Crosses one boundary at most (see the contract).
+        if self.cursor == self.current.base + self.current.len() {
+            let raw = self.current.next.load(Ordering::Acquire);
+            if raw.is_null() {
+                return None;
+            }
+            // SAFETY: `raw` points to the successor segment, whose base is
+            // `cursor` (we are at `current`'s end, so `consumed == cursor ==
+            // successor.base`). A segment is popped only when `base + len <=
+            // consumed`; for the successor that is `cursor + len <= cursor`, which
+            // is false, so it cannot be popped while we hold here (ordering rule 4).
+            // Its allocation is therefore live and still strong-referenced by the
+            // deque, so increment_strong_count is sound; the matching Drop of this
+            // Arc balances the increment. (`current` itself may now be poppable, but
+            // we hold it via `self.current` until the reassignment below.)
+            let next = unsafe {
+                Arc::increment_strong_count(raw);
+                Arc::from_raw(raw)
+            };
+            self.current = next;
+        }
+
+        let idx = (self.cursor - self.current.base) as usize;
+        if !self.current.slots[idx].state.is_filled() {
+            return None;
+        }
+
+        let value = self.current.slots[idx]
+            .data
+            .with_mut(|p| unsafe { (*p).take() })
+            .unwrap();
+        self.current.slots[idx].state.set_empty();
+        self.cursor += 1;
+        self.inner.consumed.store(self.cursor, Ordering::Release);
+
+        Some(value)
+    }
+}
+
+/// Advisory sequence-space snapshot from [`PagedRecvBuffer::snapshot`].
+///
+/// Three sequence numbers and the arrived runs between them describe the whole
+/// state: `[0, cursor)` is delivered and gone, `cursor` is where in-order delivery
+/// stands, `[cursor, frontier)` is claimed-but-undelivered, and the arrived runs
+/// mark which sequences in that span have landed (the complement is claimed but not
+/// yet filled). All accessors are derived from these; the raw runs are private so
+/// callers express intent through the methods rather than re-deriving them.
+pub(crate) struct RecvBufferSnapshot {
+    /// In-order delivery cursor: the next sequence to be delivered. Everything
+    /// below it has been delivered.
+    pub(crate) cursor: u64,
+    /// Issuance frontier: the next sequence to be claimed. Nothing at or above it
+    /// exists yet.
+    pub(crate) frontier: u64,
+    /// Contiguous arrived (filled) sequence runs within `[cursor, frontier)`, in
+    /// ascending order and non-adjacent. The gaps between them are claimed-but-
+    /// unfilled sequences.
+    arrived: Vec<std::ops::Range<u64>>,
+}
+
+impl RecvBufferSnapshot {
+    /// Number of claimed-but-undelivered sequences: `frontier - cursor`. The size of
+    /// the live window the ring is holding open.
+    pub(crate) fn outstanding(&self) -> u64 {
+        self.frontier - self.cursor
+    }
+
+    /// The first claimed-but-unfilled sequence at or after the cursor — the
+    /// head-of-line blocker that in-order delivery is waiting on — or `None` if every
+    /// outstanding sequence has arrived (delivery is limited only by the consumer).
+    ///
+    /// It is the start of the first gap: the cursor itself if the cursor has not
+    /// arrived, otherwise the end of the arrived run that begins at the cursor.
+    pub(crate) fn head_of_line(&self) -> Option<u64> {
+        match self.arrived.first() {
+            // A run starts exactly at the cursor: the blocker is just past it.
+            Some(first) if first.start == self.cursor => {
+                if first.end < self.frontier {
+                    Some(first.end)
+                } else {
+                    None
+                }
+            }
+            // The cursor itself has not arrived (a run exists later, or none does)
+            // but there is something outstanding.
+            _ if self.cursor < self.frontier => Some(self.cursor),
+            // Nothing outstanding.
+            _ => None,
+        }
+    }
+
+    /// The gaps between arrived runs within `[cursor, frontier)` — sequences claimed
+    /// but not yet filled, in ascending order. Their union with the arrived runs is
+    /// exactly `[cursor, frontier)`.
+    pub(crate) fn pending(&self) -> Vec<std::ops::Range<u64>> {
+        let mut gaps = Vec::new();
+        let mut at = self.cursor;
+        for run in &self.arrived {
+            if at < run.start {
+                gaps.push(at..run.start);
+            }
+            at = run.end;
+        }
+        if at < self.frontier {
+            gaps.push(at..self.frontier);
+        }
+        gaps
+    }
+
+    /// The contiguous arrived (filled) runs within `[cursor, frontier)`.
+    pub(crate) fn arrived(&self) -> &[std::ops::Range<u64>] {
+        &self.arrived
+    }
+}
+
+#[cfg(test)]
+impl<T> PagedRecvBuffer<T> {
+    /// Number of segments currently in the deque (test introspection only).
+    fn segment_count(&self) -> usize {
+        self.inner.locked.lock().segments.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All permutations of `0..n`, via Heap's algorithm. Used to exhaustively drive
+    /// fill orders in the sequencing tests.
+    fn permutations(n: usize) -> Vec<Vec<usize>> {
+        let mut items: Vec<usize> = (0..n).collect();
+        let mut out = Vec::new();
+        let mut c = vec![0usize; n];
+        out.push(items.clone());
+        let mut i = 0;
+        while i < n {
+            if c[i] < i {
+                if i % 2 == 0 {
+                    items.swap(0, i);
+                } else {
+                    items.swap(c[i], i);
+                }
+                out.push(items.clone());
+                c[i] += 1;
+                i = 0;
+            } else {
+                c[i] = 0;
+                i += 1;
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn new_then_poll_returns_none() {
+        let (_ring, mut consumer) = PagedRecvBuffer::<u64>::new();
+        assert_eq!(consumer.poll_next(), None);
+    }
+
+    #[test]
+    fn single_item_round_trip() {
+        let (ring, mut consumer) = PagedRecvBuffer::new();
+        let handle = ring.claim();
+        assert_eq!(handle.seq(), 0);
+        ring.fill(handle, 42u64);
+        assert_eq!(consumer.poll_next(), Some(42));
+        assert_eq!(consumer.poll_next(), None);
+    }
+
+    #[test]
+    fn out_of_order_fill_within_segment() {
+        let (ring, mut consumer) = PagedRecvBuffer::new();
+        let h0 = ring.claim();
+        let h1 = ring.claim();
+        let h2 = ring.claim();
+
+        // Fill out of order: 2, 0, 1
+        ring.fill(h2, 200u64);
+        // Cannot deliver seq 0 yet.
+        assert_eq!(consumer.poll_next(), None);
+
+        ring.fill(h0, 0u64);
+        // Now seq 0 is available but seq 1 blocks further delivery.
+        assert_eq!(consumer.poll_next(), Some(0));
+        assert_eq!(consumer.poll_next(), None);
+
+        ring.fill(h1, 100u64);
+        assert_eq!(consumer.poll_next(), Some(100));
+        assert_eq!(consumer.poll_next(), Some(200));
+        assert_eq!(consumer.poll_next(), None);
+    }
+
+    #[test]
+    fn cross_segment_delivery() {
+        let seg_size = 4;
+        let (ring, mut consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        // Claim enough to force at least 2 segment growths (3 segments total).
+        let n = seg_size * 3 + 2;
+        let handles: Vec<_> = (0..n).map(|_| ring.claim()).collect();
+        // Fill all in order.
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, i as u64);
+        }
+        // Drain all in order.
+        for i in 0..n {
+            assert_eq!(consumer.poll_next(), Some(i as u64), "mismatch at seq {i}");
+        }
+        assert_eq!(consumer.poll_next(), None);
+    }
+
+    #[test]
+    fn fill_outcome_sealed_on_last_fill() {
+        let seg_size = 8;
+        let (ring, _consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            let outcome = ring.fill(h, i as u64);
+            if i < seg_size - 1 {
+                assert_eq!(outcome, FillOutcome::Stored, "expected Stored at fill {i}");
+            } else {
+                assert_eq!(
+                    outcome,
+                    FillOutcome::SealedSegment,
+                    "expected SealedSegment on last fill"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn block_path_take_and_complete() {
+        let seg_size = 4;
+        let (ring, _consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        // Fill a full segment.
+        let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, i as u64);
+        }
+
+        // Take the completed segment.
+        let sw = ring
+            .take_completed_segment()
+            .expect("should have a full segment");
+        assert_eq!(sw.base_seq(), 0);
+
+        // Second immediate take returns None (already claimed).
+        assert!(ring.take_completed_segment().is_none());
+
+        // Complete it.
+        sw.complete();
+
+        // After completing, a new full segment can be taken.
+        let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, (seg_size + i) as u64);
+        }
+        let sw2 = ring
+            .take_completed_segment()
+            .expect("second full segment should be takeable");
+        assert_eq!(sw2.base_seq(), seg_size as u64);
+        sw2.complete();
+    }
+
+    #[test]
+    fn take_returns_none_when_partial() {
+        let seg_size = 4;
+        let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+        // Fill only some slots.
+        let handles: Vec<_> = (0..seg_size - 1).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, i as u64);
+        }
+        assert!(ring.take_completed_segment().is_none());
+    }
+
+    /// Block surface reads payloads in place via `Slot::get`, then completes.
+    #[test]
+    fn block_path_reads_payloads_in_place() {
+        let seg_size = 4;
+        let (ring, _consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, (i * 10) as u64);
+        }
+        let sw = ring.take_completed_segment().expect("full segment");
+        let seen: Vec<u64> = sw.payloads().iter().map(|s| *s.get().unwrap()).collect();
+        assert_eq!(seen, vec![0, 10, 20, 30]);
+        sw.complete();
+    }
+
+    /// `Slot::get` returns the payload for a filled slot. (The empty-slot `None`
+    /// branch is not reachable through the public block surface, which hands out only
+    /// FULL segments — every slot filled.)
+    #[test]
+    fn slot_get_returns_filled_payload() {
+        let seg_size = 4;
+        let (ring, _consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, (i * 7) as u64);
+        }
+        let sw = ring.take_completed_segment().expect("full segment");
+        for (i, slot) in sw.payloads().iter().enumerate() {
+            assert_eq!(*slot.get().expect("filled"), (i * 7) as u64);
+        }
+        sw.complete();
+    }
+
+    /// A `SegmentWrite` dropped without `complete()` still drains: the segment is
+    /// reclaimed (not left stuck DRAINING), so reclaim does not wedge behind it.
+    #[test]
+    fn drop_without_complete_reclaims() {
+        let seg_size = 2;
+        let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+        // Fill seg0 full and take it.
+        for i in 0..seg_size {
+            let h = ring.claim();
+            ring.fill(h, i as u64);
+        }
+        let sw = ring.take_completed_segment().expect("seg0 full");
+        assert_eq!(sw.base_seq(), 0);
+        // Drop WITHOUT complete(): the Drop safety net marks seg0 DRAINED.
+        drop(sw);
+        // `claim` runs reclaim before it grows, so the drained front pops on the
+        // claim *after* seg1 exists. Two claims: the first grows seg1, the second
+        // observes seg0 drained and reclaims it. A segment stuck DRAINING would
+        // never pop and the count would climb without bound.
+        for i in 0..2 {
+            let h = ring.claim();
+            ring.fill(h, 99 + i);
+        }
+        assert_eq!(
+            ring.segment_count(),
+            1,
+            "dropped-without-complete segment must drain and reclaim, not wedge"
+        );
+    }
+
+    /// `complete()` and `Drop` are exactly-once: payloads are freed once, never twice
+    /// (the DRAINED state guard makes the second drain a no-op).
+    #[test]
+    fn complete_then_drop_frees_exactly_once() {
+        use std::sync::atomic::{AtomicUsize, Ordering as O};
+        use std::sync::Arc as StdArc;
+
+        // Payload that bumps a shared counter on drop.
+        struct DropCounter(StdArc<AtomicUsize>);
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, O::SeqCst);
+            }
+        }
+
+        let drops = StdArc::new(AtomicUsize::new(0));
+        let seg_size = 2;
+        let (ring, _consumer) = PagedRecvBuffer::<DropCounter>::new_with_segment_size(seg_size);
+        for _ in 0..seg_size {
+            let h = ring.claim();
+            ring.fill(h, DropCounter(drops.clone()));
+        }
+        let sw = ring.take_completed_segment().expect("full");
+        // complete() frees both payloads.
+        sw.complete();
+        assert_eq!(
+            drops.load(O::SeqCst),
+            seg_size,
+            "complete frees every payload once"
+        );
+        // The implicit Drop after complete() must NOT double-free (state guard).
+        assert_eq!(
+            drops.load(O::SeqCst),
+            seg_size,
+            "Drop after complete is a no-op; no double free"
+        );
+    }
+
+    /// Eager per-segment reclaim: a later segment completed out of order frees its
+    /// payloads immediately, even while an earlier segment is still open.
+    #[test]
+    fn out_of_order_complete_frees_eagerly() {
+        use std::sync::atomic::{AtomicUsize, Ordering as O};
+        use std::sync::Arc as StdArc;
+
+        struct DropCounter(StdArc<AtomicUsize>);
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, O::SeqCst);
+            }
+        }
+
+        let drops = StdArc::new(AtomicUsize::new(0));
+        let seg_size = 2;
+        let (ring, _consumer) = PagedRecvBuffer::<DropCounter>::new_with_segment_size(seg_size);
+        // Claim two full segments' worth (seg0: 0,1 ; seg1: 2,3).
+        let handles: Vec<_> = (0..seg_size * 2).map(|_| ring.claim()).collect();
+        // Fill seg1 fully but leave seg0 entirely unfilled (out-of-order arrival).
+        // handles[2], handles[3] are seg1.
+        let mut it = handles.into_iter();
+        let h0 = it.next().unwrap(); // seg0 slot0 — held, not filled yet
+        let h1 = it.next().unwrap(); // seg0 slot1 — held, not filled yet
+        let h2 = it.next().unwrap();
+        let h3 = it.next().unwrap();
+        ring.fill(h2, DropCounter(drops.clone()));
+        ring.fill(h3, DropCounter(drops.clone()));
+        // seg1 is now FULL while seg0 is still OPEN. Take and complete seg1.
+        let sw = ring.take_completed_segment().expect("seg1 is full");
+        assert_eq!(
+            sw.base_seq(),
+            seg_size as u64,
+            "frontmost full segment is seg1"
+        );
+        sw.complete();
+        // seg1's two payloads freed immediately, even though seg0 sits ahead unfilled.
+        assert_eq!(
+            drops.load(O::SeqCst),
+            seg_size,
+            "out-of-order completed segment frees its budget eagerly"
+        );
+        // Fill seg0 so the held handles do not leak into later assertions.
+        ring.fill(h0, DropCounter(drops.clone()));
+        ring.fill(h1, DropCounter(drops.clone()));
+    }
+
+    /// Snapshot cursor tracks delivery after the stream consumer advances.
+    #[test]
+    fn snapshot_cursor_after_drain() {
+        let seg_size = 2;
+        let (ring, mut consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        let handles: Vec<_> = (0..5).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, i as u64);
+        }
+        // Deliver three in order.
+        for _ in 0..3 {
+            consumer.poll_next().unwrap();
+        }
+        let snap = ring.snapshot();
+        assert_eq!(
+            snap.cursor, 3,
+            "snapshot cursor reflects the consumer's position"
+        );
+        assert_eq!(snap.frontier, 5);
+        assert_eq!(snap.outstanding(), 2);
+        assert_eq!(snap.arrived(), &[3..5]);
+        assert_eq!(
+            snap.head_of_line(),
+            None,
+            "remaining outstanding have all arrived"
+        );
+    }
+
+    /// Exhaustive within-segment sequencing (invariant 3): for every fill order of a
+    /// single segment, delivery is the in-order prefix and yields all payloads
+    /// exactly once. Deterministic and single-threaded — the property is ordering
+    /// logic, not memory ordering, so it does not belong in loom.
+    #[test]
+    fn exhaustive_fill_order_within_segment() {
+        let seg_size = 4;
+        for perm in permutations(seg_size) {
+            let (ring, mut consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+            let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+
+            // Fill in the permuted order; after each fill, everything delivered so
+            // far must equal the in-order prefix that is now contiguous from 0.
+            let mut filled = vec![false; seg_size];
+            let mut delivered = Vec::new();
+            for &slot in &perm {
+                ring.fill_at(&handles, slot, (slot * 10) as u64);
+                filled[slot] = true;
+                // The deliverable prefix is the longest run of filled-from-0.
+                let mut deliverable = 0;
+                while deliverable < seg_size && filled[deliverable] {
+                    deliverable += 1;
+                }
+                while let Some(v) = consumer.poll_next() {
+                    delivered.push(v);
+                }
+                let expect: Vec<u64> = (0..deliverable as u64).map(|i| i * 10).collect();
+                assert_eq!(
+                    delivered, expect,
+                    "perm {perm:?}: wrong prefix after filling {slot}"
+                );
+            }
+            // Everything delivered, nothing left.
+            assert_eq!(consumer.poll_next(), None, "perm {perm:?}: residue");
+        }
+    }
+
+    /// Exhaustive cross-segment sequencing: every fill order across three segments
+    /// delivers the in-order prefix and yields all payloads exactly once, covering
+    /// the hop's sequencing logic deterministically (concurrency is loom's job).
+    #[test]
+    fn exhaustive_fill_order_across_segments() {
+        let seg_size = 2;
+        let n = seg_size * 3; // 6 sequences across 3 segments
+        for perm in permutations(n) {
+            let (ring, mut consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+            let handles: Vec<_> = (0..n).map(|_| ring.claim()).collect();
+
+            let mut delivered = Vec::new();
+            for &slot in &perm {
+                ring.fill_at(&handles, slot, (slot * 10) as u64);
+                while let Some(v) = consumer.poll_next() {
+                    delivered.push(v);
+                }
+            }
+            let expect: Vec<u64> = (0..n as u64).map(|i| i * 10).collect();
+            assert_eq!(delivered, expect, "perm {perm:?}: out-of-order or lost");
+            assert_eq!(consumer.poll_next(), None);
+        }
+    }
+
+    #[test]
+    fn snapshot_non_contiguous() {
+        let (ring, _consumer) = PagedRecvBuffer::new();
+        let mut handles = Vec::new();
+        for _ in 0..6 {
+            handles.push(ring.claim());
+        }
+
+        // Fill seq 0, 1, 3, 5 — leave gaps at 2 and 4.
+        ring.fill(handles.remove(0), 100u64); // seq 0
+        ring.fill(handles.remove(0), 101u64); // seq 1
+        let h2 = handles.remove(0); // seq 2 — not filled
+        ring.fill(handles.remove(0), 103u64); // seq 3
+        let h4 = handles.remove(0); // seq 4 — not filled
+        ring.fill(handles.remove(0), 105u64); // seq 5
+
+        let snap = ring.snapshot();
+        assert_eq!(snap.cursor, 0);
+        assert_eq!(snap.frontier, 6);
+        assert_eq!(snap.arrived(), &[0..2, 3..4, 5..6]);
+        assert_eq!(snap.outstanding(), 6);
+        // 0,1 arrived; the run starting at the cursor ends at 2, so 2 is the blocker.
+        assert_eq!(snap.head_of_line(), Some(2));
+        assert_eq!(snap.pending(), vec![2..3, 4..5]);
+
+        // Fill the gaps to avoid leaking.
+        ring.fill(h2, 102u64);
+        ring.fill(h4, 104u64);
+    }
+
+    /// Snapshot accessors when the cursor sequence itself has not arrived.
+    #[test]
+    fn snapshot_head_of_line_at_cursor() {
+        let (ring, _consumer) = PagedRecvBuffer::new();
+        let h0 = ring.claim();
+        let h1 = ring.claim();
+        // Fill only seq 1; seq 0 (the cursor) is the blocker.
+        ring.fill(h1, 11u64);
+
+        let snap = ring.snapshot();
+        assert_eq!(snap.cursor, 0);
+        assert_eq!(snap.frontier, 2);
+        assert_eq!(snap.head_of_line(), Some(0));
+        assert_eq!(snap.pending(), vec![0..1]);
+        assert_eq!(snap.arrived(), &[1..2]);
+
+        ring.fill(h0, 10u64);
+    }
+
+    /// Snapshot when the whole outstanding window has arrived: no head-of-line
+    /// blocker (delivery is consumer-limited only).
+    #[test]
+    fn snapshot_fully_arrived_no_blocker() {
+        let (ring, _consumer) = PagedRecvBuffer::new();
+        let h0 = ring.claim();
+        let h1 = ring.claim();
+        ring.fill(h0, 10u64);
+        ring.fill(h1, 11u64);
+
+        let snap = ring.snapshot();
+        assert_eq!(snap.outstanding(), 2);
+        assert_eq!(snap.head_of_line(), None);
+        assert!(snap.pending().is_empty());
+        assert_eq!(snap.arrived(), &[0..2]);
+    }
+
+    #[test]
+    fn reclaim_via_stream_and_claim() {
+        let seg_size = 4;
+        let (ring, mut consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        // Fill two full segments.
+        let n = seg_size * 2;
+        let handles: Vec<_> = (0..n).map(|_| ring.claim()).collect();
+        for (i, h) in handles.into_iter().enumerate() {
+            ring.fill(h, i as u64);
+        }
+        // At this point we have 2 segments in the deque.
+        assert_eq!(ring.segment_count(), 2);
+
+        // Consume all of the first segment and one item into the second.
+        for _ in 0..seg_size + 1 {
+            consumer.poll_next().unwrap();
+        }
+
+        // Trigger reclaim by claiming more (which runs reclaim_locked).
+        let h = ring.claim();
+        ring.fill(h, 999u64);
+
+        // The first segment should have been reclaimed.
+        assert_eq!(
+            ring.segment_count(),
+            2,
+            "first segment should be reclaimed, leaving the second + newly grown"
+        );
+    }
+
+    #[test]
+    fn concurrent_producer_consumer() {
+        let seg_size = 4;
+        let (ring, mut consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
+        let n = seg_size * 4;
+        let ring_clone = ring.clone();
+
+        std::thread::scope(|s| {
+            // Producer thread: claim and fill in order.
+            s.spawn(move || {
+                for i in 0..n {
+                    let h = ring_clone.claim();
+                    ring_clone.fill(h, i as u64);
+                }
+            });
+
+            // Consumer in main thread.
+            let mut received = Vec::with_capacity(n);
+            while received.len() < n {
+                if let Some(v) = consumer.poll_next() {
+                    received.push(v);
+                }
+            }
+            let expected: Vec<u64> = (0..n as u64).collect();
+            assert_eq!(received, expected);
+        });
+    }
+}
+
+#[cfg(test)]
+impl<T> PagedRecvBuffer<T> {
+    /// Test helper: fill the handle for sequence `slot`, taken out of a slice of
+    /// claimed handles by index. Lets a test drive fills in an arbitrary order
+    /// without consuming the whole slice up front. Each handle is filled at most
+    /// once; the cell is taken on use.
+    fn fill_at(&self, handles: &[SlotHandle<T>], slot: usize, value: T) {
+        // Fill by index without consuming the handle, so a test can drive an
+        // arbitrary fill order over a pre-claimed slice.
+        let h = &handles[slot];
+        let seg = h.seg.clone();
+        let idx = h.idx;
+        seg.slots[idx].data.with_mut(|p| unsafe {
+            *p = Some(value);
+        });
+        seg.slots[idx].state.publish_filled();
+        let prev = seg.filled_count.fetch_add(1, Ordering::AcqRel);
+        if prev + 1 == seg.slots.len() {
+            seg.state.set_full();
+        }
+    }
+}
+
+// Loom model-checks the real structure directly (no model of it): the compat layer
+// swaps in loom's atomics/Arc/Mutex under `cfg(s3_tm_loom)`. Segment size is set to
+// 2 per ring (via new_with_segment_size) so boundary-crossing interleavings stay
+// tractable; the algorithm is identical at any size. Six models cover the handoff,
+// the segment hop, reclaim vs an outstanding write (complete and drop paths),
+// multi-producer fill, and the block-take CAS. Run with:
+//   RUSTFLAGS="--cfg s3_tm_loom" cargo test --lib --release loom_tests -- --test-threads=1
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use super::*;
+    use crate::runtime::sync::thread;
+
+    /// Model 1 — the fill→poll_next handoff.
+    ///
+    /// One producer fills seq 0 on another thread while the consumer polls. The
+    /// `publish_filled` (Release) / `is_filled` (Acquire) pair must ensure the
+    /// consumer either sees nothing yet (`None`) or the *correct* payload — never a
+    /// slot observed filled before its data write is visible. loom's `UnsafeCell`
+    /// flags any read not ordered after the write.
+    #[test]
+    fn fill_poll_handoff() {
+        loom::model(|| {
+            let (ring, mut consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
+            let handle = ring.claim(); // seq 0, on this thread (claim takes the lock)
+
+            let producer = thread::spawn(move || {
+                ring.fill(handle, 42);
+            });
+
+            // Poll concurrently with the fill. Either outcome is legal; a torn or
+            // premature read is not.
+            if let Some(v) = consumer.poll_next() {
+                assert_eq!(v, 42, "observed filled slot must carry the published value");
+            }
+
+            producer.join().unwrap();
+
+            // After the producer has finished, the value is deliverable exactly once.
+            let tail = consumer.poll_next();
+            assert!(tail.is_none() || tail == Some(42));
+        });
+    }
+
+    /// Model 2 — the segment hop.
+    ///
+    /// With segment size 2, seqs 0,1 live in seg0 and seq 2 forces seg1 (the issuer
+    /// publishes `seg0.next` with Release). A producer fills all three while the
+    /// consumer drains across the boundary, where `poll_next` loads `next` (Acquire)
+    /// and reconstructs an `Arc` from the raw pointer. loom's Arc registry detects any
+    /// use-after-free if the hop could observe a freed segment; the `Acquire`/`Release`
+    /// on `next` must make the successor visible before use.
+    #[test]
+    fn segment_hop() {
+        loom::model(|| {
+            let (ring, mut consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
+
+            let producer = thread::spawn(move || {
+                for i in 0..3u64 {
+                    let h = ring.claim();
+                    ring.fill(h, i);
+                }
+            });
+
+            // Drain up to all three, tolerating not-yet-arrived gaps. Bounded so the
+            // model terminates.
+            let mut got = Vec::new();
+            for _ in 0..6 {
+                match consumer.poll_next() {
+                    Some(v) => got.push(v),
+                    None => {
+                        if got.len() == 3 {
+                            break;
+                        }
+                    }
+                }
+            }
+            producer.join().unwrap();
+
+            // Whatever prefix was delivered must be the in-order prefix 0,1,2,...
+            for (i, v) in got.iter().enumerate() {
+                assert_eq!(*v, i as u64, "delivery must be in order across the hop");
+            }
+            while let Some(v) = consumer.poll_next() {
+                got.push(v);
+            }
+            assert_eq!(got, vec![0, 1, 2]);
+        });
+    }
+
+    /// Model 3 — segment reclaim vs an outstanding write pin.
+    ///
+    /// Fill seg0 full (seqs 0,1) so it is takeable on the block surface. One thread
+    /// takes it and `complete`s it (frees payloads, marks DRAINED, reclaims drained
+    /// front segments); concurrently the other thread `claim`s seq 2 (which grows
+    /// seg1 and runs front-reclaim). The `SegmentWrite` pins seg0 via its `Arc`
+    /// until `complete`, so the segment must not be freed while the token is alive,
+    /// and the two reclaim paths (claim's and complete's) must not double-free.
+    /// loom's Arc registry asserts exactly-once teardown.
+    #[test]
+    fn reclaim_vs_outstanding_write() {
+        loom::model(|| {
+            let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
+            // Fill seg0 (seqs 0,1) to FULL.
+            for i in 0..2 {
+                let h = ring.claim();
+                ring.fill(h, i as u64);
+            }
+
+            let ring2 = ring.clone();
+            let taker = thread::spawn(move || {
+                let sw = ring2
+                    .take_completed_segment()
+                    .expect("seg0 is full and takeable");
+                assert_eq!(sw.base_seq(), 0);
+                sw.complete(); // frees payloads, DRAINED, reclaim_front
+            });
+
+            // Concurrently grow + reclaim from the issuer side.
+            let h = ring.claim(); // seq 2 → grows seg1, runs reclaim_locked
+            ring.fill(h, 99);
+
+            taker.join().unwrap();
+            assert!(ring.segment_count() >= 1);
+        });
+    }
+
+    /// Model 4 — two producers, out-of-order fill, one consumer.
+    ///
+    /// Both sequences of seg0 are claimed on this thread (claim is serialized under
+    /// the lock), then producer A fills seq 1 and producer B fills seq 0 concurrently
+    /// while the consumer drains. This is the multi-producer handoff that Model 1
+    /// does not exercise: two `filled_count` `fetch_add`s race, exactly one observes
+    /// the count reach the segment size and seals it, and the consumer must still see
+    /// each payload exactly once and strictly in order regardless of which fill lands
+    /// first. loom's `UnsafeCell` and Arc registry catch a torn read or a lost/dup
+    /// payload.
+    #[test]
+    fn two_producers_out_of_order() {
+        loom::model(|| {
+            let (ring, mut consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
+            let h0 = ring.claim(); // seq 0
+            let h1 = ring.claim(); // seq 1
+
+            let ring_a = ring.clone();
+            let a = thread::spawn(move || {
+                ring_a.fill(h1, 1); // out of order: seq 1 first
+            });
+            let b = thread::spawn(move || {
+                ring.fill(h0, 0);
+            });
+
+            // Drain concurrently; bounded.
+            let mut got = Vec::new();
+            for _ in 0..4 {
+                if let Some(v) = consumer.poll_next() {
+                    got.push(v);
+                }
+                if got.len() == 2 {
+                    break;
+                }
+            }
+            a.join().unwrap();
+            b.join().unwrap();
+            while let Some(v) = consumer.poll_next() {
+                got.push(v);
+            }
+            // In-order, exactly once, both present.
+            assert_eq!(got, vec![0, 1]);
+        });
+    }
+
+    /// Model 5 — two block takers race one full segment.
+    ///
+    /// seg0 is filled FULL, then two threads call `take_completed_segment`
+    /// concurrently. The `FULL → DRAINING` CAS must hand the segment to exactly one:
+    /// one thread gets `Some(SegmentWrite)`, the other `None`. This proves the
+    /// at-most-once handout invariant under contention, which the single-threaded
+    /// "second take returns None" test cannot.
+    #[test]
+    fn two_takers_race_one_segment() {
+        loom::model(|| {
+            let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
+            for i in 0..2 {
+                let h = ring.claim();
+                ring.fill(h, i as u64);
+            }
+
+            let ring2 = ring.clone();
+            let t1 = thread::spawn(move || ring2.take_completed_segment().map(|sw| sw.base_seq()));
+            let t2 = thread::spawn(move || ring.take_completed_segment().map(|sw| sw.base_seq()));
+
+            let r1 = t1.join().unwrap();
+            let r2 = t2.join().unwrap();
+
+            // Exactly one winner, and it got seg0.
+            let winners: Vec<u64> = [r1, r2].into_iter().flatten().collect();
+            assert_eq!(
+                winners,
+                vec![0],
+                "exactly one taker wins the FULL→DRAINING CAS"
+            );
+        });
+    }
+
+    /// Model 6 — segment drop (no complete) vs concurrent reclaim.
+    ///
+    /// Same shape as Model 3, but the taker **drops** the `SegmentWrite` instead of
+    /// calling `complete()`. The `Drop` safety net runs the same drain (free
+    /// payloads, set DRAINED, reclaim_front) concurrently with the issuer's `claim`
+    /// reclaim. The drain's idempotency guard and the `Arc` pin must still give
+    /// exactly-once teardown across the drop path and claim's reclaim — loom's Arc
+    /// registry catches a double-free or use-after-free.
+    #[test]
+    fn drop_without_complete_vs_reclaim() {
+        loom::model(|| {
+            let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(2);
+            for i in 0..2 {
+                let h = ring.claim();
+                ring.fill(h, i as u64);
+            }
+
+            let ring2 = ring.clone();
+            let taker = thread::spawn(move || {
+                let sw = ring2
+                    .take_completed_segment()
+                    .expect("seg0 is full and takeable");
+                assert_eq!(sw.base_seq(), 0);
+                // Drop without complete(): Drop must drain and reclaim safely.
+                drop(sw);
+            });
+
+            let h = ring.claim(); // seq 2 → grows seg1, runs reclaim_locked
+            ring.fill(h, 99);
+
+            taker.join().unwrap();
+            assert!(ring.segment_count() >= 1);
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -1330,12 +1330,20 @@ mod tests {
         }
         assert_eq!(
             outcomes,
-            vec![FillOutcome::Stored, FillOutcome::Stored, FillOutcome::DrainReady],
+            vec![
+                FillOutcome::Stored,
+                FillOutcome::Stored,
+                FillOutcome::DrainReady
+            ],
             "the fill that reaches the batch raises DrainReady"
         );
         let r0 = ring.take_drain_run(false).expect("batch-sized prefix run");
         assert_eq!(r0.base_seq(), 0);
-        assert_eq!(r0.payloads().len(), batch, "prefix run is exactly the batch");
+        assert_eq!(
+            r0.payloads().len(),
+            batch,
+            "prefix run is exactly the batch"
+        );
         r0.complete();
 
         // One slot of residue remains (slot 3). A non-terminal claim cannot take it —
@@ -1355,9 +1363,17 @@ mod tests {
         );
         let r1 = ring.take_drain_run(false).expect("segment-end residue run");
         assert_eq!(r1.base_seq(), batch as u64);
-        assert_eq!(r1.payloads().len(), seg_size - batch, "residue is the sub-batch tail");
+        assert_eq!(
+            r1.payloads().len(),
+            seg_size - batch,
+            "residue is the sub-batch tail"
+        );
         r1.complete();
-        assert_eq!(ring.released(), seg_size as u64, "every slot drained exactly once");
+        assert_eq!(
+            ring.released(),
+            seg_size as u64,
+            "every slot drained exactly once"
+        );
     }
 
     /// The block surface advances `released` (the read-ahead gate's denominator) by a
@@ -1379,14 +1395,26 @@ mod tests {
         ring.fill_at(&handles, 0, 0);
         ring.fill_at(&handles, 1, 10);
         ring.take_drain_run(false).expect("run [0,2)").complete();
-        assert_eq!(ring.released(), 2, "a block drain advances released by the run length");
-        assert_eq!(ring.consumed(), 0, "the block surface never advances the stream cursor");
+        assert_eq!(
+            ring.released(),
+            2,
+            "a block drain advances released by the run length"
+        );
+        assert_eq!(
+            ring.consumed(),
+            0,
+            "the block surface never advances the stream cursor"
+        );
 
         // Second batch of 2 arrives and drains as run [2,4).
         ring.fill_at(&handles, 2, 20);
         ring.fill_at(&handles, 3, 30);
         ring.take_drain_run(false).expect("run [2,4)").complete();
-        assert_eq!(ring.released(), 4, "released tracks total drained across runs");
+        assert_eq!(
+            ring.released(),
+            4,
+            "released tracks total drained across runs"
+        );
         assert_eq!(ring.consumed(), 0, "consumed stays put on the block path");
     }
 
@@ -1995,7 +2023,11 @@ mod loom_tests {
             // the two reclaim paths double-popping.
             let h = ring.claim();
             ring.fill(h, 100);
-            assert_eq!(ring.front_base(), 2, "drained seg0 (base 0) reclaimed exactly once");
+            assert_eq!(
+                ring.front_base(),
+                2,
+                "drained seg0 (base 0) reclaimed exactly once"
+            );
         });
     }
 
@@ -2115,7 +2147,11 @@ mod loom_tests {
             // `drained_count` and reclaim freed the right segment without double-pop.
             let h = ring.claim();
             ring.fill(h, 100);
-            assert_eq!(ring.front_base(), 2, "drop-drained seg0 (base 0) reclaimed exactly once");
+            assert_eq!(
+                ring.front_base(),
+                2,
+                "drop-drained seg0 (base 0) reclaimed exactly once"
+            );
         });
     }
 
@@ -2158,7 +2194,11 @@ mod loom_tests {
             while let Some(v) = consumer.poll_next() {
                 got.push(v);
             }
-            assert_eq!(got, vec![0, 1, 2, 3], "in-order, exactly once, across the hop");
+            assert_eq!(
+                got,
+                vec![0, 1, 2, 3],
+                "in-order, exactly once, across the hop"
+            );
         });
     }
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -6,142 +6,146 @@
 //! In-order delivery over out-of-order arrival.
 //!
 //! `PagedRecvBuffer<T>` assigns each payload a sequence number at claim time, accepts
-//! completed payloads into their slots in any order from many producers, and
-//! delivers them to a single consumer in sequence order. It grows to absorb
-//! head-of-line backlog and shrinks as delivery advances; its resident footprint
-//! tracks the gap between the oldest undelivered and newest claimed sequence,
-//! not the total sequence count.
+//! completed payloads into their slots in any order from many producers, and delivers
+//! them to a single consumer. It grows to absorb head-of-line backlog and shrinks as
+//! delivery advances; its resident footprint tracks the gap between the oldest
+//! undelivered and newest claimed sequence, not the total sequence count.
+//!
+//! A payload is consumed through exactly one of two surfaces (see Surface exclusion):
+//! the **stream** surface delivers one payload at a time in strict sequence order; the
+//! **block** surface hands out contiguous filled runs for bulk consumption (disk
+//! writes) with no in-order requirement. The Structure and Locking below are shared;
+//! each surface is then described on its own.
 //!
 //! # Structure
 //!
-//! Two levels. The primary level is a `VecDeque<Arc<Segment<T>>>` guarded by one
-//! `Mutex`; each segment holds a fixed run of `seg_size` slots covering a contiguous
-//! span of sequence numbers. The deque grows at the tail and is reclaimed from the
-//! front, so only the segments spanning the live window are resident.
+//! A `VecDeque<Arc<Segment<T>>>` guarded by one `Mutex`; each segment holds a fixed run
+//! of `seg_size` slots covering a contiguous span of sequence numbers. The deque grows
+//! at the tail and is reclaimed from the front, so only the segments spanning the live
+//! window are resident.
 //!
 //! ```text
-//!         reclaim ◀── front                    tail ──▶ grow
-//!   ┌───────────── Mutex<{ segments, issued }> ─────────────┐
-//!   │  ┌─────────┐     ┌─────────┐     ┌─────────┐          │
-//!   │  │  seg 0  │─nx─▶│  seg 1  │─nx─▶│  seg 2  │          │
-//!   │  │ F F . . │     │ F F F F │     │ F . _ _ │          │
-//!   │  │ 0 1 2 3 │     │ 4 5 6 7 │     │ 8 9     │          │
-//!   │  │ base=0  │     │ base=4  │     │ base=8  │ issued=9 │
-//!   │  └─────────┘     └────▲────┘     └─▲───────┘          │
-//!   └───────────────────────┼───────────┼──────────────────┘
-//!     consumed=6            cursor=5    fill (producers, any order, lock-free)
-//!     (RecvBufferConsumer.current ─┘
-//!      hops seg→seg via `nx`, lock-free)
+//!   reclaim ◀── front                        tail ──▶ grow
+//!   ┌─────────┐    ┌─────────┐    ┌─────────┐
+//!   │  seg 0  │─nx▶│  seg 1  │─nx▶│  seg 2  │
+//!   │ x x x x │    │ x x x . │    │ F . _ _ │
+//!   │ 0 1 2 3 │    │ 4 5 6 7 │    │ 8 9     │
+//!   │ base=0  │    │ base=4  │    │ base=8  │
+//!   └─────────┘    └───────▲─┘    └─────────┘
+//!                          │
+//!                     cursor=7   (issued=10; cursor mirrored to inner.consumed)
 //!
-//!   F = FILLED slot   _ = EMPTY slot   . = delivered/consumed   nx = next pointer
+//!   x = delivered (below the cursor; slot emptied)   F = filled, awaiting delivery
+//!   . = claimed but not yet filled (in flight)       _ = slot not yet claimed
+//!   nx = next pointer   (stream-surface view)
 //! ```
 //!
-//! In this picture the consumer has delivered seqs 0–4 (cursor at 5, the head of
-//! `seg 1`), producers have filled 5–8 out of order, seq 9 is still in flight, and
-//! `seg 0` is fully consumed (eligible for front-reclaim on the next claim). A
-//! `VecDeque` reallocation moves only the `Arc` pointers; the segments are
+//! In this picture (a stream consumer) seqs 0–6 are delivered (cursor at 7). Seq 7 is
+//! in flight and is the head-of-line gap: the cursor cannot advance until it fills,
+//! even though seq 8 has already arrived (`F` in `seg 2`) and waits behind it. Seq 9 is
+//! in flight; seqs 10–11 are not yet claimed (`issued == 10`). `seg 0` is fully
+//! delivered, eligible for front-reclaim on the next claim.
+//!
+//! A `VecDeque` reallocation moves only the `Arc` pointers; the segments are
 //! heap-stable behind `Arc`, so no producer or consumer reference is invalidated by
 //! growth. The only intrusive link is one `next` pointer per segment, by which the
-//! consumer reaches the successor segment without taking the lock.
+//! stream consumer reaches the successor segment without taking the lock.
 //!
-//! The stream surface (drawn above) tracks delivery with `consumed`. The block surface
-//! instead tracks two per-segment counters: `claim_cursor`, the number of leading
-//! slots claimed for draining, and `drained_count`, the number written and freed. A
-//! segment is reclaimable when either surface has finished it — `base + len <=
-//! consumed` for the stream, or `drained_count == len` for the block.
-//!
-//! # Locking
-//!
-//! One `Mutex` guards the segment deque and the `issued` counter. Only the issuer
-//! and block paths take it — `claim` (assign a sequence, maybe grow, opportunistic
-//! reclaim), `take_drain_run` (scan a contiguous filled run and claim it by advancing
-//! `claim_cursor`), and `complete`/drop reclaim. Each is a short critical section: a
-//! cursor scan or a `pop_front` loop, never held across the disk write itself. The two
-//! hot paths are lock-free: `fill` writes a claimed slot and publishes it with a
-//! `Release` store; `poll_next` reads the cursor slot under `Acquire` and hops
-//! segments via the `next` pointer. The delivery cursor lives in `RecvBufferConsumer` and
-//! is mirrored to an atomic `consumed` so the issuer's reclaim can read it without
-//! synchronizing with the consumer.
-//!
-//! # Roles
-//!
-//! - **issuer** — assigns sequence numbers and grows and reclaims segments. The
-//!   only writer to the deque; the one internal lock serializes issuers. Off the
-//!   hot path (producers fill lock-free), and claims are infrequent relative to
-//!   fills, so lock contention is incidental.
-//! - **producers** — each writes the single slot it claimed. Concurrent and
-//!   lock-free, touching disjoint memory.
-//! - **consumer** — reads slots in sequence order. Single and lock-free.
-//!
-//! # Surfaces
-//!
-//! [`PagedRecvBuffer::new`] returns a `(PagedRecvBuffer<T>, RecvBufferConsumer<T>)` pair, channel-style.
-//! The `PagedRecvBuffer` is cloneable and carries the producer and block surfaces; the
-//! `RecvBufferConsumer` is unique (not cloneable) and carries the stream surface.
-//!
-//! - **producer** (`PagedRecvBuffer`) — [`claim`](PagedRecvBuffer::claim) then
-//!   [`fill`](PagedRecvBuffer::fill).
-//! - **stream** (`RecvBufferConsumer`) — [`poll_next`](RecvBufferConsumer::poll_next) delivers
-//!   one payload at a time in strict sequence order, advancing a single cursor.
-//!   Taking `&mut self`, on a non-cloneable handle, makes "single consumer" a
-//!   type-level fact and lets the cursor and current-segment cache live in the
-//!   handle (so the hop needs no lock).
-//! - **block** (`PagedRecvBuffer`) — [`take_drain_run`](PagedRecvBuffer::take_drain_run)
-//!   hands out a contiguous filled *run* (a prefix of a segment, of at least the drain
-//!   batch) as an owned [`SegmentWrite`], for bulk consumption that does not need
-//!   in-order single-item delivery. Runs may be taken and completed out of order and
-//!   concurrently, and a single segment may be partitioned into several runs.
-//!
-//! An instance is driven through one consumption surface or the other, never both:
-//! the stream cursor empties slots as it passes; the block surface reads runs in place
-//! and frees them. A block-only caller drops the `RecvBufferConsumer`. **This exclusion is a
-//! caller obligation, not type-enforced** — `PagedRecvBuffer` is `Clone` and exposes the
-//! block surface, so the type system does not prevent driving both at once. Doing so
-//! races the stream `take` against the block in-place read and is undefined; the
-//! `unsafe` in both paths relies on the caller honoring this.
-//!
-//! # Slot states
+//! A slot moves `EMPTY → FILLED` and, on the stream path, back to `EMPTY`:
 //!
 //! ```text
 //!   EMPTY ──claim, then fill──▶ FILLED ──stream take──▶ EMPTY
 //! ```
 //!
 //! `FILLED` is published with a `Release` store after the payload write; a reader
-//! observes it with an `Acquire` load before reading the payload. The block
-//! surface leaves slots `FILLED` and frees them at run granularity.
+//! observes it with an `Acquire` load before reading the payload (the handoff, ordering
+//! rule 2). The block surface leaves slots `FILLED` and frees their payloads at run
+//! granularity rather than emptying them.
 //!
-//! # Segment progress (block surface)
+//! # Locking
 //!
-//! A segment carries three monotonic counts rather than a single state flag:
+//! One `Mutex` guards the segment deque and the `issued` counter. Only three paths take
+//! it — `claim` (assign a sequence, maybe grow, opportunistic reclaim),
+//! `take_drain_run` (scan a filled run and claim it by advancing `claim_cursor`), and
+//! `complete`/drop reclaim. Each is a short critical section — a cursor scan or a
+//! `pop_front` loop — never held across the disk write itself. The two hot paths are
+//! lock-free: `fill` writes a claimed slot and publishes it with a `Release` store;
+//! `poll_next` reads the cursor slot under `Acquire`. One lock acquisition per claim,
+//! none per fill.
+//!
+//! # Stream surface
+//!
+//! [`RecvBufferConsumer`] is the unique (non-cloneable) stream handle;
+//! [`poll_next`](RecvBufferConsumer::poll_next) delivers one payload at a time in
+//! strict sequence order. `poll_next` takes `&mut self`, so "single consumer" is a
+//! type-level fact: the delivery cursor and the current-segment `Arc` are fields of the
+//! handle rather than shared state, and `poll_next` reads and advances them — including
+//! the hop to a successor segment via its `next` pointer — without taking the lock.
+//!
+//! The cursor is mirrored to an atomic `consumed` (the two are always equal) so the
+//! issuer can read the delivery position for reclaim without synchronizing with the
+//! consumer. A segment is stream-reclaimable once `base + len <= consumed`: every slot
+//! it covers has been delivered.
+//!
+//! # Block surface
+//!
+//! [`PagedRecvBuffer`] is the cloneable producer/block handle;
+//! [`take_drain_run`](PagedRecvBuffer::take_drain_run) hands out a contiguous filled
+//! *run* as an owned [`SegmentWrite`] for bulk consumption. Runs may be taken and
+//! completed out of order and concurrently, and one segment may be partitioned into
+//! several runs. The block surface never uses the delivery cursor; it tracks two
+//! per-segment counters instead:
 //!
 //! ```text
-//!   filled_count   slots a producer has filled (any positions)   — lock-free
-//!   claim_cursor   leading slots claimed for draining            — under the lock
-//!   drained_count  slots written to the sink and freed           — lock-free add
+//!   block surface: one segment, seg_size = 8, drain batch = 3
 //!
-//!   claim_cursor <= len, drained_count <= len
-//!   drained_count == len  ⇒  segment reclaimable
+//!     slot      0 1 2   3 4 5   6 7
+//!     payload   D D D   F F F   F .
+//!               └run A┘ └run B┘
+//!
+//!   claim_cursor = 6   slots 0-5 claimed for draining (runs A and B)
+//!   drained_count = 3  run A written to the sink and freed; run B claimed, still
+//!                      draining (its slots stay FILLED, only the payload is freed)
+//!   slot 6 is filled but the run beyond claim_cursor (just slot 6, slot 7 in flight)
+//!   is below the drain batch, so it cannot be claimed yet
+//!
+//!   D = drained (payload freed)   F = filled   . = claimed, in flight
 //! ```
 //!
-//! `claim_cursor` and `filled_count` are *not* mutually ordered. A drainer claims a run
-//! by scanning per-slot `FILLED` state, not by reading `filled_count`, and a producer
-//! publishes a slot `FILLED` before bumping `filled_count` (the bump is a probe input,
-//! not the source of truth). So a drainer can advance `claim_cursor` past a slot whose
-//! `filled_count` increment a concurrent producer has not yet performed: from that
-//! producer's view, `claim_cursor > filled_count` transiently. Both are bounded by
-//! `len`, and the per-slot `FILLED` state — not their relative order — is what gates a
-//! safe read. The fill probe's `filled - claim_cursor` is therefore a saturating
-//! subtraction, never a bare one.
+//! - `claim_cursor` — leading slots claimed for draining, advanced only under the lock
+//!   in `take_drain_run`, so a run is handed out at most once and concurrent drainers
+//!   take disjoint runs.
+//! - `drained_count` — slots written to the sink and freed. Advanced (lock-free) when a
+//!   run completes; when it reaches the segment length every claimed slot has been
+//!   written and the segment is block-reclaimable.
 //!
 //! A *drainable run* is the contiguous `FILLED` slice between `claim_cursor` and the
-//! first unfilled slot. [`take_drain_run`](PagedRecvBuffer::take_drain_run) claims such
-//! a run by advancing `claim_cursor` under the lock — so a run is handed out at most
-//! once, and a segment may be partitioned into several runs claimed by different
-//! drainers. A non-terminal claim waits until the run spans the drain batch; a terminal
-//! claim takes whatever contiguous prefix is filled. Completing a run frees its
-//! payloads and advances `drained_count`; when that reaches the segment length every
-//! claimed slot has been written, and the segment is reclaimable. The stream surface
-//! ignores these counts and reclaims by `consumed`.
+//! first unfilled slot. A non-terminal claim takes it once it spans the drain batch (or
+//! once it reaches the end of a full segment, so a sub-batch tail residue still drains);
+//! a terminal claim takes whatever contiguous filled prefix exists. Completing a run
+//! frees its payloads and advances `drained_count`; dropping the token without
+//! completing runs the same drain.
+//!
+//! A third count, `filled_count` (slots a producer has filled, lock-free), feeds only
+//! the advisory fill probe that raises the drain edge. `claim_cursor` and `filled_count`
+//! are *not* mutually ordered: a drainer claims by scanning per-slot `FILLED` state, not
+//! by reading `filled_count`, and a producer publishes a slot `FILLED` before bumping
+//! `filled_count`. So a drainer can advance `claim_cursor` past a slot whose
+//! `filled_count` increment a concurrent producer has not yet performed — from that
+//! producer's view `claim_cursor > filled_count` transiently. Both are bounded by `len`,
+//! and the per-slot `FILLED` state, not their relative order, gates a safe read; the
+//! fill probe's `filled - claim_cursor` is therefore a saturating subtraction, never a
+//! bare one.
+//!
+//! # Surface exclusion
+//!
+//! An instance is driven through one consumption surface or the other, never both: the
+//! stream cursor empties slots as it passes; the block surface reads runs in place and
+//! frees them. A block-only caller drops the `RecvBufferConsumer`. This exclusion is a
+//! caller obligation, not type-enforced — `PagedRecvBuffer` is `Clone` and exposes the
+//! block surface, so the type system does not prevent driving both at once. Doing so
+//! races the stream `take` against the block in-place read and is undefined behavior;
+//! the `unsafe` in both paths relies on the caller honoring this.
 //!
 //! # Memory ordering and safety
 //!
@@ -159,14 +163,16 @@
 //!    So a slot is never the live target of two sequences — there is no reuse window
 //!    to race. (The window the caller must bound is *resident memory*, not aliasing:
 //!    see Caller obligations.)
-//! 4. **Segment-reclaim safety (the hop).** A segment is removed from the deque
-//!    (`pop_front`, front-only) only once `base + len <= consumed`, and only the
-//!    consumer advances `consumed`. So when the consumer hops, the successor it is
-//!    about to enter (base `== consumed`) cannot be popped, and stays strong-
-//!    referenced by the deque — which is what lets the consumer reconstruct an `Arc`
-//!    from the `next` pointer without the lock. This concerns *segment* removal
-//!    only; emptying a *slot's* payload (delivery, or future demand reclaim) leaves
-//!    the segment in place and does not bear on the hop.
+//! 4. **Segment-reclaim safety (the hop).** A front segment is removed (`pop_front`,
+//!    front-only) once `base + len <= consumed` (stream-drained) or `drained_count ==
+//!    len` (block-drained). On the stream path only the first applies, and only the
+//!    consumer advances `consumed`, so when the consumer hops, the successor it is
+//!    about to enter (base `== consumed`) has `base + len <= consumed` false and is not
+//!    block-drained (the surfaces are exclusive, so `drained_count` stays 0). It cannot
+//!    be popped and stays strong-referenced by the deque — which is what lets the
+//!    consumer reconstruct an `Arc` from the `next` pointer without the lock. This
+//!    concerns *segment* removal only; emptying a *slot's* payload leaves the segment
+//!    in place and does not bear on the hop.
 //! 5. **Outstanding block pin.** A live [`SegmentWrite`] holds an
 //!    `Arc<Segment<T>>`, so a segment with a run still being consumed by the block
 //!    surface stays alive until that token drains, even if front-reclaim pops it from
@@ -344,12 +350,12 @@ struct Inner<T> {
     /// for reclaim, so it is atomic and padded off the lock's cache line.
     consumed: CachePadded<AtomicU64>,
     /// Count of parts whose payload memory the consumer has freed, across both
-    /// surfaces: the stream surface frees one per in-order delivery, the block
-    /// surface frees a whole segment's filled slots on drain (out of order). This is
-    /// resident occupancy's complement — `issued - released` is the read-ahead gate's
-    /// denominator. Distinct from `consumed`, which is the in-order cursor reclaim
-    /// needs; on the stream path the two advance together, on the block path only
-    /// `released` moves.
+    /// surfaces: the stream surface frees one per in-order delivery, the block surface
+    /// frees a run's slots per drain (out of order; a segment may be several runs).
+    /// This is resident occupancy's complement — `issued - released` is the read-ahead
+    /// gate's denominator. Distinct from `consumed`, which is the in-order cursor
+    /// reclaim needs; on the stream path the two advance together, on the block path
+    /// only `released` moves.
     released: CachePadded<AtomicU64>,
     /// Slots per segment for this instance. Fixed at construction; used to size
     /// the initial segment and every grown successor.
@@ -412,9 +418,10 @@ impl<T> SlotHandle<T> {
 
 /// The result of a [`fill`](PagedRecvBuffer::fill).
 ///
-/// `DrainReady` is an advisory edge signal: after this fill, the count of filled
-/// slots in the segment reached the drain batch ahead of the slots already claimed
-/// for draining, so a block-surface consumer should attempt a drain via
+/// `DrainReady` is an advisory edge signal: after this fill, either the filled count
+/// reached the drain batch ahead of the slots already claimed for draining, or the
+/// segment became completely filled (so a sub-batch tail residue can still drain). A
+/// block-surface consumer should then attempt a drain via
 /// [`take_drain_run`](PagedRecvBuffer::take_drain_run). It carries no sequence and is
 /// not authoritative — the filled slots may not form a contiguous run yet (an earlier
 /// slot in the batch is still in flight), in which case `take_drain_run` claims
@@ -423,11 +430,11 @@ impl<T> SlotHandle<T> {
 /// ignores the outcome entirely.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum FillOutcome {
-    /// Payload stored; the filled count has not reached the drain batch beyond what is
-    /// already claimed for draining.
+    /// Payload stored; the segment is neither full nor has its filled count reached the
+    /// drain batch beyond what is already claimed for draining.
     Stored,
-    /// Payload stored and the filled count reached the drain batch; a block consumer
-    /// should attempt [`take_drain_run`](PagedRecvBuffer::take_drain_run).
+    /// Payload stored and a drain edge was raised (drain batch reached, or segment
+    /// filled); a block consumer should attempt [`take_drain_run`](PagedRecvBuffer::take_drain_run).
     DrainReady,
 }
 
@@ -466,6 +473,7 @@ pub(crate) struct SegmentWrite<T> {
 
 impl<T> SegmentWrite<T> {
     /// Sequence number of the run's first slot.
+    #[cfg(test)]
     pub(crate) fn base_seq(&self) -> u64 {
         self.seg.base + self.start as u64
     }
@@ -506,9 +514,9 @@ impl<T> SegmentWrite<T> {
                 }
             });
         }
-        // Release the read-ahead occupancy these parts held. Counts only slots that
-        // actually carried a payload (a terminal run may include unfilled trailing
-        // slots if claimed loosely), so the count is exact.
+        // Release the read-ahead occupancy these parts held. A claimed run is entirely
+        // filled (`take_drain_run` scans only filled slots), so `freed == len`; counting
+        // the payloads actually taken keeps the occupancy exact regardless.
         self.inner.released.fetch_add(freed, Ordering::AcqRel);
         // Publish this run as drained. `AcqRel` so a reclaimer that reads `== len`
         // (`Acquire`) has seen the payload frees above. Adds `len`, not the freed
@@ -581,6 +589,7 @@ unsafe impl<T: Send> Sync for SegmentWrite<T> {}
 impl<T> PagedRecvBuffer<T> {
     /// Create an empty ring with the default segment size ([`DEFAULT_SEG_SIZE`]),
     /// returning the producer/block handle and the unique stream [`RecvBufferConsumer`].
+    #[cfg(test)]
     pub(crate) fn new() -> (Self, RecvBufferConsumer<T>) {
         Self::new_with_segment_size(DEFAULT_SEG_SIZE)
     }
@@ -654,7 +663,8 @@ impl<T> PagedRecvBuffer<T> {
     /// writes the slot's `data`, publishes filled via [`SlotState::publish_filled`],
     /// increments the segment's `filled_count`. Returns [`FillOutcome::DrainReady`]
     /// when the filled count reaches the drain batch beyond the slots already claimed
-    /// for draining.
+    /// for draining, or when this fill completes the segment (so a sub-batch tail
+    /// residue can still drain).
     pub(crate) fn fill(&self, handle: SlotHandle<T>, value: T) -> FillOutcome {
         let SlotHandle { seg, idx, .. } = handle;
         // Sole writer for this sequence number.
@@ -772,6 +782,7 @@ impl<T> PagedRecvBuffer<T> {
     /// This is the in-order reclaim threshold, not the read-ahead gate's denominator
     /// (use [`released`](Self::released) for that): the block surface delivers to disk
     /// without advancing this cursor.
+    #[cfg(test)]
     pub(crate) fn consumed(&self) -> u64 {
         self.inner.consumed.load(Ordering::Acquire)
     }
@@ -780,9 +791,9 @@ impl<T> PagedRecvBuffer<T> {
     /// stream and block surfaces. Lock-free.
     ///
     /// This is the read-ahead gate's denominator: the issuer bounds resident
-    /// occupancy by `issued − released < W` (the caller tracks `issued`; this
+    /// occupancy by `issued − released < window` (the caller tracks `issued`; this
     /// supplies `released`). Unlike [`consumed`](Self::consumed), it advances on the
-    /// block (disk) surface too, so a download larger than `W` keeps issuing as
+    /// block (disk) surface too, so a download larger than the window keeps issuing as
     /// segments drain instead of latching shut at the window.
     pub(crate) fn released(&self) -> u64 {
         self.inner.released.load(Ordering::Acquire)
@@ -797,6 +808,7 @@ impl<T> PagedRecvBuffer<T> {
     ///
     /// Callers that need byte offsets translate sequence numbers themselves; the
     /// ring has no notion of payload size.
+    #[cfg(test)]
     pub(crate) fn snapshot(&self) -> RecvBufferSnapshot {
         let guard = self.inner.locked.lock();
         let cursor = self.inner.consumed.load(Ordering::Acquire);
@@ -860,13 +872,16 @@ impl<T> RecvBufferConsumer<T> {
             }
             // SAFETY: `raw` points to the successor segment, whose base is
             // `cursor` (we are at `current`'s end, so `consumed == cursor ==
-            // successor.base`). A segment is popped only when `base + len <=
-            // consumed`; for the successor that is `cursor + len <= cursor`, which
-            // is false, so it cannot be popped while we hold here (ordering rule 4).
-            // Its allocation is therefore live and still strong-referenced by the
-            // deque, so increment_strong_count is sound; the matching Drop of this
-            // Arc balances the increment. (`current` itself may now be poppable, but
-            // we hold it via `self.current` until the reassignment below.)
+            // successor.base`). A segment is popped when `base + len <= consumed` or
+            // when it is block-drained (`drained_count == len`); for the successor the
+            // first is `cursor + len <= cursor`, false, and the second cannot hold
+            // because driving the block surface alongside the stream is forbidden (the
+            // surface contract), so `drained_count` stays 0. It therefore cannot be
+            // popped while we hold here (ordering rule 4). Its allocation is live and
+            // still strong-referenced by the deque, so increment_strong_count is sound;
+            // the matching Drop of this Arc balances the increment. (`current` itself
+            // may now be poppable, but we hold it via `self.current` until the
+            // reassignment below.)
             let next = unsafe {
                 Arc::increment_strong_count(raw);
                 Arc::from_raw(raw)
@@ -902,6 +917,7 @@ impl<T> RecvBufferConsumer<T> {
 /// mark which sequences in that span have landed (the complement is claimed but not
 /// yet filled). All accessors are derived from these; the raw runs are private so
 /// callers express intent through the methods rather than re-deriving them.
+#[cfg(test)]
 pub(crate) struct RecvBufferSnapshot {
     /// In-order delivery cursor: the next sequence to be delivered. Everything
     /// below it has been delivered.
@@ -915,6 +931,7 @@ pub(crate) struct RecvBufferSnapshot {
     arrived: Vec<std::ops::Range<u64>>,
 }
 
+#[cfg(test)]
 impl RecvBufferSnapshot {
     /// Number of claimed-but-undelivered sequences: `frontier - cursor`. The size of
     /// the live window the ring is holding open.
@@ -975,6 +992,13 @@ impl<T> PagedRecvBuffer<T> {
     /// Number of segments currently in the deque (test introspection only).
     fn segment_count(&self) -> usize {
         self.inner.locked.lock().segments.len()
+    }
+
+    /// Base sequence of the front (oldest) segment (test introspection only). Rises as
+    /// front segments are reclaimed, so a test can assert *which* segment is gone, not
+    /// merely how many remain.
+    fn front_base(&self) -> u64 {
+        self.inner.locked.lock().segments.front().unwrap().base
     }
 }
 
@@ -1284,6 +1308,88 @@ mod tests {
         );
     }
 
+    /// A drain batch that does not divide the segment size leaves a sub-batch tail
+    /// residue. The batch-sized prefix drains on the batch edge; the tail cannot form a
+    /// batch-sized run (the segment fills first), so it drains only because the fill
+    /// that completes the segment raises the edge and `take_drain_run` takes the
+    /// segment-end residue. Without that path the residue would pin occupancy forever.
+    #[test]
+    fn non_dividing_batch_drains_segment_tail_residue() {
+        let seg_size = 4;
+        let batch = 3; // does not divide 4: prefix of 3, residue of 1
+        let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+        ring.set_drain_batch(batch);
+
+        // Fill the first `batch` slots in order via the production claim/fill path, so
+        // the asserted FillOutcome is the real probe's, not a test mirror. The fill that
+        // reaches the batch raises the edge.
+        let mut outcomes = Vec::new();
+        for i in 0..batch {
+            let h = ring.claim();
+            outcomes.push(ring.fill(h, (i * 10) as u64));
+        }
+        assert_eq!(
+            outcomes,
+            vec![FillOutcome::Stored, FillOutcome::Stored, FillOutcome::DrainReady],
+            "the fill that reaches the batch raises DrainReady"
+        );
+        let r0 = ring.take_drain_run(false).expect("batch-sized prefix run");
+        assert_eq!(r0.base_seq(), 0);
+        assert_eq!(r0.payloads().len(), batch, "prefix run is exactly the batch");
+        r0.complete();
+
+        // One slot of residue remains (slot 3). A non-terminal claim cannot take it —
+        // it is below the batch and the segment is not yet full.
+        assert!(
+            ring.take_drain_run(false).is_none(),
+            "sub-batch residue is not drainable while the segment is incomplete"
+        );
+
+        // Fill the final slot: this completes the segment (`filled == len`), which
+        // raises the edge for exactly this residue.
+        let h = ring.claim();
+        assert_eq!(
+            ring.fill(h, 30),
+            FillOutcome::DrainReady,
+            "the fill that completes the segment raises the edge for the tail residue"
+        );
+        let r1 = ring.take_drain_run(false).expect("segment-end residue run");
+        assert_eq!(r1.base_seq(), batch as u64);
+        assert_eq!(r1.payloads().len(), seg_size - batch, "residue is the sub-batch tail");
+        r1.complete();
+        assert_eq!(ring.released(), seg_size as u64, "every slot drained exactly once");
+    }
+
+    /// The block surface advances `released` (the read-ahead gate's denominator) by a
+    /// run's filled count on each drain, while `consumed` (the in-order stream cursor)
+    /// never moves — the two counters are distinct on the block path. Two batches arrive
+    /// separately (a drain between them), so the segment is claimed as two runs of 2;
+    /// `take_drain_run` takes the whole contiguous filled run available, so batches must
+    /// be separated to observe per-run accounting.
+    #[test]
+    fn block_drain_advances_released_not_consumed() {
+        let seg_size = 4;
+        let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+        ring.set_drain_batch(2);
+        let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+        assert_eq!(ring.released(), 0);
+        assert_eq!(ring.consumed(), 0);
+
+        // First batch of 2 arrives and drains as run [0,2).
+        ring.fill_at(&handles, 0, 0);
+        ring.fill_at(&handles, 1, 10);
+        ring.take_drain_run(false).expect("run [0,2)").complete();
+        assert_eq!(ring.released(), 2, "a block drain advances released by the run length");
+        assert_eq!(ring.consumed(), 0, "the block surface never advances the stream cursor");
+
+        // Second batch of 2 arrives and drains as run [2,4).
+        ring.fill_at(&handles, 2, 20);
+        ring.fill_at(&handles, 3, 30);
+        ring.take_drain_run(false).expect("run [2,4)").complete();
+        assert_eq!(ring.released(), 4, "released tracks total drained across runs");
+        assert_eq!(ring.consumed(), 0, "consumed stays put on the block path");
+    }
+
     /// `consumed()` reports the in-order delivery cursor for the read-ahead gate.
     #[test]
     fn consumed_tracks_delivery_cursor() {
@@ -1333,35 +1439,66 @@ mod tests {
         sw.complete();
     }
 
-    /// A `SegmentWrite` dropped without `complete()` still drains: its run is freed and
-    /// counted toward `drained_count`, so the segment reclaims and reclaim does not
-    /// stall behind it.
+    /// A `SegmentWrite` dropped without `complete()` still drains: its run's payloads
+    /// are freed, `released` advances, and the run is counted toward `drained_count` so
+    /// the segment reclaims and reclaim does not stall behind it.
     #[test]
     fn drop_without_complete_reclaims() {
+        use std::sync::atomic::{AtomicUsize, Ordering as O};
+        use std::sync::Arc as StdArc;
+
+        // Payload that bumps a shared counter on drop, so we can prove the drop path
+        // actually freed the run's payloads — not merely advanced the reclaim counters.
+        struct DropCounter(#[allow(dead_code)] StdArc<AtomicUsize>);
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, O::SeqCst);
+            }
+        }
+
+        let drops = StdArc::new(AtomicUsize::new(0));
         let seg_size = 2;
-        let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+        let (ring, _consumer) = PagedRecvBuffer::<DropCounter>::new_with_segment_size(seg_size);
         // Fill seg0 full and take it as one run.
-        for i in 0..seg_size {
+        for _ in 0..seg_size {
             let h = ring.claim();
-            ring.fill(h, i as u64);
+            ring.fill(h, DropCounter(drops.clone()));
         }
         let sw = ring.take_drain_run(false).expect("seg0 full");
         assert_eq!(sw.base_seq(), 0);
-        // Drop WITHOUT complete(): the Drop safety net frees the run and advances
-        // drained_count to the segment length.
+        assert_eq!(ring.released(), 0, "nothing released until the run drains");
+
+        // Drop WITHOUT complete(): the Drop safety net must free the run's payloads and
+        // advance both `released` (read-ahead occupancy) and `drained_count` (reclaim).
         drop(sw);
+        assert_eq!(
+            drops.load(O::SeqCst),
+            seg_size,
+            "drop-without-complete must free every payload in the run"
+        );
+        assert_eq!(
+            ring.released(),
+            seg_size as u64,
+            "drop-without-complete must release the run's occupancy"
+        );
+
         // `claim` runs reclaim before it grows, so the drained front pops on the
         // claim *after* seg1 exists. Two claims: the first grows seg1, the second
         // observes seg0 fully drained and reclaims it. A run left unaccounted would
         // never reach drained_count == len and the count would climb without bound.
-        for i in 0..2 {
+        for _ in 0..2 {
             let h = ring.claim();
-            ring.fill(h, 99 + i);
+            ring.fill(h, DropCounter(drops.clone()));
         }
         assert_eq!(
             ring.segment_count(),
             1,
             "dropped-without-complete run must drain and reclaim, not wedge"
+        );
+        assert_eq!(
+            ring.front_base(),
+            seg_size as u64,
+            "seg0 (base 0) is the segment reclaimed after its run drained"
         );
     }
 
@@ -1616,23 +1753,29 @@ mod tests {
         for (i, h) in handles.into_iter().enumerate() {
             ring.fill(h, i as u64);
         }
-        // At this point we have 2 segments in the deque.
+        // At this point we have 2 segments in the deque, front based at seq 0.
         assert_eq!(ring.segment_count(), 2);
+        assert_eq!(ring.front_base(), 0);
 
         // Consume all of the first segment and one item into the second.
         for _ in 0..seg_size + 1 {
             consumer.poll_next().unwrap();
         }
 
-        // Trigger reclaim by claiming more (which runs reclaim_locked).
+        // Trigger reclaim by claiming more (which runs reclaim_locked before it grows).
         let h = ring.claim();
         ring.fill(h, 999u64);
 
-        // The first segment should have been reclaimed.
+        // seg0 (base 0) is fully consumed (`base + len <= consumed`) and must be the
+        // segment reclaimed — the front now bases at seg_size, and one segment grew for
+        // the new claim, so the count returns to 2. Asserting `front_base` (not just the
+        // count) proves the *right* segment went: a reclaim that popped the wrong
+        // segment, or none, would leave `front_base == 0`.
+        assert_eq!(ring.segment_count(), 2, "seg0 reclaimed, seg2 grew");
         assert_eq!(
-            ring.segment_count(),
-            2,
-            "first segment should be reclaimed, leaving the second + newly grown"
+            ring.front_base(),
+            seg_size as u64,
+            "the fully-consumed front segment (base 0) is the one reclaimed"
         );
     }
 
@@ -1844,7 +1987,15 @@ mod loom_tests {
             ring.fill(h, 99);
 
             taker.join().unwrap();
-            assert!(ring.segment_count() >= 1);
+            // After both threads finish, seg0's run has drained (`complete`) so
+            // `drained_count == len`. A final claim runs reclaim deterministically
+            // (no new interleaving — both threads have joined), which must pop the
+            // now-drained seg0 exactly once. Asserting `front_base` past seg0, not just
+            // a count, proves the reclaim happened and freed the right segment without
+            // the two reclaim paths double-popping.
+            let h = ring.claim();
+            ring.fill(h, 100);
+            assert_eq!(ring.front_base(), 2, "drained seg0 (base 0) reclaimed exactly once");
         });
     }
 
@@ -1958,7 +2109,13 @@ mod loom_tests {
             ring.fill(h, 99);
 
             taker.join().unwrap();
-            assert!(ring.segment_count() >= 1);
+            // seg0's run drained via the Drop safety net. A final claim runs reclaim
+            // deterministically (both threads joined) and must pop the drained seg0
+            // exactly once — `front_base` past seg0 proves the drop path advanced
+            // `drained_count` and reclaim freed the right segment without double-pop.
+            let h = ring.claim();
+            ring.fill(h, 100);
+            assert_eq!(ring.front_base(), 2, "drop-drained seg0 (base 0) reclaimed exactly once");
         });
     }
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -1687,7 +1687,11 @@ mod tests {
     #[test]
     fn exhaustive_fill_order_across_segments() {
         let seg_size = 2;
-        let n = seg_size * 3; // 6 sequences across 3 segments
+        // Native: 3 segments (6! = 720 orders). Under miri, 2 segments (4! = 24) — the
+        // hop across a segment boundary is still exercised, without the factorial blowup
+        // at miri's ~1000x slowdown.
+        let segments = if cfg!(miri) { 2 } else { 3 };
+        let n = seg_size * segments;
         for perm in permutations(n) {
             let (ring, mut consumer) = PagedRecvBuffer::new_with_segment_size(seg_size);
             let handles: Vec<_> = (0..n).map(|_| ring.claim()).collect();
@@ -1816,11 +1820,20 @@ mod tests {
     /// for debug and `cargo test`), crashing the fill path. Reproduces only under real
     /// concurrency — single-threaded, `claim_cursor <= filled` always holds — so this is
     /// a multi-thread stress test at batch 1 (the disk relief regime) over a wide
-    /// segment, looped to make the race near-certain. It can only fail on a regression;
-    /// it never false-positives.
+    /// segment, looped enough to make the `claim_cursor > filled` race likely. It is a
+    /// tripwire for reverting the probe's `saturating_sub` to a bare subtraction; it can
+    /// only fail on a regression, never false-positives. The drain race's *correctness*
+    /// is proven exhaustively by the loom models — this only guards the arithmetic.
+    ///
+    /// `#[cfg_attr(miri, ignore)]`: the guarded property is saturating arithmetic (defined
+    /// behavior, invisible to miri) plus a scheduling race (loom's job); miri adds nothing
+    /// here and the loop is prohibitively slow under it.
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn fill_probe_does_not_underflow_under_concurrent_drain() {
-        for _ in 0..2_000 {
+        // Past the diminishing-returns knee for surfacing the race under native
+        // scheduling, without the wall-clock cost of the original 2000.
+        for _ in 0..200 {
             let seg_size = 16;
             let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
             ring.set_drain_batch(1);

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -17,6 +17,8 @@ use super::input::copy_fields_to_get_object_request;
 use crate::error::{self, ChunkRef, Error};
 use crate::io::AggregatedBytes;
 use crate::operation::download::body::{BodySlot, BodyWriter, ChunkOutput};
+use crate::operation::download::read_ahead::ReadAhead;
+use crate::operation::download::recv_buffer::FillOutcome;
 use crate::operation::download::chunk_meta::ChunkMetadata;
 use crate::operation::download::context::DownloadState;
 use crate::operation::download::discovery::{discover_obj, ObjectDiscovery};
@@ -34,17 +36,6 @@ pub(crate) enum DownloadWork {
         slot: Option<BodySlot>,
         etag: Option<Arc<str>>,
     },
-}
-
-impl DownloadWork {
-    /// Extract the slot from this work item, if present.
-    #[cfg(test)]
-    fn take_slot(&mut self) -> Option<BodySlot> {
-        match self {
-            DownloadWork::Discovery => None,
-            DownloadWork::GetObjectRange { slot, .. } => slot.take(),
-        }
-    }
 }
 
 /// Early return if transfer is terminal (failed/cancelled by another work item).
@@ -78,8 +69,11 @@ struct DownloadTransferInner {
     // TODO(vnext): unify bucket representation (name + kind) across operations.
     #[allow(dead_code)]
     bucket_type: BucketType,
-    /// Sequence window for backpressure control
+    /// Chunk delivery + disk-write surface.
     writer: BodyWriter,
+    /// Read-ahead window (rwnd): bounds resident occupancy by holding
+    /// `issued - consumed` under `read_ahead.window()`.
+    read_ahead: ReadAhead,
     /// Object metadata from discovery (set once discovery completes)
     object_meta: std::sync::OnceLock<ObjectMetadata>,
     /// Object-integrity result (set once discovery completes)
@@ -96,6 +90,7 @@ impl DownloadTransfer {
         writer: BodyWriter,
     ) -> Self {
         let inner = Arc::new(DownloadTransferInner {
+            read_ahead: ReadAhead::new(),
             ctx,
             state: Mutex::new(DownloadState::new()),
             request: Arc::new(input),
@@ -118,9 +113,16 @@ impl DownloadTransfer {
         self.inner.ctx.id
     }
 
-    /// Body writer for backpressure control and chunk delivery.
+    /// Body writer for chunk delivery and disk writes.
     pub(crate) fn writer(&self) -> &BodyWriter {
         &self.inner.writer
+    }
+
+    /// The read-ahead window (the receive-window issuance bound). Test-only:
+    /// production code reads `self.inner.read_ahead` directly at the gate.
+    #[cfg(test)]
+    pub(crate) fn read_ahead(&self) -> &ReadAhead {
+        &self.inner.read_ahead
     }
 
     /// Object metadata from discovery.
@@ -189,13 +191,36 @@ impl DownloadTransfer {
                 ranges_in_flight,
                 etag,
                 part_size,
-                ..
+                issued,
             } => {
-                // Check seq window before generating work
-                let Some(slot) = self.inner.writer.try_claim() else {
+                // Read-ahead gate: bound resident occupancy. `issued - consumed` is
+                // the count of parts claimed but not yet delivered in order; the gate
+                // holds it under the receive window. A slow or blocked consumer is
+                // paced for free — occupancy fills, the gate closes, issuance waits.
+                let consumed = self.inner.writer.consumed();
+                let window = self.inner.read_ahead.window();
+                if *issued - consumed >= window {
+                    // Gate closed: the issuer is `window` parts ahead of the consumer
+                    // and must wait for a delivery (which advances `consumed`) before
+                    // claiming more. This is the load-bearing line for diagnosing a
+                    // stall: a *wedge* shows up here as a gate that never reopens —
+                    // `consumed` frozen, `issued - consumed == window`, recurring every
+                    // poll. A healthy slow consumer shows the same fields advancing in
+                    // step. Trace, not debug: it fires every gated poll in steady state.
+                    tracing::trace!(
+                        target: crate::telemetry::TARGET_TRANSFER,
+                        issued = *issued,
+                        consumed,
+                        in_flight = *issued - consumed,
+                        window,
+                        "read-ahead gate closed: issuance paused until the consumer drains",
+                    );
                     self.inner.ctx.set_pending();
                     return PollWork::Pending;
-                };
+                }
+
+                let slot = self.inner.writer.claim();
+                *issued += 1;
 
                 if let Some(range) = remaining.take() {
                     // `part_size` is the stored part size for a validated multipart
@@ -313,11 +338,7 @@ impl DownloadTransfer {
         // Invariant: initial_chunk.is_some() == chunk_meta.is_some()
         let initial_work = match (initial_chunk, chunk_meta) {
             (Some(stream), Some(meta)) => {
-                let slot = self
-                    .inner
-                    .writer
-                    .try_claim()
-                    .expect("seq window should have capacity at start");
+                let slot = self.inner.writer.claim();
                 Some((stream, meta, slot))
             }
             (None, _) => None,
@@ -333,6 +354,7 @@ impl DownloadTransfer {
                 ranges_in_flight: if initial_work.is_some() { 1 } else { 0 },
                 etag: etag.clone(),
                 part_size: effective_part_size,
+                issued: if initial_work.is_some() { 1 } else { 0 },
             };
         }
 
@@ -430,11 +452,13 @@ impl DownloadTransfer {
             metadata: chunk_meta,
         };
 
-        slot.fill(chunk);
-        if let Err(e) = self.inner.writer.try_flush() {
-            // Go terminal before any wake (see fail_range).
-            let guard = self.inner.state.lock().unwrap();
-            return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
+        // Edge-triggered disk write: only the fill that seals a segment drains it.
+        if slot.fill(chunk) == FillOutcome::SealedSegment {
+            if let Err(e) = self.inner.writer.drain_sealed() {
+                // Go terminal before any wake (see fail_range).
+                let guard = self.inner.state.lock().unwrap();
+                return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
+            }
         }
 
         // disk_write reflects bytes committed to the file sink buffer.
@@ -541,11 +565,15 @@ impl DownloadTransfer {
             metadata: chunk_meta,
         };
 
-        slot.fill(chunk);
-        if let Err(e) = self.inner.writer.try_flush() {
-            // Go terminal before any wake (see fail_range).
-            let guard = self.inner.state.lock().unwrap();
-            return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
+        // Edge-triggered disk write: only the fill that seals a segment drains it
+        // (one positioned write per full segment), not every fill. Stream mode's
+        // drain_sealed is a no-op.
+        if slot.fill(chunk) == FillOutcome::SealedSegment {
+            if let Err(e) = self.inner.writer.drain_sealed() {
+                // Go terminal before any wake (see fail_range).
+                let guard = self.inner.state.lock().unwrap();
+                return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
+            }
         }
 
         // disk_write reflects bytes committed to the file sink buffer.
@@ -822,9 +850,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let (writer, _consumer) = crate::operation::download::body::new_slot_body(
-            crate::operation::download::body::DEFAULT_BODY_SLOT_CAPACITY,
-        );
+        let (writer, _consumer) = crate::operation::download::body::new_slot_body();
         let (ctx, _completion_rx) = TransferContext::new(handle);
 
         DownloadTransfer::new(ctx, BucketType::Standard, input, writer)
@@ -924,9 +950,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let (writer, _consumer) = crate::operation::download::body::new_slot_body(
-            crate::operation::download::body::DEFAULT_BODY_SLOT_CAPACITY,
-        );
+        let (writer, _consumer) = crate::operation::download::body::new_slot_body();
         let (ctx, _completion_rx) = TransferContext::new(handle);
         let transfer = DownloadTransfer::new(ctx, BucketType::Standard, input, writer);
 
@@ -1035,10 +1059,9 @@ mod tests {
         assert_done(transfer.poll_work());
     }
 
-    fn create_download_with_capacity(
+    fn create_download_for_gate(
         object_size: u64,
         part_size: u64,
-        capacity: usize,
     ) -> (
         DownloadTransfer,
         crate::operation::download::body::SlotBodyConsumer,
@@ -1067,80 +1090,58 @@ mod tests {
             .build()
             .unwrap();
 
-        let (writer, consumer) = crate::operation::download::body::new_slot_body(capacity);
+        let (writer, consumer) = crate::operation::download::body::new_slot_body();
         let (ctx, _completion_rx) = TransferContext::new(handle);
         let transfer = DownloadTransfer::new(ctx, BucketType::Standard, input, writer);
         (transfer, consumer)
     }
 
+    /// The read-ahead gate bounds issuance at the current window: with the window
+    /// forced small (as a slow consumer's pacing would), issuance proceeds up to
+    /// `issued − consumed == window()`, then stalls. (The window's *value* is the
+    /// controller's job, unit-tested in `read_ahead`; here we test the gate wiring.)
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
-    async fn test_seq_window_limits_work_generation() {
-        // Create download with many parts but small slot buffer capacity
-        let (transfer, _consumer) = create_download_with_capacity(128 * MB, 8 * MB, 3);
-
+    async fn test_read_ahead_gate_bounds_issuance() {
+        let (transfer, _consumer) = create_download_for_gate(128 * MB, 8 * MB);
         skip_discovery(&transfer).await;
-        // After discovery: claimed=1 (initial chunk took seq=0), consumed=0
-        // Capacity=3 means: claimed < consumed + capacity → claimed < 3
-        // So we can claim seq 1, 2 (claimed becomes 2, then 3)
-
-        let _w1 = assert_ready(transfer.poll_work()); // seq=1, claimed=2
-        let _w2 = assert_ready(transfer.poll_work()); // seq=2, claimed=3
-
-        // Window exhausted (claimed=3, consumed=0, capacity=3: 3 >= 0+3)
-        assert_pending(transfer.poll_work());
+        // Force a small window to exercise the gate deterministically (the rwnd default
+        // opens wide, so a slow-consumer pacing is what makes it bind).
+        transfer.read_ahead().force_window(3);
+        let w = transfer.read_ahead().window();
+        // Discovery claimed seq 0 (issued=1, consumed=0). Drive until the gate stalls.
+        let mut issued = 1u64;
+        loop {
+            match transfer.poll_work() {
+                PollWork::Ready(_item) => {
+                    issued += 1;
+                    assert!(issued <= w, "issuance ran past the window");
+                }
+                PollWork::Pending => break,
+                PollWork::Done => panic!("unexpected Done"),
+            }
+        }
+        assert_eq!(issued, w, "issuance should fill the window then stall");
     }
 
+    /// Consuming a delivered chunk advances `consumed`, reopening the gate for more
+    /// issuance (`issued − consumed` drops below the window).
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
-    async fn test_seq_window_consume_enables_more_work() {
-        let (transfer, consumer) = create_download_with_capacity(128 * MB, 8 * MB, 2);
-
+    async fn test_consume_reopens_gate() {
+        let (transfer, mut consumer) = create_download_for_gate(128 * MB, 8 * MB);
         skip_discovery(&transfer).await;
-        // After discovery: seq 0 claimed and filled by discovery, consumed=0
-        // Capacity=2 means: claimed < consumed + 2
-
-        let mut w1 = assert_ready(transfer.poll_work()); // seq=1, claimed=2
-        assert_pending(transfer.poll_work()); // claimed=2 >= 0+2
-
-        // Consume seq 0 (filled by discovery) to open the window
-        consumer.try_take_next(); // consume seq 0, consumed=1
-
-        let mut w2 = assert_ready(transfer.poll_work()); // seq=2, claimed=3
-        assert_pending(transfer.poll_work()); // claimed=3 >= 1+2
-
-        // Fill seq 1 from its work item, then consume it
-        let slot1 = w1.data_mut::<DownloadWork>().take_slot().expect("has slot");
-        let mut seg = bytes_utils::SegmentedBuf::new();
-        seg.push(bytes::Bytes::from("data"));
-        slot1.fill(ChunkOutput {
-            seq: 1,
-            offset: 0,
-            data: crate::io::AggregatedBytes(seg),
-            metadata: Default::default(),
-        });
-        consumer.try_take_next(); // consume seq 1, consumed=2
-
-        let w3 = assert_ready(transfer.poll_work()); // seq=3, claimed=4
+        transfer.read_ahead().force_window(3);
+        // Fill the window.
+        while let PollWork::Ready(_item) = transfer.poll_work() {}
         assert_pending(transfer.poll_work());
 
-        // Fill seq 2 from its work item, then consume it
-        let slot2 = w2.data_mut::<DownloadWork>().take_slot().expect("has slot");
-        let mut seg = bytes_utils::SegmentedBuf::new();
-        seg.push(bytes::Bytes::from("data"));
-        slot2.fill(ChunkOutput {
-            seq: 2,
-            offset: 0,
-            data: crate::io::AggregatedBytes(seg),
-            metadata: Default::default(),
-        });
-        consumer.try_take_next(); // consume seq 2
+        // Consume seq 0 (filled by discovery) — consumed advances 0 → 1, freeing a slot.
+        assert!(consumer.try_take_next().is_some(), "discovery chunk should deliver");
 
-        let _w4 = assert_ready(transfer.poll_work()); // seq=4
+        // Gate reopens for exactly one more claim.
+        assert_ready(transfer.poll_work());
         assert_pending(transfer.poll_work());
-
-        // Clean up remaining slots
-        drop(w3);
     }
 
     use crate::http::header::Range;

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -91,7 +91,11 @@ impl DownloadTransfer {
     ) -> Self {
         // Resolve the read-ahead knob (per-request override, else client default)
         // to a window in parts before `ctx` and `input` are moved into the struct.
-        let read_ahead = ReadAhead::with_window(ctx.handle.download_read_ahead_window(&input));
+        let window = ctx.handle.download_read_ahead_window(&input);
+        let read_ahead = ReadAhead::with_window(window);
+        // Couple the disk drain batch to the initial window, so a window below the
+        // segment size drains in smaller runs from the first part.
+        writer.sync_drain_batch(window);
         let inner = Arc::new(DownloadTransferInner {
             read_ahead,
             ctx,
@@ -130,11 +134,12 @@ impl DownloadTransfer {
     }
 
     /// Apply a dynamic read-ahead change, resolving the public knob to a window. The
-    /// next issuance-gate read observes the new value.
+    /// next issuance-gate read observes the new value, and the disk drain batch is
+    /// re-coupled to it so a window below the segment size drains in smaller runs.
     pub(crate) fn set_read_ahead(&self, mode: &crate::types::ReadAhead) {
-        self.inner
-            .read_ahead
-            .set_window(super::read_ahead::window_parts_for(mode));
+        let window = super::read_ahead::window_parts_for(mode);
+        self.inner.read_ahead.set_window(window);
+        self.inner.writer.sync_drain_batch(window);
     }
 
     /// Object metadata from discovery.
@@ -205,39 +210,48 @@ impl DownloadTransfer {
                 part_size,
                 issued,
             } => {
-                // Read-ahead gate: bound resident occupancy. `issued - released` is
-                // the count of parts claimed but whose memory the consumer has not yet
-                // freed; the gate holds it under the receive window. `released` counts
-                // both delivery surfaces (stream pull and disk drain), so a disk
-                // download paces to its drain rate rather than latching shut at the
-                // window. A slow or blocked consumer is paced for free — occupancy
-                // fills, the gate closes, issuance waits.
-                let released = self.inner.writer.released();
-                let window = self.inner.read_ahead.window();
-                if *issued - released >= window {
-                    // Gate closed: the issuer is `window` parts ahead of what the
-                    // consumer has freed and must wait for a drain before claiming
-                    // more. The load-bearing line for diagnosing a stall: a *wedge*
-                    // shows up here as a gate that never reopens — `released` frozen,
-                    // `issued - released == window`, recurring every poll. A healthy
-                    // consumer shows the same fields advancing in step. Trace, not
-                    // debug: it fires every gated poll in steady state.
-                    tracing::trace!(
-                        target: crate::telemetry::TARGET_TRANSFER,
-                        issued = *issued,
-                        released,
-                        in_flight = *issued - released,
-                        window,
-                        "read-ahead gate closed: issuance paused until the consumer drains",
-                    );
-                    self.inner.ctx.set_pending();
-                    return PollWork::Pending;
-                }
+                if remaining.is_some() {
+                    // More ranges to issue. Apply the read-ahead gate: bound resident
+                    // occupancy. `issued - released` is the count of parts claimed but
+                    // whose memory the consumer has not yet freed; the gate holds it
+                    // under the receive window. `released` counts both delivery surfaces
+                    // (stream pull and disk drain), so a disk download paces to its
+                    // drain rate rather than latching shut at the window. A slow or
+                    // blocked consumer is paced for free — occupancy fills, the gate
+                    // closes, issuance waits.
+                    //
+                    // The gate guards *issuance only*. Once every range is generated
+                    // (`remaining` is None) the completion path below runs unconditionally,
+                    // so a transfer whose last parts are still resident (e.g. a disk tail
+                    // below the drain batch, freed only by the terminal drain in
+                    // `complete`) cannot deadlock with the gate holding issuance that has
+                    // nothing left to issue.
+                    let released = self.inner.writer.released();
+                    let window = self.inner.read_ahead.window();
+                    if *issued - released >= window {
+                        // Gate closed: the issuer is `window` parts ahead of what the
+                        // consumer has freed and must wait for a drain before claiming
+                        // more. The load-bearing line for diagnosing a stall: a *wedge*
+                        // shows up here as a gate that never reopens — `released` frozen,
+                        // `issued - released == window`, recurring every poll. A healthy
+                        // consumer shows the same fields advancing in step. Trace, not
+                        // debug: it fires every gated poll in steady state.
+                        tracing::trace!(
+                            target: crate::telemetry::TARGET_TRANSFER,
+                            issued = *issued,
+                            released,
+                            in_flight = *issued - released,
+                            window,
+                            "read-ahead gate closed: issuance paused until the consumer drains",
+                        );
+                        self.inner.ctx.set_pending();
+                        return PollWork::Pending;
+                    }
 
-                let slot = self.inner.writer.claim();
-                *issued += 1;
+                    let slot = self.inner.writer.claim();
+                    *issued += 1;
 
-                if let Some(range) = remaining.take() {
+                    let range = remaining.take().expect("remaining is Some");
                     // `part_size` is the stored part size for a validated multipart
                     // object (so each range aligns to a stored part boundary and S3
                     // returns the part's checksum for the SDK to validate), else the
@@ -250,6 +264,18 @@ impl DownloadTransfer {
 
                     if chunk_end < end {
                         *remaining = Some((chunk_end + 1)..=end);
+                    } else {
+                        // Edge: the final range was just issued. From here issuance is
+                        // done and the transfer is draining its in-flight tail; the next
+                        // empty poll with no in-flight completes it. Fires once per
+                        // transfer — the lifecycle marker for "all issued, awaiting
+                        // drain", the phase a stalled transfer would be parked in.
+                        tracing::debug!(
+                            target: crate::telemetry::TARGET_TRANSFER,
+                            issued = *issued,
+                            ranges_in_flight = *ranges_in_flight + 1,
+                            "all ranges issued; draining in-flight tail",
+                        );
                     }
 
                     *ranges_in_flight += 1;
@@ -467,9 +493,10 @@ impl DownloadTransfer {
             metadata: chunk_meta,
         };
 
-        // Edge-triggered disk write: only the fill that seals a segment drains it.
-        if slot.fill(chunk) == FillOutcome::SealedSegment {
-            if let Err(e) = self.inner.writer.drain_sealed() {
+        // Edge-triggered disk write: a fill that brings the segment's filled count to
+        // the drain batch attempts a drain of the batch-ready run(s).
+        if slot.fill(chunk) == FillOutcome::DrainReady {
+            if let Err(e) = self.inner.writer.drain(false) {
                 // Go terminal before any wake (see fail_range).
                 let guard = self.inner.state.lock().unwrap();
                 return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
@@ -580,11 +607,11 @@ impl DownloadTransfer {
             metadata: chunk_meta,
         };
 
-        // Edge-triggered disk write: only the fill that seals a segment drains it
-        // (one positioned write per full segment), not every fill. Stream mode's
-        // drain_sealed is a no-op.
-        if slot.fill(chunk) == FillOutcome::SealedSegment {
-            if let Err(e) = self.inner.writer.drain_sealed() {
+        // Edge-triggered disk write: a fill that brings the segment's filled count to
+        // the drain batch attempts a drain of the batch-ready run(s) — one positioned
+        // write per coalesced run, not every fill. Stream mode's drain is a no-op.
+        if slot.fill(chunk) == FillOutcome::DrainReady {
+            if let Err(e) = self.inner.writer.drain(false) {
                 // Go terminal before any wake (see fail_range).
                 let guard = self.inner.state.lock().unwrap();
                 return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -89,8 +89,11 @@ impl DownloadTransfer {
         input: DownloadInput,
         writer: BodyWriter,
     ) -> Self {
+        // Resolve the read-ahead knob (per-request override, else client default)
+        // to a window in parts before `ctx` and `input` are moved into the struct.
+        let read_ahead = ReadAhead::with_window(ctx.handle.download_read_ahead_window(&input));
         let inner = Arc::new(DownloadTransferInner {
-            read_ahead: ReadAhead::new(),
+            read_ahead,
             ctx,
             state: Mutex::new(DownloadState::new()),
             request: Arc::new(input),
@@ -118,11 +121,20 @@ impl DownloadTransfer {
         &self.inner.writer
     }
 
-    /// The read-ahead window (the receive-window issuance bound). Test-only:
-    /// production code reads `self.inner.read_ahead` directly at the gate.
+    /// The read-ahead window (the receive-window issuance bound). The gate reads
+    /// `self.inner.read_ahead` directly and the control surface goes through
+    /// [`set_read_ahead`](Self::set_read_ahead); this accessor is for tests.
     #[cfg(test)]
     pub(crate) fn read_ahead(&self) -> &ReadAhead {
         &self.inner.read_ahead
+    }
+
+    /// Apply a dynamic read-ahead change, resolving the public knob to a window. The
+    /// next issuance-gate read observes the new value.
+    pub(crate) fn set_read_ahead(&self, mode: &crate::types::ReadAhead) {
+        self.inner
+            .read_ahead
+            .set_window(super::read_ahead::window_parts_for(mode));
     }
 
     /// Object metadata from discovery.
@@ -193,25 +205,28 @@ impl DownloadTransfer {
                 part_size,
                 issued,
             } => {
-                // Read-ahead gate: bound resident occupancy. `issued - consumed` is
-                // the count of parts claimed but not yet delivered in order; the gate
-                // holds it under the receive window. A slow or blocked consumer is
-                // paced for free — occupancy fills, the gate closes, issuance waits.
-                let consumed = self.inner.writer.consumed();
+                // Read-ahead gate: bound resident occupancy. `issued - released` is
+                // the count of parts claimed but whose memory the consumer has not yet
+                // freed; the gate holds it under the receive window. `released` counts
+                // both delivery surfaces (stream pull and disk drain), so a disk
+                // download paces to its drain rate rather than latching shut at the
+                // window. A slow or blocked consumer is paced for free — occupancy
+                // fills, the gate closes, issuance waits.
+                let released = self.inner.writer.released();
                 let window = self.inner.read_ahead.window();
-                if *issued - consumed >= window {
-                    // Gate closed: the issuer is `window` parts ahead of the consumer
-                    // and must wait for a delivery (which advances `consumed`) before
-                    // claiming more. This is the load-bearing line for diagnosing a
-                    // stall: a *wedge* shows up here as a gate that never reopens —
-                    // `consumed` frozen, `issued - consumed == window`, recurring every
-                    // poll. A healthy slow consumer shows the same fields advancing in
-                    // step. Trace, not debug: it fires every gated poll in steady state.
+                if *issued - released >= window {
+                    // Gate closed: the issuer is `window` parts ahead of what the
+                    // consumer has freed and must wait for a drain before claiming
+                    // more. The load-bearing line for diagnosing a stall: a *wedge*
+                    // shows up here as a gate that never reopens — `released` frozen,
+                    // `issued - released == window`, recurring every poll. A healthy
+                    // consumer shows the same fields advancing in step. Trace, not
+                    // debug: it fires every gated poll in steady state.
                     tracing::trace!(
                         target: crate::telemetry::TARGET_TRANSFER,
                         issued = *issued,
-                        consumed,
-                        in_flight = *issued - consumed,
+                        released,
+                        in_flight = *issued - released,
                         window,
                         "read-ahead gate closed: issuance paused until the consumer drains",
                     );
@@ -611,21 +626,23 @@ impl DownloadTransfer {
     }
 
     fn decrement_in_flight(&self) {
-        let should_wake = {
+        {
             let mut work = self.inner.state.lock().unwrap();
             if let DownloadState::Transferring {
                 ranges_in_flight, ..
             } = &mut *work
             {
                 *ranges_in_flight = ranges_in_flight.saturating_sub(1);
-                *ranges_in_flight == 0
-            } else {
-                false
             }
-        };
-        if should_wake {
-            self.inner.ctx.try_wake();
         }
+        // Repoke the issuer on every completion. A completed range has drained its
+        // payload (freeing read-ahead occupancy) and dropped the in-flight count, so
+        // a parked poll_work may now make progress — admit a part through a reopened
+        // gate, or complete the transfer when the last range lands. `try_wake` is a
+        // cheap no-op unless the issuer actually parked (it is gated on the pending
+        // flag), so poking unconditionally is correct and avoids a class of wedge
+        // where the gate reopens but nothing re-polls it.
+        self.inner.ctx.try_wake();
     }
 
     /// Transition to terminal failed state. Requires holding the work lock.
@@ -663,6 +680,34 @@ impl DownloadTransfer {
         drop(guard); // release lock before signaling waiters
         self.inner.writer.notify_consumer();
         self.inner.ctx.signal_terminal();
+    }
+}
+
+/// Runtime I/O controls for a running download.
+///
+/// Adjusts how the transfer moves data, as opposed to how it is scheduled relative
+/// to other transfers (that is [`SchedulingCtl`](crate::transfer::SchedulingCtl)).
+/// Obtained via [`DownloadHandle::io_ctl()`](crate::operation::download::DownloadHandle::io_ctl).
+#[derive(Debug)]
+pub struct DownloadIoCtl<'a> {
+    transfer: &'a DownloadTransfer,
+}
+
+impl DownloadIoCtl<'_> {
+    /// Set how far this download prefetches ahead of the consumer, overriding the
+    /// value resolved at initiation. Takes effect on the next issuance decision.
+    ///
+    /// Lowering the window caps resident memory for a consumer that has fallen
+    /// behind; raising it restores prefetch depth once the consumer catches up.
+    pub fn set_read_ahead(&self, mode: crate::types::ReadAhead) {
+        self.transfer.set_read_ahead(&mode);
+    }
+}
+
+impl DownloadTransfer {
+    /// I/O controls for this transfer.
+    pub(crate) fn io_ctl(&self) -> DownloadIoCtl<'_> {
+        DownloadIoCtl { transfer: self }
     }
 }
 
@@ -1142,6 +1187,79 @@ mod tests {
         // Gate reopens for exactly one more claim.
         assert_ready(transfer.poll_work());
         assert_pending(transfer.poll_work());
+    }
+
+    /// The window resolved at construction follows precedence: a per-request
+    /// `read_ahead` override wins; absent one, the client default applies.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_read_ahead_resolution_precedence() {
+        use crate::types::ReadAhead;
+
+        let build = |client_mode: ReadAhead, input_override: Option<ReadAhead>| {
+            let get_obj = mock!(aws_sdk_s3::Client::get_object).then_output(|| {
+                GetObjectOutput::builder()
+                    .content_length(8 * MB as i64)
+                    .content_range(format!("bytes 0-{}/{}", 8 * MB - 1, 8 * MB))
+                    .e_tag("test-etag")
+                    .body(ByteStream::from(vec![0u8; 8 * MB as usize]))
+                    .build()
+            });
+            let config = crate::Config::builder()
+                .client(mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[get_obj]))
+                .part_size(crate::types::PartSize::Target(8 * MB))
+                .read_ahead(client_mode)
+                .build();
+            let handle = crate::client::Handle::test_handle_tokio(config);
+            let input = DownloadInput::builder()
+                .bucket("test-bucket")
+                .key("test-key")
+                .set_read_ahead(input_override)
+                .build()
+                .unwrap();
+            let (writer, _consumer) = crate::operation::download::body::new_slot_body();
+            let (ctx, _rx) = TransferContext::new(handle);
+            DownloadTransfer::new(ctx, BucketType::Standard, input, writer)
+        };
+
+        // No request override: the client default resolves.
+        let t = build(ReadAhead::Parts(9), None);
+        assert_eq!(t.read_ahead().window(), 10, "client default applies");
+
+        // Request override wins over the client default.
+        let t = build(ReadAhead::Parts(9), Some(ReadAhead::Parts(3)));
+        assert_eq!(t.read_ahead().window(), 4, "request override wins");
+
+        // Client Auto resolves to the fixed default when not overridden.
+        let t = build(ReadAhead::Auto, None);
+        assert_eq!(
+            t.read_ahead().window(),
+            super::super::read_ahead::DEFAULT_WINDOW_PARTS
+        );
+    }
+
+    /// `io_ctl().set_read_ahead` resolves the public knob to a window and applies it
+    /// to the running transfer; the gate observes the new value on the next poll.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_io_ctl_set_read_ahead_resizes_window() {
+        let (transfer, _consumer) = create_download_for_gate(128 * MB, 8 * MB);
+        skip_discovery(&transfer).await;
+
+        // Parts(n) resolves to n + 1 (n speculative parts plus the demand part).
+        transfer.io_ctl().set_read_ahead(crate::types::ReadAhead::Parts(4));
+        assert_eq!(transfer.read_ahead().window(), 5);
+
+        // Parts(0) is demand paging: a window of exactly one outstanding part.
+        transfer.io_ctl().set_read_ahead(crate::types::ReadAhead::Parts(0));
+        assert_eq!(transfer.read_ahead().window(), 1);
+
+        // Auto returns to the default fixed window.
+        transfer.io_ctl().set_read_ahead(crate::types::ReadAhead::Auto);
+        assert_eq!(
+            transfer.read_ahead().window(),
+            super::super::read_ahead::DEFAULT_WINDOW_PARTS
+        );
     }
 
     use crate::http::header::Range;

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -42,7 +42,8 @@ pub(crate) enum DownloadWork {
 macro_rules! bail_if_terminal {
     ($self:expr) => {
         if !$self.inner.ctx.is_active() {
-            $self.decrement_in_flight();
+            // Bailing before any drain: no occupancy freed on this path.
+            $self.decrement_in_flight(0);
             return WorkOutcome::Cancelled;
         }
     };
@@ -151,6 +152,33 @@ impl DownloadTransfer {
         self.inner.writer.sync_drain_batch(window);
     }
 
+    /// Release one part of read-ahead occupancy for a stream delivery, then wake the
+    /// issuer.
+    ///
+    /// Called from `Body::next` after `poll_next` delivers a chunk (which frees exactly
+    /// one part's payload). The release runs **under the state lock** — the same lock
+    /// `poll_work` holds while it reads the gate and arms `set_pending` — so the
+    /// mutator protocol `lock → mutate → unlock → try_wake` holds: either the gate
+    /// observes this release and returns `Ready` without parking, or it parks and the
+    /// `try_wake` below (after the lock is dropped) fires. Without the shared lock the
+    /// two are unordered and the wake can be lost (the store-buffer race).
+    ///
+    /// The wake is unconditional, mirroring the disk completion path
+    /// ([`decrement_in_flight`](Self::decrement_in_flight)): `try_wake` is a no-op
+    /// unless the issuer actually parked, so there is no need to compute whether this
+    /// release reopened the gate — waking always is correct and adds only an atomic
+    /// swap on the (cold, per-part) delivery path.
+    pub(crate) fn release_stream_occupancy(&self) {
+        {
+            let mut work = self.inner.state.lock().unwrap();
+            if let DownloadState::Transferring { gate, .. } = &mut *work {
+                gate.release(1);
+            }
+            // Terminal (or pre-transfer): no gate to release.
+        }
+        self.inner.ctx.try_wake();
+    }
+
     /// Object metadata from discovery.
     pub(crate) fn object_meta(&self) -> Option<&ObjectMetadata> {
         self.inner.object_meta.get()
@@ -217,35 +245,33 @@ impl DownloadTransfer {
                 ranges_in_flight,
                 etag,
                 part_size,
-                issued,
+                gate,
             } => {
                 if let Some(range) = remaining.as_ref() {
-                    // Apply the read-ahead gate before issuing. `issued - released` is
-                    // the count of parts claimed but not yet freed by the consumer;
-                    // issuance waits while it is at or above the window. `released`
-                    // counts both delivery surfaces (stream pull and disk drain), so a
-                    // disk download paces to its drain rate rather than to the in-order
-                    // delivery cursor.
+                    // Apply the read-ahead gate before issuing. The gate bounds resident
+                    // occupancy at `issued - released < window`, where `released` counts
+                    // both delivery surfaces (stream pull and disk drain), so a disk
+                    // download paces to its drain rate rather than to the in-order
+                    // delivery cursor. `try_issue` reads and mutates the gate under this
+                    // state lock; the consumer's `release` does the same, so the two are
+                    // ordered and a release that reopens the gate cannot be lost against
+                    // the `set_pending` below (the mutator protocol).
                     //
                     // The gate guards issuance only. Once every range is generated
                     // (`remaining` is None) the completion path below runs unconditionally,
                     // so a transfer whose last parts are still resident (e.g. a disk tail
                     // below the drain batch, freed only by the terminal drain in
                     // `complete`) does not block on the gate with nothing left to issue.
-                    let released = self.inner.writer.released();
                     let window = self.inner.read_ahead.window();
-                    if *issued - released >= window {
+                    if !gate.try_issue(window) {
                         // Gate closed: issuance is `window` parts ahead of what the
                         // consumer has freed and waits for a drain before claiming more.
-                        // A stuck transfer holds `released` frozen at
-                        // `issued - released == window` here every poll; a healthy one
-                        // shows the fields advancing in step. Trace: fires every gated
-                        // poll in steady state.
+                        // Trace: fires every gated poll in steady state.
                         tracing::trace!(
                             target: crate::telemetry::TARGET_TRANSFER,
-                            issued = *issued,
-                            released,
-                            in_flight = *issued - released,
+                            issued = gate.issued(),
+                            released = gate.released(),
+                            in_flight = gate.resident(),
                             window,
                             "read-ahead gate closed: issuance paused until the consumer drains",
                         );
@@ -264,7 +290,6 @@ impl DownloadTransfer {
                     let chunk_range = start..=chunk_end;
 
                     let slot = self.inner.writer.claim();
-                    *issued += 1;
                     *ranges_in_flight += 1;
 
                     if chunk_end < end {
@@ -276,7 +301,7 @@ impl DownloadTransfer {
                         *remaining = None;
                         tracing::debug!(
                             target: crate::telemetry::TARGET_TRANSFER,
-                            issued = *issued,
+                            issued = gate.issued(),
                             ranges_in_flight = *ranges_in_flight,
                             "all ranges issued; draining in-flight tail",
                         );
@@ -399,7 +424,7 @@ impl DownloadTransfer {
                 ranges_in_flight: initial as usize,
                 etag: etag.clone(),
                 part_size: effective_part_size,
-                issued: initial,
+                gate: super::context::OccupancyGate::with_issued(initial),
             };
         }
 
@@ -498,12 +523,17 @@ impl DownloadTransfer {
         };
 
         // Edge-triggered disk write: a fill that brings the segment's filled count to
-        // the drain batch attempts a drain of the batch-ready run(s).
+        // the drain batch attempts a drain of the batch-ready run(s). `freed` is the
+        // occupancy this drain released, accounted under the lock in decrement_in_flight.
+        let mut freed = 0u64;
         if slot.fill(chunk) == FillOutcome::DrainReady {
-            if let Err(e) = self.inner.writer.drain(false) {
-                // Go terminal before any wake (see fail_range).
-                let guard = self.inner.state.lock().unwrap();
-                return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
+            match self.inner.writer.drain(false) {
+                Ok(f) => freed = f,
+                Err(e) => {
+                    // Go terminal before any wake (see fail_range).
+                    let guard = self.inner.state.lock().unwrap();
+                    return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
+                }
             }
         }
 
@@ -520,7 +550,7 @@ impl DownloadTransfer {
             ..Default::default()
         });
 
-        self.decrement_in_flight();
+        self.decrement_in_flight(freed);
 
         WorkOutcome::Success { data: None }
     }
@@ -614,11 +644,17 @@ impl DownloadTransfer {
         // Edge-triggered disk write: a fill that brings the segment's filled count to
         // the drain batch attempts a drain of the batch-ready run(s) — one positioned
         // write per coalesced run, not every fill. Stream mode's drain is a no-op.
+        // `freed` is the occupancy this drain released, accounted under the lock in
+        // decrement_in_flight.
+        let mut freed = 0u64;
         if slot.fill(chunk) == FillOutcome::DrainReady {
-            if let Err(e) = self.inner.writer.drain(false) {
-                // Go terminal before any wake (see fail_range).
-                let guard = self.inner.state.lock().unwrap();
-                return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
+            match self.inner.writer.drain(false) {
+                Ok(f) => freed = f,
+                Err(e) => {
+                    // Go terminal before any wake (see fail_range).
+                    let guard = self.inner.state.lock().unwrap();
+                    return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
+                }
             }
         }
 
@@ -635,7 +671,7 @@ impl DownloadTransfer {
             ..Default::default()
         });
 
-        self.decrement_in_flight();
+        self.decrement_in_flight(freed);
 
         tracing::trace!(
             target: crate::telemetry::TARGET_TRANSFER,
@@ -656,14 +692,26 @@ impl DownloadTransfer {
         self.fail(guard, e.with_chunk(location))
     }
 
-    fn decrement_in_flight(&self) {
+    /// Complete one in-flight range: drop `ranges_in_flight` and release the
+    /// `freed` parts of read-ahead occupancy this completion drained, both under
+    /// the state lock, then wake the issuer.
+    ///
+    /// Releasing the occupancy here — under the same lock `poll_work` reads the gate
+    /// and arms `set_pending` under — is what orders this completion's release against
+    /// the issuer's park (the mutator protocol `lock → mutate → unlock → try_wake`).
+    /// `freed` is the disk drain's freed count (0 if this fill did not hit a drain
+    /// edge; the run drains on a later fill).
+    fn decrement_in_flight(&self, freed: u64) {
         {
             let mut work = self.inner.state.lock().unwrap();
             if let DownloadState::Transferring {
-                ranges_in_flight, ..
+                ranges_in_flight,
+                gate,
+                ..
             } = &mut *work
             {
                 *ranges_in_flight = ranges_in_flight.saturating_sub(1);
+                gate.release(freed);
             }
         }
         // Wake the issuer on every completion. A completed range has freed its
@@ -1169,8 +1217,10 @@ mod tests {
         assert_eq!(issued, w, "issuance should fill the window then stall");
     }
 
-    /// On the stream path, delivering a chunk advances `released`, so `issued −
-    /// released` drops below the window and the gate admits another claim.
+    /// On the stream path, delivering a chunk frees one part; the download layer
+    /// releases that occupancy under the state lock (as `Body::next` does via
+    /// `release_stream_occupancy`), so `issued − released` drops below the window and
+    /// the gate admits another claim.
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_consume_reopens_gate() {
@@ -1181,11 +1231,14 @@ mod tests {
         while let PollWork::Ready(_item) = transfer.poll_work() {}
         assert_pending(transfer.poll_work());
 
-        // Consume seq 0 (filled by discovery) — consumed advances 0 → 1, freeing a slot.
+        // Consume seq 0 (filled by discovery) — the buffer delivers the chunk, then the
+        // download layer releases one part of occupancy under the state lock. This is
+        // exactly what `Body::next` does; the test drives the two steps directly.
         assert!(
             consumer.try_take_next().is_some(),
             "discovery chunk should deliver"
         );
+        transfer.release_stream_occupancy();
 
         // Gate reopens for exactly one more claim.
         assert_ready(transfer.poll_work());

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -17,12 +17,12 @@ use super::input::copy_fields_to_get_object_request;
 use crate::error::{self, ChunkRef, Error};
 use crate::io::AggregatedBytes;
 use crate::operation::download::body::{BodySlot, BodyWriter, ChunkOutput};
-use crate::operation::download::read_ahead::ReadAhead;
-use crate::operation::download::recv_buffer::FillOutcome;
 use crate::operation::download::chunk_meta::ChunkMetadata;
 use crate::operation::download::context::DownloadState;
 use crate::operation::download::discovery::{discover_obj, ObjectDiscovery};
 use crate::operation::download::object_meta::ObjectMetadata;
+use crate::operation::download::read_ahead::ReadAhead;
+use crate::operation::download::recv_buffer::FillOutcome;
 use crate::operation::download::DownloadInput;
 use crate::transfer::{IoRequest, PollWork, Transfer, TransferContext, TransferId, WorkOutcome};
 use crate::types::BucketType;
@@ -91,10 +91,8 @@ impl DownloadTransfer {
     ) -> Self {
         // Resolve the read-ahead knob (per-request override, else client default)
         // to a window in parts before `ctx` and `input` are moved into the struct.
-        let window = super::read_ahead::resolve_window(
-            input.read_ahead(),
-            ctx.handle.config.read_ahead(),
-        );
+        let window =
+            super::read_ahead::resolve_window(input.read_ahead(), ctx.handle.config.read_ahead());
         let read_ahead = ReadAhead::with_window(window);
         // Couple the disk drain batch to the initial window, so a window below the
         // segment size drains in smaller runs from the first part.
@@ -1184,7 +1182,10 @@ mod tests {
         assert_pending(transfer.poll_work());
 
         // Consume seq 0 (filled by discovery) — consumed advances 0 → 1, freeing a slot.
-        assert!(consumer.try_take_next().is_some(), "discovery chunk should deliver");
+        assert!(
+            consumer.try_take_next().is_some(),
+            "discovery chunk should deliver"
+        );
 
         // Gate reopens for exactly one more claim.
         assert_ready(transfer.poll_work());
@@ -1249,15 +1250,21 @@ mod tests {
         skip_discovery(&transfer).await;
 
         // Parts(n) resolves to n + 1 (n speculative parts plus the demand part).
-        transfer.io_ctl().set_read_ahead(crate::types::ReadAhead::Parts(4));
+        transfer
+            .io_ctl()
+            .set_read_ahead(crate::types::ReadAhead::Parts(4));
         assert_eq!(transfer.read_ahead().window(), 5);
 
         // Parts(0) is demand paging: a window of exactly one outstanding part.
-        transfer.io_ctl().set_read_ahead(crate::types::ReadAhead::Parts(0));
+        transfer
+            .io_ctl()
+            .set_read_ahead(crate::types::ReadAhead::Parts(0));
         assert_eq!(transfer.read_ahead().window(), 1);
 
         // Auto returns to the default fixed window.
-        transfer.io_ctl().set_read_ahead(crate::types::ReadAhead::Auto);
+        transfer
+            .io_ctl()
+            .set_read_ahead(crate::types::ReadAhead::Auto);
         assert_eq!(
             transfer.read_ahead().window(),
             super::super::read_ahead::DEFAULT_WINDOW_PARTS

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -71,8 +71,8 @@ struct DownloadTransferInner {
     bucket_type: BucketType,
     /// Chunk delivery + disk-write surface.
     writer: BodyWriter,
-    /// Read-ahead window (rwnd): bounds resident occupancy by holding
-    /// `issued - consumed` under `read_ahead.window()`.
+    /// Read-ahead window: bounds resident occupancy by holding `issued - released`
+    /// under `read_ahead.window()`.
     read_ahead: ReadAhead,
     /// Object metadata from discovery (set once discovery completes)
     object_meta: std::sync::OnceLock<ObjectMetadata>,
@@ -91,7 +91,10 @@ impl DownloadTransfer {
     ) -> Self {
         // Resolve the read-ahead knob (per-request override, else client default)
         // to a window in parts before `ctx` and `input` are moved into the struct.
-        let window = ctx.handle.download_read_ahead_window(&input);
+        let window = super::read_ahead::resolve_window(
+            input.read_ahead(),
+            ctx.handle.config.read_ahead(),
+        );
         let read_ahead = ReadAhead::with_window(window);
         // Couple the disk drain batch to the initial window, so a window below the
         // segment size drains in smaller runs from the first part.
@@ -125,12 +128,20 @@ impl DownloadTransfer {
         &self.inner.writer
     }
 
-    /// The read-ahead window (the receive-window issuance bound). The gate reads
-    /// `self.inner.read_ahead` directly and the control surface goes through
-    /// [`set_read_ahead`](Self::set_read_ahead); this accessor is for tests.
+    /// The read-ahead window. The gate reads `self.inner.read_ahead` directly and the
+    /// control surface goes through [`set_read_ahead`](Self::set_read_ahead); this
+    /// accessor is for tests.
     #[cfg(test)]
     pub(crate) fn read_ahead(&self) -> &ReadAhead {
         &self.inner.read_ahead
+    }
+
+    /// I/O controls for this transfer, for exercising the public control surface in
+    /// tests. Production access is via
+    /// [`DownloadHandle::io_ctl`](super::handle::DownloadHandle::io_ctl).
+    #[cfg(test)]
+    pub(crate) fn io_ctl(&self) -> super::handle::DownloadIoCtl<'_> {
+        super::handle::DownloadIoCtl::for_test(self)
     }
 
     /// Apply a dynamic read-ahead change, resolving the public knob to a window. The
@@ -210,32 +221,28 @@ impl DownloadTransfer {
                 part_size,
                 issued,
             } => {
-                if remaining.is_some() {
-                    // More ranges to issue. Apply the read-ahead gate: bound resident
-                    // occupancy. `issued - released` is the count of parts claimed but
-                    // whose memory the consumer has not yet freed; the gate holds it
-                    // under the receive window. `released` counts both delivery surfaces
-                    // (stream pull and disk drain), so a disk download paces to its
-                    // drain rate rather than latching shut at the window. A slow or
-                    // blocked consumer is paced for free — occupancy fills, the gate
-                    // closes, issuance waits.
+                if let Some(range) = remaining.as_ref() {
+                    // Apply the read-ahead gate before issuing. `issued - released` is
+                    // the count of parts claimed but not yet freed by the consumer;
+                    // issuance waits while it is at or above the window. `released`
+                    // counts both delivery surfaces (stream pull and disk drain), so a
+                    // disk download paces to its drain rate rather than to the in-order
+                    // delivery cursor.
                     //
-                    // The gate guards *issuance only*. Once every range is generated
+                    // The gate guards issuance only. Once every range is generated
                     // (`remaining` is None) the completion path below runs unconditionally,
                     // so a transfer whose last parts are still resident (e.g. a disk tail
                     // below the drain batch, freed only by the terminal drain in
-                    // `complete`) cannot deadlock with the gate holding issuance that has
-                    // nothing left to issue.
+                    // `complete`) does not block on the gate with nothing left to issue.
                     let released = self.inner.writer.released();
                     let window = self.inner.read_ahead.window();
                     if *issued - released >= window {
-                        // Gate closed: the issuer is `window` parts ahead of what the
-                        // consumer has freed and must wait for a drain before claiming
-                        // more. The load-bearing line for diagnosing a stall: a *wedge*
-                        // shows up here as a gate that never reopens — `released` frozen,
-                        // `issued - released == window`, recurring every poll. A healthy
-                        // consumer shows the same fields advancing in step. Trace, not
-                        // debug: it fires every gated poll in steady state.
+                        // Gate closed: issuance is `window` parts ahead of what the
+                        // consumer has freed and waits for a drain before claiming more.
+                        // A stuck transfer holds `released` frozen at
+                        // `issued - released == window` here every poll; a healthy one
+                        // shows the fields advancing in step. Trace: fires every gated
+                        // poll in steady state.
                         tracing::trace!(
                             target: crate::telemetry::TARGET_TRANSFER,
                             issued = *issued,
@@ -248,10 +255,6 @@ impl DownloadTransfer {
                         return PollWork::Pending;
                     }
 
-                    let slot = self.inner.writer.claim();
-                    *issued += 1;
-
-                    let range = remaining.take().expect("remaining is Some");
                     // `part_size` is the stored part size for a validated multipart
                     // object (so each range aligns to a stored part boundary and S3
                     // returns the part's checksum for the SDK to validate), else the
@@ -262,23 +265,24 @@ impl DownloadTransfer {
                     let chunk_end = cmp::min(start + part_size - 1, end);
                     let chunk_range = start..=chunk_end;
 
+                    let slot = self.inner.writer.claim();
+                    *issued += 1;
+                    *ranges_in_flight += 1;
+
                     if chunk_end < end {
                         *remaining = Some((chunk_end + 1)..=end);
                     } else {
-                        // Edge: the final range was just issued. From here issuance is
-                        // done and the transfer is draining its in-flight tail; the next
-                        // empty poll with no in-flight completes it. Fires once per
-                        // transfer — the lifecycle marker for "all issued, awaiting
-                        // drain", the phase a stalled transfer would be parked in.
+                        // The final range was just issued: issuance is done and the
+                        // transfer drains its in-flight tail, completing on the next
+                        // empty poll with nothing in flight. Logged once per transfer.
+                        *remaining = None;
                         tracing::debug!(
                             target: crate::telemetry::TARGET_TRANSFER,
                             issued = *issued,
-                            ranges_in_flight = *ranges_in_flight + 1,
+                            ranges_in_flight = *ranges_in_flight,
                             "all ranges issued; draining in-flight tail",
                         );
                     }
-
-                    *ranges_in_flight += 1;
 
                     PollWork::Ready(IoRequest {
                         data: Some(Box::new(DownloadWork::GetObjectRange {
@@ -389,13 +393,15 @@ impl DownloadTransfer {
         };
 
         {
+            // The discovery chunk, if present, is one claimed part already in flight.
+            let initial = u64::from(initial_work.is_some());
             let mut work = self.inner.state.lock().unwrap();
             *work = DownloadState::Transferring {
                 remaining,
-                ranges_in_flight: if initial_work.is_some() { 1 } else { 0 },
+                ranges_in_flight: initial as usize,
                 etag: etag.clone(),
                 part_size: effective_part_size,
-                issued: if initial_work.is_some() { 1 } else { 0 },
+                issued: initial,
             };
         }
 
@@ -662,13 +668,12 @@ impl DownloadTransfer {
                 *ranges_in_flight = ranges_in_flight.saturating_sub(1);
             }
         }
-        // Repoke the issuer on every completion. A completed range has drained its
-        // payload (freeing read-ahead occupancy) and dropped the in-flight count, so
-        // a parked poll_work may now make progress — admit a part through a reopened
-        // gate, or complete the transfer when the last range lands. `try_wake` is a
-        // cheap no-op unless the issuer actually parked (it is gated on the pending
-        // flag), so poking unconditionally is correct and avoids a class of wedge
-        // where the gate reopens but nothing re-polls it.
+        // Wake the issuer on every completion. A completed range has freed its
+        // read-ahead occupancy and dropped the in-flight count, so a pending poll_work
+        // can now issue another part or complete the transfer. `try_wake` is a no-op
+        // unless the issuer parked (gated on the pending flag), so waking on every
+        // completion is unconditional and covers the case where occupancy frees but
+        // nothing re-polls.
         self.inner.ctx.try_wake();
     }
 
@@ -707,34 +712,6 @@ impl DownloadTransfer {
         drop(guard); // release lock before signaling waiters
         self.inner.writer.notify_consumer();
         self.inner.ctx.signal_terminal();
-    }
-}
-
-/// Runtime I/O controls for a running download.
-///
-/// Adjusts how the transfer moves data, as opposed to how it is scheduled relative
-/// to other transfers (that is [`SchedulingCtl`](crate::transfer::SchedulingCtl)).
-/// Obtained via [`DownloadHandle::io_ctl()`](crate::operation::download::DownloadHandle::io_ctl).
-#[derive(Debug)]
-pub struct DownloadIoCtl<'a> {
-    transfer: &'a DownloadTransfer,
-}
-
-impl DownloadIoCtl<'_> {
-    /// Set how far this download prefetches ahead of the consumer, overriding the
-    /// value resolved at initiation. Takes effect on the next issuance decision.
-    ///
-    /// Lowering the window caps resident memory for a consumer that has fallen
-    /// behind; raising it restores prefetch depth once the consumer catches up.
-    pub fn set_read_ahead(&self, mode: crate::types::ReadAhead) {
-        self.transfer.set_read_ahead(&mode);
-    }
-}
-
-impl DownloadTransfer {
-    /// I/O controls for this transfer.
-    pub(crate) fn io_ctl(&self) -> DownloadIoCtl<'_> {
-        DownloadIoCtl { transfer: self }
     }
 }
 
@@ -922,7 +899,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let (writer, _consumer) = crate::operation::download::body::new_slot_body();
+        let (writer, _consumer) = crate::operation::download::body::new_recv_body();
         let (ctx, _completion_rx) = TransferContext::new(handle);
 
         DownloadTransfer::new(ctx, BucketType::Standard, input, writer)
@@ -1022,7 +999,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let (writer, _consumer) = crate::operation::download::body::new_slot_body();
+        let (writer, _consumer) = crate::operation::download::body::new_recv_body();
         let (ctx, _completion_rx) = TransferContext::new(handle);
         let transfer = DownloadTransfer::new(ctx, BucketType::Standard, input, writer);
 
@@ -1136,7 +1113,7 @@ mod tests {
         part_size: u64,
     ) -> (
         DownloadTransfer,
-        crate::operation::download::body::SlotBodyConsumer,
+        crate::operation::download::body::RecvBodyConsumer,
     ) {
         let chunk = vec![0u8; part_size as usize];
         let get_obj = mock!(aws_sdk_s3::Client::get_object).then_output(move || {
@@ -1162,23 +1139,21 @@ mod tests {
             .build()
             .unwrap();
 
-        let (writer, consumer) = crate::operation::download::body::new_slot_body();
+        let (writer, consumer) = crate::operation::download::body::new_recv_body();
         let (ctx, _completion_rx) = TransferContext::new(handle);
         let transfer = DownloadTransfer::new(ctx, BucketType::Standard, input, writer);
         (transfer, consumer)
     }
 
-    /// The read-ahead gate bounds issuance at the current window: with the window
-    /// forced small (as a slow consumer's pacing would), issuance proceeds up to
-    /// `issued − consumed == window()`, then stalls. (The window's *value* is the
-    /// controller's job, unit-tested in `read_ahead`; here we test the gate wiring.)
+    /// The read-ahead gate bounds issuance at the current window: with a small window,
+    /// issuance proceeds up to `issued − released == window()`, then stalls. Tests the
+    /// gate wiring; `read_ahead`'s own tests cover resolving the window value.
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_read_ahead_gate_bounds_issuance() {
         let (transfer, _consumer) = create_download_for_gate(128 * MB, 8 * MB);
         skip_discovery(&transfer).await;
-        // Force a small window to exercise the gate deterministically (the rwnd default
-        // opens wide, so a slow-consumer pacing is what makes it bind).
+        // Force a small window so a few polls exercise the gate; the default is large.
         transfer.read_ahead().force_window(3);
         let w = transfer.read_ahead().window();
         // Discovery claimed seq 0 (issued=1, consumed=0). Drive until the gate stalls.
@@ -1196,8 +1171,8 @@ mod tests {
         assert_eq!(issued, w, "issuance should fill the window then stall");
     }
 
-    /// Consuming a delivered chunk advances `consumed`, reopening the gate for more
-    /// issuance (`issued − consumed` drops below the window).
+    /// On the stream path, delivering a chunk advances `released`, so `issued −
+    /// released` drops below the window and the gate admits another claim.
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_consume_reopens_gate() {
@@ -1244,7 +1219,7 @@ mod tests {
                 .set_read_ahead(input_override)
                 .build()
                 .unwrap();
-            let (writer, _consumer) = crate::operation::download::body::new_slot_body();
+            let (writer, _consumer) = crate::operation::download::body::new_recv_body();
             let (ctx, _rx) = TransferContext::new(handle);
             DownloadTransfer::new(ctx, BucketType::Standard, input, writer)
         };

--- a/aws-sdk-s3-transfer-manager/src/runtime/sync/loom.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/sync/loom.rs
@@ -59,7 +59,7 @@ pub(crate) mod sync {
 
     pub(crate) mod atomic {
         pub(crate) use loom::sync::atomic::{
-            AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering,
+            AtomicBool, AtomicPtr, AtomicU64, AtomicU8, AtomicUsize, Ordering,
         };
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/sync/std.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/sync/std.rs
@@ -175,7 +175,7 @@ pub(crate) mod sync {
 
     pub(crate) mod atomic {
         pub(crate) use std::sync::atomic::{
-            AtomicBool, AtomicU64, AtomicU8, AtomicUsize, Ordering,
+            AtomicBool, AtomicPtr, AtomicU64, AtomicU8, AtomicUsize, Ordering,
         };
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -36,6 +36,23 @@ pub enum ConcurrencyMode {
     Explicit(usize),
 }
 
+/// How far a download may prefetch ahead of the consumer.
+///
+/// Read-ahead is speculative issuance: parts fetched before the consumer has read
+/// up to them. This bounds that speculation. It does not gate in-order delivery or
+/// override the memory budget; those are separate bounds.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ReadAhead {
+    /// Read ahead as far as available memory allows.
+    #[default]
+    Auto,
+
+    /// Read ahead at most `n` parts beyond the consumer's position. `0` fetches only
+    /// the part the consumer is waiting on (no speculation). Still bounded by memory.
+    Parts(usize),
+}
+
 /// Throughput target(s)
 #[derive(Debug, Clone)]
 pub struct TargetThroughput {

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -506,3 +506,62 @@ async fn test_download_empty_object() {
     handle.join().await.expect("join should succeed");
     server_handle.shutdown().await.expect("shutdown");
 }
+
+// ── Read-ahead window gate: slow-consumer progress ───────────────────────────
+//
+// The read-ahead gate bounds issuance to `issued - consumed < window`. When the
+// in-order consumer lags, occupancy fills the window and the gate closes; it must
+// reopen as the consumer drains so the transfer completes, never stall permanently.
+// These tests drive the gate against the localhost mock (real HTTP client, real
+// concurrent in-flight GETs) with a deliberately slow consumer.
+//
+// Each test is wrapped in a `timeout` so a stalled gate surfaces as a failure with
+// output (run with `RUST_LOG=aws_sdk_s3_transfer_manager::transfer=trace` to see the
+// gate-closed line and whether `consumed` is advancing), not as a hung test.
+
+/// A many-part download whose consumer drains slower than the issuer fetches, so the
+/// gate repeatedly fills and must reopen. Must complete and return every byte intact.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_download_slow_consumer_does_not_wedge() {
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let part_size = ByteUnit::Mebibyte.as_bytes_usize();
+    // 64 parts at 1 MiB, 16-way concurrency: the issuer runs well ahead of the slow
+    // in-order consumer, exercising the gate's reopen path repeatedly.
+    let (server, server_handle, tm) = setup_concurrent(part_size, 16).await;
+
+    let content: Vec<u8> = (0..64 * part_size).map(|i| (i % 256) as u8).collect();
+    let expected = content.clone();
+    server
+        .add_object("test-bucket", "slow-key", content, None)
+        .await
+        .expect("add object");
+
+    let result = timeout(Duration::from_secs(30), async {
+        let mut handle = tm
+            .download()
+            .bucket("test-bucket")
+            .key("slow-key")
+            .initiate()
+            .expect("initiate download");
+
+        let mut data = Vec::new();
+        while let Some(chunk) = handle.body_mut().next().await {
+            let chunk = chunk.expect("chunk");
+            data.extend_from_slice(&chunk.data.into_bytes());
+            // Slow consumer: pull, then pause, holding the in-order cursor back so
+            // occupancy fills the window and the gate closes between pulls.
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        handle.join().await.expect("join should succeed");
+        data
+    })
+    .await
+    .expect("slow-consumer download did not complete within 30s (gate failed to reopen)");
+
+    assert_eq!(result.len(), expected.len(), "size mismatch");
+    assert_eq!(result, expected, "data integrity check failed");
+    server_handle.shutdown().await.expect("shutdown");
+}
+

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -669,4 +669,3 @@ async fn test_download_to_disk_below_segment_window_drains_in_runs() {
     assert_eq!(written, content, "data integrity check failed");
     server_handle.shutdown().await.expect("shutdown");
 }
-

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -567,13 +567,13 @@ async fn test_download_slow_consumer_does_not_wedge() {
 
 /// A disk download whose part count exceeds the read-ahead window must complete.
 ///
-/// The disk consumer drains via the block surface (`drain_sealed`), which frees a
-/// whole segment at a time and does not advance the in-order delivery cursor. The
-/// read-ahead gate must release occupancy on that drain, or issuance latches shut at
-/// the window and the transfer wedges with the buffer drained to empty. A small
-/// `ReadAhead::Parts` window makes the object exceed it cheaply (no multi-GiB
-/// object); the window is kept above the buffer's segment granularity so segments
-/// can seal and drain. Under a timeout so the wedge fails fast instead of hanging.
+/// The disk consumer drains via the block surface, which frees runs and does not
+/// advance the in-order delivery cursor. The read-ahead gate must release occupancy on
+/// that drain, or issuance latches shut at the window and the transfer wedges with the
+/// buffer drained to empty. A small `ReadAhead::Parts` window makes the object exceed
+/// it cheaply (no multi-GiB object); the window here spans more than one segment so
+/// segments seal and drain whole. Under a timeout so the wedge fails fast instead of
+/// hanging.
 #[cfg(any(unix, windows))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_download_to_disk_exceeding_read_ahead_window_does_not_wedge() {
@@ -613,6 +613,56 @@ async fn test_download_to_disk_exceeding_read_ahead_window_does_not_wedge() {
     })
     .await
     .expect("disk download did not complete within 30s (gate failed to reopen on drain)");
+
+    assert_eq!(written.len(), content.len(), "size mismatch");
+    assert_eq!(written, content, "data integrity check failed");
+    server_handle.shutdown().await.expect("shutdown");
+}
+
+/// Disk download with a read-ahead window *below* the buffer's segment size — the
+/// relief regime. Here a segment can never fill within the window, so the drain batch
+/// drops below the segment size and segments drain as partial contiguous runs rather
+/// than whole. This exercises the sub-segment drain path (and proves it does not wedge:
+/// a window that cannot seal a segment must still drain and reopen the gate). A small
+/// `ReadAhead::Parts(2)` window against a multi-segment object keeps it cheap. The
+/// positioned writes must still reassemble the object byte-for-byte under a timeout.
+#[cfg(any(unix, windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_download_to_disk_below_segment_window_drains_in_runs() {
+    use aws_sdk_s3_transfer_manager::types::ReadAhead;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let (server, server_handle, tm) = setup_concurrent(part_size, 8).await;
+
+    // 40 parts against a window of 3 (Parts(2) → 2 speculative + 1 demand), far below
+    // the 16-part segment. No segment ever seals within the window, so every drain is a
+    // partial run; the gate must still reopen on each run drain or the transfer wedges.
+    let size = 40 * part_size;
+    let content = deterministic_data(size);
+    server
+        .add_object("test-bucket", "disk-subseg-key", content.clone(), None)
+        .await
+        .expect("add object");
+
+    let dir = tempfile::tempdir().unwrap();
+    let dest_path = dir.path().join("output.dat");
+
+    let written = timeout(Duration::from_secs(30), async {
+        let handle = tm
+            .download()
+            .bucket("test-bucket")
+            .key("disk-subseg-key")
+            .read_ahead(ReadAhead::Parts(2))
+            .write_to_path(&dest_path)
+            .await
+            .unwrap();
+        handle.join().await.unwrap();
+        std::fs::read(&dest_path).unwrap()
+    })
+    .await
+    .expect("sub-segment-window disk download did not complete within 30s (gate failed to reopen on a partial-run drain)");
 
     assert_eq!(written.len(), content.len(), "size mismatch");
     assert_eq!(written, content, "data integrity check failed");

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -509,9 +509,10 @@ async fn test_download_empty_object() {
 
 // ── Read-ahead window gate: slow-consumer progress ───────────────────────────
 //
-// The read-ahead gate bounds issuance to `issued - consumed < window`. When the
+// The read-ahead gate bounds issuance to `issued - released < window`. When the
 // in-order consumer lags, occupancy fills the window and the gate closes; it must
 // reopen as the consumer drains so the transfer completes, never stall permanently.
+// (On the stream path `released` advances with the delivery cursor `consumed`.)
 // These tests drive the gate against the localhost mock (real HTTP client, real
 // concurrent in-flight GETs) with a deliberately slow consumer.
 //

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -565,3 +565,57 @@ async fn test_download_slow_consumer_does_not_wedge() {
     server_handle.shutdown().await.expect("shutdown");
 }
 
+/// A disk download whose part count exceeds the read-ahead window must complete.
+///
+/// The disk consumer drains via the block surface (`drain_sealed`), which frees a
+/// whole segment at a time and does not advance the in-order delivery cursor. The
+/// read-ahead gate must release occupancy on that drain, or issuance latches shut at
+/// the window and the transfer wedges with the buffer drained to empty. A small
+/// `ReadAhead::Parts` window makes the object exceed it cheaply (no multi-GiB
+/// object); the window is kept above the buffer's segment granularity so segments
+/// can seal and drain. Under a timeout so the wedge fails fast instead of hanging.
+#[cfg(any(unix, windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_download_to_disk_exceeding_read_ahead_window_does_not_wedge() {
+    use aws_sdk_s3_transfer_manager::types::ReadAhead;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let (server, server_handle, tm) = setup_concurrent(part_size, 8).await;
+
+    // 40 parts (200 MiB) against a window of 32 (Parts(31) → 31 speculative + 1
+    // demand): the gate fills and must reopen on disk drains. The window spans two
+    // 16-part segments, so a segment seals and drains while issuance is gated — the
+    // path that wedged before the gate counted disk drains. Kept modest: the 5 MiB
+    // minimum part size makes larger objects costly on the test filesystem.
+    let size = 40 * part_size;
+    let content = deterministic_data(size);
+    server
+        .add_object("test-bucket", "disk-window-key", content.clone(), None)
+        .await
+        .expect("add object");
+
+    let dir = tempfile::tempdir().unwrap();
+    let dest_path = dir.path().join("output.dat");
+
+    let written = timeout(Duration::from_secs(30), async {
+        let handle = tm
+            .download()
+            .bucket("test-bucket")
+            .key("disk-window-key")
+            .read_ahead(ReadAhead::Parts(31))
+            .write_to_path(&dest_path)
+            .await
+            .unwrap();
+        handle.join().await.unwrap();
+        std::fs::read(&dest_path).unwrap()
+    })
+    .await
+    .expect("disk download did not complete within 30s (gate failed to reopen on drain)");
+
+    assert_eq!(written.len(), content.len(), "size mismatch");
+    assert_eq!(written, content, "data integrity check failed");
+    server_handle.shutdown().await.expect("shutdown");
+}
+


### PR DESCRIPTION
## Summary

Replaces the download delivery path's fixed-capacity slot ring with a paged receive buffer and an occupancy-bounded read-ahead gate. The buffer grows to absorb head-of-line backlog and reclaims from the front as delivery advances; issuance is gated on resident occupancy (`issued - released < window`) rather than on a fixed ring capacity. This fixes a disk-download wedge, decouples the memory bound from the delivery buffer, and adds a public read-ahead control surface.

## Why

The base delivery path is `SlotBuffer`: a fixed-size ring of `capacity` slots indexed by `seq % capacity`. Three limits motivate the change.

**One fixed structure serves three roles.** The ring's capacity is simultaneously the issuance permit (`claimed - consumed < capacity` gates the next ranged GET), the delivery buffer, and the memory bound. They cannot move independently: the buffer cannot grow to absorb a burst of out-of-order arrivals without also loosening the memory bound, and the memory bound cannot tighten without also throttling issuance.

**One cursor cannot express two positions.** The ring tracks a single `consumed` cursor — the in-order delivery position. That is the right bound for a streaming consumer, but a download to disk does not consume in order: it drains filled parts to their file offsets as they arrive, out of order, and never advances an in-order cursor. Resident occupancy (how much buffer is live) and in-order delivery position (how far the stream has been read) are different quantities, and one cursor cannot be both.

**The disk-download wedge.** Because issuance was gated on the in-order cursor, a disk download larger than the ring latched shut. It issued a ring's worth of parts, drained them to disk (freeing the buffer), but the in-order cursor never advanced past the first not-yet-delivered part — so `claimed - consumed` stayed at capacity and issuance never resumed. Observed as a multi-GiB disk download that received a ring's worth, then stalled with zero further bytes written and falling RSS.

## How it works

### PagedRecvBuffer

`PagedRecvBuffer<T>` assigns each payload a sequence number at claim time, accepts completed payloads into their slots in any order from many producers, and delivers them to a single consumer. It is a `VecDeque<Arc<Segment<T>>>` under one `Mutex`; each segment is a fixed run of slots covering a contiguous span of sequences. The deque grows at the tail and reclaims from the front, so resident memory tracks the gap between the oldest undelivered and newest claimed sequence, not the total count.

```text
  reclaim ◀── front                        tail ──▶ grow
  ┌─────────┐    ┌─────────┐    ┌─────────┐
  │  seg 0  │─nx▶│  seg 1  │─nx▶│  seg 2  │
  │ x x x x │    │ x x x . │    │ F . _ _ │
  │ 0 1 2 3 │    │ 4 5 6 7 │    │ 8 9     │
  │ base=0  │    │ base=4  │    │ base=8  │
  └─────────┘    └───────▲─┘    └─────────┘
                         │
                    cursor=7   (issued=10)

  x = delivered   F = filled, awaiting delivery
  . = claimed, in flight   _ = not yet claimed   nx = next pointer
```

The two hot paths are lock-free: `fill` writes a claimed slot and publishes it with a `Release` store; `poll_next` reads the cursor slot under `Acquire` and hops to the successor segment via an intrusive `next` pointer without taking the lock. Only the issuer paths — `claim` (assign a sequence, maybe grow, opportunistic reclaim) and segment reclaim — take the lock, in short critical sections that never span a fill, a delivery, or an I/O.

### The occupancy gate

Issuance of a speculative part requires `issued - released < window`. `issued` counts parts claimed for issuance; `released` counts parts whose payload memory has been freed. `issued - released` is resident occupancy in parts — an exact quantity, not an estimate. The gate bounds how far issuance runs ahead of consumption and nothing more:

- Fast consumer: `released` keeps pace, occupancy stays low, the gate does not bind.
- Slow consumer: occupancy fills to the window, the gate closes, issuance waits. Resident memory is bounded at `window` parts.
- Blocked consumer (a stalled or not-yet-filled part): occupancy pins at the window, leaving a full window of slack to make progress around the hole rather than collapsing to a single outstanding part.

The window is a fixed per-transfer cap held in an `AtomicU64`, sized above the bandwidth-delay product of a 100 Gbps link so it does not bind a consumer that keeps pace. It is atomic (not a constant) so it can be lowered with a lock-free store while a transfer runs.

### Two surfaces, one occupancy counter

The buffer is consumed through exactly one of two surfaces per instance:

- **Stream** (`RecvBufferConsumer::poll_next`) — one payload at a time, in strict sequence order, emptying each slot as it passes. Its single non-cloneable handle makes "single consumer" a type fact.
- **Block** (`take_drain_run`) — hands out a contiguous filled run of a segment as an owned `SegmentWrite` token, for bulk consumption (disk write) that does not need in-order delivery. Runs may be taken and completed out of order and concurrently.

`released` is incremented by *both* surfaces — one per in-order stream delivery, and by a run's filled count on each block drain. `consumed`, the in-order delivery cursor, is separate and drives only stream-path reclaim. Because the gate reads `issued - released`, a disk download paces to its drain rate instead of latching shut on the in-order cursor — the fix for the wedge. Each range completion repokes the issuer, so a drain that frees occupancy wakes a gated poll.

### The drain primitive

The block surface drains through `take_drain_run`, backed by two per-segment cursors: `claim_cursor` (leading slots claimed for draining, advanced only under the lock, so a run is handed out at most once) and `drained_count` (slots written to the sink and freed; when it reaches the segment length the segment is reclaimable). A drain claims the contiguous filled run beyond `claim_cursor` when it reaches the drain batch, when the segment fills (so a sub-batch tail residue still drains), or when the call is terminal. The batch is a minimum trigger coupled to the read-ahead window (`min(seg_size, window)`), so a window smaller than a segment drains in smaller runs instead of never sealing a segment. Dropping a token without completing runs the same drain, so an aborted consumer still frees its run and cannot stall reclaim.

### Positioned disk writes behind a seam

Disk delivery reads a claimed run's payloads in place and writes them at their absolute object offsets via `pwritev`, coalescing offset-contiguous payloads into one positioned write. The write target sits behind a `SinkWrite` trait (`FileSink` for the file path), so the drain orchestration is exercised against an in-memory capture in tests and an alternative write strategy can replace the file write without touching the buffer or the drain logic.

### Public read-ahead control

`crate::types::ReadAhead { Auto, Parts(n) }` is exposed at three scopes, precedence dynamic > request > client:

- `Config::builder().read_ahead(..)` — client default.
- `download().read_ahead(..)` — per-request override.
- `handle.io_ctl().set_read_ahead(..)` — dynamic, on a running transfer.

`Parts(n)` caps read-ahead at `n` parts of speculation beyond the part the consumer is waiting on (`n + 1` resident), so `Parts(0)` is demand paging. `Auto` uses the fixed per-transfer cap. The knob resolves to a window in one place, `window_parts_for`, used at construction and by the dynamic setter. I/O controls live on a new `DownloadIoCtl`, separate from `SchedulingCtl` (data movement vs scheduling).

## How to review

Start with `recv_buffer.rs` — it is the core and stands alone. Its module doc walks the structure, the two surfaces, and the six memory-ordering/safety rules; the concurrency is model-checked (loom) and the sequencing is covered by deterministic unit tests. Read it before the wiring.

Then `transfer.rs::poll_work` — the occupancy gate (`issued - released < window`) and the completion repoke. The gate condition and the `released` accounting are what fix the wedge.

Then `body.rs` — the `SinkWrite`/`FileSink` seam and the drain orchestration (run coalescing, offset translation). `read_ahead.rs` is the window controller and the knob-to-window resolution; `types.rs`/`input.rs`/`builders.rs`/`config.rs`/`handle.rs` are the public `ReadAhead` surface and are mechanical.

## Testing

`recv_buffer` is covered at three levels: deterministic unit tests for the sequencing logic (exhaustive fill-order permutations, head-of-line blocking, the segment hop, drain-run partition and gaps, terminal partial-tail drain, exactly-once free, out-of-order eager reclaim, and the block-vs-stream counter split); loom models for the concurrency edges (the fill/poll handoff, the hop, reclaim against an outstanding write and against a drop, multi-producer out-of-order fill, and drainers racing and partitioning a segment); and miri (stacked borrows) over the unit suite. A concurrent stress test drives fill-then-drain at batch 1 and asserts every slot drains exactly once, guarding the fill-probe's saturating subtraction against a regression.

Download integration tests against the mock S3 server cover the behaviors this change targets: a disk download exceeding the read-ahead window (the wedge), a disk download with a window below the segment size (the sub-segment drain regime), and a slow-consumer transfer that must pace rather than wedge.

## Changes

```
aws-sdk-s3-transfer-manager/
  src/
    operation/download/
      recv_buffer.rs    NEW — paged receive buffer, stream + block surfaces, drain primitive
      read_ahead.rs     NEW — occupancy window controller, ReadAhead knob resolution
      body.rs           slot ring → PagedRecvBuffer; SinkWrite/FileSink seam; positioned writes
      transfer.rs       occupancy gate in poll_work; completion repoke
      handle.rs         DownloadIoCtl (runtime read-ahead control)
      input.rs          per-request read_ahead override
      builders.rs       read_ahead fluent setter
      context.rs        Transferring.issued (issuance cursor)
      download.rs        wiring
    types.rs            ReadAhead { Auto, Parts(n) }
    config.rs           client-default read_ahead
    runtime/sync/{std,loom}.rs   atomics used by the buffer under the loom shim
  examples/cp.rs        jemalloc receive-path config for the download benchmark
integration-tests/
  src/download.rs       disk-exceeds-window, sub-segment-window, slow-consumer tests
```

## Notes for review

- The occupancy window is a fixed per-transfer cap. Cross-transfer arbitration against a global memory budget, and an `Auto`-mode resident-size adaptation, layer on top of the `AtomicU64` window and are not part of this change.
- The disk drain executes its positioned write inline on the execute path; moving the blocking file operations (temp-file create, rename) off the caller's runtime is tracked separately and is orthogonal to this change.
