### PR TITLE
vnext: Memory Budget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "jemallocator",
+ "libc",
  "loom",
  "md5",
  "nix",
@@ -317,6 +318,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4727,6 +4729,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/aws-sdk-s3-transfer-manager/Cargo.toml
+++ b/aws-sdk-s3-transfer-manager/Cargo.toml
@@ -45,7 +45,16 @@ dial9-tokio-telemetry = { version = "0.3", optional = true, features = ["cpu-pro
 dial9 = ["dep:dial9-tokio-telemetry"]
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.31", features = ["uio", "fs"] }
+nix = { version = "0.31", features = ["uio", "fs", "resource"] }
+
+# Total physical RAM via sysctl(hw.memsize).
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2"
+
+# Total physical RAM via GlobalMemoryStatusEx; descriptor limit is not low on
+# Windows, so the connection cap there is the absolute ceiling.
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 aws-sdk-s3 = { version = "1.128.0", features = ["behavior-version-latest", "test-util"] }

--- a/aws-sdk-s3-transfer-manager/examples/cp.rs
+++ b/aws-sdk-s3-transfer-manager/examples/cp.rs
@@ -6,7 +6,9 @@ use aws_sdk_s3_transfer_manager::io::InputStream;
 use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_sdk_s3_transfer_manager::metrics::Throughput;
 use aws_sdk_s3_transfer_manager::operation::download::Body;
-use aws_sdk_s3_transfer_manager::types::{ConcurrencyMode, PartSize, TargetThroughput};
+use aws_sdk_s3_transfer_manager::types::{
+    ConcurrencyMode, MemoryBudgetConfig, PartSize, TargetThroughput,
+};
 use aws_smithy_types::date_time::{DateTime, Format};
 use clap::{CommandFactory, Parser};
 use std::error::Error;
@@ -450,6 +452,17 @@ async fn run() -> Result<(), BoxError> {
     let mut config_loader = aws_sdk_s3_transfer_manager::from_env()
         .concurrency(args.concurrency.mode())
         .part_size(PartSize::Target(args.part_size));
+
+    // S3FIO_MEMORY_LIMIT=N caps the transfer manager's memory budget at N GiB
+    // (in-flight plus buffered transfer data; transfers backpressure at the cap).
+    if let Some(gib) = std::env::var("S3FIO_MEMORY_LIMIT")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+    {
+        let bytes = gib * ByteUnit::Gibibyte.as_bytes_usize();
+        tracing::info!(gib, "memory budget limit (S3FIO_MEMORY_LIMIT, GiB)");
+        config_loader = config_loader.memory_budget(MemoryBudgetConfig::Limit(bytes));
+    }
 
     #[cfg(feature = "dial9")]
     if let Some(guard) = telemetry_guard {

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -15,10 +15,13 @@ use crate::Config;
 use std::sync::Arc;
 use std::time::Duration;
 
-#[cfg(test)]
-use crate::runtime::memory::DEFAULT_MEMORY_BUDGET_BYTES;
 use crate::runtime::memory::{MemoryBudget, BUDGET_CHUNK_BYTES};
 use crate::runtime::ExecutionRuntime;
+
+/// Non-binding budget for test handles, which size objects far below it, so the
+/// budget never gates in state-machine and mock-SDK tests.
+#[cfg(test)]
+const TEST_MEMORY_BUDGET_BYTES: usize = 8 * ByteUnit::Gibibyte.as_bytes_usize();
 
 /// Transfer manager client for Amazon Simple Storage Service.
 #[derive(Debug, Clone)]
@@ -94,7 +97,7 @@ impl Handle {
                 runtime,
                 controller: Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
                 telemetry: Arc::new(Telemetry::new(std::time::Duration::from_millis(500))),
-                memory_budget: MemoryBudget::new(DEFAULT_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
+                memory_budget: MemoryBudget::new(TEST_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
             }
         })
     }
@@ -153,7 +156,7 @@ impl Handle {
                 runtime,
                 controller: Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
                 telemetry: Arc::new(Telemetry::new(std::time::Duration::from_millis(500))),
-                memory_budget: MemoryBudget::new(DEFAULT_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
+                memory_budget: MemoryBudget::new(TEST_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
             }
         })
     }

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -15,6 +15,9 @@ use crate::Config;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(test)]
+use crate::runtime::memory::DEFAULT_MEMORY_BUDGET_BYTES;
+use crate::runtime::memory::{MemoryBudget, BUDGET_CHUNK_BYTES};
 use crate::runtime::ExecutionRuntime;
 
 /// Transfer manager client for Amazon Simple Storage Service.
@@ -23,7 +26,9 @@ pub struct Client {
     pub(crate) handle: Arc<Handle>,
 }
 
-/// Whatever is needed to carry out operations, e.g. scheduler, budgets, config, env details, etc
+/// Shared state backing every transfer operation: configuration, the S3 client,
+/// the scheduler, the execution runtime, the concurrency controller, telemetry,
+/// and the memory budget.
 #[derive(Debug)]
 pub(crate) struct Handle {
     pub(crate) config: crate::Config,
@@ -32,6 +37,7 @@ pub(crate) struct Handle {
     pub(crate) runtime: Arc<dyn ExecutionRuntime>,
     pub(crate) controller: Arc<dyn ConcurrencyController>,
     pub(crate) telemetry: Arc<Telemetry>,
+    pub(crate) memory_budget: Arc<MemoryBudget>,
 }
 
 impl Handle {
@@ -88,6 +94,7 @@ impl Handle {
                 runtime,
                 controller: Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
                 telemetry: Arc::new(Telemetry::new(std::time::Duration::from_millis(500))),
+                memory_budget: MemoryBudget::new(DEFAULT_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
             }
         })
     }
@@ -146,6 +153,7 @@ impl Handle {
                 runtime,
                 controller: Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
                 telemetry: Arc::new(Telemetry::new(std::time::Duration::from_millis(500))),
+                memory_budget: MemoryBudget::new(DEFAULT_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
             }
         })
     }
@@ -184,6 +192,9 @@ impl Client {
         #[cfg(feature = "dial9")]
         let telemetry_guard = config.take_telemetry_guard().map(std::sync::Arc::new);
 
+        // Resolve the budget once: it sizes the Handle's MemoryBudget.
+        let budget_capacity = config.memory_budget().resolve();
+
         let handle = Arc::new_cyclic(|weak_handle| {
             let scheduler = Scheduler::new(weak_handle.clone());
             let runtime: Arc<dyn ExecutionRuntime> = {
@@ -216,6 +227,7 @@ impl Client {
                 runtime,
                 controller,
                 telemetry,
+                memory_budget: MemoryBudget::new(budget_capacity, BUDGET_CHUNK_BYTES),
             }
         });
         Client { handle }
@@ -224,6 +236,13 @@ impl Client {
     /// Returns the client's configuration
     pub fn config(&self) -> &Config {
         &self.handle.config
+    }
+
+    /// Snapshot the global memory budget's resolved ceiling and current admission
+    /// state. For the configured intent (before resolution), see
+    /// [`config().memory_budget()`](Config::memory_budget).
+    pub fn memory_budget(&self) -> crate::types::MemoryBudgetSnapshot {
+        self.handle.memory_budget.stats()
     }
 
     /// Upload a single object from S3.

--- a/aws-sdk-s3-transfer-manager/src/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/config.rs
@@ -7,7 +7,7 @@ use aws_runtime::user_agent::FrameworkMetadata;
 use std::cmp;
 
 use crate::metrics::unit::ByteUnit;
-use crate::types::{ConcurrencyMode, PartSize, ReadAhead};
+use crate::types::{ConcurrencyMode, MemoryBudgetConfig, PartSize, ReadAhead};
 
 pub(crate) mod loader;
 
@@ -71,6 +71,7 @@ pub struct Config {
     target_part_size: PartSize,
     concurrency: ConcurrencyMode,
     read_ahead: ReadAhead,
+    memory_budget: MemoryBudgetConfig,
     framework_metadata: Option<FrameworkMetadata>,
     s3_client_source: Option<S3ClientSource>,
     #[cfg(feature = "dial9")]
@@ -108,6 +109,11 @@ impl Config {
         &self.read_ahead
     }
 
+    /// Returns the memory budget configuration.
+    pub fn memory_budget(&self) -> &MemoryBudgetConfig {
+        &self.memory_budget
+    }
+
     /// Returns the framework metadata setting when using transfer manager.
     #[doc(hidden)]
     pub fn framework_metadata(&self) -> Option<&FrameworkMetadata> {
@@ -137,6 +143,7 @@ pub struct Builder {
     target_part_size: PartSize,
     concurrency: ConcurrencyMode,
     read_ahead: ReadAhead,
+    memory_budget: MemoryBudgetConfig,
     pub(crate) framework_metadata: Option<FrameworkMetadata>,
     client: Option<aws_sdk_s3::Client>,
     s3_client_config: Option<S3ClientConfig>,
@@ -220,6 +227,15 @@ impl Builder {
         self
     }
 
+    /// Set the memory budget: an upper bound on memory used for in-flight and
+    /// buffered transfer data. At the limit transfers backpressure rather than
+    /// fail. Default is [`MemoryBudgetConfig::Auto`] (a safe fraction of detected
+    /// RAM).
+    pub fn memory_budget(mut self, budget: MemoryBudgetConfig) -> Self {
+        self.memory_budget = budget;
+        self
+    }
+
     /// Sets the framework metadata for the transfer manager.
     ///
     /// This _optional_ name is used to identify the framework using transfer manager in the user agent that
@@ -275,6 +291,7 @@ impl Builder {
             target_part_size: self.target_part_size,
             concurrency: self.concurrency,
             read_ahead: self.read_ahead,
+            memory_budget: self.memory_budget,
             framework_metadata: self.framework_metadata,
             s3_client_source: Some(s3_client_source),
             #[cfg(feature = "dial9")]

--- a/aws-sdk-s3-transfer-manager/src/config/loader.rs
+++ b/aws-sdk-s3-transfer-manager/src/config/loader.rs
@@ -10,7 +10,7 @@ use aws_sdk_s3::config::{Intercept, IntoShared};
 use aws_types::os_shim_internal::Env;
 
 use crate::config::{Builder, Config};
-use crate::types::{ConcurrencyMode, PartSize};
+use crate::types::{ConcurrencyMode, MemoryBudgetConfig, PartSize};
 
 #[derive(Debug)]
 struct S3TransferManagerInterceptor {
@@ -83,6 +83,14 @@ impl ConfigLoader {
     /// Default is [ConcurrencyMode::Auto].
     pub fn concurrency(mut self, mode: ConcurrencyMode) -> Self {
         self.builder = self.builder.concurrency(mode);
+        self
+    }
+
+    /// Set the memory budget: an upper bound on memory used for in-flight and
+    /// buffered transfer data. At the limit transfers backpressure rather than
+    /// fail. Default is [`MemoryBudgetConfig::Auto`].
+    pub fn memory_budget(mut self, budget: MemoryBudgetConfig) -> Self {
+        self.builder = self.builder.memory_budget(budget);
         self
     }
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -11,7 +11,7 @@ use crate::runtime::sync::sync::Arc;
 
 use super::chunk_meta::ChunkMetadata;
 use super::recv_buffer::{
-    FillOutcome, PagedRecvBuffer, RecvBufferConsumer, SegmentWrite, SlotHandle,
+    DrainMode, FillOutcome, PagedRecvBuffer, RecvBufferConsumer, SegmentWrite, SlotHandle,
 };
 
 /// Segment size for the paged buffer. Re-exported from `recv_buffer` for test access.
@@ -201,14 +201,14 @@ impl BodyWriter {
     /// Returns the number of parts freed across the runs drained by this call — the
     /// read-ahead occupancy the caller releases. The buffer does not track a running
     /// total; the download layer accounts for the freed count under its state lock.
-    pub(crate) fn drain(&self, terminal: bool) -> Result<u64, std::io::Error> {
+    pub(crate) fn drain(&self, mode: DrainMode) -> Result<u64, std::io::Error> {
         let mut freed = 0u64;
         if let Mode::Disk {
             sink,
             object_range_start,
         } = &*self.mode
         {
-            while let Some(sw) = self.buffer.take_drain_run(terminal) {
+            while let Some(sw) = self.buffer.take_drain_run(mode) {
                 write_run(sink.as_ref(), *object_range_start, &sw)?;
                 freed += sw.complete();
             }
@@ -224,13 +224,29 @@ impl BodyWriter {
         if !matches!(&*self.mode, Mode::Disk { .. }) {
             return Ok(0);
         }
-        let terminal_parts = self.drain(true)?;
+        let terminal_parts = self.drain(DrainMode::Eager)?;
         tracing::debug!(
             target: crate::telemetry::TARGET_TRANSFER,
             terminal_parts,
             "terminal drain complete; tail flushed to disk",
         );
         Ok(terminal_parts)
+    }
+
+    /// Whether a forced eager drain would free at least one resident part right now:
+    /// the disk surface holds a contiguous filled run at some segment's claim cursor.
+    /// Stream mode returns false — its consumer drives release, so it never pins budget
+    /// behind the drain batch. Gates budget-pressure relief (`drain_or_park`).
+    pub(crate) fn has_drainable_resident(&self) -> bool {
+        matches!(&*self.mode, Mode::Disk { .. }) && self.buffer.has_drainable_prefix()
+    }
+
+    /// Flush the resident filled prefix to disk now, below the drain batch — budget
+    /// backpressure relief, distinct in intent from the terminal `finalize` but using
+    /// the same eager take. Returns the parts freed so the caller releases their
+    /// read-ahead occupancy. Not terminal: the transfer keeps issuing after this.
+    pub(crate) fn flush_resident(&self) -> Result<u64, std::io::Error> {
+        self.drain(DrainMode::Eager)
     }
 
     /// Couple the drain batch to the read-ahead window: a window narrower than a
@@ -655,7 +671,7 @@ mod tests {
     // --- Disk driver tests ---
 
     use super::{
-        new_recv_body_with_disk_mode, new_recv_body_with_sink, BodyWriter as Writer,
+        new_recv_body_with_disk_mode, new_recv_body_with_sink, BodyWriter as Writer, DrainMode,
         RecvBodyConsumer, SinkWrite,
     };
     use bytes::Buf as _;
@@ -734,6 +750,33 @@ mod tests {
         (writer, consumer, sink)
     }
 
+    /// `has_drainable_resident` gates budget-relief draining. It is true only on the
+    /// disk surface with a filled run at the cursor: stream mode returns false (the
+    /// consumer drives release there, so an eager drain would be a no-op that spins),
+    /// and a resident run only exists once a slot at the cursor is filled.
+    #[test]
+    fn has_drainable_resident_only_on_disk_with_a_filled_run() {
+        // Stream mode: even with a filled slot, never drainable-resident.
+        let (stream_writer, _consumer) = new_recv_body();
+        stream_writer.claim().fill(chunk_at(0, 0, b"streamed"));
+        assert!(
+            !stream_writer.has_drainable_resident(),
+            "stream mode has no drainable-resident run (consumer drives release)"
+        );
+
+        // Disk mode: empty → false; filled at the cursor → true.
+        let (disk_writer, _consumer, _sink) = new_recv_body_with_capture(0);
+        assert!(
+            !disk_writer.has_drainable_resident(),
+            "disk mode with nothing filled is not drainable-resident"
+        );
+        disk_writer.claim().fill(chunk_at(0, 0, b"resident"));
+        assert!(
+            disk_writer.has_drainable_resident(),
+            "disk mode with a filled run at the cursor is drainable-resident"
+        );
+    }
+
     #[test]
     fn disk_writes_full_segment() {
         use super::SEG_SIZE;
@@ -751,7 +794,7 @@ mod tests {
         }
 
         // The last fill sealed the segment; drain it.
-        writer.drain(false).unwrap();
+        writer.drain(DrainMode::Batched).unwrap();
 
         let contents = std::fs::read(&path).unwrap();
         for i in 0..SEG_SIZE as u64 {
@@ -844,7 +887,7 @@ mod tests {
             slot.fill(chunk_at(i, offset, data.as_bytes()));
         }
 
-        writer.drain(false).unwrap();
+        writer.drain(DrainMode::Batched).unwrap();
 
         let contents = std::fs::read(&path).unwrap();
         for i in 0..n as u64 {
@@ -924,7 +967,7 @@ mod tests {
             let outcome = slot.fill(chunk_at(i, i * 100, format!("d{i}").as_bytes()));
             // Drain on the batch edge, as execute_get_range does.
             if outcome == super::FillOutcome::DrainReady {
-                freed_total += writer.drain(false).unwrap();
+                freed_total += writer.drain(DrainMode::Batched).unwrap();
             }
         }
         // A terminal drain flushes any sub-batch tail so the total accounts for every part.
@@ -1010,7 +1053,7 @@ mod tests {
                         let outcome = slot.fill(chunk_at(seq as u64, offset, &part_bytes(seq)));
                         // Mirror execute_get_range: drain on the batch edge.
                         if outcome == super::FillOutcome::DrainReady {
-                            let freed = writer.drain(false).unwrap();
+                            let freed = writer.drain(DrainMode::Batched).unwrap();
                             freed_total.fetch_add(freed, std::sync::atomic::Ordering::Relaxed);
                         }
                     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -6,6 +6,7 @@
 use bytes::Buf;
 
 use crate::io::AggregatedBytes;
+use crate::runtime::memory::Reservation;
 use crate::runtime::sync::sync::Arc;
 
 use super::chunk_meta::ChunkMetadata;
@@ -123,6 +124,13 @@ pub(crate) struct BodySlot {
     handle: Option<SlotHandle<ChunkOutput>>,
     buffer: PagedRecvBuffer<ChunkOutput>,
     notify: Arc<WakeNotify>,
+    /// Memory-budget reservation held from claim, moved into the chunk at
+    /// [`fill`](Self::fill). The reservation then rides the `ChunkOutput` through
+    /// the buffer and drops with it: on the stream surface when the consumer drops
+    /// the delivered chunk (its true residency), on the disk surface when the drain
+    /// frees the payload after copy-out. `None` until [`attach_reservation`], and on
+    /// paths that do not reserve (tests).
+    reservation: Option<Reservation>,
 }
 
 impl std::fmt::Debug for BodySlot {
@@ -139,10 +147,20 @@ impl BodySlot {
         self.handle.as_ref().expect("slot already consumed").seq()
     }
 
+    /// Attach the memory-budget reservation backing this chunk. Held on the slot
+    /// from claim until [`fill`](Self::fill) moves it into the `ChunkOutput`, so it
+    /// drops with the chunk's bytes rather than at the ring boundary.
+    pub(crate) fn attach_reservation(&mut self, reservation: Reservation) {
+        self.reservation = Some(reservation);
+    }
+
     /// Publish a completed chunk into this slot. Wakes the stream consumer
-    /// and returns the fill outcome (whether a segment was sealed).
-    pub(crate) fn fill(mut self, chunk: ChunkOutput) -> FillOutcome {
+    /// and returns the fill outcome (whether a segment was sealed). The slot's
+    /// reservation moves into the chunk so it rides through the buffer and drops
+    /// with the delivered bytes.
+    pub(crate) fn fill(mut self, mut chunk: ChunkOutput) -> FillOutcome {
         let handle = self.handle.take().expect("slot already consumed");
+        chunk.reservation = self.reservation.take().map(Arc::new);
         let outcome = self.buffer.fill(handle, chunk);
         self.notify.notify_one();
         outcome
@@ -172,6 +190,7 @@ impl BodyWriter {
             handle: Some(handle),
             buffer: self.buffer.clone(),
             notify: self.notify.clone(),
+            reservation: None,
         }
     }
 
@@ -395,6 +414,12 @@ pub struct ChunkOutput {
     /// The metadata associated with this particular ranged GetObject request. This contains all the
     /// metadata returned by the S3 GetObject operation.
     pub metadata: ChunkMetadata,
+    /// Memory-budget reservation accounting for this chunk's bytes. Rides the chunk
+    /// from fill through delivery; the budget is charged until the last clone of the
+    /// delivered chunk drops (`AggregatedBytes` clones share the same backing bytes,
+    /// so an `Arc` reservation matches that residency exactly). `None` on paths that
+    /// do not reserve against the budget.
+    pub(crate) reservation: Option<Arc<Reservation>>,
 }
 
 impl std::fmt::Debug for ChunkOutput {
@@ -487,6 +512,7 @@ mod tests {
             offset: 0,
             data,
             metadata: Default::default(),
+            reservation: None,
         }
     }
 
@@ -644,6 +670,7 @@ mod tests {
             offset,
             data: AggregatedBytes(seg),
             metadata: Default::default(),
+            reservation: None,
         }
     }
 
@@ -1010,5 +1037,122 @@ mod tests {
             expected,
             "out-of-order concurrent drain must reassemble the object byte-for-byte"
         );
+    }
+
+    // --- Reservation lease-lifetime tests ---
+    //
+    // The budget caps TOTAL memory the transfer manager holds, not ring residency
+    // (the read-ahead window already bounds that). So a reservation must live for as
+    // long as the bytes it accounts for are resident: on the stream surface the bytes
+    // escape to the consumer in the delivered `ChunkOutput` and stay resident until
+    // the consumer drops it, so the reservation must ride the chunk and release on
+    // consumer-drop — NOT at the ring boundary. On the disk surface the drain copies
+    // the bytes out and frees them, so the reservation releases at drain.
+
+    use crate::runtime::memory::MemoryBudget;
+
+    #[test]
+    fn stream_reservation_rides_chunk_and_releases_on_consumer_drop() {
+        let chunk_bytes = 1024;
+        let budget = MemoryBudget::new(chunk_bytes * 4, chunk_bytes);
+        let (writer, mut consumer) = new_recv_body();
+
+        // Claim, reserve, fill — the producer path. One chunk charged.
+        let mut slot = writer.claim();
+        slot.attach_reservation(budget.try_reserve(chunk_bytes).expect("has capacity"));
+        assert_eq!(budget.in_use_chunks(), 1);
+        slot.fill(chunk_resp(0, {
+            let mut seg = SegmentedBuf::new();
+            seg.push(Bytes::from("hello"));
+            AggregatedBytes(seg)
+        }));
+
+        // Still charged while the chunk sits in the ring.
+        assert_eq!(budget.in_use_chunks(), 1);
+
+        // Deliver to the consumer. The chunk (and its reservation) leaves the ring as
+        // an owned value — the bytes are now resident in the consumer's hands, so the
+        // budget must STILL be charged. Releasing here would be the lease-lifetime bug.
+        let chunk = consumer.try_take_next().expect("chunk delivered");
+        assert_eq!(chunk.data.clone().to_vec(), b"hello");
+        assert_eq!(
+            budget.in_use_chunks(),
+            1,
+            "reservation must survive delivery: the bytes are resident in the consumer"
+        );
+
+        // Consumer drops the chunk: the bytes are freed, so the reservation releases.
+        drop(chunk);
+        assert_eq!(
+            budget.in_use_chunks(),
+            0,
+            "reservation must release when the consumer drops the delivered chunk"
+        );
+    }
+
+    #[test]
+    fn stream_reservation_holds_until_last_chunk_clone_drops() {
+        // `ChunkOutput` is Clone and its `AggregatedBytes` clone shares the same backing
+        // `Bytes` (a refcount bump, no copy), so the bytes stay resident until the last
+        // clone drops. The `Arc<Reservation>` matches that: the budget stays charged
+        // until the final clone is gone, never double-charged for the shared buffer.
+        let chunk_bytes = 1024;
+        let budget = MemoryBudget::new(chunk_bytes * 4, chunk_bytes);
+        let (writer, mut consumer) = new_recv_body();
+
+        let mut slot = writer.claim();
+        slot.attach_reservation(budget.try_reserve(chunk_bytes).expect("has capacity"));
+        slot.fill(chunk_resp(0, {
+            let mut seg = SegmentedBuf::new();
+            seg.push(Bytes::from("shared"));
+            AggregatedBytes(seg)
+        }));
+
+        let chunk = consumer.try_take_next().expect("chunk delivered");
+        let clone = chunk.clone();
+        assert_eq!(
+            budget.in_use_chunks(),
+            1,
+            "one physical buffer, charged once"
+        );
+
+        // Dropping one clone does not release: the other still holds the bytes.
+        drop(chunk);
+        assert_eq!(
+            budget.in_use_chunks(),
+            1,
+            "a surviving clone still holds the resident bytes"
+        );
+
+        // The last clone drops: now the bytes are gone and the reservation releases.
+        drop(clone);
+        assert_eq!(budget.in_use_chunks(), 0, "released on last clone drop");
+    }
+
+    #[test]
+    fn disk_reservation_releases_on_drain() {
+        let chunk_bytes = 1024;
+        let budget = MemoryBudget::new(chunk_bytes * 4, chunk_bytes);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out");
+        let file = std::fs::File::create(&path).unwrap();
+        let (writer, _consumer) = new_recv_body_with_sink(file, 0, false);
+
+        let mut slot = writer.claim();
+        slot.attach_reservation(budget.try_reserve(chunk_bytes).expect("has capacity"));
+        slot.fill(chunk_at(0, 0, b"flushed"));
+
+        // Charged while resident in the ring, before the drain copies it out.
+        assert_eq!(budget.in_use_chunks(), 1);
+
+        // The drain writes the bytes to the sink and frees the ring payload; the disk
+        // surface owns nothing after copy-out, so the reservation releases here.
+        writer.finalize().unwrap();
+        assert_eq!(
+            budget.in_use_chunks(),
+            0,
+            "disk drain copies out and frees the bytes; the reservation releases at drain"
+        );
+        assert_eq!(&std::fs::read(&path).unwrap()[..7], b"flushed");
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -149,7 +149,7 @@ impl BodySlot {
 
     /// Attach the memory-budget reservation backing this chunk. Held on the slot
     /// from claim until [`fill`](Self::fill) moves it into the `ChunkOutput`, so it
-    /// drops with the chunk's bytes rather than at the ring boundary.
+    /// drops with the chunk's bytes rather than at the buffer boundary.
     pub(crate) fn attach_reservation(&mut self, reservation: Reservation) {
         self.reservation = Some(reservation);
     }
@@ -1041,12 +1041,12 @@ mod tests {
 
     // --- Reservation lease-lifetime tests ---
     //
-    // The budget caps TOTAL memory the transfer manager holds, not ring residency
+    // The budget caps TOTAL memory the transfer manager holds, not buffer residency
     // (the read-ahead window already bounds that). So a reservation must live for as
     // long as the bytes it accounts for are resident: on the stream surface the bytes
     // escape to the consumer in the delivered `ChunkOutput` and stay resident until
     // the consumer drops it, so the reservation must ride the chunk and release on
-    // consumer-drop — NOT at the ring boundary. On the disk surface the drain copies
+    // consumer-drop — NOT at the buffer boundary. On the disk surface the drain copies
     // the bytes out and frees them, so the reservation releases at drain.
 
     use crate::runtime::memory::MemoryBudget;
@@ -1067,10 +1067,10 @@ mod tests {
             AggregatedBytes(seg)
         }));
 
-        // Still charged while the chunk sits in the ring.
+        // Still charged while the chunk sits in the buffer.
         assert_eq!(budget.in_use_chunks(), 1);
 
-        // Deliver to the consumer. The chunk (and its reservation) leaves the ring as
+        // Deliver to the consumer. The chunk (and its reservation) leaves the buffer as
         // an owned value — the bytes are now resident in the consumer's hands, so the
         // budget must STILL be charged. Releasing here would be the lease-lifetime bug.
         let chunk = consumer.try_take_next().expect("chunk delivered");
@@ -1142,10 +1142,10 @@ mod tests {
         slot.attach_reservation(budget.try_reserve(chunk_bytes).expect("has capacity"));
         slot.fill(chunk_at(0, 0, b"flushed"));
 
-        // Charged while resident in the ring, before the drain copies it out.
+        // Charged while resident in the buffer, before the drain copies it out.
         assert_eq!(budget.in_use_chunks(), 1);
 
-        // The drain writes the bytes to the sink and frees the ring payload; the disk
+        // The drain writes the bytes to the sink and frees the buffer payload; the disk
         // surface owns nothing after copy-out, so the reservation releases here.
         writer.finalize().unwrap();
         assert_eq!(

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -101,7 +101,7 @@ enum Mode {
 }
 
 /// Producer handle to the download body buffer. Held at `self.inner.writer`
-/// in the transfer. Cheap to clone (all state behind Arc).
+/// in the transfer. Clone shares all state via `Arc`.
 #[derive(Clone)]
 pub(crate) struct BodyWriter {
     buffer: PagedRecvBuffer<ChunkOutput>,

--- a/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
@@ -8,7 +8,7 @@ use crate::runtime::memory::WaitTicket;
 
 /// A claimed slot whose backing memory is not yet reserved. Held while a transfer
 /// is budget-blocked: the read-ahead gate admitted the slot (`gate.try_issue`
-/// already counted it as issued) and it was claimed from the ring, but it cannot be
+/// already counted it as issued) and it was claimed from the buffer, but it cannot be
 /// filled until the budget grants `ticket`. Dropping it (on terminal) releases the
 /// slot and cancels the budget wait.
 #[derive(Debug)]

--- a/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/context.rs
@@ -3,6 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::operation::download::body::BodySlot;
+use crate::runtime::memory::WaitTicket;
+
+/// A claimed slot whose backing memory is not yet reserved. Held while a transfer
+/// is budget-blocked: the read-ahead gate admitted the slot (`gate.try_issue`
+/// already counted it as issued) and it was claimed from the ring, but it cannot be
+/// filled until the budget grants `ticket`. Dropping it (on terminal) releases the
+/// slot and cancels the budget wait.
+#[derive(Debug)]
+pub(crate) struct PendingClaim {
+    pub(crate) slot: BodySlot,
+    pub(crate) ticket: WaitTicket,
+}
+
 /// Mutable state for tracking download work progress
 #[derive(Debug)]
 pub(crate) enum DownloadState {
@@ -28,6 +42,12 @@ pub(crate) enum DownloadState {
         /// Read-ahead occupancy accounting. Bounds resident memory by gating
         /// issuance on `issued - released < window`.
         gate: OccupancyGate,
+        /// A claimed-but-unfilled slot whose memory reservation is still pending,
+        /// held only while budget-blocked. `Some` after the gate admitted a slot
+        /// (already counted in `gate.issued`) but the budget queued the reservation;
+        /// taken once the budget grants. Dropping the state on terminal releases the
+        /// slot and cancels the wait.
+        pending: Option<PendingClaim>,
     },
 
     /// Terminal state - transfer ended (success, failure, or cancelled)
@@ -38,6 +58,21 @@ pub(crate) enum DownloadState {
 impl DownloadState {
     pub(crate) fn new() -> Self {
         DownloadState::PendingDiscovery
+    }
+
+    /// The sanctioned transition to `Terminal`. Extracts a budget-parked claim, if any, so the
+    /// caller can drop it AFTER releasing the state lock. `WaitTicket::drop` takes the budget
+    /// lock, which must never nest under the state lock this state is guarded by; returning the
+    /// claim here makes releasing the lock first the only way to use this method. Assign
+    /// `Terminal` through this method rather than directly.
+    #[must_use = "drop the returned PendingClaim only after releasing the state lock"]
+    pub(crate) fn enter_terminal(&mut self) -> Option<PendingClaim> {
+        let pending = match self {
+            DownloadState::Transferring { pending, .. } => pending.take(),
+            _ => None,
+        };
+        *self = DownloadState::Terminal;
+        pending
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/read_ahead.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/read_ahead.rs
@@ -28,8 +28,10 @@
 //! - Fast consumer: `released` keeps pace, `issued - released` stays small, the
 //!   gate does not bind, and the transfer runs at the concurrency limit.
 //! - Slow consumer: `released` lags, `issued - released` fills to the window, the
-//!   gate closes, and issuance pauses until the consumer drains. Resident memory is
-//!   bounded at `window` parts.
+//!   gate closes, and issuance pauses until the consumer drains. This transfer's
+//!   resident occupancy is then bounded at `window` parts; aggregate memory across
+//!   transfers is bounded separately by the global budget, which typically binds a
+//!   transfer before its window fills.
 //! - Blocked consumer (a stalled or missing part): `released` cannot advance past
 //!   the hole, occupancy pins at the window, and issuance stops at `window`, leaving
 //!   a full window of slack to make progress around the hole rather than collapsing
@@ -40,10 +42,12 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-/// Fixed read-ahead window, in parts. A per-transfer cap on resident occupancy:
-/// with an 8 MiB part this holds at most 8 GiB of buffer for one transfer, while
-/// staying well above the bandwidth-delay product of a 100 Gbps link (so the gate
-/// does not bind a consumer that keeps pace).
+/// Fixed read-ahead window, in parts. A per-transfer cap on how far speculative
+/// issuance runs ahead of consumption, set well above the bandwidth-delay product of
+/// a 100 Gbps link so the gate does not bind a consumer that keeps pace. It is a
+/// per-transfer prefetch-depth ceiling, not the memory bound: aggregate resident
+/// memory is bounded by the global [`MemoryBudget`](crate::runtime::memory), which
+/// under concurrency binds a transfer well before it reaches this window.
 ///
 /// The default for the public [`ReadAhead::Auto`](crate::types::ReadAhead) mode;
 /// [`window_parts_for`] resolves the knob to a window in parts.
@@ -146,8 +150,8 @@ mod tests {
     #[test]
     fn window_does_not_drift_on_its_own() {
         // The controller never changes the window itself; only an explicit
-        // set_window (the budget clamp or the dynamic knob) moves it. Repeated reads
-        // with no writer are stable.
+        // set_window (the dynamic read-ahead knob) moves it. Repeated reads with no
+        // writer are stable.
         let ra = ReadAhead::new();
         let w = ra.window();
         for _ in 0..1000 {

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -430,6 +430,18 @@ pub(crate) enum FillOutcome {
     DrainReady,
 }
 
+/// How aggressively [`take_drain_run`](PagedRecvBuffer::take_drain_run) claims a run.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum DrainMode {
+    /// Steady-state coalescing: claim a run only once it reaches the drain batch (or a
+    /// full segment's residue). The fill-triggered drain uses this so writes coalesce.
+    Batched,
+    /// Take any contiguous filled prefix now, however short. Used by the terminal flush
+    /// (drain the tail below the batch at end-of-stream) and by budget-pressure relief
+    /// (release resident chunks a transfer would otherwise pin while parked).
+    Eager,
+}
+
 /// An owned token granting consumption of one claimed run of a segment's payloads.
 ///
 /// A run is the contiguous slice `[start, start + len)` of a segment's slots, claimed
@@ -719,12 +731,13 @@ impl<T> PagedRecvBuffer<T> {
     /// Claim the frontmost drainable run as an owned [`SegmentWrite`], or `None`.
     ///
     /// Walks segments front to back under the lock. For each segment, scans the
-    /// contiguous `FILLED` run beyond its `claim_cursor`. A non-terminal call claims
-    /// that run only if it spans at least the drain batch, and then claims the whole
-    /// run (coalescing greedily, bounded by the segment). A terminal call claims
+    /// contiguous `FILLED` run beyond its `claim_cursor`. [`DrainMode::Batched`] claims
+    /// that run only if it spans at least the drain batch, and then claims the whole run
+    /// (coalescing greedily, bounded by the segment). [`DrainMode::Eager`] claims
     /// whatever contiguous filled run exists, however short — this is what drains the
-    /// partial final segment at end-of-stream, which a non-terminal call would leave
-    /// below the batch forever. The run is `[claim_cursor, claim_cursor + len)`.
+    /// partial final segment at end-of-stream (which `Batched` would leave below the
+    /// batch forever) and what relieves budget pressure. The run is
+    /// `[claim_cursor, claim_cursor + len)`.
     ///
     /// Advancing `claim_cursor` under the lock makes a run claimed at most once: a
     /// second caller, racing or sequential, observes the advanced cursor and scans
@@ -733,11 +746,13 @@ impl<T> PagedRecvBuffer<T> {
     /// `publish_filled` `Release` — the same handoff [`poll_next`](RecvBufferConsumer::poll_next)
     /// relies on — so the claimed run's payloads are safe to read.
     ///
-    /// # Terminal caller obligation
-    /// Pass `terminal` only once issuance is complete and all outstanding fills have
-    /// landed: a slot claimed here must not receive a later fill (it would race the
-    /// block consumer reading the run). Unfilled trailing slots are simply not claimed.
-    pub(crate) fn take_drain_run(&self, terminal: bool) -> Option<SegmentWrite<T>> {
+    /// # Eager caller obligation (end-of-stream)
+    /// The terminal flush passes [`DrainMode::Eager`] only once issuance is complete and
+    /// all outstanding fills have landed: a slot claimed here must not receive a later
+    /// fill (it would race the block consumer reading the run). Unfilled trailing slots
+    /// are not claimed. The budget-relief caller also passes `Eager` but only for
+    /// a prefix with no outstanding fill ahead of it (guaranteed by its own gating).
+    pub(crate) fn take_drain_run(&self, mode: DrainMode) -> Option<SegmentWrite<T>> {
         let guard = self.inner.locked.lock();
         let batch = self.inner.drain_batch.load(Ordering::Relaxed);
         for seg in guard.segments.iter() {
@@ -754,7 +769,10 @@ impl<T> PagedRecvBuffer<T> {
             // window smaller than a segment would pin that residue forever). A terminal
             // claim takes whatever contiguous filled prefix exists.
             let at_segment_end = end == seg.slots.len();
-            let take = if terminal || avail >= batch || (avail > 0 && at_segment_end) {
+            let take = if matches!(mode, DrainMode::Eager)
+                || avail >= batch
+                || (avail > 0 && at_segment_end)
+            {
                 avail
             } else {
                 0
@@ -773,6 +791,18 @@ impl<T> PagedRecvBuffer<T> {
             }
         }
         None
+    }
+
+    /// Whether a [`DrainMode::Eager`] `take_drain_run` would claim a run right now: some
+    /// segment has a `FILLED` slot at its `claim_cursor`. Peek only — does not advance
+    /// the cursor. Gates budget-relief draining so a transfer only emits a drain work
+    /// item when a drain would actually free a chunk (no empty-drain spin).
+    pub(crate) fn has_drainable_prefix(&self) -> bool {
+        let guard = self.inner.locked.lock();
+        guard.segments.iter().any(|seg| {
+            let start = seg.claim_cursor.load(Ordering::Relaxed);
+            start < seg.slots.len() && seg.slots[start].state.is_filled()
+        })
     }
 
     /// The in-order delivery cursor: the next sequence the consumer will deliver, i.e.
@@ -1121,7 +1151,7 @@ mod tests {
         }
     }
 
-    /// At the default batch (the segment size), `take_drain_run(false)` yields a whole
+    /// At the default batch (the segment size), `take_drain_run(DrainMode::Batched)` yields a whole
     /// segment as one run, exactly once, and the next segment after completion.
     #[test]
     fn block_path_take_and_complete() {
@@ -1135,13 +1165,13 @@ mod tests {
 
         // Claim the full segment as one run.
         let sw = ring
-            .take_drain_run(false)
+            .take_drain_run(DrainMode::Batched)
             .expect("should have a full segment");
         assert_eq!(sw.base_seq(), 0);
         assert_eq!(sw.payloads().len(), seg_size);
 
         // Second immediate take returns None (whole segment already claimed).
-        assert!(ring.take_drain_run(false).is_none());
+        assert!(ring.take_drain_run(DrainMode::Batched).is_none());
 
         // Complete it.
         sw.complete();
@@ -1152,7 +1182,7 @@ mod tests {
             ring.fill(h, (seg_size + i) as u64);
         }
         let sw2 = ring
-            .take_drain_run(false)
+            .take_drain_run(DrainMode::Batched)
             .expect("second full segment should be takeable");
         assert_eq!(sw2.base_seq(), seg_size as u64);
         sw2.complete();
@@ -1169,7 +1199,7 @@ mod tests {
         for (i, h) in handles.into_iter().enumerate() {
             ring.fill(h, i as u64);
         }
-        assert!(ring.take_drain_run(false).is_none());
+        assert!(ring.take_drain_run(DrainMode::Batched).is_none());
     }
 
     /// A relief-regime batch below the segment size drains a segment in disjoint runs
@@ -1186,22 +1216,25 @@ mod tests {
         // First batch arrives: slots 0,1.
         ring.fill_at(&handles, 0, 0);
         ring.fill_at(&handles, 1, 10);
-        let r0 = ring.take_drain_run(false).expect("first run");
+        let r0 = ring.take_drain_run(DrainMode::Batched).expect("first run");
         assert_eq!(r0.base_seq(), 0);
         let seen0: Vec<u64> = r0.payloads().iter().map(|s| *s.get().unwrap()).collect();
         assert_eq!(seen0, vec![0, 10]);
         // Nothing more until the next batch arrives.
-        assert!(ring.take_drain_run(false).is_none());
+        assert!(ring.take_drain_run(DrainMode::Batched).is_none());
 
         // Second batch arrives: slots 2,3.
         ring.fill_at(&handles, 2, 20);
         ring.fill_at(&handles, 3, 30);
-        let r1 = ring.take_drain_run(false).expect("second run");
+        let r1 = ring.take_drain_run(DrainMode::Batched).expect("second run");
         assert_eq!(r1.base_seq(), 2);
         let seen1: Vec<u64> = r1.payloads().iter().map(|s| *s.get().unwrap()).collect();
         assert_eq!(seen1, vec![20, 30]);
 
-        assert!(ring.take_drain_run(false).is_none(), "segment exhausted");
+        assert!(
+            ring.take_drain_run(DrainMode::Batched).is_none(),
+            "segment exhausted"
+        );
         r0.complete();
         r1.complete();
     }
@@ -1221,20 +1254,65 @@ mod tests {
         ring.fill_at(&handles, 3, 30);
 
         // The contiguous run from 0 is [0,2); slot 2 blocks the rest.
-        let r0 = ring.take_drain_run(false).expect("prefix before the gap");
+        let r0 = ring
+            .take_drain_run(DrainMode::Batched)
+            .expect("prefix before the gap");
         assert_eq!(r0.base_seq(), 0);
         assert_eq!(r0.payloads().len(), 2);
         // Nothing more: the run beyond the cursor starts at the unfilled slot 2.
-        assert!(ring.take_drain_run(false).is_none());
+        assert!(ring.take_drain_run(DrainMode::Batched).is_none());
 
         // Fill the gap; now [2,4) is a contiguous run of the batch size.
         ring.fill_at(&handles, 2, 20);
-        let r1 = ring.take_drain_run(false).expect("run after the gap fills");
+        let r1 = ring
+            .take_drain_run(DrainMode::Batched)
+            .expect("run after the gap fills");
         assert_eq!(r1.base_seq(), 2);
         let seen: Vec<u64> = r1.payloads().iter().map(|s| *s.get().unwrap()).collect();
         assert_eq!(seen, vec![20, 30]);
         r0.complete();
         r1.complete();
+    }
+
+    /// `has_drainable_prefix` reports whether an `Eager` take would claim a run: true
+    /// exactly when a `FILLED` slot sits at some segment's claim cursor. It is the peek
+    /// that gates budget-relief draining, so a leading gap (in-flight part ahead of a
+    /// filled one) must read false — that prefix is not drainable until the gap fills,
+    /// and its in-flight GET carries the drain instead.
+    #[test]
+    fn has_drainable_prefix_tracks_the_cursor_slot() {
+        let seg_size = 4;
+        let (ring, _consumer) = PagedRecvBuffer::<u64>::new_with_segment_size(seg_size);
+        let handles: Vec<_> = (0..seg_size).map(|_| ring.claim()).collect();
+
+        // Empty: nothing filled at the cursor.
+        assert!(!ring.has_drainable_prefix(), "empty buffer has no prefix");
+
+        // Leading gap: slot 1 filled, slot 0 (the cursor) still in flight → false.
+        ring.fill_at(&handles, 1, 10);
+        assert!(
+            !ring.has_drainable_prefix(),
+            "a filled slot behind an unfilled cursor slot is not a drainable prefix"
+        );
+
+        // Fill the cursor slot → now a run starts at the cursor → true.
+        ring.fill_at(&handles, 0, 0);
+        assert!(
+            ring.has_drainable_prefix(),
+            "a FILLED slot at the cursor is a drainable prefix"
+        );
+
+        // Claim the run (advancing the cursor past it); the remaining slots 2,3 are
+        // unfilled, so the cursor slot is again empty → false.
+        let sw = ring
+            .take_drain_run(DrainMode::Eager)
+            .expect("prefix [0,2) is claimable");
+        assert_eq!(sw.payloads().len(), 2);
+        assert!(
+            !ring.has_drainable_prefix(),
+            "after claiming the prefix the cursor slot is unfilled again"
+        );
+        sw.complete();
     }
 
     /// A terminal claim takes a partial prefix below the batch that a non-terminal
@@ -1249,15 +1327,17 @@ mod tests {
             ring.fill(h, (i * 10) as u64);
         }
         // Non-terminal: below batch, nothing.
-        assert!(ring.take_drain_run(false).is_none());
+        assert!(ring.take_drain_run(DrainMode::Batched).is_none());
         // Terminal: take the filled prefix.
-        let sw = ring.take_drain_run(true).expect("partial tail run");
+        let sw = ring
+            .take_drain_run(DrainMode::Eager)
+            .expect("partial tail run");
         assert_eq!(sw.base_seq(), 0);
         let seen: Vec<u64> = sw.payloads().iter().map(|s| *s.get().unwrap()).collect();
         assert_eq!(seen, vec![0, 10]);
         sw.complete();
         // Once claimed, a second terminal call finds nothing more here.
-        assert!(ring.take_drain_run(true).is_none());
+        assert!(ring.take_drain_run(DrainMode::Eager).is_none());
     }
 
     /// Reclaim gates on every claimed slot being drained: a segment split into two runs
@@ -1271,10 +1351,10 @@ mod tests {
         // Two batches arrive separately, so each is claimed as its own run.
         ring.fill_at(&handles, 0, 0);
         ring.fill_at(&handles, 1, 1);
-        let r0 = ring.take_drain_run(false).expect("run [0,2)");
+        let r0 = ring.take_drain_run(DrainMode::Batched).expect("run [0,2)");
         ring.fill_at(&handles, 2, 2);
         ring.fill_at(&handles, 3, 3);
-        let r1 = ring.take_drain_run(false).expect("run [2,4)");
+        let r1 = ring.take_drain_run(DrainMode::Batched).expect("run [2,4)");
 
         // Complete only the first run, then grow + reclaim. seg0 is not fully drained
         // (drained_count == 2 < 4), so it must not be reclaimed.
@@ -1327,7 +1407,9 @@ mod tests {
             ],
             "the fill that reaches the batch raises DrainReady"
         );
-        let r0 = ring.take_drain_run(false).expect("batch-sized prefix run");
+        let r0 = ring
+            .take_drain_run(DrainMode::Batched)
+            .expect("batch-sized prefix run");
         assert_eq!(r0.base_seq(), 0);
         assert_eq!(
             r0.payloads().len(),
@@ -1339,7 +1421,7 @@ mod tests {
         // One slot of residue remains (slot 3). A non-terminal claim cannot take it —
         // it is below the batch and the segment is not yet full.
         assert!(
-            ring.take_drain_run(false).is_none(),
+            ring.take_drain_run(DrainMode::Batched).is_none(),
             "sub-batch residue is not drainable while the segment is incomplete"
         );
 
@@ -1351,7 +1433,9 @@ mod tests {
             FillOutcome::DrainReady,
             "the fill that completes the segment raises the edge for the tail residue"
         );
-        let r1 = ring.take_drain_run(false).expect("segment-end residue run");
+        let r1 = ring
+            .take_drain_run(DrainMode::Batched)
+            .expect("segment-end residue run");
         assert_eq!(r1.base_seq(), batch as u64);
         assert_eq!(
             r1.payloads().len(),
@@ -1383,7 +1467,10 @@ mod tests {
         // First batch of 2 arrives and drains as run [0,2).
         ring.fill_at(&handles, 0, 0);
         ring.fill_at(&handles, 1, 10);
-        let freed = ring.take_drain_run(false).expect("run [0,2)").complete();
+        let freed = ring
+            .take_drain_run(DrainMode::Batched)
+            .expect("run [0,2)")
+            .complete();
         assert_eq!(freed, 2, "a block drain frees the run length");
         assert_eq!(
             ring.consumed(),
@@ -1394,7 +1481,10 @@ mod tests {
         // Second batch of 2 arrives and drains as run [2,4).
         ring.fill_at(&handles, 2, 20);
         ring.fill_at(&handles, 3, 30);
-        let freed = ring.take_drain_run(false).expect("run [2,4)").complete();
+        let freed = ring
+            .take_drain_run(DrainMode::Batched)
+            .expect("run [2,4)")
+            .complete();
         assert_eq!(freed, 2, "the second run frees its own length");
         assert_eq!(ring.consumed(), 0, "consumed stays put on the block path");
     }
@@ -1425,7 +1515,9 @@ mod tests {
         for (i, h) in handles.into_iter().enumerate() {
             ring.fill(h, (i * 10) as u64);
         }
-        let sw = ring.take_drain_run(false).expect("full segment");
+        let sw = ring
+            .take_drain_run(DrainMode::Batched)
+            .expect("full segment");
         let seen: Vec<u64> = sw.payloads().iter().map(|s| *s.get().unwrap()).collect();
         assert_eq!(seen, vec![0, 10, 20, 30]);
         sw.complete();
@@ -1442,7 +1534,9 @@ mod tests {
         for (i, h) in handles.into_iter().enumerate() {
             ring.fill(h, (i * 7) as u64);
         }
-        let sw = ring.take_drain_run(false).expect("full segment");
+        let sw = ring
+            .take_drain_run(DrainMode::Batched)
+            .expect("full segment");
         for (i, slot) in sw.payloads().iter().enumerate() {
             assert_eq!(*slot.get().expect("filled"), (i * 7) as u64);
         }
@@ -1476,7 +1570,7 @@ mod tests {
             let h = ring.claim();
             ring.fill(h, DropCounter(drops.clone()));
         }
-        let sw = ring.take_drain_run(false).expect("seg0 full");
+        let sw = ring.take_drain_run(DrainMode::Batched).expect("seg0 full");
         assert_eq!(sw.base_seq(), 0);
         assert_eq!(
             drops.load(O::SeqCst),
@@ -1535,7 +1629,7 @@ mod tests {
             let h = ring.claim();
             ring.fill(h, DropCounter(drops.clone()));
         }
-        let sw = ring.take_drain_run(false).expect("full");
+        let sw = ring.take_drain_run(DrainMode::Batched).expect("full");
         // complete() frees both payloads.
         sw.complete();
         assert_eq!(
@@ -1581,7 +1675,9 @@ mod tests {
         ring.fill(h3, DropCounter(drops.clone()));
         // seg1 is now full while seg0 has no contiguous filled run. take_drain_run
         // skips seg0 (its run from the cursor is empty) and claims seg1.
-        let sw = ring.take_drain_run(false).expect("seg1 is full");
+        let sw = ring
+            .take_drain_run(DrainMode::Batched)
+            .expect("seg1 is full");
         assert_eq!(
             sw.base_seq(),
             seg_size as u64,
@@ -1833,7 +1929,7 @@ mod tests {
                     let freed_total = freed_total.clone();
                     s.spawn(move || {
                         if ring.fill(h, 0) == FillOutcome::DrainReady {
-                            while let Some(sw) = ring.take_drain_run(false) {
+                            while let Some(sw) = ring.take_drain_run(DrainMode::Batched) {
                                 freed_total.fetch_add(sw.complete(), O::Relaxed);
                             }
                         }
@@ -1842,7 +1938,7 @@ mod tests {
             });
             // Terminal sweep mops up any run a filler produced after its own drain
             // scan (the fill/drain interleaving can leave a slot claimed-but-untaken).
-            while let Some(sw) = ring.take_drain_run(true) {
+            while let Some(sw) = ring.take_drain_run(DrainMode::Eager) {
                 freed_total.fetch_add(sw.complete(), O::Relaxed);
             }
             // Beyond the underflow (a bare subtraction panics here under overflow-checks),
@@ -2006,7 +2102,7 @@ mod loom_tests {
             let ring2 = ring.clone();
             let taker = thread::spawn(move || {
                 let sw = ring2
-                    .take_drain_run(false)
+                    .take_drain_run(DrainMode::Batched)
                     .expect("seg0 is full and drainable");
                 assert_eq!(sw.base_seq(), 0);
                 sw.complete(); // frees payloads, drained_count += len, reclaim_front
@@ -2080,7 +2176,7 @@ mod loom_tests {
 
     /// Model 5 — two drainers race one full segment at the default batch.
     ///
-    /// seg0 is filled full, then two threads call `take_drain_run(false)` concurrently
+    /// seg0 is filled full, then two threads call `take_drain_run(DrainMode::Batched)` concurrently
     /// with the batch equal to the segment size, so the only drainable run is the whole
     /// segment. Advancing `claim_cursor` under the lock must hand that run to exactly
     /// one: one thread gets `Some(SegmentWrite)` based at 0, the other `None`. This
@@ -2096,8 +2192,15 @@ mod loom_tests {
             }
 
             let ring2 = ring.clone();
-            let t1 = thread::spawn(move || ring2.take_drain_run(false).map(|sw| sw.base_seq()));
-            let t2 = thread::spawn(move || ring.take_drain_run(false).map(|sw| sw.base_seq()));
+            let t1 = thread::spawn(move || {
+                ring2
+                    .take_drain_run(DrainMode::Batched)
+                    .map(|sw| sw.base_seq())
+            });
+            let t2 = thread::spawn(move || {
+                ring.take_drain_run(DrainMode::Batched)
+                    .map(|sw| sw.base_seq())
+            });
 
             let r1 = t1.join().unwrap();
             let r2 = t2.join().unwrap();
@@ -2132,7 +2235,7 @@ mod loom_tests {
             let ring2 = ring.clone();
             let taker = thread::spawn(move || {
                 let sw = ring2
-                    .take_drain_run(false)
+                    .take_drain_run(DrainMode::Batched)
                     .expect("seg0 is full and drainable");
                 assert_eq!(sw.base_seq(), 0);
                 // Drop without complete(): Drop must drain and reclaim safely.
@@ -2256,7 +2359,7 @@ mod loom_tests {
 
     /// Model 9 — two drainers race two distinct full segments.
     ///
-    /// seg0 and seg1 are both full, then two threads call `take_drain_run(false)`
+    /// seg0 and seg1 are both full, then two threads call `take_drain_run(DrainMode::Batched)`
     /// concurrently at the default batch (so each segment is one run). The forward
     /// scan plus the `claim_cursor` advance must hand the two segments' runs to the two
     /// drainers — one each, no duplicate, no segment skipped. Model 5 proves
@@ -2273,8 +2376,15 @@ mod loom_tests {
             }
 
             let ring2 = ring.clone();
-            let t1 = thread::spawn(move || ring2.take_drain_run(false).map(|sw| sw.base_seq()));
-            let t2 = thread::spawn(move || ring.take_drain_run(false).map(|sw| sw.base_seq()));
+            let t1 = thread::spawn(move || {
+                ring2
+                    .take_drain_run(DrainMode::Batched)
+                    .map(|sw| sw.base_seq())
+            });
+            let t2 = thread::spawn(move || {
+                ring.take_drain_run(DrainMode::Batched)
+                    .map(|sw| sw.base_seq())
+            });
 
             let r1 = t1.join().unwrap();
             let r2 = t2.join().unwrap();
@@ -2330,7 +2440,7 @@ mod loom_tests {
             let da = drops.clone();
             let a = thread::spawn(move || {
                 ring_a.fill(h0, DropCounter(da));
-                if let Some(sw) = ring_a.take_drain_run(false) {
+                if let Some(sw) = ring_a.take_drain_run(DrainMode::Batched) {
                     sw.complete();
                 }
             });
@@ -2338,7 +2448,7 @@ mod loom_tests {
             let db = drops.clone();
             let b = thread::spawn(move || {
                 ring_b.fill(h1, DropCounter(db));
-                if let Some(sw) = ring_b.take_drain_run(false) {
+                if let Some(sw) = ring_b.take_drain_run(DrainMode::Batched) {
                     sw.complete();
                 }
             });
@@ -2348,7 +2458,7 @@ mod loom_tests {
 
             // Mop up any slot a drainer's scan missed (its sibling filled after the
             // scan). Single-threaded here, so no race; terminal takes a lone slot.
-            while let Some(sw) = ring.take_drain_run(true) {
+            while let Some(sw) = ring.take_drain_run(DrainMode::Eager) {
                 sw.complete();
             }
 
@@ -2358,6 +2468,68 @@ mod loom_tests {
                 drops.load(Ordering::SeqCst),
                 2,
                 "each slot's payload freed exactly once across partitioned runs"
+            );
+        });
+    }
+
+    /// Model 11 — two concurrent `Eager` drainers partition one segment.
+    ///
+    /// The budget-relief path (`DrainResident`) drains with [`DrainMode::Eager`], so a
+    /// mid-stream `flush_resident` on one transfer can race a concurrent drain on
+    /// another against the same segment. `Eager` takes any contiguous filled prefix
+    /// rather than waiting for the batch, so it claims more aggressively than `Batched`
+    /// — this checks that the under-lock `claim_cursor` advance still partitions the
+    /// segment into disjoint runs under that aggression. Mirror of Model 10 with both
+    /// racing drainers switched to `Eager` (the mode the deadlock fix introduced to a
+    /// concurrent path). A `DropCounter` proves each slot's payload frees exactly once;
+    /// an overlap would double-free or trip loom's `UnsafeCell` on the in-place reads.
+    #[test]
+    fn two_eager_drainers_partition_one_segment() {
+        loom::model(|| {
+            #[derive(Clone)]
+            struct DropCounter(Arc<AtomicUsize>);
+            impl Drop for DropCounter {
+                fn drop(&mut self) {
+                    self.0.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+
+            let drops = Arc::new(AtomicUsize::new(0));
+            let (ring, _consumer) = PagedRecvBuffer::<DropCounter>::new_with_segment_size(2);
+            // Batch left at the default (segment size 2); Eager ignores it and takes any
+            // filled prefix, which is the point of the race.
+            let h0 = ring.claim();
+            let h1 = ring.claim();
+
+            let ring_a = ring.clone();
+            let da = drops.clone();
+            let a = thread::spawn(move || {
+                ring_a.fill(h0, DropCounter(da));
+                if let Some(sw) = ring_a.take_drain_run(DrainMode::Eager) {
+                    sw.complete();
+                }
+            });
+            let ring_b = ring.clone();
+            let db = drops.clone();
+            let b = thread::spawn(move || {
+                ring_b.fill(h1, DropCounter(db));
+                if let Some(sw) = ring_b.take_drain_run(DrainMode::Eager) {
+                    sw.complete();
+                }
+            });
+
+            a.join().unwrap();
+            b.join().unwrap();
+
+            // Mop up any slot whose filler had not reached its own scan.
+            while let Some(sw) = ring.take_drain_run(DrainMode::Eager) {
+                sw.complete();
+            }
+
+            assert_eq!(
+                drops.load(Ordering::SeqCst),
+                2,
+                "each slot's payload freed exactly once across partitioned Eager runs"
             );
         });
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/recv_buffer.rs
@@ -188,7 +188,7 @@
 //!
 //! # Caller obligations
 //!
-//! The ring does not bound its own growth: it allocates a segment whenever a claim
+//! The buffer does not bound its own growth: it allocates a segment whenever a claim
 //! reaches a sequence past the current tail. The caller must bound outstanding
 //! (claimed-but-undelivered) sequences, or resident memory grows without limit.
 
@@ -440,7 +440,7 @@ pub(crate) enum FillOutcome {
 /// call that produced it: a synchronous consumer completes it immediately, an
 /// asynchronous one parks it and completes it on a later event.
 ///
-/// The strong ring reference keeps the buffer accounting alive for exactly the
+/// The strong buffer reference keeps the buffer accounting alive for exactly the
 /// outstanding-write window — the correct lifetime, since a write may be reading a
 /// run's bytes when every other handle has dropped. It is bounded (released at
 /// `complete` or drop) and forms no cycle (segments do not point back at `Inner`).
@@ -587,14 +587,14 @@ unsafe impl<T: Send> Send for SegmentWrite<T> {}
 unsafe impl<T: Send> Sync for SegmentWrite<T> {}
 
 impl<T> PagedRecvBuffer<T> {
-    /// Create an empty ring with the default segment size ([`DEFAULT_SEG_SIZE`]),
+    /// Create an empty buffer with the default segment size ([`DEFAULT_SEG_SIZE`]),
     /// returning the producer/block handle and the unique stream [`RecvBufferConsumer`].
     #[cfg(test)]
     pub(crate) fn new() -> (Self, RecvBufferConsumer<T>) {
         Self::new_with_segment_size(DEFAULT_SEG_SIZE)
     }
 
-    /// Create an empty ring whose segments hold `seg_size` slots each. One segment
+    /// Create an empty buffer whose segments hold `seg_size` slots each. One segment
     /// based at sequence 0 exists initially, shared by the producer/block handle and
     /// the consumer's `current`. Panics if `seg_size == 0`.
     pub(crate) fn new_with_segment_size(seg_size: usize) -> (Self, RecvBufferConsumer<T>) {
@@ -797,7 +797,7 @@ impl<T> PagedRecvBuffer<T> {
     /// is advisory and never a correctness input. Cold path.
     ///
     /// Callers that need byte offsets translate sequence numbers themselves; the
-    /// ring has no notion of payload size.
+    /// buffer has no notion of payload size.
     #[cfg(test)]
     pub(crate) fn snapshot(&self) -> RecvBufferSnapshot {
         let guard = self.inner.locked.lock();
@@ -924,7 +924,7 @@ pub(crate) struct RecvBufferSnapshot {
 #[cfg(test)]
 impl RecvBufferSnapshot {
     /// Number of claimed-but-undelivered sequences: `frontier - cursor`. The size of
-    /// the live window the ring is holding open.
+    /// the live window the buffer is holding open.
     pub(crate) fn outstanding(&self) -> u64 {
         self.frontier - self.cursor
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -62,7 +62,7 @@ macro_rules! bail_if_terminal {
 
 /// Download transfer that generates and executes download work.
 ///
-/// Cheap to clone - all state is behind `Arc`.
+/// Clone shares all state via `Arc`.
 #[derive(Debug, Clone)]
 pub(crate) struct DownloadTransfer {
     inner: Arc<DownloadTransferInner>,
@@ -738,7 +738,8 @@ impl DownloadTransfer {
             ..Default::default()
         });
 
-        if self.decrement_in_flight(freed) {
+        let reached_terminal = self.decrement_in_flight(freed);
+        if reached_terminal {
             return self.finalize_completion();
         }
 
@@ -863,7 +864,8 @@ impl DownloadTransfer {
             ..Default::default()
         });
 
-        if self.decrement_in_flight(freed) {
+        let reached_terminal = self.decrement_in_flight(freed);
+        if reached_terminal {
             return self.finalize_completion();
         }
 

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -473,7 +473,7 @@ impl DownloadTransfer {
                 let terminal_wake = self.inner.discovery_notify.notified();
                 if let Some(reservation) = ticket.take() {
                     tracing::debug!(
-                        target: crate::telemetry::TARGET_MEMORY,
+                        target: crate::telemetry::TARGET_SCHEDULING,
                         tid = %self.inner.ctx.id,
                         len,
                         "discovery chunk reservation granted; resuming",

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -304,7 +304,7 @@ impl DownloadTransfer {
                         return self.park();
                     }
 
-                    // Gate admitted (and counted) the slot. Claim it from the ring and
+                    // Gate admitted (and counted) the slot. Claim it from the buffer and
                     // reserve its backing memory against the budget. A grant issues now;
                     // a queued reservation stashes the claimed slot in `pending` and
                     // parks until the budget wakes us. The gate's `issued` bump stays —

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -18,12 +18,13 @@ use crate::error::{self, ChunkRef, Error};
 use crate::io::AggregatedBytes;
 use crate::operation::download::body::{BodySlot, BodyWriter, ChunkOutput};
 use crate::operation::download::chunk_meta::ChunkMetadata;
-use crate::operation::download::context::DownloadState;
+use crate::operation::download::context::{DownloadState, PendingClaim};
 use crate::operation::download::discovery::{discover_obj, ObjectDiscovery};
 use crate::operation::download::object_meta::ObjectMetadata;
 use crate::operation::download::read_ahead::ReadAhead;
 use crate::operation::download::recv_buffer::FillOutcome;
 use crate::operation::download::DownloadInput;
+use crate::runtime::memory::{NotifyFn, Reservation, Reserve};
 use crate::transfer::{IoRequest, PollWork, Transfer, TransferContext, TransferId, WorkOutcome};
 use crate::types::BucketType;
 
@@ -38,12 +39,22 @@ pub(crate) enum DownloadWork {
     },
 }
 
+/// Bytes in the next chunk sliced from `remaining` at `part_size`: the reservation
+/// size for that chunk. Peek only — does not advance `remaining`.
+fn chunk_len(remaining: &std::ops::RangeInclusive<u64>, part_size: u64) -> usize {
+    let start = *remaining.start();
+    let end = *remaining.end();
+    let chunk_end = cmp::min(start + part_size - 1, end);
+    (chunk_end - start + 1) as usize
+}
+
 /// Early return if transfer is terminal (failed/cancelled by another work item).
 macro_rules! bail_if_terminal {
     ($self:expr) => {
         if !$self.inner.ctx.is_active() {
-            // Bailing before any drain: no occupancy freed on this path.
-            $self.decrement_in_flight(0);
+            // Bailing before any drain: no occupancy freed on this path. The transfer is
+            // already terminal so `decrement_in_flight` will find `Terminal` and return false.
+            let _ = $self.decrement_in_flight(0);
             return WorkOutcome::Cancelled;
         }
     };
@@ -246,16 +257,31 @@ impl DownloadTransfer {
                 etag,
                 part_size,
                 gate,
+                pending,
             } => {
-                if let Some(range) = remaining.as_ref() {
-                    // Apply the read-ahead gate before issuing. The gate bounds resident
-                    // occupancy at `issued - released < window`, where `released` counts
-                    // both delivery surfaces (stream pull and disk drain), so a disk
-                    // download paces to its drain rate rather than to the in-order
-                    // delivery cursor. `try_issue` reads and mutates the gate under this
-                    // state lock; the consumer's `release` does the same, so the two are
-                    // ordered and a release that reopens the gate cannot be lost against
-                    // the `set_pending` below (the mutator protocol).
+                // Resolve the slot to issue into this poll, if one is ready. Two gates
+                // compose in order — the per-transfer read-ahead window, then the global
+                // memory budget — so issuance takes their min. The window is gated first
+                // (via `gate.try_issue`) so a window-blocked transfer never holds a slice
+                // of the fungible budget it cannot use yet, starving other transfers.
+                let slot = if pending.is_some() {
+                    // A budget-parked claim takes priority: the gate already admitted and
+                    // counted its slot (held in `pending`, not re-gated), waiting only on
+                    // the reservation the budget queued.
+                    match self.resume_pending_claim(pending) {
+                        Some(slot) => slot,
+                        // Not granted yet; the queued ticket is the waker.
+                        None => return self.park(),
+                    }
+                } else if let Some(range) = remaining.as_ref() {
+                    // Read-ahead gate. The gate bounds resident occupancy at
+                    // `issued - released < window`, where `released` counts both delivery
+                    // surfaces (stream pull and disk drain), so a disk download paces to
+                    // its drain rate rather than to the in-order delivery cursor.
+                    // `try_issue` reads and mutates the gate under this state lock; the
+                    // consumer's `release` does the same, so the two are ordered and a
+                    // release that reopens the gate cannot be lost against the
+                    // `set_pending` below (the mutator protocol).
                     //
                     // The gate guards issuance only. Once every range is generated
                     // (`remaining` is None) the completion path below runs unconditionally,
@@ -275,56 +301,195 @@ impl DownloadTransfer {
                             window,
                             "read-ahead gate closed: issuance paused until the consumer drains",
                         );
-                        self.inner.ctx.set_pending();
-                        return PollWork::Pending;
+                        return self.park();
                     }
 
-                    // `part_size` is the stored part size for a validated multipart
-                    // object (so each range aligns to a stored part boundary and S3
-                    // returns the part's checksum for the SDK to validate), else the
-                    // configured download part size. Set at discovery.
-                    let part_size = *part_size;
-                    let start = *range.start();
-                    let end = *range.end();
-                    let chunk_end = cmp::min(start + part_size - 1, end);
-                    let chunk_range = start..=chunk_end;
-
-                    let slot = self.inner.writer.claim();
-                    *ranges_in_flight += 1;
-
-                    if chunk_end < end {
-                        *remaining = Some((chunk_end + 1)..=end);
-                    } else {
-                        // The final range was just issued: issuance is done and the
-                        // transfer drains its in-flight tail, completing on the next
-                        // empty poll with nothing in flight. Logged once per transfer.
-                        *remaining = None;
-                        tracing::debug!(
-                            target: crate::telemetry::TARGET_TRANSFER,
-                            issued = gate.issued(),
-                            ranges_in_flight = *ranges_in_flight,
-                            "all ranges issued; draining in-flight tail",
-                        );
+                    // Gate admitted (and counted) the slot. Claim it from the ring and
+                    // reserve its backing memory against the budget. A grant issues now;
+                    // a queued reservation stashes the claimed slot in `pending` and
+                    // parks until the budget wakes us. The gate's `issued` bump stays —
+                    // the parked claim legitimately occupies its one window seat — so a
+                    // budget-parked transfer holds exactly the slot it will fill.
+                    let range_len = chunk_len(range, *part_size);
+                    match self.reserve_claim(range_len, pending) {
+                        Some(slot) => slot,
+                        // Budget-parked; `pending` now holds the claimed slot.
+                        None => return self.park(),
                     }
-
-                    PollWork::Ready(IoRequest {
-                        data: Some(Box::new(DownloadWork::GetObjectRange {
-                            range: chunk_range,
-                            slot: Some(slot),
-                            etag: etag.clone(),
-                        })),
-                    })
                 } else if *ranges_in_flight > 0 {
-                    // All ranges generated, waiting for in-flight to complete
-                    self.inner.ctx.set_pending();
-                    PollWork::Pending
+                    // All ranges generated, waiting for in-flight to complete.
+                    return self.park();
                 } else {
-                    // All done - success
+                    // No-data completion: the object carried no ranges (0-byte object
+                    // whose discovery produced no initial chunk). Data-carrying terminal
+                    // completions happen in `execute` via `finalize_completion`.
                     self.complete(state);
-                    PollWork::Done
+                    return PollWork::Done;
+                };
+
+                // A slot is ready. Commit the range it issues, sliced from the unchanged
+                // `remaining` (identical for a fresh claim or a resumed pending one).
+                // `part_size` is the stored part size for a validated multipart object
+                // (so each range aligns to a stored part boundary and S3 returns the
+                // part's checksum for the SDK to validate), else the configured download
+                // part size. Set at discovery.
+                let part_size = *part_size;
+                let range = remaining
+                    .as_ref()
+                    .expect("a ready slot implies a remaining range to issue");
+                let start = *range.start();
+                let end = *range.end();
+                let chunk_end = cmp::min(start + part_size - 1, end);
+                let chunk_range = start..=chunk_end;
+
+                *ranges_in_flight += 1;
+
+                if chunk_end < end {
+                    *remaining = Some((chunk_end + 1)..=end);
+                } else {
+                    // The final range was just issued: issuance is done and the transfer
+                    // drains its in-flight tail, completing on the next empty poll with
+                    // nothing in flight. Logged once per transfer.
+                    *remaining = None;
+                    tracing::debug!(
+                        target: crate::telemetry::TARGET_TRANSFER,
+                        issued = gate.issued(),
+                        ranges_in_flight = *ranges_in_flight,
+                        "all ranges issued; draining in-flight tail",
+                    );
                 }
+
+                PollWork::Ready(IoRequest {
+                    data: Some(Box::new(DownloadWork::GetObjectRange {
+                        range: chunk_range,
+                        slot: Some(slot),
+                        etag: etag.clone(),
+                    })),
+                })
             }
             DownloadState::Terminal => PollWork::Done,
+        }
+    }
+
+    /// Park the transfer: mark it pending so the scheduler stops polling it until a
+    /// waker re-readies it — the consumer freeing occupancy (gate), the budget granting
+    /// a queued reservation, or a GET completion decrementing the in-flight count.
+    fn park(&self) -> PollWork {
+        self.inner.ctx.set_pending();
+        PollWork::Pending
+    }
+
+    /// Resume a budget-parked claim. The gate already admitted and counted the slot
+    /// before parking, so it is not re-gated; this only checks whether the budget has
+    /// granted the queued reservation. Returns the slot with its reservation attached
+    /// once granted, or `None` while still queued (the ticket is the waker).
+    fn resume_pending_claim(&self, pending: &mut Option<PendingClaim>) -> Option<BodySlot> {
+        let granted = pending.as_mut().unwrap().ticket.take();
+        granted.map(|reservation| {
+            let mut claim = pending.take().unwrap();
+            claim.slot.attach_reservation(reservation);
+            claim.slot
+        })
+    }
+
+    /// Claim a slot and reserve its backing memory against the global budget. The
+    /// read-ahead gate has already admitted (and counted) this slot. Returns the slot
+    /// with its reservation attached on an immediate grant; on a queued reservation,
+    /// stashes the claimed slot in `pending` and returns `None` so the caller parks
+    /// until the budget wakes it.
+    fn reserve_claim(
+        &self,
+        range_len: usize,
+        pending: &mut Option<PendingClaim>,
+    ) -> Option<BodySlot> {
+        let mut slot = self.inner.writer.claim();
+        // Common case: the budget has room and no one is queued. Grant without building a waker
+        // (`try_reserve` grants under exactly the same condition `reserve` returns `Ready`).
+        if let Some(reservation) = self.inner.ctx.handle.memory_budget.try_reserve(range_len) {
+            slot.attach_reservation(reservation);
+            return Some(slot);
+        }
+        // Budget full or a waiter is queued: build the waker and park on a queued reservation.
+        let notify: NotifyFn = {
+            let scheduler = self.inner.ctx.handle.scheduler.clone();
+            let tid = self.inner.ctx.id;
+            Arc::new(move || scheduler.wake(tid))
+        };
+        match self
+            .inner
+            .ctx
+            .handle
+            .memory_budget
+            .reserve(range_len, notify)
+        {
+            Reserve::Ready(reservation) => {
+                slot.attach_reservation(reservation);
+                Some(slot)
+            }
+            Reserve::Pending(ticket) => {
+                *pending = Some(PendingClaim { slot, ticket });
+                None
+            }
+        }
+    }
+
+    /// Reserve budget for a chunk of `len` bytes, awaiting a grant if the budget is
+    /// full. Used by the discovery path: discovery has already issued the GET and must
+    /// account its chunk's memory, but it runs inside an async `execute` (not the
+    /// re-pollable `poll_work`), so it backpressures by awaiting here — holding the
+    /// response stream undrained — rather than parking on the scheduler. The head
+    /// (seq 0) reserving before any read-ahead range keeps the budget FIFO head-first,
+    /// which guarantees forward progress under a tight cap.
+    ///
+    /// Returns `None` if the transfer goes terminal (cancel/fail) while parked on the
+    /// budget: a per-transfer cancel only flips the status flag and wakes waiters on
+    /// `discovery_notify`, so the wait is raced against it and rechecks `is_active` on
+    /// each wake — otherwise a discovery parked under a tight budget would hang until
+    /// the budget granted (only shutdown, not per-transfer cancel, aborts `execute`).
+    ///
+    /// A budget-parked discovery holds its worker/concurrency slot for the whole
+    /// `execute` future (unlike the `poll_work` read-ahead park, which returns `Pending`
+    /// and releases the slot), so a pathologically small budget relative to concurrency
+    /// can reduce effective worker parallelism; forward progress is still guaranteed by
+    /// FIFO plus the idle forced-grant.
+    ///
+    /// The two wakers have different permit semantics, so the register-before-check
+    /// ordering is required for `discovery_notify` but not the budget waker:
+    /// `notify_waiters` stores no permit, so a terminal wake is lost unless its
+    /// `notified()` future exists before the `is_active` check; `notify_one` stores a
+    /// permit for an unregistered waiter, which the next `take` consumes regardless of
+    /// ordering.
+    async fn reserve_chunk(&self, len: usize) -> Option<Reservation> {
+        let notify = Arc::new(tokio::sync::Notify::new());
+        let waker = Arc::clone(&notify);
+        let notify_fn: NotifyFn = Arc::new(move || waker.notify_one());
+        match self.inner.ctx.handle.memory_budget.reserve(len, notify_fn) {
+            Reserve::Ready(reservation) => Some(reservation),
+            Reserve::Pending(mut ticket) => loop {
+                // Register interest on both wakers BEFORE checking state, so a terminal
+                // transition that fires `discovery_notify` between the check and the
+                // await cannot be lost (tokio `Notify::notify_waiters` stores no permit).
+                let budget_wake = notify.notified();
+                let terminal_wake = self.inner.discovery_notify.notified();
+                if let Some(reservation) = ticket.take() {
+                    tracing::debug!(
+                        target: crate::telemetry::TARGET_MEMORY,
+                        tid = %self.inner.ctx.id,
+                        len,
+                        "discovery chunk reservation granted; resuming",
+                    );
+                    return Some(reservation);
+                }
+                if !self.inner.ctx.is_active() {
+                    // Terminal while parked: the WaitTicket drops here, cancelling the
+                    // queued budget request. Abandon the chunk so `execute` returns.
+                    return None;
+                }
+                tokio::select! {
+                    _ = budget_wake => {}
+                    _ = terminal_wake => {}
+                }
+            },
         }
     }
 
@@ -404,10 +569,30 @@ impl DownloadTransfer {
         // If there's an initial chunk, claim seq BEFORE waking to prevent race
         // where poll_work exhausts the window before we can claim our seq.
         // Invariant: initial_chunk.is_some() == chunk_meta.is_some()
+        //
+        // Reserve the discovery chunk's memory here too: it is already resident (the
+        // discovery GET fetched it), so it must be accounted before any read-ahead
+        // range issues. Awaiting the reservation head-first keeps the budget FIFO
+        // ordered — under a tight budget the head part is admitted before the window
+        // fans out — and backpressures by holding this chunk undelivered rather than
+        // parking on the scheduler (discovery runs in async `execute`, not poll_work).
         let initial_work = match (initial_chunk, chunk_meta) {
             (Some(stream), Some(meta)) => {
-                let slot = self.inner.writer.claim();
-                Some((stream, meta, slot))
+                let mut slot = self.inner.writer.claim();
+                match self.reserve_chunk(chunk_content_len as usize).await {
+                    Some(reservation) => {
+                        slot.attach_reservation(reservation);
+                        Some((stream, meta, slot))
+                    }
+                    // Terminal (cancel/fail by another path) while reserving the discovery
+                    // chunk: the transfer is already in its terminal state, so drop the
+                    // claimed slot (waking the consumer) and return without transitioning
+                    // to Transferring. `execute` reports Cancelled.
+                    None => {
+                        drop(slot);
+                        return WorkOutcome::Cancelled;
+                    }
+                }
             }
             (None, _) => None,
             (Some(_), None) => {
@@ -425,6 +610,7 @@ impl DownloadTransfer {
                 etag: etag.clone(),
                 part_size: effective_part_size,
                 gate: super::context::OccupancyGate::with_issued(initial),
+                pending: None,
             };
         }
 
@@ -520,6 +706,8 @@ impl DownloadTransfer {
                 .unwrap_or(0),
             data: AggregatedBytes(segmented),
             metadata: chunk_meta,
+            // The slot carries the reservation; fill() moves it into the chunk.
+            reservation: None,
         };
 
         // Edge-triggered disk write: a fill that brings the segment's filled count to
@@ -550,7 +738,9 @@ impl DownloadTransfer {
             ..Default::default()
         });
 
-        self.decrement_in_flight(freed);
+        if self.decrement_in_flight(freed) {
+            return self.finalize_completion();
+        }
 
         WorkOutcome::Success { data: None }
     }
@@ -639,6 +829,8 @@ impl DownloadTransfer {
             offset: *range.start(),
             data: AggregatedBytes(segmented),
             metadata: chunk_meta,
+            // The slot carries the reservation; fill() moves it into the chunk.
+            reservation: None,
         };
 
         // Edge-triggered disk write: a fill that brings the segment's filled count to
@@ -671,7 +863,9 @@ impl DownloadTransfer {
             ..Default::default()
         });
 
-        self.decrement_in_flight(freed);
+        if self.decrement_in_flight(freed) {
+            return self.finalize_completion();
+        }
 
         tracing::trace!(
             target: crate::telemetry::TARGET_TRANSFER,
@@ -692,35 +886,65 @@ impl DownloadTransfer {
         self.fail(guard, e.with_chunk(location))
     }
 
-    /// Complete one in-flight range: drop `ranges_in_flight` and release the
-    /// `freed` parts of read-ahead occupancy this completion drained, both under
-    /// the state lock, then wake the issuer.
+    /// Complete one in-flight range: drop `ranges_in_flight`, release `freed` parts of
+    /// read-ahead occupancy, and report whether this was the terminal completion (issuance
+    /// done and nothing left in flight). Both counters move under the state lock so the
+    /// terminal transition is claimed exactly once: the caller that observes `true` owns
+    /// completion, and any concurrently-woken `poll_work` sees `Terminal`.
     ///
-    /// Releasing the occupancy here — under the same lock `poll_work` reads the gate
-    /// and arms `set_pending` under — is what orders this completion's release against
-    /// the issuer's park (the mutator protocol `lock → mutate → unlock → try_wake`).
-    /// `freed` is the disk drain's freed count (0 if this fill did not hit a drain
-    /// edge; the run drains on a later fill).
-    fn decrement_in_flight(&self, freed: u64) {
-        {
+    /// Releasing the occupancy under the same lock `poll_work` reads the gate and arms
+    /// `set_pending` under is what orders this completion's release against the issuer's
+    /// park (the mutator protocol `lock -> mutate -> unlock -> try_wake`). `freed` is the
+    /// disk drain's freed count (0 if this fill did not hit a drain edge).
+    fn decrement_in_flight(&self, freed: u64) -> bool {
+        let (terminal, pending) = {
             let mut work = self.inner.state.lock().unwrap();
-            if let DownloadState::Transferring {
-                ranges_in_flight,
-                gate,
-                ..
-            } = &mut *work
-            {
-                *ranges_in_flight = ranges_in_flight.saturating_sub(1);
-                gate.release(freed);
+            match &mut *work {
+                DownloadState::Transferring {
+                    ranges_in_flight,
+                    gate,
+                    remaining,
+                    ..
+                } => {
+                    *ranges_in_flight = ranges_in_flight.saturating_sub(1);
+                    gate.release(freed);
+                    if remaining.is_none() && *ranges_in_flight == 0 {
+                        // Terminal: claim the transition under this lock so a
+                        // concurrently-woken poll_work cannot also complete.
+                        (true, work.enter_terminal())
+                    } else {
+                        (false, None)
+                    }
+                }
+                _ => (false, None),
             }
+        };
+        drop(pending);
+        // Wake the issuer on every non-terminal completion so a pending poll_work can
+        // issue more. A terminal completion is finalized by the caller in `execute`.
+        if !terminal {
+            self.inner.ctx.try_wake();
         }
-        // Wake the issuer on every completion. A completed range has freed its
-        // read-ahead occupancy and dropped the in-flight count, so a pending poll_work
-        // can now issue another part or complete the transfer. `try_wake` is a no-op
-        // unless the issuer parked (gated on the pending flag), so waking on every
-        // completion is unconditional and covers the case where occupancy frees but
-        // nothing re-polls.
-        self.inner.ctx.try_wake();
+        terminal
+    }
+
+    /// Finalize a transfer that reached its terminal completion in `execute`: flush the
+    /// tail to disk (releasing the last reservations as their `ChunkOutput`s drop), set the
+    /// terminal status, and signal waiters. The state is already `Terminal` (claimed under
+    /// the lock in `decrement_in_flight`); this runs after the lock is released so disk IO
+    /// never happens under it. Symmetric with `fail`, which error paths already call from
+    /// `execute`.
+    fn finalize_completion(&self) -> WorkOutcome {
+        if let Err(e) = self.inner.writer.finalize() {
+            // Finalize failed: transition to failed. The state is already Terminal; `fail`
+            // calls `enter_terminal` which is idempotent on Terminal (returns None).
+            let guard = self.inner.state.lock().unwrap();
+            return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
+        }
+        self.inner.ctx.set_completed();
+        self.inner.writer.notify_consumer();
+        self.inner.ctx.signal_terminal();
+        WorkOutcome::Success { data: None }
     }
 
     /// Transition to terminal failed state. Requires holding the work lock.
@@ -736,10 +960,12 @@ impl DownloadTransfer {
         let classification = crate::scheduler::classify_error(&error);
         // Order matters: set status/error before any wakeups
         self.inner.ctx.set_failed(error);
-        // Transition to Terminal
-        *guard = DownloadState::Terminal;
-        drop(guard); // release lock before signaling waiters
-                     // Wake all waiters
+        // Transition to Terminal, taking any budget-parked claim so its WaitTicket::drop (which
+        // locks the budget) runs after we release the state lock, never nested under it.
+        let pending = guard.enter_terminal();
+        drop(guard); // release lock before dropping the claim and signaling waiters
+        drop(pending);
+        // Wake all waiters
         self.inner.discovery_notify.notify_waiters();
         let _ = self.inner.writer.finalize();
         self.inner.writer.notify_consumer();
@@ -754,8 +980,9 @@ impl DownloadTransfer {
             return;
         }
         self.inner.ctx.set_completed();
-        *guard = DownloadState::Terminal;
-        drop(guard); // release lock before signaling waiters
+        let pending = guard.enter_terminal();
+        drop(guard); // release lock before dropping the claim and signaling waiters
+        drop(pending);
         self.inner.writer.notify_consumer();
         self.inner.ctx.signal_terminal();
     }
@@ -778,6 +1005,18 @@ impl Transfer for DownloadTransfer {
     }
 
     fn on_terminal(&self) {
+        // Release a budget-parked claim if one is held: an external cancel does not run the
+        // `fail`/`complete` transition that would take it, so the queued `WaitTicket` would
+        // otherwise linger in the shared budget — and could even be granted a live reservation
+        // into a dead transfer's slot, shrinking the budget for others until this transfer's Arc
+        // drops. `enter_terminal` takes it under the state lock; drop it after releasing the lock
+        // so `WaitTicket::drop` (which takes the budget lock) never nests under the state lock.
+        let pending = {
+            let mut state = self.inner.state.lock().unwrap();
+            state.enter_terminal()
+        };
+        drop(pending);
+
         self.inner.discovery_notify.notify_waiters();
         let _ = self.inner.writer.finalize();
         self.inner.writer.notify_consumer();
@@ -1243,6 +1482,257 @@ mod tests {
         // Gate reopens for exactly one more claim.
         assert_ready(transfer.poll_work());
         assert_pending(transfer.poll_work());
+    }
+
+    /// The memory budget is the second issuance gate, past the read-ahead window: with
+    /// the window wide open, a transfer still parks when the budget is exhausted,
+    /// holding its claimed slot in `pending`, and resumes when a delivered chunk frees
+    /// a reservation the budget re-grants. Distinct from the window gate above (this
+    /// leaves the window open and binds on bytes).
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_budget_blocks_then_resumes() {
+        use crate::runtime::memory::BUDGET_CHUNK_BYTES;
+
+        // Object = 3 parts of one chunk each. Discovery fetches part 0 (seq 0) and
+        // reserves its chunk, so in_use == 1 after discovery; remaining covers 1 + 2.
+        let part_size = BUDGET_CHUNK_BYTES as u64;
+        let object_size = 3 * part_size;
+        let (transfer, mut consumer) = create_download_for_gate(object_size, part_size);
+
+        skip_discovery(&transfer).await;
+        let budget = transfer.ctx().handle.memory_budget.clone();
+        assert_eq!(budget.in_use_chunks(), 1, "discovery chunk is reserved");
+
+        // Tighten to 2 chunks: the discovery chunk plus room for exactly one range. The
+        // window stays wide (default), so only the budget can bind here.
+        budget.set_limit(2 * BUDGET_CHUNK_BYTES);
+
+        // poll #1: part 1 fits (need 1, free 1) → Ready.
+        let _w1 = assert_ready(transfer.poll_work());
+        assert_eq!(budget.in_use_chunks(), 2);
+
+        // poll #2: part 2 does not fit (in_use 2, cap 2) → parked on the budget, holding
+        // the claimed slot in `pending` until a chunk frees.
+        assert_pending(transfer.poll_work());
+        {
+            let state = transfer.inner.state.lock().unwrap();
+            match &*state {
+                DownloadState::Transferring { pending, .. } => {
+                    assert!(pending.is_some(), "claim should be parked on the budget");
+                }
+                _ => panic!("expected Transferring"),
+            }
+        }
+
+        // Consume the discovery chunk (seq 0) and drop it: its reservation releases,
+        // freeing a chunk the budget immediately re-grants to the parked part-2 claim.
+        drop(consumer.try_take_next().expect("discovery chunk is filled"));
+        assert_eq!(
+            budget.in_use_chunks(),
+            2,
+            "freed chunk re-granted to the parked waiter"
+        );
+
+        // poll #3: the parked claim was granted → Ready, pending cleared.
+        let _w2 = assert_ready(transfer.poll_work());
+        {
+            let state = transfer.inner.state.lock().unwrap();
+            match &*state {
+                DownloadState::Transferring { pending, .. } => {
+                    assert!(pending.is_none(), "parked claim should be consumed");
+                }
+                _ => panic!("expected Transferring"),
+            }
+        }
+        assert_eq!(budget.in_use_chunks(), 2);
+    }
+
+    /// Cancelling a transfer while it is budget-parked must cancel the queued budget
+    /// wait and release the held slot — otherwise the `WaitTicket` lingers in the
+    /// shared budget (and could be granted a live reservation into a dead transfer),
+    /// shrinking the budget for every other transfer. `on_terminal` (the external-cancel
+    /// hook) is responsible, since cancel does not run the `fail`/`complete` transition.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_cancel_while_budget_parked_releases_ticket_and_slot() {
+        use crate::runtime::memory::BUDGET_CHUNK_BYTES;
+
+        let part_size = BUDGET_CHUNK_BYTES as u64;
+        let object_size = 3 * part_size;
+        let (transfer, mut consumer) = create_download_for_gate(object_size, part_size);
+
+        skip_discovery(&transfer).await;
+        let budget = transfer.ctx().handle.memory_budget.clone();
+        budget.set_limit(2 * BUDGET_CHUNK_BYTES);
+
+        // poll #1 issues part 1 (in_use 2); poll #2 parks part 2 on the budget.
+        let _w1 = assert_ready(transfer.poll_work());
+        assert_pending(transfer.poll_work());
+        assert_eq!(
+            budget.stats().waiters,
+            1,
+            "part 2's reservation is queued on the budget"
+        );
+
+        // Cancel and run the terminal hook, exactly as `cancel_descriptor` does.
+        assert!(transfer.ctx().set_cancelled());
+        transfer.on_terminal();
+
+        // The parked PendingClaim was dropped: its WaitTicket left the queue and its
+        // held slot released. The queue is empty, so a freed chunk cannot be misgranted
+        // to the dead transfer.
+        assert_eq!(
+            budget.stats().waiters,
+            0,
+            "cancel must dequeue the parked budget waiter"
+        );
+
+        // The invariant under test is the WAITER release; assert in_use did not grow
+        // past what is actually reserved (no phantom grant to the cancelled waiter).
+        assert_eq!(
+            budget.in_use_chunks(),
+            2,
+            "exactly the discovery + part-1 reservations remain; none granted to the cancelled waiter"
+        );
+
+        // The consumer is woken and sees terminal rather than hanging on seq.
+        // (Discovery chunk may still deliver; the point is no deadlock.)
+        let _ = consumer.try_take_next();
+    }
+
+    /// The failure path must release a budget-parked claim. `fail` reaches `Terminal` through
+    /// `enter_terminal`, which extracts the parked `PendingClaim` under the state lock so its
+    /// `WaitTicket` (whose drop locks the budget) is dropped only after the lock is released,
+    /// rather than nested under it. That lock ordering is not observable from a single-threaded
+    /// test; this guards the functional half — that failing while parked dequeues the waiter and
+    /// grants it no phantom reservation — for the fail path the cancel test does not cover.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_fail_while_budget_parked_releases_ticket_and_slot() {
+        use crate::runtime::memory::BUDGET_CHUNK_BYTES;
+
+        let part_size = BUDGET_CHUNK_BYTES as u64;
+        let object_size = 3 * part_size;
+        let (transfer, mut consumer) = create_download_for_gate(object_size, part_size);
+
+        skip_discovery(&transfer).await;
+        let budget = transfer.ctx().handle.memory_budget.clone();
+        budget.set_limit(2 * BUDGET_CHUNK_BYTES);
+
+        // poll #1 issues part 1 (in_use 2); poll #2 parks part 2 on the budget.
+        let _w1 = assert_ready(transfer.poll_work());
+        assert_pending(transfer.poll_work());
+        assert_eq!(
+            budget.stats().waiters,
+            1,
+            "part 2's reservation is queued on the budget"
+        );
+
+        // Fail the transfer while the claim is parked, exactly as `fail_range` does: take the
+        // state lock and run the fail transition.
+        let err = error::Error::new(error::ErrorKind::RuntimeError, "injected test failure");
+        {
+            let guard = transfer.inner.state.lock().unwrap();
+            let _ = transfer.fail(guard, err);
+        }
+
+        // The parked PendingClaim was dropped by `enter_terminal`: its WaitTicket left the queue.
+        assert_eq!(
+            budget.stats().waiters,
+            0,
+            "fail must dequeue the parked budget waiter"
+        );
+        assert_eq!(
+            budget.in_use_chunks(),
+            2,
+            "exactly the discovery + part-1 reservations remain; none granted to the failed waiter"
+        );
+
+        let _ = consumer.try_take_next();
+    }
+
+    /// A single-chunk disk download must flush its tail and release its budget reservation
+    /// from `execute` -- not from a later `poll_work`. Budget reclamation is event-driven
+    /// off the disk drain, never gated on a re-poll.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn terminal_drain_and_release_happen_in_execute() {
+        use crate::runtime::memory::BUDGET_CHUNK_BYTES;
+
+        let part_size = BUDGET_CHUNK_BYTES as u64;
+        // Single chunk: object_size == part_size. Discovery fetches the entire object in
+        // one chunk; no range requests are generated. The terminal completion path runs
+        // when execute_read_discovery_body finishes filling that single chunk.
+        let object_size = part_size;
+
+        let chunk = vec![0u8; part_size as usize];
+        let get_obj = mock!(aws_sdk_s3::Client::get_object).then_output(move || {
+            GetObjectOutput::builder()
+                .content_length(part_size as i64)
+                .content_range(format!("bytes 0-{}/{}", part_size - 1, object_size))
+                .e_tag("test-etag")
+                .body(ByteStream::from(chunk.clone()))
+                .build()
+        });
+        let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[get_obj]);
+
+        let config = crate::Config::builder()
+            .client(client)
+            .part_size(crate::types::PartSize::Target(part_size))
+            .build();
+
+        let handle = crate::client::Handle::test_handle_tokio(config);
+        let budget = handle.memory_budget.clone();
+
+        let input = DownloadInput::builder()
+            .bucket("test-bucket")
+            .key("test-key")
+            .build()
+            .unwrap();
+
+        // Disk-mode body so finalize drains to a file, releasing reservations on drop.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out");
+        let file = std::fs::File::create(&path).unwrap();
+        let (writer, _consumer) =
+            crate::operation::download::body::new_recv_body_with_sink(file, 0, false);
+        let (ctx, _completion_rx) = TransferContext::new(handle);
+        let transfer = DownloadTransfer::new(ctx, BucketType::Standard, input, writer);
+
+        // Budget starts empty.
+        assert_eq!(budget.in_use_chunks(), 0);
+
+        // Drive discovery: poll_work returns discovery work, execute fetches it.
+        // After discovery, the discovery chunk is reserved (in_use == 1) and remaining
+        // is None (single-chunk object), with ranges_in_flight == 1.
+        let mut work = assert_ready(transfer.poll_work());
+        let outcome = execute(&transfer, &mut work).await;
+
+        // The terminal execute must have finalized (drained to disk) and released the
+        // reservation -- all without any subsequent poll_work.
+        assert!(
+            matches!(outcome, WorkOutcome::Success { .. }),
+            "expected Success, got {:?}",
+            outcome
+        );
+        assert_eq!(
+            budget.in_use_chunks(),
+            0,
+            "terminal drain + reservation release must happen in execute, not a later poll_work"
+        );
+        assert!(
+            !transfer.ctx().is_active(),
+            "transfer must be completed after terminal execute"
+        );
+
+        // Verify data landed on disk.
+        let written = std::fs::read(&path).unwrap();
+        assert_eq!(
+            written.len(),
+            part_size as usize,
+            "all bytes should be flushed to disk"
+        );
     }
 
     /// The window resolved at construction follows precedence: a per-request

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -22,7 +22,7 @@ use crate::operation::download::context::{DownloadState, PendingClaim};
 use crate::operation::download::discovery::{discover_obj, ObjectDiscovery};
 use crate::operation::download::object_meta::ObjectMetadata;
 use crate::operation::download::read_ahead::ReadAhead;
-use crate::operation::download::recv_buffer::FillOutcome;
+use crate::operation::download::recv_buffer::{DrainMode, FillOutcome};
 use crate::operation::download::DownloadInput;
 use crate::runtime::memory::{NotifyFn, Reservation, Reserve};
 use crate::transfer::{IoRequest, PollWork, Transfer, TransferContext, TransferId, WorkOutcome};
@@ -37,6 +37,11 @@ pub(crate) enum DownloadWork {
         slot: Option<BodySlot>,
         etag: Option<Arc<str>>,
     },
+    /// Budget-pressure relief: flush the resident filled run to disk, releasing its
+    /// reservations, so a budget-parked transfer does not pin chunks it has no other
+    /// path to release. Emitted by [`drain_or_park`](DownloadTransfer::drain_or_park)
+    /// and handled in `execute`; carries no data (operates on the writer).
+    DrainResident,
 }
 
 /// Bytes in the next chunk sliced from `remaining` at `part_size`: the reservation
@@ -270,8 +275,9 @@ impl DownloadTransfer {
                     // the reservation the budget queued.
                     match self.resume_pending_claim(pending) {
                         Some(slot) => slot,
-                        // Not granted yet; the queued ticket is the waker.
-                        None => return self.park(),
+                        // Not granted yet; the queued ticket is the waker. Flush any
+                        // resident run first so we do not pin budget while parked.
+                        None => return self.drain_or_park(),
                     }
                 } else if let Some(range) = remaining.as_ref() {
                     // Read-ahead gate. The gate bounds resident occupancy at
@@ -313,8 +319,9 @@ impl DownloadTransfer {
                     let range_len = chunk_len(range, *part_size);
                     match self.reserve_claim(range_len, pending) {
                         Some(slot) => slot,
-                        // Budget-parked; `pending` now holds the claimed slot.
-                        None => return self.park(),
+                        // Budget-parked; `pending` now holds the claimed slot. Flush any
+                        // resident run first so we do not pin budget while parked.
+                        None => return self.drain_or_park(),
                     }
                 } else if *ranges_in_flight > 0 {
                     // All ranges generated, waiting for in-flight to complete.
@@ -377,6 +384,30 @@ impl DownloadTransfer {
     fn park(&self) -> PollWork {
         self.inner.ctx.set_pending();
         PollWork::Pending
+    }
+
+    /// Budget-park decision. A transfer that parks on the budget while holding a
+    /// drainable resident run pins those chunks with no path to release them: the run
+    /// is below the drain batch (so no fill-triggered drain frees it) and the transfer
+    /// cannot reach terminal (its `remaining` part is what is blocked on the budget).
+    /// Spread across concurrent disk transfers this deadlocks — none can release, so
+    /// none is granted. To avoid it, flush the resident run first (releasing its budget)
+    /// by emitting a `DrainResident` work item, and only park when there is nothing to
+    /// flush. The drain runs in `execute` (poll_work does no I/O); its completion
+    /// re-polls this transfer via `generate_work`, and the freed budget re-grants FIFO.
+    ///
+    /// Only the budget-park sites call this. A `has_drainable_resident` guard keeps it a
+    /// no-op-to-park when the resident prefix is blocked behind an in-flight gap (that
+    /// GET's completion carries the drain instead) or in stream mode (the consumer
+    /// drives release), so it never spins emitting empty drains.
+    fn drain_or_park(&self) -> PollWork {
+        if self.inner.writer.has_drainable_resident() {
+            PollWork::Ready(IoRequest {
+                data: Some(Box::new(DownloadWork::DrainResident)),
+            })
+        } else {
+            self.park()
+        }
     }
 
     /// Resume a budget-parked claim. The gate already admitted and counted the slot
@@ -506,7 +537,36 @@ impl DownloadTransfer {
                 )
                 .await
             }
+            DownloadWork::DrainResident => self.execute_drain_resident(),
         }
+    }
+
+    /// Flush the resident filled run to disk, releasing its budget reservations, then
+    /// release the freed read-ahead occupancy. Emitted by [`drain_or_park`] when a
+    /// transfer would otherwise park on the budget while pinning a resident run.
+    ///
+    /// Unlike a fill-triggered drain, no GET completed here, so `ranges_in_flight` is
+    /// untouched; only occupancy is released (matching the gate side of
+    /// [`decrement_in_flight`](Self::decrement_in_flight), under the same state lock so
+    /// the release is ordered against the issuer's park). Dropping the drained
+    /// `ChunkOutput`s frees their reservations, which the budget re-grants FIFO; the
+    /// `on_completion -> generate_work` after this returns re-polls this transfer.
+    fn execute_drain_resident(&self) -> WorkOutcome {
+        let freed = match self.inner.writer.flush_resident() {
+            Ok(f) => f,
+            Err(e) => {
+                let guard = self.inner.state.lock().unwrap();
+                return self.fail(guard, error::Error::new(error::ErrorKind::IOError, e));
+            }
+        };
+        {
+            let mut work = self.inner.state.lock().unwrap();
+            if let DownloadState::Transferring { gate, .. } = &mut *work {
+                gate.release(freed);
+            }
+        }
+        self.inner.ctx.try_wake();
+        WorkOutcome::Success { data: None }
     }
 
     async fn execute_discovery(&self) -> WorkOutcome {
@@ -715,7 +775,7 @@ impl DownloadTransfer {
         // occupancy this drain released, accounted under the lock in decrement_in_flight.
         let mut freed = 0u64;
         if slot.fill(chunk) == FillOutcome::DrainReady {
-            match self.inner.writer.drain(false) {
+            match self.inner.writer.drain(DrainMode::Batched) {
                 Ok(f) => freed = f,
                 Err(e) => {
                     // Go terminal before any wake (see fail_range).
@@ -841,7 +901,7 @@ impl DownloadTransfer {
         // decrement_in_flight.
         let mut freed = 0u64;
         if slot.fill(chunk) == FillOutcome::DrainReady {
-            match self.inner.writer.drain(false) {
+            match self.inner.writer.drain(DrainMode::Batched) {
                 Ok(f) => freed = f,
                 Err(e) => {
                     // Go terminal before any wake (see fail_range).
@@ -1550,6 +1610,35 @@ mod tests {
         assert_eq!(budget.in_use_chunks(), 2);
     }
 
+    /// A stream-mode transfer that budget-parks must return `Pending`, never a
+    /// `DrainResident` work item. `drain_or_park` gates on `has_drainable_resident`,
+    /// which is false in stream mode (the consumer drives release), so the budget
+    /// deadlock relief does not apply and must not spin emitting empty drains.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn stream_budget_park_does_not_emit_drain_resident() {
+        use crate::runtime::memory::BUDGET_CHUNK_BYTES;
+
+        // Stream-mode transfer (create_download_for_gate uses new_recv_body). 3 parts.
+        let part_size = BUDGET_CHUNK_BYTES as u64;
+        let object_size = 3 * part_size;
+        let (transfer, _consumer) = create_download_for_gate(object_size, part_size);
+
+        skip_discovery(&transfer).await;
+        let budget = transfer.ctx().handle.memory_budget.clone();
+        // Tighten to the discovery chunk only: the next range reservation cannot fit.
+        budget.set_limit(BUDGET_CHUNK_BYTES);
+
+        // The transfer holds a filled seq-0 (resident on the stream surface) and parks
+        // on the budget for part 1. Because it is stream mode, the relief path is off:
+        // poll_work returns Pending, not Ready(DrainResident).
+        match transfer.poll_work() {
+            PollWork::Pending => {}
+            PollWork::Ready(_) => panic!("stream-mode budget park must not emit DrainResident"),
+            PollWork::Done => panic!("unexpected Done"),
+        }
+    }
+
     /// Cancelling a transfer while it is budget-parked must cancel the queued budget
     /// wait and release the held slot — otherwise the `WaitTicket` lingers in the
     /// shared budget (and could be granted a live reservation into a dead transfer),
@@ -1735,6 +1824,246 @@ mod tests {
             part_size as usize,
             "all bytes should be flushed to disk"
         );
+    }
+
+    /// Build a disk-mode download transfer on an already-constructed (shared) handle,
+    /// so several transfers can contend for one budget. Returns the transfer plus the
+    /// tempdir/consumer guards the caller must keep alive for the transfer's lifetime.
+    #[cfg(test)]
+    fn build_disk_transfer_on(
+        handle: Arc<crate::client::Handle>,
+    ) -> (
+        DownloadTransfer,
+        crate::operation::download::body::RecvBodyConsumer,
+        tempfile::TempDir,
+    ) {
+        let input = DownloadInput::builder()
+            .bucket("test-bucket")
+            .key("test-key")
+            .build()
+            .unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let file = std::fs::File::create(dir.path().join("out")).unwrap();
+        let (writer, consumer) =
+            crate::operation::download::body::new_recv_body_with_sink(file, 0, false);
+        let (ctx, _completion_rx) = TransferContext::new(handle);
+        let transfer = DownloadTransfer::new(ctx, BucketType::Standard, input, writer);
+        (transfer, consumer, dir)
+    }
+
+    /// Drive several transfers on a shared budget to completion by round-robin
+    /// poll+execute, standing in for the scheduler's generate_work loop. Returns once
+    /// every transfer is `Done`. A bounded step budget converts a genuine deadlock into
+    /// a test failure (all transfers `Pending` with no progress) rather than a hang.
+    #[cfg(test)]
+    async fn drive_to_completion(transfers: &[&DownloadTransfer]) {
+        let mut done = vec![false; transfers.len()];
+        // Generous ceiling: each transfer needs O(parts) poll+execute steps, plus drain
+        // relief steps. Far above any real count here; exceeding it means no progress.
+        let max_steps = 10_000;
+        for _ in 0..max_steps {
+            if done.iter().all(|d| *d) {
+                return;
+            }
+            let mut progressed = false;
+            for (i, t) in transfers.iter().enumerate() {
+                if done[i] {
+                    continue;
+                }
+                match t.poll_work() {
+                    PollWork::Ready(mut work) => {
+                        execute(t, &mut work).await;
+                        progressed = true;
+                    }
+                    PollWork::Done => {
+                        done[i] = true;
+                        progressed = true;
+                    }
+                    PollWork::Pending => {}
+                }
+            }
+            if !progressed {
+                panic!(
+                    "no transfer made progress: all Pending with work outstanding \
+                     (budget deadlock regressed)"
+                );
+            }
+        }
+        panic!("drive_to_completion exceeded {max_steps} steps without completing");
+    }
+
+    /// REGRESSION (PR #154 review, landonxjames): the fungible-budget deadlock for
+    /// concurrent multi-part disk transfers below the drain batch must NOT wedge.
+    ///
+    /// Before the fix: a disk chunk's reservation released only on a drain (fires at the
+    /// batch `min(SEG_SIZE=16, window)` or a full segment) or the terminal finalize. A
+    /// multi-part object below a segment (2..15 parts) held ALL parts resident until
+    /// terminal — which needs every part issued, which needs budget. Spread across
+    /// concurrent transfers under a tight shared budget, none could reach its part count,
+    /// so none finalized/drained/released and the `in_use == 0` forced-grant never fired.
+    ///
+    /// The fix (`drain_or_park` → `DownloadWork::DrainResident`): a transfer about to
+    /// park on the budget while holding a resident run flushes it first, releasing the
+    /// chunks FIFO. This test drives two 2-part transfers on a 2-chunk shared budget to
+    /// completion; pre-fix it would spin all-`Pending` (caught by `drive_to_completion`'s
+    /// no-progress panic), post-fix both finish and the budget fully releases.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn concurrent_multipart_disk_below_drain_batch_completes() {
+        use crate::runtime::memory::BUDGET_CHUNK_BYTES;
+
+        let part_size = BUDGET_CHUNK_BYTES as u64; // 1 part == 1 chunk
+        let object_size = 2 * part_size; // 2 parts, below the 16-part drain batch
+
+        // Range-echoing mock: the content-range must match the requested range or
+        // execute_get_range fails validation. (Fixed body works only for single-chunk.)
+        let get_obj = mock!(aws_sdk_s3::Client::get_object).then_compute_response(move |req| {
+            let start = req
+                .range()
+                .and_then(|r| r.parse::<crate::http::header::Range>().ok())
+                .map(|r| match r.0 {
+                    crate::http::header::ByteRange::Inclusive(s, _) => s,
+                    crate::http::header::ByteRange::AllFrom(s) => s,
+                    _ => 0,
+                })
+                .unwrap_or(0);
+            let end = std::cmp::min(start + part_size, object_size) - 1;
+            let chunk = vec![0u8; (end - start + 1) as usize];
+            aws_smithy_mocks::MockResponse::Output(
+                GetObjectOutput::builder()
+                    .content_length((end - start + 1) as i64)
+                    .content_range(format!("bytes {}-{}/{}", start, end, object_size))
+                    .e_tag("test-etag")
+                    .body(ByteStream::from(chunk))
+                    .build(),
+            )
+        });
+        let config = crate::Config::builder()
+            .client(mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[get_obj]))
+            .part_size(crate::types::PartSize::Target(part_size))
+            .build();
+        let handle = crate::client::Handle::test_handle_tokio(config);
+        let budget = handle.memory_budget.clone();
+        // Tight shared budget: exactly two chunks (one discovery chunk per transfer).
+        budget.set_limit(2 * BUDGET_CHUNK_BYTES);
+
+        let (a, _ca, _da) = build_disk_transfer_on(handle.clone());
+        let (b, _cb, _db) = build_disk_transfer_on(handle.clone());
+
+        // Pre-fix this wedges (both park holding an undrainable resident seq-0 while
+        // queued for part-1). Post-fix each flushes its resident run before parking, so
+        // both complete under the 2-chunk budget.
+        drive_to_completion(&[&a, &b]).await;
+
+        assert!(!a.ctx().is_active(), "transfer A completed");
+        assert!(!b.ctx().is_active(), "transfer B completed");
+        assert_eq!(
+            budget.in_use_chunks(),
+            0,
+            "all reservations released after both transfers complete"
+        );
+        assert_eq!(budget.stats().waiters, 0, "no budget waiters remain");
+    }
+
+    /// REGRESSION (PR #154 review generalization, aajtodd): the budget deadlock is
+    /// NOT specific to small objects (`total_parts < batch`). It is the general
+    /// "park holding undrained resident parts" wedge, reachable with LARGE multipart
+    /// objects that are nowhere near terminal.
+    ///
+    /// Two transfers, each a 20-part object (far above the 16-part drain batch, so the
+    /// small-object predicate `total_parts < batch` does NOT apply). Drive each to hold
+    /// 3 filled-undrained resident parts (3 < 16, so no non-terminal drain), then let a
+    /// tight shared budget cap them mid-stream with 17 parts still remaining. Neither
+    /// can issue (budget full), drain (below batch), or reach terminal (`remaining` far
+    /// from done). Each is waiting on the other to release, and neither can — the exact
+    /// wedge, with objects an order of magnitude larger than the drain batch.
+    ///
+    /// Drives both to completion under the tight budget: pre-fix this wedges (caught by
+    /// `drive_to_completion`'s no-progress panic), post-fix the `DrainResident` relief
+    /// lets both finish. Proves the fix is not the small-object special case.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn concurrent_large_multipart_partial_fills_completes() {
+        use crate::runtime::memory::BUDGET_CHUNK_BYTES;
+
+        let part_size = BUDGET_CHUNK_BYTES as u64; // 1 part == 1 chunk
+        let parts_per_object = 20u64; // WELL above the 16-part drain batch
+        let object_size = parts_per_object * part_size;
+        let resident_per_transfer = 3u64; // 3 < 16: never drains non-terminally
+
+        // Range-echoing mock: each GET's content-range must match the requested range,
+        // or execute_get_range's validate_content_range fails the transfer. (A fixed
+        // `then_output` body works only for single-chunk objects.)
+        let get_obj = mock!(aws_sdk_s3::Client::get_object).then_compute_response(move |req| {
+            let start = req
+                .range()
+                .and_then(|r| r.parse::<crate::http::header::Range>().ok())
+                .map(|r| match r.0 {
+                    crate::http::header::ByteRange::Inclusive(s, _) => s,
+                    crate::http::header::ByteRange::AllFrom(s) => s,
+                    _ => 0,
+                })
+                .unwrap_or(0);
+            let end = std::cmp::min(start + part_size, object_size) - 1;
+            let chunk = vec![0u8; (end - start + 1) as usize];
+            aws_smithy_mocks::MockResponse::Output(
+                GetObjectOutput::builder()
+                    .content_length((end - start + 1) as i64)
+                    .content_range(format!("bytes {}-{}/{}", start, end, object_size))
+                    .e_tag("test-etag")
+                    .body(ByteStream::from(chunk))
+                    .build(),
+            )
+        });
+        let config = crate::Config::builder()
+            .client(mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[get_obj]))
+            .part_size(crate::types::PartSize::Target(part_size))
+            .build();
+        let handle = crate::client::Handle::test_handle_tokio(config);
+        let budget = handle.memory_budget.clone();
+
+        let (a, _ca, _da) = build_disk_transfer_on(handle.clone());
+        let (b, _cb, _db) = build_disk_transfer_on(handle.clone());
+
+        // Budget room for exactly the resident parts of both transfers, nothing more.
+        // Once both fill to that depth neither can reserve another part without a drain.
+        let cap_chunks = 2 * resident_per_transfer;
+        budget.set_limit(cap_chunks as usize * BUDGET_CHUNK_BYTES);
+
+        // Drive each transfer to hold `resident_per_transfer` filled-undrained parts:
+        // discovery fills seq 0, then (resident-1) range GETs fill seqs 1.. . Each fill's
+        // in-execute Batched drain frees nothing (below batch), so all stay resident.
+        async fn fill_resident(t: &DownloadTransfer, resident: u64) {
+            skip_discovery(t).await; // seq 0 filled + reserved
+            for _ in 1..resident {
+                let mut w = assert_ready(t.poll_work());
+                execute(t, &mut w).await;
+            }
+        }
+        fill_resident(&a, resident_per_transfer).await;
+        fill_resident(&b, resident_per_transfer).await;
+
+        assert_eq!(
+            budget.in_use_chunks(),
+            cap_chunks,
+            "both transfers hold their resident parts; budget is exactly full"
+        );
+
+        // Both are mid-stream (17 parts each remaining) with the budget full. Pre-fix
+        // this wedges — neither can issue, drain (below batch), or reach terminal, and
+        // each waits on the other. Post-fix each flushes its resident run before parking,
+        // so both complete under the tight budget. `drive_to_completion` panics on a
+        // no-progress wedge instead of hanging.
+        drive_to_completion(&[&a, &b]).await;
+
+        assert!(!a.ctx().is_active(), "large-object transfer A completed");
+        assert!(!b.ctx().is_active(), "large-object transfer B completed");
+        assert_eq!(
+            budget.in_use_chunks(),
+            0,
+            "all reservations released after both large multipart transfers complete"
+        );
+        assert_eq!(budget.stats().waiters, 0, "no budget waiters remain");
     }
 
     /// The window resolved at construction follows precedence: a per-request

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -22,19 +22,11 @@
 //! head-of-line blocking — a large request at the front idles the budget while
 //! free chunks accumulate to its need — which arises only under mixed part sizes;
 //! a uniform part size never triggers it.
-//!
-//! The download path reserves against it (see `operation::download::transfer`).
-//! `set_limit` and a few introspection methods are not yet wired to a caller and
-//! carry their own gating.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
 
 use crate::metrics::unit::ByteUnit;
-// The compat-layer Mutex is loom-instrumented under `cfg(s3_tm_loom)`, which is
-// what exercises the budget/slot lock-ordering invariant. `Arc` stays `std`: the
-// budget is held as `std::sync::Arc` across the call graph, and loom tracks the
-// locks, not the refcount.
 use crate::runtime::sync::Mutex;
 
 /// Closure the budget invokes to wake a parked reserver (= `scheduler.wake(tid)`).
@@ -142,9 +134,6 @@ impl std::fmt::Debug for WaitTicket {
 /// Nominal 8 MiB accounting unit for budget reservations. A part costs
 /// `ceil(part_size / chunk)` chunks, so non-uniform part sizes account correctly.
 pub(crate) const BUDGET_CHUNK_BYTES: usize = 8 * ByteUnit::Mebibyte.as_bytes_usize();
-/// Non-binding budget for test handles, which size objects far below it.
-#[cfg(test)]
-pub(crate) const DEFAULT_MEMORY_BUDGET_BYTES: usize = 8 * ByteUnit::Gibibyte.as_bytes_usize();
 
 // A request fits when the free chunks cover its need. The `in_use == 0` clause is
 // the forced grant: a request larger than the entire capacity can only ever proceed
@@ -607,7 +596,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_barge_small_request_does_not_jump_queued_large() {
+    fn test_arrival_order_small_request_does_not_jump_queued_large() {
         let chunk = 1024;
         let budget = MemoryBudget::new(chunk * 4, chunk); // 4 chunks capacity
         let (n_hold, _) = notify_flag();
@@ -626,11 +615,11 @@ mod tests {
         };
 
         // A 1-chunk request WOULD fit on capacity alone (1 chunk is free), so this
-        // isolates no-barge from exhaustion: it is rejected only because a waiter
-        // is queued ahead of it.
+        // isolates arrival order from exhaustion: it is rejected only because a
+        // waiter is queued ahead of it.
         assert!(
             budget.try_reserve(chunk).is_none(),
-            "no-barge: must not jump the queued waiter even though it fits"
+            "arrival order: must not jump the queued waiter even though it fits"
         );
 
         // Drain the queue: releasing the holder frees 3 chunks; the parked 2-chunk
@@ -641,7 +630,7 @@ mod tests {
         assert_eq!(budget.in_use_chunks(), 2);
 
         // Same 1-chunk request now succeeds: the queue is empty and 2 chunks are
-        // free, confirming the earlier rejection was no-barge, not exhaustion.
+        // free, confirming the earlier rejection was arrival order, not exhaustion.
         assert!(
             budget.try_reserve(chunk).is_some(),
             "with an empty queue and free capacity the request now fits"

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -393,9 +393,21 @@ impl Drop for WaitTicket {
                 drop(res);
             }
             WaitState::Waiting => {
-                // Cancel: remove this waiter from the queue.
-                let mut inner = self.budget.inner.lock();
-                inner.waiters.retain(|w| !Arc::ptr_eq(&w.slot, &self.slot));
+                // Cancel: remove this waiter from the queue, then drain. Removing a
+                // queued waiter can unblock those behind it — cancelling the front
+                // exposes the next waiter to free capacity that arrival order had held
+                // it back from — so the queue must be re-evaluated here, or that waiter
+                // stays parked until an unrelated reservation happens to release.
+                // Notifies fire after the budget lock is dropped (the same discipline
+                // `Reservation::drop` follows).
+                let notifies = {
+                    let mut inner = self.budget.inner.lock();
+                    inner.waiters.retain(|w| !Arc::ptr_eq(&w.slot, &self.slot));
+                    drain(&self.budget, &mut inner)
+                };
+                for f in notifies {
+                    f();
+                }
             }
             WaitState::Taken => {}
         }
@@ -812,6 +824,58 @@ mod tests {
     }
 
     #[test]
+    fn test_cancel_front_waiter_grants_next_that_now_fits() {
+        // Arrival order can park a waiter that would fit on free capacity behind a
+        // larger front waiter. If the front is then cancelled, the freed head-of-line
+        // must let the next waiter through immediately — the cancel is what unblocks
+        // it, so the cancel path must drain. Otherwise it stays parked until some
+        // unrelated reservation happens to release (a liveness gap).
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 4, chunk); // capacity = 4 chunks
+        let (n_hold, _) = notify_flag();
+        let (n_big, flag_big) = notify_flag();
+        let (n_small, flag_small) = notify_flag();
+
+        // Hold 3 of 4 chunks: 1 free.
+        let _holder = match budget.reserve(chunk * 3, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Front waiter needs 2 (does not fit: 1 free < 2) → parks.
+        let ticket_big = match budget.reserve(chunk * 2, n_big) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+        // Next waiter needs 1 (would fit on the 1 free chunk) but parks behind the
+        // larger front — arrival order forbids jumping it.
+        let mut ticket_small = match budget.reserve(chunk, n_small) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+        assert_eq!(budget.stats().waiters, 2);
+
+        // Cancel the FRONT waiter. No reservation releases here — `_holder` still holds
+        // its 3 chunks. The small waiter is now the front and fits on the 1 free chunk.
+        drop(ticket_big);
+
+        // The cancel must have drained the queue and granted the small waiter.
+        assert!(
+            flag_small.load(Ordering::Acquire),
+            "cancelling the front waiter must grant the next one that now fits"
+        );
+        assert!(
+            !flag_big.load(Ordering::Acquire),
+            "cancelled waiter is not granted"
+        );
+        let _res_small = ticket_small
+            .take()
+            .expect("small waiter granted by the cancel");
+        assert_eq!(budget.in_use_chunks(), 4, "3 held + 1 just granted");
+        assert_eq!(budget.stats().waiters, 0);
+    }
+
+    #[test]
     fn test_wait_ticket_drop_after_granted_returns_chunks() {
         let chunk = 1024;
         let budget = MemoryBudget::new(chunk * 2, chunk); // 2 chunks
@@ -936,6 +1000,54 @@ mod loom_tests {
 
             drop(granted);
             drop(ticket);
+            assert_eq!(budget.in_use_chunks(), 0);
+        });
+    }
+
+    #[test]
+    fn cancel_front_grants_next_races_take() {
+        // Cancelling the front waiter drains the queue and can grant the next waiter,
+        // so the cancel path takes `budget -> slot` (to store the grant) just like a
+        // release. This races that cancel against the granted waiter's `take`. The
+        // cancelling thread already released its own slot lock before taking the budget
+        // lock (WaitTicket::drop extracts state first), so no `slot -> budget` inversion
+        // exists; loom exhausts the interleavings and would report a deadlock or a
+        // double/lost grant.
+        loom::model(|| {
+            let chunk = 1024;
+            let budget = MemoryBudget::new(chunk, chunk); // capacity = 1 chunk
+
+            // Holder pins the single chunk; front and next both park behind it.
+            let holder = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Ready(r) => r,
+                Reserve::Pending(_) => unreachable!("first reserve fits"),
+            };
+            let front = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Pending(t) => t,
+                Reserve::Ready(_) => unreachable!("budget is full"),
+            };
+            let mut next = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Pending(t) => t,
+                Reserve::Ready(_) => unreachable!("budget is full"),
+            };
+
+            // Free the chunk, then race cancelling the front (which drains and grants
+            // `next`) against `next.take()`.
+            drop(holder);
+            let h = thread::spawn(move || drop(front));
+            let taken = next.take();
+            h.join().unwrap();
+
+            // The freed chunk reaches `next` exactly once, via whichever side wins.
+            let granted = taken.or_else(|| next.take());
+            assert!(
+                granted.is_some(),
+                "cancelling the front must grant the next waiter that now fits"
+            );
+            assert_eq!(budget.in_use_chunks(), 1);
+
+            drop(granted);
+            drop(next);
             assert_eq!(budget.in_use_chunks(), 0);
         });
     }

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -7,12 +7,25 @@
 //!
 //! `MemoryBudget` tracks how many fixed-size chunks of memory are logically
 //! reserved across all transfers. It grants reservations (RAII tickets whose drop
-//! returns chunks), parks callers when the budget is exhausted, and wakes them
-//! strictly FIFO as chunks are released.
+//! returns chunks), parks callers when the budget is exhausted, and wakes them in
+//! strict arrival order as chunks are released.
 //!
-//! The download path reserves against it (see `operation::download::transfer`); a
-//! couple of methods are consumed only by tests or future callers and carry their
-//! own gating.
+//! # Admission order
+//!
+//! Reservations are granted first-come-first-served: a request is served only once
+//! every earlier-queued request has been. A fresh request never jumps one already
+//! waiting, even when free chunks would satisfy it, and the release-time drain
+//! stops at the first queued request that does not fit rather than serving smaller
+//! ones behind it. This bounds the wait for every `need <= capacity` request: once
+//! queued it sees `in_use` only fall until its need is met, so a stream of smaller
+//! requests can never indefinitely defer a larger one ahead of them. The cost is
+//! head-of-line blocking — a large request at the front idles the budget while
+//! free chunks accumulate to its need — which arises only under mixed part sizes;
+//! a uniform part size never triggers it.
+//!
+//! The download path reserves against it (see `operation::download::transfer`).
+//! `set_limit` and a few introspection methods are not yet wired to a caller and
+//! carry their own gating.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -144,9 +157,10 @@ fn can_grant(need: u64, in_use: u64, capacity: u64) -> bool {
     need <= capacity.saturating_sub(in_use) || in_use == 0
 }
 
-/// Drain the wait queue strictly FIFO. Grants the front waiter if it fits, stops
-/// at the first that does not (no skip-ahead). Returns collected NotifyFns that
-/// callers MUST invoke AFTER releasing the budget lock.
+/// Drain the wait queue in arrival order. Grants the front waiter if it fits, stops
+/// at the first that does not (no skip-ahead, so a smaller request behind a too-large
+/// front is not served early). Returns collected NotifyFns that callers MUST invoke
+/// AFTER releasing the budget lock.
 fn drain(budget: &Arc<MemoryBudget>, inner: &mut Inner) -> Vec<NotifyFn> {
     let mut notifies = Vec::new();
     while let Some(front) = inner.waiters.front() {
@@ -216,21 +230,16 @@ impl MemoryBudget {
         bytes.div_ceil(self.chunk) as u64
     }
 
-    /// Attempt an immediate grant without parking. Returns `None` if the queue is non-empty
-    /// (no-barge) or the request does not fit; registers no waker and never enqueues a waiter.
-    /// Grants under exactly the condition [`reserve`](Self::reserve) returns `Ready`, so it is
-    /// the allocation-free fast path when a caller can re-drive itself on failure.
+    /// Attempt an immediate grant without parking. Returns `None` if a request is already
+    /// queued (arrival order is preserved) or this one does not fit; registers no waker and
+    /// never enqueues a waiter. Grants under exactly the condition [`reserve`](Self::reserve)
+    /// returns `Ready`, so it is the allocation-free fast path when a caller can re-drive
+    /// itself on failure.
     pub(crate) fn try_reserve(self: &Arc<Self>, bytes: usize) -> Option<Reservation> {
         let need = self.chunks_for(bytes);
         let mut inner = self.inner.lock();
-        // No-barge: a fresh request never jumps a queued waiter, even if it would fit.
-        // Combined with strict-FIFO drain (which stops at the first front that does not
-        // fit), this makes a front waiter see in_use only fall until its need is met, so it
-        // is never starved for need <= capacity. Bargeing would let a stream of small
-        // requests indefinitely starve a larger queued one. Cost: strict FIFO
-        // head-of-line-blocks smaller requests behind a large front waiter (the budget
-        // idles while it accumulates) — bounded, only under mixed part sizes; uniform part
-        // size never triggers it.
+        // Arrival-order admission (see module doc): a queued request is never bypassed,
+        // even by a fresh one that would fit.
         if !inner.waiters.is_empty() {
             return None;
         }
@@ -251,14 +260,8 @@ impl MemoryBudget {
     pub(crate) fn reserve(self: &Arc<Self>, bytes: usize, notify: NotifyFn) -> Reserve {
         let need = self.chunks_for(bytes);
         let mut inner = self.inner.lock();
-        // No-barge: a fresh request never jumps a queued waiter, even if it would fit.
-        // Combined with strict-FIFO drain (which stops at the first front that does not
-        // fit), this makes a front waiter see in_use only fall until its need is met, so it
-        // is never starved for need <= capacity. Bargeing would let a stream of small
-        // requests indefinitely starve a larger queued one. Cost: strict FIFO
-        // head-of-line-blocks smaller requests behind a large front waiter (the budget
-        // idles while it accumulates) — bounded, only under mixed part sizes; uniform part
-        // size never triggers it.
+        // Arrival-order admission (see module doc): a queued request is never bypassed,
+        // even by a fresh one that would fit.
         if inner.waiters.is_empty() && can_grant(need, inner.in_use, inner.capacity) {
             inner.in_use += need;
             tracing::trace!(
@@ -303,8 +306,7 @@ impl MemoryBudget {
     /// Resize the capacity (in bytes). Growing may drain parked waiters. Shrinking is soft: it
     /// never revokes already-granted chunks, only tightens future grants.
     ///
-    /// The budget is resizable by design; the measured/adaptive sizing loop that will drive this
-    /// is tracked in the memory-budget workstream. `allow(dead_code)` until that caller lands.
+    /// Resizable by design, but not yet wired to a caller, so it carries `allow(dead_code)`.
     #[allow(dead_code)]
     pub(crate) fn set_limit(self: &Arc<Self>, capacity_bytes: usize) {
         let new_capacity = (capacity_bytes / self.chunk) as u64;
@@ -860,6 +862,7 @@ mod tests {
 #[cfg(all(test, s3_tm_loom))]
 mod loom_tests {
     use super::*;
+    use crate::runtime::sync::sync::atomic::{AtomicBool, Ordering};
     use crate::runtime::sync::thread;
 
     fn noop_notify() -> NotifyFn {
@@ -901,15 +904,29 @@ mod loom_tests {
         // Releasing the holder (drain stores the grant) races the waiter taking it.
         // After both complete the grant is delivered exactly once and accounting is
         // consistent across release.
+        //
+        // The waiter carries a real `NotifyFn` (production passes `scheduler.wake`, which
+        // re-polls the parked transfer) rather than a no-op, so the release exercises the
+        // actual notify path: `Reservation::drop` collects notifies under the budget lock
+        // AFTER the drain has stored every grant, then fires them once the lock is dropped.
+        // A regression that fired the notify before publishing the grant — the lost-wake
+        // class this wireup is exposed to — would let the woken side take() nothing, which
+        // the `taken.or_else(take)` recovery plus the exactly-once accounting below catch.
         loom::model(|| {
             let chunk = 1024;
             let budget = MemoryBudget::new(chunk, chunk); // capacity = 1 chunk
+
+            let woken = Arc::new(AtomicBool::new(false));
+            let notify: NotifyFn = {
+                let woken = Arc::clone(&woken);
+                Arc::new(move || woken.store(true, Ordering::SeqCst))
+            };
 
             let holder = match budget.reserve(chunk, noop_notify()) {
                 Reserve::Ready(r) => r,
                 Reserve::Pending(_) => unreachable!("first reserve fits"),
             };
-            let mut ticket = match budget.reserve(chunk, noop_notify()) {
+            let mut ticket = match budget.reserve(chunk, notify) {
                 Reserve::Pending(t) => t,
                 Reserve::Ready(_) => unreachable!("budget is full"),
             };
@@ -922,6 +939,10 @@ mod loom_tests {
             // or a second take() retrieves it now.
             let granted = taken.or_else(|| ticket.take());
             assert!(granted.is_some(), "waiter must be granted after release");
+            assert!(
+                woken.load(Ordering::SeqCst),
+                "release must fire the parked waiter's notify",
+            );
             assert_eq!(budget.in_use_chunks(), 1);
 
             drop(granted);

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -1,0 +1,895 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Fungible global memory admission-control budget.
+//!
+//! `MemoryBudget` tracks how many fixed-size chunks of memory are logically
+//! reserved across all transfers. It grants reservations (RAII tickets whose drop
+//! returns chunks), parks callers when the budget is exhausted, and wakes them
+//! strictly FIFO as chunks are released.
+//!
+//! The primitive is complete and unit-tested but not yet wired into a transfer:
+//! the download reserve/release integration is deferred to the receive-buffer
+//! rework (see the memory-budget notes in the project workspace). Until then the
+//! whole module is dead code.
+#![allow(dead_code)]
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use crate::metrics::unit::ByteUnit;
+// The compat-layer Mutex is loom-instrumented under `cfg(s3_tm_loom)`, which is
+// what exercises the budget/slot lock-ordering invariant. `Arc` stays `std`: the
+// budget is held as `std::sync::Arc` across the call graph, and loom tracks the
+// locks, not the refcount.
+use crate::runtime::sync::Mutex;
+
+/// Closure the budget invokes to wake a parked reserver (= `scheduler.wake(tid)`).
+pub(crate) type NotifyFn = Arc<dyn Fn() + Send + Sync>;
+
+/// Fungible global memory budget. Accounts in fixed-size chunks; grants RAII
+/// `Reservation` tickets whose drop returns chunks and wakes parked waiters.
+pub(crate) struct MemoryBudget {
+    inner: Mutex<Inner>,
+    /// Fixed nominal accounting unit, in bytes (e.g. 8 MiB). NOT any transfer's
+    /// part size: a part of `n` bytes costs `ceil(n / chunk)` chunks, so a 16 MiB
+    /// part against an 8 MiB chunk costs 2. Bounds accounting error to within one
+    /// chunk per reservation while keeping the budget part-size-agnostic.
+    chunk: usize,
+}
+
+impl std::fmt::Debug for MemoryBudget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryBudget")
+            .field("chunk", &self.chunk)
+            .finish_non_exhaustive()
+    }
+}
+
+// Lock-ordering invariant (developer note).
+//
+// Two lock flavors exist: the budget lock (`MemoryBudget.inner`) and per-waiter
+// slot locks (`WaitSlot.state`). The orderings `budget → slot` (drain stores a
+// grant) and `slot → budget` (WaitTicket::drop acts on a waiter) must NEVER nest,
+// or they deadlock: drain holds budget and takes slot while a concurrent
+// WaitTicket::drop holds slot and takes budget. Enforced by:
+// - `drain`: takes a slot lock only briefly to store a grant; never drops a
+//   Reservation while holding a slot lock.
+// - `WaitTicket::take`: takes the slot lock only; never touches the budget lock.
+// - `WaitTicket::drop`: takes the slot lock, extracts the state, RELEASES the slot
+//   lock, THEN acts (dropping a granted Reservation re-locks budget; canceling a
+//   Waiting entry locks budget). Neither path holds slot while taking budget.
+
+/// Budget state behind the single budget lock.
+struct Inner {
+    /// Chunks currently reserved (granted and not yet released).
+    in_use: u64,
+    /// Chunk ceiling; resizable via `set_limit`.
+    capacity: u64,
+    /// Parked requests in strict arrival order; the front is served first.
+    waiters: VecDeque<Waiter>,
+    /// Cumulative count of requests that ever parked (returned `Pending`).
+    /// Monotonic; distinguishes a budget that has bound from one that never has.
+    total_parked: u64,
+}
+
+/// A parked reservation request: how many chunks it needs, the slot through which
+/// drain delivers its grant, and the closure to wake it once granted.
+struct Waiter {
+    need: u64,
+    slot: Arc<WaitSlot>,
+    notify: NotifyFn,
+}
+
+/// Per-waiter slot through which drain delivers a granted Reservation. Carries its
+/// own lock so a grant can be stored without holding the budget lock for long.
+struct WaitSlot {
+    state: Mutex<WaitState>,
+}
+
+/// Lifecycle of a parked request's slot.
+enum WaitState {
+    /// Enqueued, not yet granted.
+    Waiting,
+    /// drain has granted a reservation; awaiting `WaitTicket::take`.
+    Granted(Reservation),
+    /// The grant was taken (or the ticket dropped); terminal.
+    Taken,
+}
+
+/// Result of `MemoryBudget::reserve`: either an immediate grant or a ticket to
+/// poll later after the budget wakes the caller.
+pub(crate) enum Reserve {
+    /// The request fit immediately; chunks are reserved.
+    Ready(Reservation),
+    /// The request was enqueued; poll the ticket after the notify fires.
+    Pending(WaitTicket),
+}
+
+/// RAII ticket representing reserved chunks. Drop returns the chunks to the budget
+/// and drains parked waiters that now fit.
+pub(crate) struct Reservation {
+    budget: Arc<MemoryBudget>,
+    chunks: u64,
+}
+
+/// Opaque handle to a parked reservation request. The caller holds this until
+/// `take()` yields the granted `Reservation` (after the budget's notify fires).
+pub(crate) struct WaitTicket {
+    slot: Arc<WaitSlot>,
+    budget: Arc<MemoryBudget>,
+}
+
+impl std::fmt::Debug for WaitTicket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WaitTicket").finish_non_exhaustive()
+    }
+}
+
+/// Nominal 8 MiB accounting unit for budget reservations. A part costs
+/// `ceil(part_size / chunk)` chunks, so non-uniform part sizes account correctly.
+pub(crate) const BUDGET_CHUNK_BYTES: usize = 8 * ByteUnit::Mebibyte.as_bytes_usize();
+/// Non-binding budget for test handles, which size objects far below it.
+#[cfg(test)]
+pub(crate) const DEFAULT_MEMORY_BUDGET_BYTES: usize = 8 * ByteUnit::Gibibyte.as_bytes_usize();
+
+// A request fits when the free chunks cover its need. The `in_use == 0` clause is
+// the forced grant: a request larger than the entire capacity can only ever proceed
+// when nothing else holds the budget, and strict FIFO guarantees that point is
+// eventually reached for the front waiter. This is the sole path by which a
+// `need > capacity` request makes progress (the upload / un-sliced-object backstop;
+// downloads slice to part_size so never hit it). Without it such a request would
+// park forever.
+fn can_grant(need: u64, in_use: u64, capacity: u64) -> bool {
+    need <= capacity.saturating_sub(in_use) || in_use == 0
+}
+
+/// Drain the wait queue strictly FIFO. Grants the front waiter if it fits, stops
+/// at the first that does not (no skip-ahead). Returns collected NotifyFns that
+/// callers MUST invoke AFTER releasing the budget lock.
+fn drain(budget: &Arc<MemoryBudget>, inner: &mut Inner) -> Vec<NotifyFn> {
+    let mut notifies = Vec::new();
+    while let Some(front) = inner.waiters.front() {
+        if !can_grant(front.need, inner.in_use, inner.capacity) {
+            break;
+        }
+        let waiter = inner.waiters.pop_front().unwrap();
+        inner.in_use += waiter.need;
+        let reservation = Reservation {
+            budget: budget.clone(),
+            chunks: waiter.need,
+        };
+        {
+            let mut slot_state = waiter.slot.state.lock();
+            *slot_state = WaitState::Granted(reservation);
+        }
+        notifies.push(waiter.notify);
+    }
+    notifies
+}
+
+impl MemoryBudget {
+    /// Create a new budget. `chunk_bytes` is the fixed accounting unit (must be > 0).
+    /// Capacity is `floor(capacity_bytes / chunk_bytes)` chunks, with a floor of one
+    /// chunk: a capacity that rounds to zero would force every request through the
+    /// idle-only grant path, serializing all transfers, so a budget configured below
+    /// one chunk is raised to one rather than silently throttling to a single part.
+    pub(crate) fn new(capacity_bytes: usize, chunk_bytes: usize) -> Arc<Self> {
+        assert!(chunk_bytes > 0, "chunk_bytes must be > 0");
+        let capacity = (capacity_bytes / chunk_bytes).max(1) as u64;
+        if capacity_bytes < chunk_bytes {
+            tracing::debug!(
+                requested_bytes = capacity_bytes,
+                chunk_bytes,
+                "memory budget below one chunk; raised to a single chunk"
+            );
+        }
+        tracing::debug!(
+            capacity_chunks = capacity,
+            chunk_bytes,
+            "memory budget resolved"
+        );
+        Arc::new(Self {
+            inner: Mutex::new(Inner {
+                in_use: 0,
+                capacity,
+                waiters: VecDeque::new(),
+                total_parked: 0,
+            }),
+            chunk: chunk_bytes,
+        })
+    }
+
+    /// Number of chunks required to hold `bytes` (ceiling division).
+    pub(crate) fn chunks_for(&self, bytes: usize) -> u64 {
+        if bytes == 0 {
+            return 0;
+        }
+        bytes.div_ceil(self.chunk) as u64
+    }
+
+    /// Attempt an immediate grant without parking. Returns None if the queue is
+    /// non-empty (no-barge) or the request does not fit. Unlike
+    /// [`reserve`](Self::reserve) it never enqueues a waiter and registers no waker.
+    pub(crate) fn try_reserve(self: &Arc<Self>, bytes: usize) -> Option<Reservation> {
+        let need = self.chunks_for(bytes);
+        let mut inner = self.inner.lock();
+        // No-barge: a fresh request never jumps a queued waiter, even if it would fit.
+        // Combined with strict-FIFO drain (which stops at the first front that does not
+        // fit), this makes a front waiter see in_use only fall until its need is met, so it
+        // is never starved for need <= capacity. Bargeing would let a stream of small
+        // requests indefinitely starve a larger queued one. Cost: strict FIFO
+        // head-of-line-blocks smaller requests behind a large front waiter (the budget
+        // idles while it accumulates) — bounded, only under mixed part sizes; uniform part
+        // size never triggers it.
+        if !inner.waiters.is_empty() {
+            return None;
+        }
+        if can_grant(need, inner.in_use, inner.capacity) {
+            inner.in_use += need;
+            Some(Reservation {
+                budget: Arc::clone(self),
+                chunks: need,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Reserve chunks for `bytes`. Returns `Ready` with an immediate grant when the
+    /// queue is empty and the request fits, otherwise enqueues a waiter and returns
+    /// `Pending` with a `WaitTicket`.
+    pub(crate) fn reserve(self: &Arc<Self>, bytes: usize, notify: NotifyFn) -> Reserve {
+        let need = self.chunks_for(bytes);
+        let mut inner = self.inner.lock();
+        // No-barge: a fresh request never jumps a queued waiter, even if it would fit.
+        // Combined with strict-FIFO drain (which stops at the first front that does not
+        // fit), this makes a front waiter see in_use only fall until its need is met, so it
+        // is never starved for need <= capacity. Bargeing would let a stream of small
+        // requests indefinitely starve a larger queued one. Cost: strict FIFO
+        // head-of-line-blocks smaller requests behind a large front waiter (the budget
+        // idles while it accumulates) — bounded, only under mixed part sizes; uniform part
+        // size never triggers it.
+        if inner.waiters.is_empty() && can_grant(need, inner.in_use, inner.capacity) {
+            inner.in_use += need;
+            return Reserve::Ready(Reservation {
+                budget: Arc::clone(self),
+                chunks: need,
+            });
+        }
+        let slot = Arc::new(WaitSlot {
+            state: Mutex::new(WaitState::Waiting),
+        });
+        inner.waiters.push_back(Waiter {
+            need,
+            slot: Arc::clone(&slot),
+            notify,
+        });
+        inner.total_parked += 1;
+        Reserve::Pending(WaitTicket {
+            slot,
+            budget: Arc::clone(self),
+        })
+    }
+
+    /// Resize the capacity (in bytes). Growing may drain parked waiters. Shrinking
+    /// is soft: never revokes already-granted chunks, just tightens future grants.
+    pub(crate) fn set_limit(self: &Arc<Self>, capacity_bytes: usize) {
+        let new_capacity = (capacity_bytes / self.chunk) as u64;
+        let notifies = {
+            let mut inner = self.inner.lock();
+            inner.capacity = new_capacity;
+            drain(self, &mut inner)
+        };
+        for f in notifies {
+            f();
+        }
+    }
+
+    /// Chunks currently reserved (granted and not yet released).
+    pub(crate) fn in_use_chunks(&self) -> u64 {
+        self.inner.lock().in_use
+    }
+
+    /// Current capacity in chunks.
+    pub(crate) fn capacity_chunks(&self) -> u64 {
+        self.inner.lock().capacity
+    }
+
+    /// The fixed chunk size in bytes.
+    pub(crate) fn chunk_bytes(&self) -> usize {
+        self.chunk
+    }
+
+    /// Snapshot the budget's admission state under a single lock. Chunk counts are
+    /// converted to bytes; `reserved_bytes` is admitted memory (a ceiling), not
+    /// resident memory.
+    pub(crate) fn stats(&self) -> crate::types::MemoryBudgetSnapshot {
+        let inner = self.inner.lock();
+        crate::types::MemoryBudgetSnapshot {
+            capacity_bytes: inner.capacity * self.chunk as u64,
+            reserved_bytes: inner.in_use * self.chunk as u64,
+            waiters: inner.waiters.len(),
+            total_parked: inner.total_parked,
+        }
+    }
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        let notifies = {
+            let mut inner = self.budget.inner.lock();
+            inner.in_use = inner.in_use.saturating_sub(self.chunks);
+            drain(&self.budget, &mut inner)
+        };
+        for f in notifies {
+            f();
+        }
+    }
+}
+
+impl WaitTicket {
+    /// If the budget has granted this ticket's reservation, take it out and return
+    /// it. Returns None if still waiting or already taken.
+    pub(crate) fn take(&mut self) -> Option<Reservation> {
+        let mut slot_state = self.slot.state.lock();
+        let state = std::mem::replace(&mut *slot_state, WaitState::Taken);
+        match state {
+            WaitState::Granted(res) => Some(res),
+            WaitState::Waiting => {
+                *slot_state = WaitState::Waiting;
+                None
+            }
+            WaitState::Taken => {
+                *slot_state = WaitState::Taken;
+                None
+            }
+        }
+    }
+}
+
+impl Drop for WaitTicket {
+    fn drop(&mut self) {
+        // Take the state out under the slot lock, then release it before acting.
+        let state = {
+            let mut slot_state = self.slot.state.lock();
+            std::mem::replace(&mut *slot_state, WaitState::Taken)
+        };
+        // Slot lock is released here. Now act on the extracted state.
+        match state {
+            WaitState::Granted(res) => {
+                // Granted but never taken: drop the reservation to return chunks.
+                // Safe: slot lock is released, so Reservation::drop can lock the budget.
+                drop(res);
+            }
+            WaitState::Waiting => {
+                // Cancel: remove this waiter from the queue.
+                let mut inner = self.budget.inner.lock();
+                inner.waiters.retain(|w| !Arc::ptr_eq(&w.slot, &self.slot));
+            }
+            WaitState::Taken => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+    fn notify_flag() -> (NotifyFn, Arc<AtomicBool>) {
+        let flag = Arc::new(AtomicBool::new(false));
+        let f = Arc::clone(&flag);
+        (Arc::new(move || f.store(true, Ordering::Release)), flag)
+    }
+
+    fn notify_counter() -> (NotifyFn, Arc<AtomicU64>) {
+        let counter = Arc::new(AtomicU64::new(0));
+        let c = Arc::clone(&counter);
+        (
+            Arc::new(move || {
+                c.fetch_add(1, Ordering::Release);
+            }),
+            counter,
+        )
+    }
+
+    #[test]
+    fn test_chunks_for_rounds_up() {
+        let budget = MemoryBudget::new(1024, 100);
+        assert_eq!(budget.chunks_for(0), 0);
+        assert_eq!(budget.chunks_for(1), 1);
+        assert_eq!(budget.chunks_for(100), 1);
+        assert_eq!(budget.chunks_for(101), 2);
+    }
+
+    #[test]
+    fn test_capacity_floored_at_one_chunk() {
+        // A budget configured below one chunk would otherwise round to zero
+        // capacity, forcing every request through the idle-only grant path and
+        // serializing transfers. It is raised to one chunk instead.
+        let chunk = 8 * 1024 * 1024;
+        let budget = MemoryBudget::new(chunk / 2, chunk);
+        assert_eq!(budget.capacity_chunks(), 1);
+        // The first request fits; a second parks rather than barging.
+        let first = budget.try_reserve(chunk);
+        assert!(first.is_some());
+        assert!(budget.try_reserve(chunk).is_none());
+    }
+
+    #[test]
+    fn test_stats_reports_bytes_and_park_counter() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 2, chunk); // capacity = 2 chunks
+
+        let s = budget.stats();
+        assert_eq!(s.capacity_bytes, (chunk * 2) as u64);
+        assert_eq!(s.reserved_bytes, 0);
+        assert_eq!(s.waiters, 0);
+        assert_eq!(s.total_parked, 0);
+
+        // Reserve both chunks: reserved tracks in bytes, still no parking.
+        let holder = match budget.reserve(chunk * 2, notify_flag().0) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+        let s = budget.stats();
+        assert_eq!(s.reserved_bytes, (chunk * 2) as u64);
+        assert_eq!(s.waiters, 0);
+        assert_eq!(s.total_parked, 0);
+
+        // Next request parks: waiters rises and the cumulative counter ticks.
+        let ticket = match budget.reserve(chunk, notify_flag().0) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+        let s = budget.stats();
+        assert_eq!(s.waiters, 1);
+        assert_eq!(s.total_parked, 1);
+
+        // Drop the waiter: waiters falls back, but total_parked is monotonic.
+        drop(ticket);
+        let s = budget.stats();
+        assert_eq!(s.waiters, 0);
+        assert_eq!(s.total_parked, 1, "park counter is cumulative");
+
+        drop(holder);
+    }
+
+    #[test]
+    fn test_reserve_within_capacity_is_ready_and_tracks_in_use() {
+        let chunk = 8 * 1024 * 1024; // 8 MiB
+        let budget = MemoryBudget::new(chunk * 4, chunk);
+        let (notify, _flag) = notify_flag();
+
+        match budget.reserve(chunk * 2, notify) {
+            Reserve::Ready(_res) => {
+                assert_eq!(budget.in_use_chunks(), 2);
+            }
+            Reserve::Pending(_) => panic!("expected Ready"),
+        }
+    }
+
+    #[test]
+    fn test_drop_returns_chunks() {
+        let chunk = 8 * 1024 * 1024;
+        let budget = MemoryBudget::new(chunk * 4, chunk);
+        let (notify, _flag) = notify_flag();
+
+        let res = match budget.reserve(chunk * 2, notify) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+        assert_eq!(budget.in_use_chunks(), 2);
+        drop(res);
+        assert_eq!(budget.in_use_chunks(), 0);
+    }
+
+    #[test]
+    fn test_exhaustion_returns_pending_then_release_grants_waiter() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 2, chunk); // 2 chunks capacity
+        let (n1, _) = notify_flag();
+        let (n2, flag2) = notify_flag();
+        let (n2_counter, counter) = notify_counter();
+        // Use counter-based notify to check exactly-once
+        let _ = n2; // discard flag-based
+        let _ = flag2;
+
+        // Fill capacity
+        let res1 = match budget.reserve(chunk * 2, n1) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+        assert_eq!(budget.in_use_chunks(), 2);
+
+        // Next reserve exhausts budget -> Pending
+        let mut ticket = match budget.reserve(chunk, n2_counter) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // ticket.take() is None (still waiting)
+        assert!(ticket.take().is_none());
+
+        // Drop the first reservation -> should grant the waiter
+        drop(res1);
+
+        // Notify fired exactly once
+        assert_eq!(counter.load(Ordering::Acquire), 1);
+
+        // ticket.take() now returns Some
+        let res2 = ticket.take().expect("should be granted");
+        assert_eq!(budget.in_use_chunks(), 1);
+        drop(res2);
+        assert_eq!(budget.in_use_chunks(), 0);
+    }
+
+    #[test]
+    fn test_strict_fifo_two_waiters_granted_in_order() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk, chunk); // capacity = 1 chunk
+        let (n_hold, _) = notify_flag();
+        let (n_a, flag_a) = notify_flag();
+        let (n_b, flag_b) = notify_flag();
+
+        // Hold the single chunk
+        let holder = match budget.reserve(chunk, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Waiter A needs 1 chunk
+        let mut ticket_a = match budget.reserve(chunk, n_a) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Waiter B needs 1 chunk
+        let mut ticket_b = match budget.reserve(chunk, n_b) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Release holder -> A granted, B still waiting
+        drop(holder);
+        assert!(flag_a.load(Ordering::Acquire));
+        assert!(!flag_b.load(Ordering::Acquire));
+
+        let res_a = ticket_a.take().expect("A should be granted");
+        assert!(ticket_b.take().is_none());
+
+        // Release A -> B granted
+        drop(res_a);
+        assert!(flag_b.load(Ordering::Acquire));
+        let _res_b = ticket_b.take().expect("B should be granted");
+    }
+
+    #[test]
+    fn test_no_barge_small_request_does_not_jump_queued_large() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 4, chunk); // 4 chunks capacity
+        let (n_hold, _) = notify_flag();
+        let (n_large, flag_large) = notify_flag();
+
+        // Hold 3 of 4 chunks, leaving 1 free.
+        let holder = match budget.reserve(chunk * 3, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Queue a 2-chunk waiter. It does not fit now (1 free < 2), so it parks.
+        let mut ticket_large = match budget.reserve(chunk * 2, n_large) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // A 1-chunk request WOULD fit on capacity alone (1 chunk is free), so this
+        // isolates no-barge from exhaustion: it is rejected only because a waiter
+        // is queued ahead of it.
+        assert!(
+            budget.try_reserve(chunk).is_none(),
+            "no-barge: must not jump the queued waiter even though it fits"
+        );
+
+        // Drain the queue: releasing the holder frees 3 chunks; the parked 2-chunk
+        // waiter is granted, leaving in_use == 2.
+        drop(holder);
+        assert!(flag_large.load(Ordering::Acquire));
+        let _res_large = ticket_large.take().expect("waiter should be granted");
+        assert_eq!(budget.in_use_chunks(), 2);
+
+        // Same 1-chunk request now succeeds: the queue is empty and 2 chunks are
+        // free, confirming the earlier rejection was no-barge, not exhaustion.
+        assert!(
+            budget.try_reserve(chunk).is_some(),
+            "with an empty queue and free capacity the request now fits"
+        );
+    }
+
+    #[test]
+    fn test_forced_grant_oversized_when_idle() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 2, chunk); // 2 chunks capacity
+
+        // try_reserve of 5 chunks while in_use == 0 -> Ready (forced grant)
+        let res = budget
+            .try_reserve(chunk * 5)
+            .expect("forced grant when idle");
+        assert_eq!(budget.in_use_chunks(), 5);
+        drop(res);
+
+        // Test forced grant via FIFO: hold 1 chunk, queue a 5-chunk waiter,
+        // then release -> waiter granted once in_use hits 0.
+        let (n_hold, _) = notify_flag();
+        let (n_big, flag_big) = notify_flag();
+
+        let holder = match budget.reserve(chunk, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        let mut ticket = match budget.reserve(chunk * 5, n_big) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Release holder -> in_use becomes 0 -> forced grant fires
+        drop(holder);
+        assert!(flag_big.load(Ordering::Acquire));
+        let res = ticket.take().expect("oversized waiter should be granted");
+        assert_eq!(budget.in_use_chunks(), 5);
+        drop(res);
+    }
+
+    #[test]
+    fn test_set_limit_grow_drains_waiters() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk, chunk); // 1 chunk capacity
+        let (n_hold, _) = notify_flag();
+        let (n_wait, flag_wait) = notify_flag();
+
+        // Fill capacity
+        let _holder = match budget.reserve(chunk, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Park a waiter needing 1 chunk
+        let mut ticket = match budget.reserve(chunk, n_wait) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Grow capacity to 2 -> waiter now fits
+        budget.set_limit(chunk * 2);
+        assert!(flag_wait.load(Ordering::Acquire));
+        let _res = ticket.take().expect("should be granted after grow");
+        assert_eq!(budget.in_use_chunks(), 2);
+    }
+
+    #[test]
+    fn test_set_limit_shrink_is_soft() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 4, chunk); // 4 chunks
+        let (n, _) = notify_flag();
+
+        // Reserve 3 chunks
+        let res = match budget.reserve(chunk * 3, n) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+        assert_eq!(budget.in_use_chunks(), 3);
+
+        // Shrink capacity below in_use: no panic, reservation still valid
+        budget.set_limit(chunk); // capacity now 1 chunk
+        assert_eq!(budget.capacity_chunks(), 1);
+        assert_eq!(budget.in_use_chunks(), 3); // unchanged
+
+        // New reserve is gated by lower capacity
+        let (n2, _) = notify_flag();
+        match budget.reserve(chunk, n2) {
+            Reserve::Pending(_) => {} // expected: 3 in_use > 1 capacity
+            Reserve::Ready(_) => panic!("expected Pending under shrunk capacity"),
+        }
+
+        drop(res);
+    }
+
+    #[test]
+    fn test_wait_ticket_drop_while_waiting_removes_from_queue() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk, chunk); // 1 chunk
+        let (n_hold, _) = notify_flag();
+        let (n_wait, flag_wait) = notify_flag();
+
+        // Fill capacity
+        let holder = match budget.reserve(chunk, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Park a waiter
+        let ticket = match budget.reserve(chunk, n_wait) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Drop the ticket (cancel the waiter)
+        drop(ticket);
+
+        // Release the holder — the dropped waiter must not be granted
+        drop(holder);
+        assert!(!flag_wait.load(Ordering::Acquire));
+        assert_eq!(budget.in_use_chunks(), 0);
+
+        // A subsequent waiter works correctly
+        let (n_new, flag_new) = notify_flag();
+        match budget.reserve(chunk, n_new) {
+            Reserve::Ready(_) => {} // queue is empty, fits
+            Reserve::Pending(_) => panic!("expected Ready after cancel"),
+        }
+        let _ = flag_new;
+    }
+
+    #[test]
+    fn test_cancel_middle_waiter_preserves_order_of_others() {
+        // Three waiters queued behind a holder; cancel the middle one. The
+        // remaining two must still be granted in arrival order — guarding against
+        // a cancel that removes the wrong entry (or all entries).
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk, chunk); // capacity = 1 chunk
+        let (n_hold, _) = notify_flag();
+        let (n_a, flag_a) = notify_flag();
+        let (n_b, flag_b) = notify_flag();
+        let (n_c, flag_c) = notify_flag();
+
+        let holder = match budget.reserve(chunk, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+        let mut ticket_a = match budget.reserve(chunk, n_a) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+        let ticket_b = match budget.reserve(chunk, n_b) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+        let mut ticket_c = match budget.reserve(chunk, n_c) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Cancel the middle waiter (B).
+        drop(ticket_b);
+
+        // Release the holder: A (front) is granted; B and C are not yet.
+        drop(holder);
+        assert!(flag_a.load(Ordering::Acquire), "A should be granted first");
+        assert!(!flag_b.load(Ordering::Acquire), "B was cancelled");
+        assert!(!flag_c.load(Ordering::Acquire), "C waits behind A");
+        let res_a = ticket_a.take().expect("A granted");
+
+        // Release A: C is now front (B was removed, not C) and is granted.
+        drop(res_a);
+        assert!(
+            flag_c.load(Ordering::Acquire),
+            "C should be granted after A"
+        );
+        let _res_c = ticket_c.take().expect("C granted");
+        assert_eq!(budget.in_use_chunks(), 1);
+    }
+
+    #[test]
+    fn test_wait_ticket_drop_after_granted_returns_chunks() {
+        let chunk = 1024;
+        let budget = MemoryBudget::new(chunk * 2, chunk); // 2 chunks
+        let (n_hold, _) = notify_flag();
+        let (n_wait, flag_wait) = notify_flag();
+
+        // Reserve 2 chunks (fill capacity)
+        let holder = match budget.reserve(chunk * 2, n_hold) {
+            Reserve::Ready(r) => r,
+            Reserve::Pending(_) => panic!("expected Ready"),
+        };
+
+        // Park a 1-chunk waiter
+        let ticket = match budget.reserve(chunk, n_wait) {
+            Reserve::Pending(t) => t,
+            Reserve::Ready(_) => panic!("expected Pending"),
+        };
+
+        // Release holder: drain grants the waiter (notify fires)
+        drop(holder);
+        assert!(flag_wait.load(Ordering::Acquire));
+        assert_eq!(budget.in_use_chunks(), 1); // 1 chunk granted to waiter
+
+        // Drop the ticket WITHOUT calling take() — granted-but-untaken chunks released
+        drop(ticket);
+        assert_eq!(budget.in_use_chunks(), 0);
+    }
+}
+
+// Concurrency models for the lock-ordering invariant: `drain` takes the budget
+// lock then a slot lock; `WaitTicket::drop` takes a slot lock then the budget
+// lock. The invariant is that these never nest (drain holds the slot lock only to
+// store a grant; WaitTicket::drop releases the slot lock before touching the
+// budget). Loom exhaustively explores the interleavings; a regression that nested
+// the locks would deadlock (loom reports it) and a regression in the accounting
+// would trip an assertion.
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use super::*;
+    use crate::runtime::sync::thread;
+
+    fn noop_notify() -> NotifyFn {
+        Arc::new(|| {})
+    }
+
+    #[test]
+    fn release_races_cancel() {
+        // One holder fills the budget, one waiter is parked. Releasing the holder
+        // (drain: budget -> slot) races dropping the waiter's ticket
+        // (cancel/return: slot -> budget). Whatever the interleaving, the holder's
+        // chunk is returned and the waiter ends with no chunk outstanding.
+        loom::model(|| {
+            let chunk = 1024;
+            let budget = MemoryBudget::new(chunk, chunk); // capacity = 1 chunk
+
+            let holder = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Ready(r) => r,
+                Reserve::Pending(_) => unreachable!("first reserve fits"),
+            };
+            let ticket = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Pending(t) => t,
+                Reserve::Ready(_) => unreachable!("budget is full"),
+            };
+
+            let h = thread::spawn(move || drop(holder));
+            drop(ticket);
+            h.join().unwrap();
+
+            // Reaching here means no deadlock. The waiter was either cancelled
+            // before its grant or granted then released by the ticket drop; either
+            // way nothing remains reserved.
+            assert_eq!(budget.in_use_chunks(), 0);
+        });
+    }
+
+    #[test]
+    fn release_races_take() {
+        // Releasing the holder (drain stores the grant) races the waiter taking it.
+        // After both complete the grant is delivered exactly once and accounting is
+        // consistent across release.
+        loom::model(|| {
+            let chunk = 1024;
+            let budget = MemoryBudget::new(chunk, chunk); // capacity = 1 chunk
+
+            let holder = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Ready(r) => r,
+                Reserve::Pending(_) => unreachable!("first reserve fits"),
+            };
+            let mut ticket = match budget.reserve(chunk, noop_notify()) {
+                Reserve::Pending(t) => t,
+                Reserve::Ready(_) => unreachable!("budget is full"),
+            };
+
+            let h = thread::spawn(move || drop(holder));
+            let taken = ticket.take();
+            h.join().unwrap();
+
+            // The holder is gone, so the grant is available: take() either caught it
+            // or a second take() retrieves it now.
+            let granted = taken.or_else(|| ticket.take());
+            assert!(granted.is_some(), "waiter must be granted after release");
+            assert_eq!(budget.in_use_chunks(), 1);
+
+            drop(granted);
+            drop(ticket);
+            assert_eq!(budget.in_use_chunks(), 0);
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -10,11 +10,9 @@
 //! returns chunks), parks callers when the budget is exhausted, and wakes them
 //! strictly FIFO as chunks are released.
 //!
-//! The primitive is complete and unit-tested but not yet wired into a transfer:
-//! the download reserve/release integration is deferred to the receive-buffer
-//! rework (see the memory-budget notes in the project workspace). Until then the
-//! whole module is dead code.
-#![allow(dead_code)]
+//! The download path reserves against it (see `operation::download::transfer`); a
+//! couple of methods are consumed only by tests or future callers and carry their
+//! own gating.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -157,6 +155,14 @@ fn drain(budget: &Arc<MemoryBudget>, inner: &mut Inner) -> Vec<NotifyFn> {
         }
         let waiter = inner.waiters.pop_front().unwrap();
         inner.in_use += waiter.need;
+        tracing::trace!(
+            target: crate::telemetry::TARGET_MEMORY,
+            need = waiter.need,
+            in_use = inner.in_use,
+            capacity = inner.capacity,
+            waiters = inner.waiters.len(),
+            "budget grant to parked waiter",
+        );
         let reservation = Reservation {
             budget: budget.clone(),
             chunks: waiter.need,
@@ -210,9 +216,10 @@ impl MemoryBudget {
         bytes.div_ceil(self.chunk) as u64
     }
 
-    /// Attempt an immediate grant without parking. Returns None if the queue is
-    /// non-empty (no-barge) or the request does not fit. Unlike
-    /// [`reserve`](Self::reserve) it never enqueues a waiter and registers no waker.
+    /// Attempt an immediate grant without parking. Returns `None` if the queue is non-empty
+    /// (no-barge) or the request does not fit; registers no waker and never enqueues a waiter.
+    /// Grants under exactly the condition [`reserve`](Self::reserve) returns `Ready`, so it is
+    /// the allocation-free fast path when a caller can re-drive itself on failure.
     pub(crate) fn try_reserve(self: &Arc<Self>, bytes: usize) -> Option<Reservation> {
         let need = self.chunks_for(bytes);
         let mut inner = self.inner.lock();
@@ -254,6 +261,13 @@ impl MemoryBudget {
         // size never triggers it.
         if inner.waiters.is_empty() && can_grant(need, inner.in_use, inner.capacity) {
             inner.in_use += need;
+            tracing::trace!(
+                target: crate::telemetry::TARGET_MEMORY,
+                need,
+                in_use = inner.in_use,
+                capacity = inner.capacity,
+                "budget reserve granted",
+            );
             return Reserve::Ready(Reservation {
                 budget: Arc::clone(self),
                 chunks: need,
@@ -268,14 +282,30 @@ impl MemoryBudget {
             notify,
         });
         inner.total_parked += 1;
+        // Saturation edge: a reserve had to park. The budget cannot admit `need`
+        // until a live reservation releases, so a caller that never sees a release
+        // waits here indefinitely. Logged per park (a parked reserve is already a
+        // backpressure event, not steady-state noise).
+        tracing::debug!(
+            target: crate::telemetry::TARGET_MEMORY,
+            need,
+            in_use = inner.in_use,
+            capacity = inner.capacity,
+            waiters = inner.waiters.len(),
+            "budget reserve parked: request queued until a reservation releases",
+        );
         Reserve::Pending(WaitTicket {
             slot,
             budget: Arc::clone(self),
         })
     }
 
-    /// Resize the capacity (in bytes). Growing may drain parked waiters. Shrinking
-    /// is soft: never revokes already-granted chunks, just tightens future grants.
+    /// Resize the capacity (in bytes). Growing may drain parked waiters. Shrinking is soft: it
+    /// never revokes already-granted chunks, only tightens future grants.
+    ///
+    /// The budget is resizable by design; the measured/adaptive sizing loop that will drive this
+    /// is tracked in the memory-budget workstream. `allow(dead_code)` until that caller lands.
+    #[allow(dead_code)]
     pub(crate) fn set_limit(self: &Arc<Self>, capacity_bytes: usize) {
         let new_capacity = (capacity_bytes / self.chunk) as u64;
         let notifies = {
@@ -288,19 +318,18 @@ impl MemoryBudget {
         }
     }
 
-    /// Chunks currently reserved (granted and not yet released).
+    /// Chunks currently reserved (granted and not yet released). Test introspection;
+    /// production reads admission state through [`stats`](Self::stats).
+    #[cfg(test)]
     pub(crate) fn in_use_chunks(&self) -> u64 {
         self.inner.lock().in_use
     }
 
-    /// Current capacity in chunks.
+    /// Current capacity in chunks. Test introspection; production reads admission
+    /// state through [`stats`](Self::stats).
+    #[cfg(test)]
     pub(crate) fn capacity_chunks(&self) -> u64 {
         self.inner.lock().capacity
-    }
-
-    /// The fixed chunk size in bytes.
-    pub(crate) fn chunk_bytes(&self) -> usize {
-        self.chunk
     }
 
     /// Snapshot the budget's admission state under a single lock. Chunk counts are
@@ -322,6 +351,14 @@ impl Drop for Reservation {
         let notifies = {
             let mut inner = self.budget.inner.lock();
             inner.in_use = inner.in_use.saturating_sub(self.chunks);
+            tracing::trace!(
+                target: crate::telemetry::TARGET_MEMORY,
+                released = self.chunks,
+                in_use = inner.in_use,
+                capacity = inner.capacity,
+                waiters = inner.waiters.len(),
+                "budget reservation released",
+            );
             drain(&self.budget, &mut inner)
         };
         for f in notifies {

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -156,7 +156,7 @@ fn drain(budget: &Arc<MemoryBudget>, inner: &mut Inner) -> Vec<NotifyFn> {
         let waiter = inner.waiters.pop_front().unwrap();
         inner.in_use += waiter.need;
         tracing::trace!(
-            target: crate::telemetry::TARGET_MEMORY,
+            target: crate::telemetry::TARGET_SCHEDULING,
             need = waiter.need,
             in_use = inner.in_use,
             capacity = inner.capacity,
@@ -262,7 +262,7 @@ impl MemoryBudget {
         if inner.waiters.is_empty() && can_grant(need, inner.in_use, inner.capacity) {
             inner.in_use += need;
             tracing::trace!(
-                target: crate::telemetry::TARGET_MEMORY,
+                target: crate::telemetry::TARGET_SCHEDULING,
                 need,
                 in_use = inner.in_use,
                 capacity = inner.capacity,
@@ -287,7 +287,7 @@ impl MemoryBudget {
         // waits here indefinitely. Logged per park (a parked reserve is already a
         // backpressure event, not steady-state noise).
         tracing::debug!(
-            target: crate::telemetry::TARGET_MEMORY,
+            target: crate::telemetry::TARGET_SCHEDULING,
             need,
             in_use = inner.in_use,
             capacity = inner.capacity,
@@ -352,7 +352,7 @@ impl Drop for Reservation {
             let mut inner = self.budget.inner.lock();
             inner.in_use = inner.in_use.saturating_sub(self.chunks);
             tracing::trace!(
-                target: crate::telemetry::TARGET_MEMORY,
+                target: crate::telemetry::TARGET_SCHEDULING,
                 released = self.chunks,
                 in_use = inner.in_use,
                 capacity = inner.capacity,

--- a/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
@@ -18,6 +18,7 @@ mod topology;
 pub(crate) use topology::Topology;
 
 pub(crate) mod memory;
+pub(crate) mod platform;
 pub(crate) mod sync;
 
 use aws_smithy_runtime_api::client::http::SharedHttpClient;

--- a/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use managed::ManagedThreadRuntime;
 mod topology;
 pub(crate) use topology::Topology;
 
+pub(crate) mod memory;
 pub(crate) mod sync;
 
 use aws_smithy_runtime_api::client::http::SharedHttpClient;

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -1,0 +1,627 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Machine-resource detection for sizing the connection and memory budgets.
+//!
+//! Detection is best-effort: a failure yields a conservative cap, never an
+//! unbounded one.
+
+use crate::metrics::unit::ByteUnit;
+use std::path::{Path, PathBuf};
+
+// Connection-cap sizing from the descriptor limit and memory budget. The
+// consumer is the managed-runtime connection pool, which caps `max_connections`
+// from these. Each item below carries `#[allow(dead_code)]` until that wiring
+// exists.
+
+/// Fraction of the process file-descriptor limit the connection pool may use.
+/// The remainder is headroom for disk sinks, the directory walker, logging, and
+/// other descriptors the process holds.
+#[allow(dead_code)]
+const POOL_FD_BUDGET_FRACTION: f64 = 0.5;
+
+/// Ceiling on pooled connections regardless of descriptor headroom. Bounds the
+/// request fan-out against a single S3 endpoint, and is the cap on platforms
+/// with no low descriptor limit.
+#[allow(dead_code)]
+const ABSOLUTE_MAX_CONN: usize = 10_000;
+
+/// Floor so a low descriptor limit does not cap the pool below a usable count.
+#[allow(dead_code)]
+const MIN_CONN: usize = 10;
+
+/// Global cap on pooled connections from the descriptor limit alone, used where
+/// the memory budget is not yet known (the runtime-builder default). Machine-
+/// derived and independent of the throughput target. `clamp(POOL_FD_BUDGET_FRACTION
+/// x RLIMIT_NOFILE, MIN_CONN, ABSOLUTE_MAX_CONN)` on Unix; `ABSOLUTE_MAX_CONN`
+/// where there is no low descriptor limit or detection fails.
+#[allow(dead_code)]
+pub(crate) fn connection_cap() -> usize {
+    cap(fd_limit(), usize::MAX)
+}
+
+/// Global connection cap including the memory term: a connection that can never
+/// hold a chunk is wasted, so the budget caps connections at the chunk count it
+/// can fund. `clamp(min(fd_budget, budget_capacity / chunk), MIN_CONN,
+/// ABSOLUTE_MAX_CONN)`.
+#[allow(dead_code)]
+pub(crate) fn connection_cap_with_memory(
+    budget_capacity_bytes: usize,
+    chunk_bytes: usize,
+) -> usize {
+    cap(fd_limit(), budget_capacity_bytes / chunk_bytes.max(1))
+}
+
+/// Apply the descriptor fraction, take the smaller of it and the memory-funded
+/// connection count, and clamp to `[MIN_CONN, ABSOLUTE_MAX_CONN]`.
+#[allow(dead_code)]
+fn cap(fd_limit: Option<usize>, mem_conns: usize) -> usize {
+    let fd_budget = fd_limit
+        .map(|n| (n as f64 * POOL_FD_BUDGET_FRACTION) as usize)
+        .unwrap_or(ABSOLUTE_MAX_CONN);
+    fd_budget.min(mem_conns).clamp(MIN_CONN, ABSOLUTE_MAX_CONN)
+}
+
+/// Soft `RLIMIT_NOFILE` on Unix; `None` where there is no low descriptor limit
+/// or detection fails.
+///
+/// Ref: getrlimit(2) <https://man7.org/linux/man-pages/man2/getrlimit.2.html>
+#[allow(dead_code)]
+#[cfg(unix)]
+fn fd_limit() -> Option<usize> {
+    use nix::sys::resource::{getrlimit, Resource};
+    match getrlimit(Resource::RLIMIT_NOFILE) {
+        Ok((soft, _hard)) if soft > 0 => usize::try_from(soft).ok(),
+        _ => None,
+    }
+}
+
+#[allow(dead_code)]
+#[cfg(not(unix))]
+fn fd_limit() -> Option<usize> {
+    None
+}
+
+/// Share of detected RAM the memory budget may take under `Auto`. The budget is
+/// a good-citizen ceiling: the remainder is left for the OS page cache
+/// (download-to-disk), the rest of this process, and any co-tenant on the box.
+const SAFE_MEM_FRACTION: f64 = 0.25;
+
+/// Floor on the resolved budget. Funds a usable prefetch pipeline (64 chunks at
+/// the 8 MiB accounting unit) on a small or memory-constrained box.
+const MIN_BUDGET_BYTES: usize = 512 * ByteUnit::Mebibyte.as_bytes_usize();
+
+/// Ceiling on the resolved budget. Beyond this, more buffer does not raise
+/// sustained throughput, so a larger box gains nothing and its unclaimed share
+/// stays available to everything else. Caps the effective fraction on big boxes.
+const MAX_BUDGET_BYTES: usize = 32 * ByteUnit::Gibibyte.as_bytes_usize();
+
+/// Budget when RAM cannot be detected (non-Linux, or a read failure). Bounded,
+/// large enough for one transfer's pipeline.
+const UNDETECTABLE_MEM_BYTES: usize = 2 * ByteUnit::Gibibyte.as_bytes_usize();
+
+/// Memory budget under `MemoryBudgetConfig::Auto`: `SAFE_MEM_FRACTION` of
+/// detected RAM, rounded to a power of two and clamped to
+/// `[MIN_BUDGET_BYTES, MAX_BUDGET_BYTES]`; `UNDETECTABLE_MEM_BYTES` when RAM is
+/// unknown.
+///
+/// The budget is a backstop, not the operating point: the concurrency
+/// controller settles at line rate well below it, and it binds only when a slow
+/// consumer backs parts up in the prefetch ring. RAM is an imprecise proxy for
+/// that ceiling — network bandwidth sets the real pipeline depth, and bandwidth
+/// is uncorrelated with RAM across instance families (m5.24xlarge and
+/// m5n.24xlarge share 384 GiB of RAM but differ 4x in bandwidth). The clamp
+/// keeps the estimate safe at both ends; NIC-aware sizing is a separate refinement.
+pub(crate) fn machine_safe_mem() -> usize {
+    auto_budget(available_ram())
+}
+
+/// `Auto` policy as a pure function of detected RAM.
+fn auto_budget(ram: Option<usize>) -> usize {
+    match ram {
+        Some(bytes) => {
+            round_pow2(scale(bytes, SAFE_MEM_FRACTION)).clamp(MIN_BUDGET_BYTES, MAX_BUDGET_BYTES)
+        }
+        None => UNDETECTABLE_MEM_BYTES,
+    }
+}
+
+/// Memory budget for an explicit `MemoryBudgetConfig::Fraction`. The fraction is
+/// clamped to `(0.0, 1.0]` (a non-finite or non-positive value falls back to
+/// `SAFE_MEM_FRACTION`); the result is floored at `MIN_BUDGET_BYTES` but not
+/// capped — an explicit fraction is taken at the caller's word.
+/// `UNDETECTABLE_MEM_BYTES` when RAM is unknown.
+pub(crate) fn mem_for_fraction(fraction: f64) -> usize {
+    if !(fraction.is_finite() && fraction > 0.0) || fraction > 1.0 {
+        tracing::debug!(
+            requested = fraction,
+            "memory budget fraction outside (0.0, 1.0]; clamping"
+        );
+    }
+    mem_for_fraction_from(available_ram(), fraction)
+}
+
+/// `Fraction` policy as a pure function of detected RAM.
+fn mem_for_fraction_from(ram: Option<usize>, fraction: f64) -> usize {
+    let fraction = if fraction.is_finite() && fraction > 0.0 {
+        fraction.min(1.0)
+    } else {
+        SAFE_MEM_FRACTION
+    };
+    match ram {
+        Some(bytes) => scale(bytes, fraction).max(MIN_BUDGET_BYTES),
+        None => UNDETECTABLE_MEM_BYTES,
+    }
+}
+
+/// Apply a fraction to a byte count. The `f64` cast saturates rather than
+/// overflowing; callers validate the fraction first.
+fn scale(bytes: usize, fraction: f64) -> usize {
+    (bytes as f64 * fraction) as usize
+}
+
+/// Round to the nearer power of two; ties round up. `0` maps to `0`. Rounding to
+/// nearest (rather than `next_power_of_two`'s round-up) keeps the budget near the
+/// intended fraction instead of overshooting when the input sits just above a
+/// power of two.
+fn round_pow2(n: usize) -> usize {
+    match n.checked_next_power_of_two() {
+        Some(upper) if upper == n => n,
+        Some(upper) => {
+            let lower = upper >> 1;
+            if n - lower < upper - n {
+                lower
+            } else {
+                upper
+            }
+        }
+        // `n` exceeds the largest power of two: that power is the nearest.
+        None => 1usize << (usize::BITS - 1),
+    }
+}
+
+/// Usable RAM: the smaller of the cgroup memory limit and physical RAM. Linux
+/// only; `None` elsewhere or on a read failure, in which case the caller falls
+/// back to a conservative default.
+#[cfg(target_os = "linux")]
+fn available_ram() -> Option<usize> {
+    match (meminfo_total(), cgroup_mem_limit()) {
+        (Some(total), Some(cgroup)) => Some(total.min(cgroup)),
+        (total, None) => total,
+        (None, cgroup) => cgroup,
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn available_ram() -> Option<usize> {
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn available_ram() -> Option<usize> {
+    // hw.memsize is total physical memory in bytes; macOS has no cgroup.
+    // Ref: sysctl(3), hw.memsize key
+    // <https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sysctl.3.html>
+    let mut bytes: u64 = 0;
+    let mut len = std::mem::size_of::<u64>();
+    // SAFETY: sysctlbyname writes a u64 into `bytes`; `len` holds its size. The
+    // name is a valid nul-terminated string.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            c"hw.memsize".as_ptr(),
+            (&mut bytes as *mut u64).cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc == 0 && bytes > 0 {
+        usize::try_from(bytes).ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn available_ram() -> Option<usize> {
+    use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+    // ullTotalPhys is total physical memory in bytes.
+    // Ref: GlobalMemoryStatusEx / MEMORYSTATUSEX
+    // <https://learn.microsoft.com/windows/win32/api/sysinfoapi/nf-sysinfoapi-globalmemorystatusex>
+    // SAFETY: a zeroed MEMORYSTATUSEX with dwLength set is the documented input;
+    // GlobalMemoryStatusEx fills it and returns nonzero on success.
+    let mut status: MEMORYSTATUSEX = unsafe { std::mem::zeroed() };
+    status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+    let ok = unsafe { GlobalMemoryStatusEx(&mut status) };
+    if ok != 0 && status.ullTotalPhys > 0 {
+        usize::try_from(status.ullTotalPhys).ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn meminfo_total() -> Option<usize> {
+    parse_meminfo_total(&std::fs::read_to_string("/proc/meminfo").ok()?)
+}
+
+/// Effective cgroup memory limit for this process, container-aware: resolve the
+/// process's cgroup path from /proc/self/cgroup, find the controller mount from
+/// /proc/self/mountinfo, and take the min of `memory.max` (v2) /
+/// `memory.limit_in_bytes` (v1) from the leaf cgroup up to the mount root (a
+/// parent cgroup may impose a tighter limit). Tries v2, then v1 (hybrid). `None`
+/// when no limit is set, then `available_ram` uses physical RAM.
+///
+/// Refs: cgroups(7) /proc/[pid]/cgroup <https://man7.org/linux/man-pages/man7/cgroups.7.html>;
+/// cgroup v2 memory.max <https://docs.kernel.org/admin-guide/cgroup-v2.html>;
+/// cgroup v1 memory.limit_in_bytes <https://docs.kernel.org/admin-guide/cgroup-v1/memory.html>
+#[cfg(target_os = "linux")]
+fn cgroup_mem_limit() -> Option<usize> {
+    let proc_cgroup = std::fs::read_to_string("/proc/self/cgroup").ok()?;
+    let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").unwrap_or_default();
+    min_limit(&cgroup_v2_files(&proc_cgroup, &mountinfo))
+        .or_else(|| min_limit(&cgroup_v1_files(&proc_cgroup, &mountinfo)))
+}
+
+/// Read each candidate limit file and return the smallest real limit; "max" and
+/// the v1 unlimited sentinel are ignored ("max" via `parse_cgroup_limit`, the
+/// sentinel via `min` with physical RAM in `available_ram`).
+#[cfg(target_os = "linux")]
+fn min_limit(files: &[PathBuf]) -> Option<usize> {
+    files
+        .iter()
+        .filter_map(|f| std::fs::read_to_string(f).ok())
+        .filter_map(|s| parse_cgroup_limit(&s))
+        .min()
+}
+
+/// Parse `MemTotal` (kB) from /proc/meminfo into bytes. The kernel always emits
+/// this value in kB.
+///
+/// Ref: proc_meminfo(5) <https://man7.org/linux/man-pages/man5/proc_meminfo.5.html>
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_meminfo_total(meminfo: &str) -> Option<usize> {
+    let line = meminfo.lines().find(|l| l.starts_with("MemTotal:"))?;
+    line.split_whitespace()
+        .nth(1)?
+        .parse::<usize>()
+        .ok()?
+        .checked_mul(1024)
+}
+
+/// Parse a cgroup memory-limit value into bytes. "max" (v2 unlimited) yields
+/// `None`. The v1 unlimited sentinel is a huge number that `available_ram`
+/// discards via `min` with physical RAM, so it needs no special case.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_cgroup_limit(raw: &str) -> Option<usize> {
+    let raw = raw.trim();
+    if raw == "max" {
+        return None;
+    }
+    raw.parse().ok()
+}
+
+/// `memory.max` candidate paths for the cgroup v2 unified hierarchy, leaf-first.
+/// Empty when this process has no v2 cgroup line.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn cgroup_v2_files(proc_cgroup: &str, mountinfo: &str) -> Vec<PathBuf> {
+    let Some(path) = cgroup_v2_path(proc_cgroup) else {
+        return Vec::new();
+    };
+    let mount =
+        mountinfo_mount(mountinfo, "cgroup2", None).unwrap_or_else(|| "/sys/fs/cgroup".to_string());
+    walk_paths(&mount, &path, "memory.max")
+}
+
+/// `memory.limit_in_bytes` candidate paths for the cgroup v1 memory controller,
+/// leaf-first. Empty when this process has no v1 memory cgroup line.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn cgroup_v1_files(proc_cgroup: &str, mountinfo: &str) -> Vec<PathBuf> {
+    let Some(path) = cgroup_v1_memory_path(proc_cgroup) else {
+        return Vec::new();
+    };
+    let mount = mountinfo_mount(mountinfo, "cgroup", Some("memory"))
+        .unwrap_or_else(|| "/sys/fs/cgroup/memory".to_string());
+    walk_paths(&mount, &path, "memory.limit_in_bytes")
+}
+
+/// The cgroup path from a v2 unified line (`0::<path>`).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn cgroup_v2_path(proc_cgroup: &str) -> Option<String> {
+    proc_cgroup.lines().find_map(|line| {
+        let mut fields = line.splitn(3, ':');
+        match (fields.next(), fields.next(), fields.next()) {
+            (Some("0"), Some(""), Some(path)) => Some(path.to_string()),
+            _ => None,
+        }
+    })
+}
+
+/// The cgroup path from the v1 line whose controllers include `memory`
+/// (`<id>:<controllers>:<path>`).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn cgroup_v1_memory_path(proc_cgroup: &str) -> Option<String> {
+    proc_cgroup.lines().find_map(|line| {
+        let mut fields = line.splitn(3, ':');
+        let (_id, controllers, path) = (fields.next()?, fields.next()?, fields.next()?);
+        controllers
+            .split(',')
+            .any(|c| c == "memory")
+            .then(|| path.to_string())
+    })
+}
+
+/// Mount point of the first /proc/self/mountinfo entry matching `fstype` and, if
+/// given, containing `super_opt` in its super options. mountinfo splits on " - "
+/// into `<...> mountpoint options [optional]` and `<fstype> <source> <superopts>`.
+///
+/// Ref: proc_pid_mountinfo(5) <https://man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html>
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn mountinfo_mount(mountinfo: &str, fstype: &str, super_opt: Option<&str>) -> Option<String> {
+    mountinfo.lines().find_map(|line| {
+        let (left, right) = line.split_once(" - ")?;
+        let mut right_fields = right.split_whitespace();
+        if right_fields.next()? != fstype {
+            return None;
+        }
+        if let Some(opt) = super_opt {
+            let superopts = right_fields.nth(1).unwrap_or("");
+            if !superopts.split(',').any(|o| o == opt) {
+                return None;
+            }
+        }
+        // mountpoint is the 5th field of the left part.
+        left.split_whitespace().nth(4).map(str::to_string)
+    })
+}
+
+/// Limit-file paths from `<mount><cgroup_path>` up to `<mount>`, leaf-first, so a
+/// tighter parent limit is included.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn walk_paths(mount: &str, cgroup_path: &str, filename: &str) -> Vec<PathBuf> {
+    let mount = Path::new(mount);
+    let rel = cgroup_path.trim_start_matches('/');
+    let mut dir = if rel.is_empty() {
+        mount.to_path_buf()
+    } else {
+        mount.join(rel)
+    };
+    let mut out = Vec::new();
+    loop {
+        out.push(dir.join(filename));
+        if dir == mount {
+            break;
+        }
+        match dir.parent() {
+            Some(parent) if parent.starts_with(mount) => dir = parent.to_path_buf(),
+            _ => break,
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GIB: usize = 1024 * 1024 * 1024;
+
+    #[test]
+    fn test_cap_none_is_absolute_max() {
+        // No detection (non-Unix, or getrlimit failed) -> absolute ceiling.
+        assert_eq!(cap(None, usize::MAX), ABSOLUTE_MAX_CONN);
+    }
+
+    #[test]
+    fn test_cap_low_fd_floored() {
+        // 8 descriptors -> 4 by fraction -> floored to MIN_CONN.
+        assert_eq!(cap(Some(8), usize::MAX), MIN_CONN);
+    }
+
+    #[test]
+    fn test_cap_mid_fd_is_fraction() {
+        assert_eq!(cap(Some(1024), usize::MAX), 512);
+    }
+
+    #[test]
+    fn test_cap_high_fd_clamped() {
+        // 40k descriptors -> 20k by fraction -> clamped to the absolute ceiling.
+        assert_eq!(cap(Some(40_000), usize::MAX), ABSOLUTE_MAX_CONN);
+    }
+
+    #[test]
+    fn test_cap_infinite_fd_saturates() {
+        // RLIM_INFINITY surfaces as usize::MAX; the fraction saturates, then clamps.
+        assert_eq!(cap(Some(usize::MAX), usize::MAX), ABSOLUTE_MAX_CONN);
+    }
+
+    #[test]
+    fn test_cap_memory_term_binds() {
+        // FD allows 512 (1024 x 0.5) but the budget funds only 100 chunks.
+        assert_eq!(cap(Some(1024), 100), 100);
+    }
+
+    #[test]
+    fn test_connection_cap_within_bounds() {
+        assert!((MIN_CONN..=ABSOLUTE_MAX_CONN).contains(&connection_cap()));
+    }
+
+    #[test]
+    fn test_connection_cap_with_memory_is_bounded_by_chunks() {
+        // 16-chunk budget caps connections at 16 (or lower if descriptors are scarce).
+        let chunk = 8 * 1024 * 1024;
+        let cap = connection_cap_with_memory(16 * chunk, chunk);
+        assert!((MIN_CONN..=16).contains(&cap));
+    }
+
+    const MIB: usize = 1024 * 1024;
+
+    #[test]
+    fn test_auto_budget_undetectable_fallback() {
+        assert_eq!(auto_budget(None), UNDETECTABLE_MEM_BYTES);
+    }
+
+    #[test]
+    fn test_auto_budget_tiers() {
+        // Reported RAM runs a little under the marketed size (firmware/kernel
+        // reserve), so 0.25x lands just under a power of two; nearest-rounding
+        // recovers the intended tier. (marketed GiB, reported GiB, expected budget)
+        let cases = [
+            (1.0, 1.0, 512 * MIB),    // floor
+            (2.0, 1.8, 512 * MIB),    // 0.45 GiB -> 512 MiB
+            (4.0, 3.7, GIB),          // 0.93 GiB -> 1 GiB
+            (8.0, 7.7, 2 * GIB),      // 1.93 GiB -> 2 GiB
+            (16.0, 15.3, 4 * GIB),    // 3.83 GiB -> 4 GiB
+            (32.0, 30.6, 8 * GIB),    // 7.65 GiB -> 8 GiB
+            (64.0, 61.0, 16 * GIB),   // 15.25 GiB -> 16 GiB
+            (128.0, 123.0, 32 * GIB), // 30.75 GiB -> 32 GiB (cap)
+            (256.0, 250.0, 32 * GIB), // would be 62 GiB -> capped
+            (512.0, 504.0, 32 * GIB), // capped
+        ];
+        for (marketed, reported_gib, expected) in cases {
+            let ram = (reported_gib * GIB as f64) as usize;
+            assert_eq!(
+                auto_budget(Some(ram)),
+                expected,
+                "marketed {marketed} GiB (reported {reported_gib})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_auto_budget_floor_and_cap_bind() {
+        assert_eq!(auto_budget(Some(0)), MIN_BUDGET_BYTES);
+        assert_eq!(auto_budget(Some(usize::MAX)), MAX_BUDGET_BYTES);
+    }
+
+    #[test]
+    fn test_fraction_applied_uncapped() {
+        // An explicit fraction is taken at the caller's word: no power-of-two
+        // rounding, no ceiling.
+        assert_eq!(mem_for_fraction_from(Some(64 * GIB), 0.5), 32 * GIB);
+        assert_eq!(mem_for_fraction_from(Some(200 * GIB), 0.25), 50 * GIB);
+    }
+
+    #[test]
+    fn test_fraction_floored() {
+        // 1 GiB x 0.25 = 256 MiB -> floored.
+        assert_eq!(mem_for_fraction_from(Some(GIB), 0.25), MIN_BUDGET_BYTES);
+    }
+
+    #[test]
+    fn test_fraction_invalid_falls_back_to_safe() {
+        // Non-finite, non-positive, or >1.0 fall back / clamp rather than
+        // producing a zero or unbounded budget.
+        for bad in [f64::NAN, f64::INFINITY, -1.0, 0.0] {
+            assert_eq!(
+                mem_for_fraction_from(Some(64 * GIB), bad),
+                mem_for_fraction_from(Some(64 * GIB), SAFE_MEM_FRACTION),
+                "fraction {bad} should fall back to SAFE_MEM_FRACTION"
+            );
+        }
+        assert_eq!(mem_for_fraction_from(Some(64 * GIB), 2.0), 64 * GIB);
+    }
+
+    #[test]
+    fn test_round_pow2() {
+        assert_eq!(round_pow2(0), 0);
+        assert_eq!(round_pow2(1), 1);
+        assert_eq!(round_pow2(2), 2);
+        assert_eq!(round_pow2(3), 4); // tie-ish, closer to 4
+        assert_eq!(round_pow2(5), 4);
+        assert_eq!(round_pow2(6), 8); // tie rounds up
+        assert_eq!(round_pow2(7), 8);
+        assert_eq!(round_pow2(100), 128);
+        assert_eq!(round_pow2(usize::MAX), 1usize << (usize::BITS - 1));
+    }
+
+    #[test]
+    fn test_parse_meminfo_total() {
+        let s = "MemFree: 100 kB\nMemTotal:    65536000 kB\nBuffers: 5 kB\n";
+        assert_eq!(parse_meminfo_total(s), Some(65536000 * 1024));
+    }
+
+    #[test]
+    fn test_parse_meminfo_missing() {
+        assert_eq!(parse_meminfo_total("Foo: 1 kB\n"), None);
+    }
+
+    #[test]
+    fn test_parse_cgroup_max_is_none() {
+        assert_eq!(parse_cgroup_limit("max\n"), None);
+    }
+
+    #[test]
+    fn test_parse_cgroup_value() {
+        assert_eq!(parse_cgroup_limit("4294967296\n"), Some(4_294_967_296));
+    }
+
+    #[test]
+    fn test_cgroup_v2_path() {
+        assert_eq!(
+            cgroup_v2_path("0::/foo/bar\n"),
+            Some("/foo/bar".to_string())
+        );
+        assert_eq!(cgroup_v2_path("0::/\n"), Some("/".to_string()));
+        // A pure-v1 file has no "0::" line.
+        assert_eq!(cgroup_v2_path("11:memory:/x\n"), None);
+    }
+
+    #[test]
+    fn test_cgroup_v1_memory_path() {
+        let f = "12:pids:/a\n4:cpu,cpuacct:/b\n3:memory:/foo/bar\n";
+        assert_eq!(cgroup_v1_memory_path(f), Some("/foo/bar".to_string()));
+        assert_eq!(cgroup_v1_memory_path("0::/unified\n"), None);
+    }
+
+    #[test]
+    fn test_mountinfo_mount_v2() {
+        let mi = "35 24 0:30 / /sys/fs/cgroup rw,nosuid - cgroup2 cgroup2 rw,nsdelegate\n";
+        assert_eq!(
+            mountinfo_mount(mi, "cgroup2", None),
+            Some("/sys/fs/cgroup".to_string())
+        );
+    }
+
+    #[test]
+    fn test_mountinfo_mount_v1_memory() {
+        let mi = "30 24 0:26 / /sys/fs/cgroup/cpu rw - cgroup cgroup rw,cpu\n\
+                  31 24 0:27 / /sys/fs/cgroup/memory rw - cgroup cgroup rw,memory\n";
+        assert_eq!(
+            mountinfo_mount(mi, "cgroup", Some("memory")),
+            Some("/sys/fs/cgroup/memory".to_string())
+        );
+        // The cpu controller is not the memory one.
+        assert_eq!(mountinfo_mount(mi, "cgroup", Some("hugetlb")), None);
+    }
+
+    #[test]
+    fn test_walk_paths_subcgroup() {
+        assert_eq!(
+            walk_paths("/sys/fs/cgroup", "/foo/bar", "memory.max"),
+            vec![
+                PathBuf::from("/sys/fs/cgroup/foo/bar/memory.max"),
+                PathBuf::from("/sys/fs/cgroup/foo/memory.max"),
+                PathBuf::from("/sys/fs/cgroup/memory.max"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_walk_paths_root() {
+        // A namespaced container sees its cgroup as "/": only the mount root.
+        assert_eq!(
+            walk_paths("/sys/fs/cgroup", "/", "memory.max"),
+            vec![PathBuf::from("/sys/fs/cgroup/memory.max")]
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn test_available_ram_detected_on_supported_platforms() {
+        // The detected machine has at least 1 GiB; guards the platform syscall.
+        assert!(available_ram().expect("RAM detected") >= GIB);
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -109,7 +109,7 @@ const UNDETECTABLE_MEM_BYTES: usize = 2 * ByteUnit::Gibibyte.as_bytes_usize();
 ///
 /// The budget is a backstop, not the operating point: the concurrency
 /// controller settles at line rate well below it, and it binds only when a slow
-/// consumer backs parts up in the prefetch ring. RAM is an imprecise proxy for
+/// consumer backs parts up in the prefetch buffer. RAM is an imprecise proxy for
 /// that ceiling — network bandwidth sets the real pipeline depth, and bandwidth
 /// is uncorrelated with RAM across instance families (m5.24xlarge and
 /// m5n.24xlarge share 384 GiB of RAM but differ 4x in bandwidth). The clamp
@@ -444,11 +444,19 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "connection_cap calls getrlimit, a syscall miri cannot emulate"
+    )]
     fn test_connection_cap_within_bounds() {
         assert!((MIN_CONN..=ABSOLUTE_MAX_CONN).contains(&connection_cap()));
     }
 
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "connection_cap_with_memory calls getrlimit, a syscall miri cannot emulate"
+    )]
     fn test_connection_cap_with_memory_is_bounded_by_chunks() {
         // 16-chunk budget caps connections at 16 (or lower if descriptors are scarce).
         let chunk = 8 * 1024 * 1024;
@@ -620,6 +628,10 @@ mod tests {
 
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "available_ram reads /proc and calls platform syscalls miri cannot emulate"
+    )]
     fn test_available_ram_detected_on_supported_platforms() {
         // The detected machine has at least 1 GiB; guards the platform syscall.
         assert!(available_ram().expect("RAM detected") >= GIB);

--- a/aws-sdk-s3-transfer-manager/src/telemetry.rs
+++ b/aws-sdk-s3-transfer-manager/src/telemetry.rs
@@ -31,6 +31,10 @@ pub(crate) const TARGET_EXECUTION: &str = "aws_sdk_s3_transfer_manager::executio
 /// Transfer lifecycle: enqueue, complete, cancel, fail, state transitions.
 pub(crate) const TARGET_TRANSFER: &str = "aws_sdk_s3_transfer_manager::transfer";
 
+/// Memory-budget admission control: reserve/grant/release flow (`trace`) and
+/// saturation edges where a reserve parks until a reservation releases (`debug`).
+pub(crate) const TARGET_MEMORY: &str = "aws_sdk_s3_transfer_manager::memory";
+
 /// Observability surface for transfer operations.
 ///
 /// Groups latency tracking and throughput counters. Transfers record

--- a/aws-sdk-s3-transfer-manager/src/telemetry.rs
+++ b/aws-sdk-s3-transfer-manager/src/telemetry.rs
@@ -8,10 +8,10 @@
 //! These targets allow filtering logs by concern rather than module path:
 //!
 //! ```text
-//! RUST_LOG=aws_s3_transfer_manager::concurrency=debug   # adaptive algorithm decisions
-//! RUST_LOG=aws_s3_transfer_manager::scheduling=debug     # scheduler + memory-budget capacity
-//! RUST_LOG=aws_s3_transfer_manager::execution=trace      # per-work-item execute/complete
-//! RUST_LOG=aws_s3_transfer_manager::transfer=debug       # transfer lifecycle events
+//! RUST_LOG=aws_sdk_s3_transfer_manager::concurrency=debug   # adaptive algorithm decisions
+//! RUST_LOG=aws_sdk_s3_transfer_manager::scheduling=debug    # scheduler + memory-budget capacity
+//! RUST_LOG=aws_sdk_s3_transfer_manager::execution=trace     # per-work-item execute/complete
+//! RUST_LOG=aws_sdk_s3_transfer_manager::transfer=debug      # transfer lifecycle events
 //! ```
 
 use crate::metrics::latency::LatencyTracker;

--- a/aws-sdk-s3-transfer-manager/src/telemetry.rs
+++ b/aws-sdk-s3-transfer-manager/src/telemetry.rs
@@ -9,7 +9,7 @@
 //!
 //! ```text
 //! RUST_LOG=aws_s3_transfer_manager::concurrency=debug   # adaptive algorithm decisions
-//! RUST_LOG=aws_s3_transfer_manager::scheduling=debug     # scheduler capacity, worker pool
+//! RUST_LOG=aws_s3_transfer_manager::scheduling=debug     # scheduler + memory-budget capacity
 //! RUST_LOG=aws_s3_transfer_manager::execution=trace      # per-work-item execute/complete
 //! RUST_LOG=aws_s3_transfer_manager::transfer=debug       # transfer lifecycle events
 //! ```
@@ -22,7 +22,8 @@ use std::time::Duration;
 /// Adaptive concurrency controller: phase transitions, target changes, probe results.
 pub(crate) const TARGET_CONCURRENCY: &str = "aws_sdk_s3_transfer_manager::concurrency";
 
-/// Scheduler capacity decisions, worker pool growth.
+/// Scheduler capacity decisions, worker pool growth, and memory-budget admission
+/// (reserve/grant/release flow, and saturation edges where a reserve parks).
 pub(crate) const TARGET_SCHEDULING: &str = "aws_sdk_s3_transfer_manager::scheduling";
 
 /// Per-work-item execution: dispatch, complete, skip, panic.
@@ -30,10 +31,6 @@ pub(crate) const TARGET_EXECUTION: &str = "aws_sdk_s3_transfer_manager::executio
 
 /// Transfer lifecycle: enqueue, complete, cancel, fail, state transitions.
 pub(crate) const TARGET_TRANSFER: &str = "aws_sdk_s3_transfer_manager::transfer";
-
-/// Memory-budget admission control: reserve/grant/release flow (`trace`) and
-/// saturation edges where a reserve parks until a reservation releases (`debug`).
-pub(crate) const TARGET_MEMORY: &str = "aws_sdk_s3_transfer_manager::memory";
 
 /// Observability surface for transfer operations.
 ///

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -35,10 +35,11 @@ pub enum MemoryBudgetConfig {
     /// or non-positive value falls back to the `Auto` fraction. The result is
     /// floored at a minimum usable budget but, unlike `Auto`, is not capped.
     Fraction(f64),
-    /// An explicit byte limit. Bypasses detection, but is still floored at one
-    /// accounting chunk (8 MiB) — a smaller value would serialize transfers. Use
-    /// the [`ByteUnit`](crate::metrics::unit::ByteUnit) helpers to express it,
-    /// e.g. `Limit(2 * ByteUnit::Gibibyte.as_bytes_usize())`.
+    /// An explicit byte limit. Bypasses detection. A value below one accounting
+    /// chunk (8 MiB) is raised to a single chunk when the budget is built, since a
+    /// smaller budget would serialize transfers. Use the
+    /// [`ByteUnit`](crate::metrics::unit::ByteUnit) helpers to express it, e.g.
+    /// `Limit(2 * ByteUnit::Gibibyte.as_bytes_usize())`.
     Limit(usize),
 }
 

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -19,6 +19,29 @@ pub enum PartSize {
     Target(u64),
 }
 
+/// Upper bound on memory the transfer manager uses for in-flight and buffered
+/// transfer data. At the limit transfers backpressure rather than fail.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default)]
+pub enum MemoryBudgetConfig {
+    /// Size the budget from the machine, leaving headroom for the OS page cache
+    /// and the rest of the process. Derived from detected RAM (cgroup-aware) and
+    /// bounded so a small box stays usable and a large one does not over-reserve;
+    /// expect a budget on the order of a quarter of RAM, in the low gigabytes for
+    /// a typical box. The exact policy is intentionally unspecified and may change.
+    #[default]
+    Auto,
+    /// The given fraction of detected RAM, clamped to `(0.0, 1.0]`. A non-finite
+    /// or non-positive value falls back to the `Auto` fraction. The result is
+    /// floored at a minimum usable budget but, unlike `Auto`, is not capped.
+    Fraction(f64),
+    /// An explicit byte limit. Bypasses detection, but is still floored at one
+    /// accounting chunk (8 MiB) — a smaller value would serialize transfers. Use
+    /// the [`ByteUnit`](crate::metrics::unit::ByteUnit) helpers to express it,
+    /// e.g. `Limit(2 * ByteUnit::Gibibyte.as_bytes_usize())`.
+    Limit(usize),
+}
+
 /// Point-in-time view of the global memory budget's admission state.
 ///
 /// Returned by [`Client::memory_budget`](crate::Client::memory_budget). Reports
@@ -40,6 +63,17 @@ pub struct MemoryBudgetSnapshot {
     /// Cumulative count of requests that ever parked. Distinguishes a budget that
     /// has bound at least once from one that never has.
     pub total_parked: u64,
+}
+
+impl MemoryBudgetConfig {
+    /// Resolve to the budget capacity in bytes.
+    pub(crate) fn resolve(&self) -> usize {
+        match self {
+            MemoryBudgetConfig::Auto => crate::runtime::platform::machine_safe_mem(),
+            MemoryBudgetConfig::Fraction(f) => crate::runtime::platform::mem_for_fraction(*f),
+            MemoryBudgetConfig::Limit(bytes) => *bytes,
+        }
+    }
 }
 
 /// The concurrency mode the client should use for executing requests.

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -19,6 +19,29 @@ pub enum PartSize {
     Target(u64),
 }
 
+/// Point-in-time view of the global memory budget's admission state.
+///
+/// Returned by [`Client::memory_budget`](crate::Client::memory_budget). Reports
+/// what the budget has admitted against its resolved ceiling and whether
+/// transfers are parked waiting on it. `reserved_bytes` is an upper bound — it
+/// counts reserved chunks, not bytes actually resident; per-transfer resident
+/// memory is reported separately.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub struct MemoryBudgetSnapshot {
+    /// The resolved ceiling in bytes (what [`MemoryBudgetConfig`] produced on this
+    /// machine).
+    pub capacity_bytes: u64,
+    /// Bytes currently reserved. Admission level, not resident memory.
+    pub reserved_bytes: u64,
+    /// Requests parked waiting for a grant right now. Zero means the budget is not
+    /// currently binding.
+    pub waiters: usize,
+    /// Cumulative count of requests that ever parked. Distinguishes a budget that
+    /// has bound at least once from one that never has.
+    pub total_parked: u64,
+}
+
 /// The concurrency mode the client should use for executing requests.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default)]

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -669,3 +669,98 @@ async fn test_download_to_disk_below_segment_window_drains_in_runs() {
     assert_eq!(written, content, "data integrity check failed");
     server_handle.shutdown().await.expect("shutdown");
 }
+
+// ── Global memory budget: concurrent disk transfers below the drain batch ─────
+//
+// The memory budget is fungible across all transfers. A disk transfer's chunk
+// reservation releases only when the drain copies it out, and a non-terminal drain
+// fires only at the drain batch (16 parts) or a full segment. Concurrent multi-part
+// disk transfers each below that batch hold their parts resident until terminal —
+// which needs every part issued, which needs budget. Under a shared budget too tight
+// for all of them at once, none could finalize/drain/release: a global stall. The fix
+// flushes a transfer's resident run before it parks on the budget. This drives the
+// exact wedge from the public API (real HTTP, real scheduler, real disk writes) and
+// asserts every transfer completes with bytes intact.
+
+/// Several concurrent multi-part downloads to disk, each below the drain batch, sharing
+/// a budget too small to hold them all at once, must all complete. A regression
+/// re-wedges and the timeout fires.
+#[cfg(any(unix, windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_concurrent_disk_downloads_under_tight_budget_do_not_wedge() {
+    use aws_sdk_s3_transfer_manager::types::MemoryBudgetConfig;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let parts_per_object = 6; // multi-part, below the 16-part drain batch
+    let object_size = parts_per_object * part_size;
+    let transfers = 4;
+
+    // The budget accounting chunk is 8 MiB, so a 5 MiB part costs one chunk. The four
+    // objects together need `transfers * parts_per_object` = 24 chunks; cap at 8 — far
+    // below that, so no object can hold its full part count and the pre-fix wedge is
+    // reachable, while leaving room for a few resident parts per transfer.
+    let budget_bytes = 8 * 8 * ByteUnit::Mebibyte.as_bytes_usize();
+
+    let server = S3MockServer::builder()
+        .with_in_memory_store()
+        .build()
+        .expect("build mock server");
+    let server_handle = server.start().await.expect("start mock server");
+    let s3_client = server_handle.client().await;
+    let tm = aws_sdk_s3_transfer_manager::Client::new(
+        aws_sdk_s3_transfer_manager::Config::builder()
+            .client(s3_client)
+            .part_size(PartSize::Target(part_size as u64))
+            .concurrency(ConcurrencyMode::Explicit(transfers))
+            .memory_budget(MemoryBudgetConfig::Limit(budget_bytes))
+            .build(),
+    );
+
+    let mut expected = Vec::with_capacity(transfers);
+    for i in 0..transfers {
+        let content = deterministic_data(object_size);
+        server
+            .add_object("test-bucket", &format!("obj-{i}"), content.clone(), None)
+            .await
+            .expect("add object");
+        expected.push(content);
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let results = timeout(Duration::from_secs(30), async {
+        let mut tasks = Vec::with_capacity(transfers);
+        for i in 0..transfers {
+            let tm = tm.clone();
+            let dest = dir.path().join(format!("out-{i}.dat"));
+            tasks.push(tokio::spawn(async move {
+                let handle = tm
+                    .download()
+                    .bucket("test-bucket")
+                    .key(format!("obj-{i}"))
+                    .write_to_path(&dest)
+                    .await
+                    .expect("initiate download");
+                handle.join().await.expect("join download");
+                std::fs::read(&dest).expect("read output")
+            }));
+        }
+        let mut out = Vec::with_capacity(transfers);
+        for t in tasks {
+            out.push(t.await.expect("task join"));
+        }
+        out
+    })
+    .await
+    .expect(
+        "concurrent disk downloads did not complete within 30s \
+         (budget deadlock: resident parts pinned across transfers)",
+    );
+
+    for (i, (got, want)) in results.iter().zip(expected.iter()).enumerate() {
+        assert_eq!(got.len(), want.len(), "obj-{i} size mismatch");
+        assert_eq!(got, want, "obj-{i} data integrity check failed");
+    }
+    server_handle.shutdown().await.expect("shutdown");
+}


### PR DESCRIPTION
## Summary

Adds a global memory budget that bounds total resident transfer data across all concurrent transfers, and wires the download path onto it. Prior flow control bounded memory only per-transfer, through each download's read-ahead window; N concurrent transfers could each fill a window, so aggregate resident memory scaled with concurrency and had no ceiling. The budget is a fungible, chunk-accounted admission gate: a transfer reserves before it buffers, and at the limit transfers backpressure — park and resume — rather than fail or over-allocate. It sizes itself from detected machine RAM by default and is observable through the client.

## Why

Read-ahead (#153) gave each download an occupancy window: issuance runs ahead of consumption up to `window` resident parts, then waits. That bounds one transfer. It does not bound a fleet of them — `download_objects` runs thousands of child downloads, and nothing capped their combined footprint. The window is also per-transfer by construction: it cannot express "all transfers together stay under X bytes," because no single transfer knows what the others hold.

A global bound has to be fungible (any transfer draws from one shared pool, since demand is unpredictable and shifts between transfers), part-size-agnostic (parts vary in size within and across transfers), and it has to backpressure rather than fail — a download that cannot reserve should wait for memory to free, not error. It also has to compose with the existing per-transfer window without the two gates fighting.

## How it works

### The budget primitive

`MemoryBudget` (`runtime/memory.rs`) tracks fixed-size chunks logically reserved across all transfers behind one lock. A request for `n` bytes costs `ceil(n / chunk)` chunks (`chunk` = 8 MiB nominal), so non-uniform part sizes account correctly without the budget knowing any transfer's part size.

```text
reserve(bytes) ─┬─ fits & queue empty ──▶ Reserve::Ready(Reservation)   ── RAII; drop returns chunks
                └─ else ────────────────▶ Reserve::Pending(WaitTicket)  ── parked FIFO; notify on grant

Reservation::drop ──▶ return chunks ──▶ drain waiters front-to-back (strict FIFO, no skip-ahead)
```

- `reserve(bytes, notify)` grants immediately (`Ready`) when the wait queue is empty and the request fits; otherwise it enqueues a waiter and returns `Pending(WaitTicket)`, invoking `notify` when a later release grants it. `try_reserve(bytes)` is the allocation-free fast path: it grants under exactly the same condition but registers no waker and never enqueues, for a caller that can re-drive itself.
- `Reservation` is an RAII ticket; its drop returns the chunks and drains the wait queue. `WaitTicket` is the parked-request handle; `take()` yields the granted reservation once the notify fires, and dropping it cancels a still-queued waiter or releases an already-granted one.
- **Arrival-order admission.** A fresh request never jumps a queued waiter even if it would fit, and the drain stops at the first front waiter that does not fit rather than skipping past it. Together these guarantee a queued request of `need <= capacity` sees `in_use` only fall until its need is met — it cannot be starved by a stream of smaller requests. The cost is bounded head-of-line blocking under mixed part sizes; uniform part sizes never trigger it.
- **Idle-only forced grant.** A request larger than the entire capacity is granted only when `in_use == 0`. Strict FIFO guarantees the front waiter eventually reaches that point, so an oversized request (an un-sliced upload; downloads slice to part size and never hit it) makes progress instead of parking forever.

The one non-obvious invariant is lock ordering. Two lock flavors exist — the budget lock and per-waiter slot locks — and the release path (`budget → slot`, to store a grant) and `WaitTicket::drop` (`slot → budget`, to cancel or return) must never nest, or they deadlock. `WaitTicket::drop` extracts the slot state under the slot lock, releases it, then acts. This is model-checked under loom.

### Sizing and configuration

The `Auto` default sizes the budget from detected physical RAM — cgroup-aware on Linux, `sysctl` on macOS, `GlobalMemoryStatusEx` on Windows — as `round_pow2(0.25 * RAM)` clamped to `[512 MiB, 32 GiB]`. The clamp auto-tapers the effective fraction on large boxes and keeps a small box usable; an undetectable environment falls back to a fixed default. `MemoryBudgetConfig::{Fraction, Limit}` override the proportion or set an explicit ceiling. `Config::builder().memory_budget(..)` sets it; `Client::memory_budget()` returns a `MemoryBudgetSnapshot` (capacity, reserved bytes, live waiters, cumulative park count) for observability.

### Wiring the download path

A download reserves against the budget as it issues work, and the reservation rides the buffered bytes until they leave memory:

- **Two gates, window first.** Read-ahead issuance takes the min of two gates: the per-transfer occupancy window (`gate.try_issue`), then the budget (`reserve`). The window is checked first so a window-blocked transfer never holds a slice of the fungible budget it cannot yet use, which would starve other transfers.
- **Reservation lifetime = byte residency.** A reservation is taken when a slot is claimed, moves into the `ChunkOutput` at `fill`, and drops when the bytes it accounts for leave memory: on the stream surface when the consumer drops the delivered chunk, on the disk surface when the drain copies the bytes out. It is held as `Arc<Reservation>` so a cloned `ChunkOutput` (sharing the same backing bytes) is charged once and released on the last clone.
- **Budget-blocked read-ahead parks without failing.** When the budget queues a read-ahead claim, the transfer holds the claimed slot in `DownloadState::Transferring.pending` (a `PendingClaim`) and returns `PollWork::Pending`; the budget's notify re-readies it. The gate's `issued` bump stays, so the parked transfer holds exactly the slot it will fill.
- **Terminal completion runs in `execute`, not `poll_work`.** This is the one non-mechanical restructure in the diff, and it exists so budget release is never gated on a re-poll. A chunk's reservation releases when its bytes drain to disk; a chunk below the drain batch drains only at completion. If completion runs in `poll_work`, reclaiming that budget needs a scheduler re-poll — but under a saturated budget the transfers holding budget are the ones needing the re-poll, and the re-poll is gated by the scheduler capacity (`dispatched < target`) they hold (discovery parks inside `execute`, keeping its slot). That is a circular wait, and it hung the `256 KiB × 10k` concurrent disk benchmark. So `decrement_in_flight` detects terminal completion under the state lock and claims the `Terminal` transition there (a concurrently-woken `poll_work` cannot double-complete), and `execute` finalizes inline — tail drain plus reservation release through the normal drop path, symmetric with `fail()`. `poll_work`'s completion arm now handles only the zero-byte object.
- **`enter_terminal` is the sole path to `Terminal`.** It extracts any budget-parked `PendingClaim` under the state lock so the `WaitTicket` drop (which takes the budget lock) happens only after the state lock is released, keeping the budget lock from nesting under the state lock. `#[must_use]`, so the claim cannot be silently dropped in place.

## How to review

Start with **`runtime/memory.rs`** — the primitive stands alone. Its module doc, the lock-ordering note above `Inner`, and `can_grant` / `drain` / `WaitTicket::drop` are the core; the concurrency is model-checked (loom) and the arrival-order/forced-grant/cancel semantics are covered by unit tests. Read it before the wiring.

Then **`operation/download/transfer.rs`** — `reserve_claim` (the two-gate issuance and the `try_reserve` fast path), `reserve_chunk` (the discovery reserve), and the terminal-completion rework: `decrement_in_flight` returning whether it claimed terminal, and `finalize_completion` doing the inline tail drain. The gate ordering and the terminal claim are where correctness lives.

Then **`operation/download/context.rs`** (`PendingClaim`, `enter_terminal`) and **`operation/download/body.rs`** (the reservation moving `BodySlot → ChunkOutput` at `fill`, and dropping with the delivered bytes).

**`runtime/platform.rs`** (RAM detection), **`types.rs`** / **`config.rs`** / **`client.rs`** (the `MemoryBudgetConfig` surface and `Client::memory_budget()`) are mechanical.

## Testing

The primitive's unit tests (`memory.rs`) cover the admission semantics — chunk rounding, ready/pending grants, drop-returns-chunks, exhaustion-then-release, strict arrival order, the idle-only forced grant, waiter cancellation (including a middle waiter), and soft shrink. Two loom models check the lock-ordering invariant: `release_races_cancel` and `release_races_take` race the release path (`budget → slot`) against `WaitTicket::drop` (`slot → budget`); a nested-lock regression would deadlock and loom would report it.

The wiring tests (`transfer.rs`, `body.rs`) cover the download-path integration: a read-ahead claim parking on a tight budget and resuming on release, both terminal paths (cancel, fail) dropping a budget-parked claim without leaking a chunk or a queued waiter, budget release happening in the terminal `execute` with no subsequent `poll_work` (pinning the deadlock fix), and the reservation riding a `ChunkOutput` — charged once across clones, released when the bytes leave memory on both the stream and disk surfaces.

Verified on this branch: 507 lib tests pass; `fmt` and `clippy` (default features) clean; both loom models pass under `--cfg s3_tm_loom`. On the standard s3fio benchmark suite the two originally-failing download workloads (the `256 KiB × 10k` concurrent hang and the 32 GiB disk transfer) now pass.

## Changes

```
aws-sdk-s3-transfer-manager/
  src/
    runtime/
      memory.rs         NEW — MemoryBudget primitive: reserve/try_reserve, FIFO drain,
                              WaitTicket, RAII Reservation; unit + loom tests
      platform.rs       NEW — physical-RAM detection (Linux cgroup / macOS / Windows), budget sizing
      mod.rs            module wiring
    operation/download/
      transfer.rs       two-gate issuance; reserve_claim/reserve_chunk; terminal completion
                              moved into execute (decrement_in_flight, finalize_completion)
      context.rs        PendingClaim; enter_terminal (sole Terminal transition)
      body.rs           reservation rides BodySlot → ChunkOutput; releases with the bytes
    types.rs            MemoryBudgetConfig { Auto, Fraction, Limit }, MemoryBudgetSnapshot
    config.rs           client-default memory_budget setter
    client.rs           Handle.memory_budget; Client::memory_budget() snapshot
    telemetry.rs        budget reserve/grant/release folded onto the scheduling target
    examples/cp.rs      surface the budget config in the example
```

## Notes for review

- Budget observability rides the existing `scheduling` telemetry target (`aws_sdk_s3_transfer_manager::scheduling`): reserve/grant/release at `trace`, the saturation edge where a reserve parks at `debug`. A budget that can block a transfer must be observable in the field. It does not get a standalone target yet — the budget is a global admission gate, same class as scheduler capacity, and a separate env var is one more thing to forget and silently lose telemetry on; a dedicated target can come when a buffer pool lands and earns richer memory telemetry.
- `set_limit` (runtime resize) and the connection-cap detection in `platform.rs` carry `allow(dead_code)`: the resize has no adaptive-sizing driver yet and the connection cap has no connection-pool consumer yet. Both are tracked; the driver work is separate from this change.
- The budget bounds admitted memory (a ceiling on what transfers may buffer), not RSS.
- The budget is a global primitive; download is its first consumer. Upload bounds its in-flight bytes only through scheduler concurrency today, so a fleet of `upload_objects` children has the same unbounded-aggregate exposure this closes for downloads. Wiring upload onto the same budget is the follow-up — the primitive already carries the piece upload needs (the idle-only forced grant handles an un-sliced or oversized part), so it is consumer wiring, not a primitive change.
