### PR TITLE
concurrency: seed a fixed instance-aware target for Auto

### DIFF
--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -5,10 +5,7 @@
 
 use crate::metrics::unit::ByteUnit;
 use crate::runtime::ManagedThreadRuntime;
-use crate::scheduler::{
-    AdaptiveConcurrencyController, AdaptiveConfig, ConcurrencyController, FixedConcurrency,
-    Scheduler,
-};
+use crate::scheduler::{ConcurrencyController, FixedConcurrency, Scheduler};
 use crate::telemetry::Telemetry;
 use crate::types::{ConcurrencyMode, PartSize};
 use crate::Config;
@@ -172,23 +169,17 @@ impl Client {
     /// Creates a new client from a transfer manager config.
     pub fn new(mut config: Config) -> Client {
         // 1. Create concurrency controller and telemetry
-        let (controller, telemetry): (Arc<dyn ConcurrencyController>, _) =
-            match config.concurrency() {
-                ConcurrencyMode::Explicit(n) => (
-                    Arc::new(FixedConcurrency::new(*n)),
-                    Arc::new(Telemetry::new(Duration::from_millis(500))),
-                ),
-                // TODO: implement support for target throughput
-                _ => {
-                    let adaptive_config = AdaptiveConfig::default();
-                    let telemetry = Arc::new(Telemetry::new(adaptive_config.window.duration));
-                    let controller = Arc::new(AdaptiveConcurrencyController::new(
-                        adaptive_config,
-                        Arc::clone(&telemetry.io_counters),
-                    ));
-                    (controller, telemetry)
-                }
-            };
+        let (controller, telemetry): (Arc<dyn ConcurrencyController>, _) = {
+            // Resolve the concurrency target once, at construction. The preview
+            // ships a fixed instance-aware seed rather than the adaptive
+            // controller (which is left in the tree for a later release); see
+            // `runtime::platform` concurrency seeding.
+            let target = resolve_concurrency_target(&config);
+            (
+                Arc::new(FixedConcurrency::new(target)),
+                Arc::new(Telemetry::new(Duration::from_millis(500))),
+            )
+        };
 
         // 2. Build Handle with Arc::new_cyclic so scheduler and runtime
         //    can hold Weak<Handle> without creating a reference cycle.
@@ -390,6 +381,56 @@ impl Client {
     }
 }
 
+/// Resolve the fixed in-flight concurrency target for a config. Called by
+/// [`Client::new`] to build the [`FixedConcurrency`] controller.
+///
+/// - [`ConcurrencyMode::Explicit`] — the caller's value verbatim.
+/// - [`ConcurrencyMode::TargetThroughput`] — derived from the download target
+///   (the scheduler has one global concurrency target; independent up/down
+///   limiting is not yet supported).
+/// - [`ConcurrencyMode::Auto`] — instance-aware seed from the detected machine
+///   profile. Uses the loader-detected profile when present; otherwise falls
+///   back to cheap local vCPU detection (no blocking DMI/IMDS read on this path).
+fn resolve_concurrency_target(config: &Config) -> usize {
+    use crate::runtime::platform;
+    match config.concurrency() {
+        // Guard the trait's `target >= 1` invariant: `Explicit(0)` would panic in
+        // `FixedConcurrency::new`. Clamp to 1 rather than panic on a config value.
+        ConcurrencyMode::Explicit(n) => (*n).max(1),
+        ConcurrencyMode::TargetThroughput(t) => {
+            let gbps = t.download().as_unit_per_sec(ByteUnit::Gigabit);
+            let target = platform::seed_from_gbps(gbps);
+            tracing::debug!(
+                target: crate::telemetry::TARGET_CONCURRENCY,
+                gbps,
+                seed = target,
+                "resolved TargetThroughput concurrency",
+            );
+            target
+        }
+        ConcurrencyMode::Auto => {
+            // Prefer the loader-detected profile. On the bypass path (a config
+            // built directly, no loader) fall back to cheap local vCPU detection
+            // with no instance type — keeps `Client::new` free of blocking
+            // DMI/IMDS reads; instance-aware seeding requires the async loader.
+            let (instance_type, vcpus, from_profile) = match config.machine_profile() {
+                Some(p) => (p.instance_type.clone(), p.vcpus, true),
+                None => (None, platform::local_vcpus(), false),
+            };
+            let target = platform::auto_concurrency_seed(instance_type.as_deref(), vcpus);
+            tracing::debug!(
+                target: crate::telemetry::TARGET_CONCURRENCY,
+                instance_type = ?instance_type,
+                vcpus,
+                from_profile,
+                seed = target,
+                "resolved Auto concurrency seed",
+            );
+            target
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -445,5 +486,91 @@ mod tests {
             weak.upgrade().is_none(),
             "Weak should be invalid after Handle drop"
         );
+    }
+
+    // --- concurrency resolution wiring ---
+
+    use crate::runtime::platform::MachineProfile;
+    use crate::types::{ConcurrencyMode, TargetThroughput};
+
+    fn config_with(mode: ConcurrencyMode, profile: Option<MachineProfile>) -> crate::Config {
+        let s3_client = aws_smithy_mocks::mock_client!(aws_sdk_s3, []);
+        crate::config::Config::builder()
+            .client(s3_client)
+            .concurrency(mode)
+            .machine_profile(profile)
+            .build()
+    }
+
+    #[test]
+    fn resolve_explicit_is_verbatim() {
+        let config = config_with(ConcurrencyMode::Explicit(42), None);
+        assert_eq!(resolve_concurrency_target(&config), 42);
+    }
+
+    #[test]
+    fn resolve_target_throughput_derives_from_download() {
+        // 100 Gbps target -> ceil(100 / 0.4) = 250 in-flight.
+        let config = config_with(
+            ConcurrencyMode::TargetThroughput(TargetThroughput::new_gigabits_per_sec(100)),
+            None,
+        );
+        assert_eq!(resolve_concurrency_target(&config), 250);
+    }
+
+    #[test]
+    fn resolve_auto_uses_profile_instance_type() {
+        // m6idn.16xlarge @ 64 vCPU -> 100 Gbps -> 250.
+        let profile = MachineProfile {
+            instance_type: Some("m6idn.16xlarge".to_string()),
+            vcpus: 64,
+        };
+        let config = config_with(ConcurrencyMode::Auto, Some(profile));
+        assert_eq!(resolve_concurrency_target(&config), 250);
+    }
+
+    #[test]
+    fn resolve_auto_profile_without_instance_type_uses_vcpu_fallback() {
+        // Detected vCPU but no instance type (IMDS/DMI miss recorded by loader):
+        // fallback 4 * 16 = 64.
+        let profile = MachineProfile {
+            instance_type: None,
+            vcpus: 16,
+        };
+        let config = config_with(ConcurrencyMode::Auto, Some(profile));
+        assert_eq!(resolve_concurrency_target(&config), 64);
+    }
+
+    #[test]
+    fn resolve_auto_bypass_path_uses_vcpu_fallback() {
+        // A config built directly (no loader) has no profile; resolution falls to
+        // cheap local vCPU detection with no instance type — never a blocking
+        // DMI/IMDS read. Pin the value to the fallback formula so a regression in
+        // the fallback multiplier is caught (not just "within clamp bounds").
+        let config = config_with(ConcurrencyMode::Auto, None);
+        let vcpus = crate::runtime::platform::local_vcpus();
+        let expected = crate::runtime::platform::auto_concurrency_seed(None, vcpus);
+        assert_eq!(resolve_concurrency_target(&config), expected);
+    }
+
+    #[test]
+    fn resolve_explicit_zero_is_clamped_not_panic() {
+        // `FixedConcurrency::new(0)` would panic; resolution must guard it.
+        let config = config_with(ConcurrencyMode::Explicit(0), None);
+        assert_eq!(resolve_concurrency_target(&config), 1);
+    }
+
+    // FIXME: crossbeam-epoch is incompatible with miri
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn client_new_wires_resolved_target_into_controller() {
+        // End-to-end: the resolved seed reaches the live controller's target().
+        let profile = MachineProfile {
+            instance_type: Some("c8gn.16xlarge".to_string()), // 3.125 * 64 = 200 Gbps -> 500
+            vcpus: 64,
+        };
+        let config = config_with(ConcurrencyMode::Auto, Some(profile));
+        let client = Client::new(config);
+        assert_eq!(client.handle.controller.target(), 500);
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -168,13 +168,22 @@ impl Drop for Handle {
 impl Client {
     /// Creates a new client from a transfer manager config.
     pub fn new(mut config: Config) -> Client {
+        // Machine facts for auto-sizing: use the loader-detected profile if the
+        // config came through `ConfigLoader::load`, else detect locally (DMI +
+        // vCPU + RAM — cheap pseudo-file reads, no network). Detected once and
+        // shared by both the concurrency seed and the memory budget.
+        let profile = config
+            .machine_profile()
+            .cloned()
+            .unwrap_or_else(crate::runtime::platform::MachineProfile::detect_local);
+
         // 1. Create concurrency controller and telemetry
         let (controller, telemetry): (Arc<dyn ConcurrencyController>, _) = {
             // Resolve the concurrency target once, at construction. The preview
             // ships a fixed instance-aware seed rather than the adaptive
             // controller (which is left in the tree for a later release); see
             // `runtime::platform` concurrency seeding.
-            let target = resolve_concurrency_target(&config);
+            let target = resolve_concurrency_target(config.concurrency(), &profile);
             (
                 Arc::new(FixedConcurrency::new(target)),
                 Arc::new(Telemetry::new(Duration::from_millis(500))),
@@ -186,8 +195,9 @@ impl Client {
         #[cfg(feature = "dial9")]
         let telemetry_guard = config.take_telemetry_guard().map(std::sync::Arc::new);
 
-        // Resolve the budget once: it sizes the Handle's MemoryBudget.
-        let budget_capacity = config.memory_budget().resolve();
+        // Resolve the budget once from the same detected RAM: it sizes the
+        // Handle's MemoryBudget.
+        let budget_capacity = config.memory_budget().resolve(profile.ram_bytes);
 
         let handle = Arc::new_cyclic(|weak_handle| {
             let scheduler = Scheduler::new(weak_handle.clone());
@@ -381,19 +391,23 @@ impl Client {
     }
 }
 
-/// Resolve the fixed in-flight concurrency target for a config. Called by
-/// [`Client::new`] to build the [`FixedConcurrency`] controller.
+/// Resolve the fixed in-flight concurrency target from the concurrency mode and
+/// the detected machine profile. Called by [`Client::new`] to build the
+/// [`FixedConcurrency`] controller.
 ///
 /// - [`ConcurrencyMode::Explicit`] — the caller's value verbatim.
 /// - [`ConcurrencyMode::TargetThroughput`] — derived from the download target
 ///   (the scheduler has one global concurrency target; independent up/down
 ///   limiting is not yet supported).
-/// - [`ConcurrencyMode::Auto`] — instance-aware seed from the detected machine
-///   profile. Uses the loader-detected profile when present; otherwise falls
-///   back to cheap local vCPU detection (no blocking DMI/IMDS read on this path).
-fn resolve_concurrency_target(config: &Config) -> usize {
+/// - [`ConcurrencyMode::Auto`] — instance-aware seed from the profile's instance
+///   type and vCPU count; falls back to a vCPU-scaled seed when the family is
+///   unknown or the instance type was not detected.
+fn resolve_concurrency_target(
+    mode: &ConcurrencyMode,
+    profile: &crate::runtime::platform::MachineProfile,
+) -> usize {
     use crate::runtime::platform;
-    match config.concurrency() {
+    match mode {
         // Guard the trait's `target >= 1` invariant: `Explicit(0)` would panic in
         // `FixedConcurrency::new`. Clamp to 1 rather than panic on a config value.
         ConcurrencyMode::Explicit(n) => (*n).max(1),
@@ -409,20 +423,12 @@ fn resolve_concurrency_target(config: &Config) -> usize {
             target
         }
         ConcurrencyMode::Auto => {
-            // Prefer the loader-detected profile. On the bypass path (a config
-            // built directly, no loader) fall back to cheap local vCPU detection
-            // with no instance type — keeps `Client::new` free of blocking
-            // DMI/IMDS reads; instance-aware seeding requires the async loader.
-            let (instance_type, vcpus, from_profile) = match config.machine_profile() {
-                Some(p) => (p.instance_type.clone(), p.vcpus, true),
-                None => (None, platform::local_vcpus(), false),
-            };
-            let target = platform::auto_concurrency_seed(instance_type.as_deref(), vcpus);
+            let target =
+                platform::auto_concurrency_seed(profile.instance_type.as_deref(), profile.vcpus);
             tracing::debug!(
                 target: crate::telemetry::TARGET_CONCURRENCY,
-                instance_type = ?instance_type,
-                vcpus,
-                from_profile,
+                instance_type = ?profile.instance_type,
+                vcpus = profile.vcpus,
                 seed = target,
                 "resolved Auto concurrency seed",
             );
@@ -493,6 +499,16 @@ mod tests {
     use crate::runtime::platform::MachineProfile;
     use crate::types::{ConcurrencyMode, TargetThroughput};
 
+    /// A profile with the given instance type and vCPU count; RAM is irrelevant
+    /// to concurrency resolution.
+    fn profile(instance_type: Option<&str>, vcpus: usize) -> MachineProfile {
+        MachineProfile {
+            instance_type: instance_type.map(str::to_string),
+            vcpus,
+            ram_bytes: None,
+        }
+    }
+
     fn config_with(mode: ConcurrencyMode, profile: Option<MachineProfile>) -> crate::Config {
         let s3_client = aws_smithy_mocks::mock_client!(aws_sdk_s3, []);
         crate::config::Config::builder()
@@ -504,60 +520,39 @@ mod tests {
 
     #[test]
     fn resolve_explicit_is_verbatim() {
-        let config = config_with(ConcurrencyMode::Explicit(42), None);
-        assert_eq!(resolve_concurrency_target(&config), 42);
+        assert_eq!(
+            resolve_concurrency_target(&ConcurrencyMode::Explicit(42), &profile(None, 8)),
+            42
+        );
     }
 
     #[test]
     fn resolve_target_throughput_derives_from_download() {
         // 100 Gbps target -> ceil(100 / 0.4) = 250 in-flight.
-        let config = config_with(
-            ConcurrencyMode::TargetThroughput(TargetThroughput::new_gigabits_per_sec(100)),
-            None,
-        );
-        assert_eq!(resolve_concurrency_target(&config), 250);
+        let mode =
+            ConcurrencyMode::TargetThroughput(TargetThroughput::new_gigabits_per_sec(100));
+        assert_eq!(resolve_concurrency_target(&mode, &profile(None, 8)), 250);
     }
 
     #[test]
     fn resolve_auto_uses_profile_instance_type() {
         // m6idn.16xlarge @ 64 vCPU -> 100 Gbps -> 250.
-        let profile = MachineProfile {
-            instance_type: Some("m6idn.16xlarge".to_string()),
-            vcpus: 64,
-        };
-        let config = config_with(ConcurrencyMode::Auto, Some(profile));
-        assert_eq!(resolve_concurrency_target(&config), 250);
+        let p = profile(Some("m6idn.16xlarge"), 64);
+        assert_eq!(resolve_concurrency_target(&ConcurrencyMode::Auto, &p), 250);
     }
 
     #[test]
     fn resolve_auto_profile_without_instance_type_uses_vcpu_fallback() {
-        // Detected vCPU but no instance type (IMDS/DMI miss recorded by loader):
-        // fallback 4 * 16 = 64.
-        let profile = MachineProfile {
-            instance_type: None,
-            vcpus: 16,
-        };
-        let config = config_with(ConcurrencyMode::Auto, Some(profile));
-        assert_eq!(resolve_concurrency_target(&config), 64);
-    }
-
-    #[test]
-    fn resolve_auto_bypass_path_uses_vcpu_fallback() {
-        // A config built directly (no loader) has no profile; resolution falls to
-        // cheap local vCPU detection with no instance type — never a blocking
-        // DMI/IMDS read. Pin the value to the fallback formula so a regression in
-        // the fallback multiplier is caught (not just "within clamp bounds").
-        let config = config_with(ConcurrencyMode::Auto, None);
-        let vcpus = crate::runtime::platform::local_vcpus();
-        let expected = crate::runtime::platform::auto_concurrency_seed(None, vcpus);
-        assert_eq!(resolve_concurrency_target(&config), expected);
+        // Detected vCPU but no instance type (DMI/IMDS miss): fallback 4 * 16 = 64.
+        let p = profile(None, 16);
+        assert_eq!(resolve_concurrency_target(&ConcurrencyMode::Auto, &p), 64);
     }
 
     #[test]
     fn resolve_explicit_zero_is_clamped_not_panic() {
         // `FixedConcurrency::new(0)` would panic; resolution must guard it.
-        let config = config_with(ConcurrencyMode::Explicit(0), None);
-        assert_eq!(resolve_concurrency_target(&config), 1);
+        let p = profile(None, 8);
+        assert_eq!(resolve_concurrency_target(&ConcurrencyMode::Explicit(0), &p), 1);
     }
 
     // FIXME: crossbeam-epoch is incompatible with miri
@@ -565,12 +560,23 @@ mod tests {
     #[test]
     fn client_new_wires_resolved_target_into_controller() {
         // End-to-end: the resolved seed reaches the live controller's target().
-        let profile = MachineProfile {
-            instance_type: Some("c8gn.16xlarge".to_string()), // 3.125 * 64 = 200 Gbps -> 500
-            vcpus: 64,
-        };
-        let config = config_with(ConcurrencyMode::Auto, Some(profile));
+        // c8gn.16xlarge: 3.125 Gbps/vCPU * 64 = 200 Gbps -> 500.
+        let config = config_with(
+            ConcurrencyMode::Auto,
+            Some(profile(Some("c8gn.16xlarge"), 64)),
+        );
         let client = Client::new(config);
         assert_eq!(client.handle.controller.target(), 500);
+    }
+
+    // FIXME: crossbeam-epoch is incompatible with miri
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn client_new_bypass_path_detects_locally() {
+        // No profile on the config (built directly, not via the loader):
+        // Client::new detects locally and still resolves a valid, clamped target.
+        let config = config_with(ConcurrencyMode::Auto, None);
+        let client = Client::new(config);
+        assert!((10..=10_000).contains(&client.handle.controller.target()));
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -529,8 +529,7 @@ mod tests {
     #[test]
     fn resolve_target_throughput_derives_from_download() {
         // 100 Gbps target -> ceil(100 / 0.4) = 250 in-flight.
-        let mode =
-            ConcurrencyMode::TargetThroughput(TargetThroughput::new_gigabits_per_sec(100));
+        let mode = ConcurrencyMode::TargetThroughput(TargetThroughput::new_gigabits_per_sec(100));
         assert_eq!(resolve_concurrency_target(&mode, &profile(None, 8)), 250);
     }
 
@@ -552,7 +551,10 @@ mod tests {
     fn resolve_explicit_zero_is_clamped_not_panic() {
         // `FixedConcurrency::new(0)` would panic; resolution must guard it.
         let p = profile(None, 8);
-        assert_eq!(resolve_concurrency_target(&ConcurrencyMode::Explicit(0), &p), 1);
+        assert_eq!(
+            resolve_concurrency_target(&ConcurrencyMode::Explicit(0), &p),
+            1
+        );
     }
 
     // FIXME: crossbeam-epoch is incompatible with miri
@@ -574,9 +576,15 @@ mod tests {
     #[test]
     fn client_new_bypass_path_detects_locally() {
         // No profile on the config (built directly, not via the loader):
-        // Client::new detects locally and still resolves a valid, clamped target.
+        // Client::new detects locally. Off EC2 (the test host) DMI yields no
+        // instance type, so the resolved target must equal the vCPU fallback for
+        // the detected core count — pinning it, so a regression that stops
+        // feeding local vCPU into resolution is caught (not just a clamp-range
+        // check that holds by construction).
+        use crate::runtime::platform;
+        let expected = platform::auto_concurrency_seed(None, platform::local_vcpus());
         let config = config_with(ConcurrencyMode::Auto, None);
         let client = Client::new(config);
-        assert!((10..=10_000).contains(&client.handle.controller.target()));
+        assert_eq!(client.handle.controller.target(), expected);
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -542,9 +542,9 @@ mod tests {
 
     #[test]
     fn resolve_auto_profile_without_instance_type_uses_vcpu_fallback() {
-        // Detected vCPU but no instance type (DMI/IMDS miss): fallback 4 * 16 = 64.
+        // Detected vCPU but no instance type (DMI/IMDS miss): fallback 5 * 16 = 80.
         let p = profile(None, 16);
-        assert_eq!(resolve_concurrency_target(&ConcurrencyMode::Auto, &p), 64);
+        assert_eq!(resolve_concurrency_target(&ConcurrencyMode::Auto, &p), 80);
     }
 
     #[test]

--- a/aws-sdk-s3-transfer-manager/src/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/config.rs
@@ -74,6 +74,10 @@ pub struct Config {
     memory_budget: MemoryBudgetConfig,
     framework_metadata: Option<FrameworkMetadata>,
     s3_client_source: Option<S3ClientSource>,
+    /// Machine facts detected once by the async config loader, off the
+    /// `Client::new` hot path. `None` when the config was built directly
+    /// (bypassing the loader); consumers then fall back to cheap local detection.
+    machine_profile: Option<crate::runtime::platform::MachineProfile>,
     #[cfg(feature = "dial9")]
     pub(crate) telemetry_guard: Option<dial9_tokio_telemetry::telemetry::TelemetryGuard>,
 }
@@ -114,6 +118,12 @@ impl Config {
         &self.memory_budget
     }
 
+    /// Machine facts detected by the async config loader, if this config was
+    /// built through it. `None` when built directly.
+    pub(crate) fn machine_profile(&self) -> Option<&crate::runtime::platform::MachineProfile> {
+        self.machine_profile.as_ref()
+    }
+
     /// Returns the framework metadata setting when using transfer manager.
     #[doc(hidden)]
     pub fn framework_metadata(&self) -> Option<&FrameworkMetadata> {
@@ -147,6 +157,7 @@ pub struct Builder {
     pub(crate) framework_metadata: Option<FrameworkMetadata>,
     client: Option<aws_sdk_s3::Client>,
     s3_client_config: Option<S3ClientConfig>,
+    machine_profile: Option<crate::runtime::platform::MachineProfile>,
     #[cfg(feature = "dial9")]
     telemetry_guard: Option<dial9_tokio_telemetry::telemetry::TelemetryGuard>,
 }
@@ -279,6 +290,17 @@ impl Builder {
         self
     }
 
+    /// Set the machine profile detected by the async config loader. Internal:
+    /// populated by [`ConfigLoader`](crate::config::loader::ConfigLoader), not a
+    /// public builder method.
+    pub(crate) fn machine_profile(
+        mut self,
+        profile: Option<crate::runtime::platform::MachineProfile>,
+    ) -> Self {
+        self.machine_profile = profile;
+        self
+    }
+
     /// Consumes the builder and constructs a [`Config`]
     pub fn build(self) -> Config {
         let s3_client_source = match (self.client, self.s3_client_config) {
@@ -294,6 +316,7 @@ impl Builder {
             memory_budget: self.memory_budget,
             framework_metadata: self.framework_metadata,
             s3_client_source: Some(s3_client_source),
+            machine_profile: self.machine_profile,
             #[cfg(feature = "dial9")]
             telemetry_guard: self.telemetry_guard,
         }

--- a/aws-sdk-s3-transfer-manager/src/config/loader.rs
+++ b/aws-sdk-s3-transfer-manager/src/config/loader.rs
@@ -121,6 +121,10 @@ impl ConfigLoader {
     pub async fn load(self) -> Config {
         let shared_config = aws_config::defaults(BehaviorVersion::latest()).load().await;
 
+        // Detect machine facts here, on the async load path, so client
+        // construction stays free of blocking DMI reads and network IMDS calls.
+        let profile = detect_machine_profile().await;
+
         let mut sdk_client_builder = aws_sdk_s3::config::Builder::from(&shared_config);
 
         let interceptor = S3TransferManagerInterceptor {
@@ -129,8 +133,100 @@ impl ConfigLoader {
         sdk_client_builder.push_interceptor(S3TransferManagerInterceptor::into_shared(interceptor));
         let builder = self
             .builder
+            .machine_profile(Some(profile))
             .s3_config(crate::config::S3ClientConfig::new(sdk_client_builder));
         builder.build()
+    }
+}
+
+/// Detect the machine profile for auto-sizing: instance type via local DMI, then
+/// IMDS *only* when DMI is inconclusive, plus the usable vCPU count. Detection
+/// failure yields `None` for the instance type and consumers fall back to
+/// vCPU-scaled defaults.
+///
+/// The IMDS fallback is gated on DMI being inconclusive. On **Linux**, DMI
+/// answers "is this EC2" locally: a readable `NotEc2` reading skips IMDS (no
+/// network call on a Linux laptop, on-prem host, or another cloud); only an
+/// `Unknown` (a container without DMI) probes IMDS. On **non-Linux** there is no
+/// DMI path, so detection is always `Unknown` and IMDS is always attempted —
+/// this is deliberate (EC2 does run Windows/macOS, and IMDS is the only detection
+/// path there), the cost being that a non-EC2 non-Linux host makes one IMDS probe
+/// per client build. In all cases the probe honors `AWS_EC2_METADATA_DISABLED`
+/// and is bounded to a single short attempt (~500ms), so a miss is cheap.
+async fn detect_machine_profile() -> crate::runtime::platform::MachineProfile {
+    use crate::runtime::platform::{self, DmiDetection};
+    // `detect_instance_type_dmi` reads DMI attributes with synchronous `std::fs`,
+    // which runs inline on the async worker rather than via `spawn_blocking`. This
+    // is intentional: the reads target `/sys/.../dmi/id/*`, which are RAM-backed
+    // sysfs pseudo-files served by the kernel from the SMBIOS table parsed at boot
+    // (no disk I/O), and this runs once at client construction. The `spawn_blocking`
+    // hop would cost more than the reads it guards. (Ref: sysfs(5); the crate's
+    // hot-path fs is handled separately by the blocking-fs work.)
+    let instance_type = match platform::detect_instance_type_dmi() {
+        DmiDetection::Instance(ty) => Some(ty),
+        DmiDetection::NotEc2 => None,
+        DmiDetection::Unknown => imds_instance_type().await,
+    };
+    platform::MachineProfile {
+        instance_type,
+        vcpus: platform::local_vcpus(),
+    }
+}
+
+/// Whether the user disabled EC2 IMDS via `AWS_EC2_METADATA_DISABLED=true`. The
+/// raw `imds::Client` does not honor this itself (only the region/credentials
+/// providers do), so we check it before constructing one.
+fn imds_disabled() -> bool {
+    imds_disabled_value(std::env::var("AWS_EC2_METADATA_DISABLED").ok().as_deref())
+}
+
+/// Pure predicate for the disable flag, split out so it is testable without
+/// mutating the process environment (which would race concurrent tests).
+///
+/// Lenient: accepts the common truthy spellings (`true`, `1`, `yes`, `on`,
+/// case-insensitive). Anything else — including unset, `false`, `0`, or an
+/// unrecognized value — leaves IMDS enabled.
+fn imds_disabled_value(raw: Option<&str>) -> bool {
+    matches!(
+        raw.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("true" | "1" | "yes" | "on")
+    )
+}
+
+/// Query the EC2 instance type from IMDS. `None` on any failure (IMDS disabled,
+/// not on EC2, hop-limited, timeout). IMDS returns only the instance-type string
+/// — no bandwidth data — so it feeds the family table like the DMI path.
+///
+/// Bounded to a single attempt with short connect/read timeouts: this only runs
+/// when DMI was inconclusive, and a non-EC2 host must not pay the library default
+/// (4 attempts, 1s connect each). On EC2 the endpoint is link-local and answers
+/// in microseconds, so one short attempt is ample.
+async fn imds_instance_type() -> Option<String> {
+    if imds_disabled() {
+        tracing::debug!(
+            target: crate::telemetry::TARGET_CONCURRENCY,
+            "IMDS disabled via AWS_EC2_METADATA_DISABLED; using vCPU-scaled fallback",
+        );
+        return None;
+    }
+    let client = aws_config::imds::Client::builder()
+        .max_attempts(1)
+        .connect_timeout(std::time::Duration::from_millis(500))
+        .read_timeout(std::time::Duration::from_millis(500))
+        .build();
+    match client.get("/latest/meta-data/instance-type").await {
+        Ok(ty) => {
+            let ty = ty.as_ref().trim().to_string();
+            (!ty.is_empty()).then_some(ty)
+        }
+        Err(err) => {
+            tracing::debug!(
+                target: crate::telemetry::TARGET_CONCURRENCY,
+                error = %err,
+                "IMDS instance-type lookup failed; using vCPU-scaled fallback",
+            );
+            None
+        }
     }
 }
 
@@ -157,6 +253,38 @@ mod tests {
             .interceptors()
             .any(|item| item.name() == "S3TransferManager");
         assert!(tm_interceptor_exists);
+    }
+
+    // `load()` always populates a MachineProfile with a real vCPU count. Instance
+    // type is environment-dependent (Some on EC2 with DMI, None off-EC2); we only
+    // assert the profile exists and vCPU is sane, so the test is host-independent.
+    //
+    // Off-EC2 this exercises the bounded IMDS fallback (1 attempt, 500ms), which
+    // fast-fails; that path is intentionally short so this stays quick in CI.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn load_populates_machine_profile() {
+        let config = crate::from_env().load().await;
+        let profile = config
+            .machine_profile()
+            .expect("loader populates a machine profile");
+        assert!(profile.vcpus >= 1);
+    }
+
+    // Tests the pure parser, so it never touches the process environment and
+    // cannot race the concurrent `load()`-based tests that read the same var.
+    #[test]
+    fn imds_disabled_parses_flag() {
+        use super::imds_disabled_value;
+        // Truthy spellings, case- and whitespace-insensitive.
+        for truthy in ["true", "TRUE", "  true  ", "1", "yes", "YES", "on"] {
+            assert!(imds_disabled_value(Some(truthy)), "{truthy:?} disables");
+        }
+        // Everything else leaves IMDS enabled.
+        for falsy in ["false", "0", "no", "off", "", "  ", "enabled", "2"] {
+            assert!(!imds_disabled_value(Some(falsy)), "{falsy:?} stays enabled");
+        }
+        assert!(!imds_disabled_value(None), "unset defaults to enabled");
     }
 
     #[cfg_attr(miri, ignore)]

--- a/aws-sdk-s3-transfer-manager/src/config/loader.rs
+++ b/aws-sdk-s3-transfer-manager/src/config/loader.rs
@@ -170,6 +170,7 @@ async fn detect_machine_profile() -> crate::runtime::platform::MachineProfile {
     platform::MachineProfile {
         instance_type,
         vcpus: platform::local_vcpus(),
+        ram_bytes: platform::available_ram(),
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -426,11 +426,19 @@ fn walk_paths(mount: &str, cgroup_path: &str, filename: &str) -> Vec<PathBuf> {
 const GBPS_PER_CONN: f64 = 0.4;
 
 /// In-flight requests per vCPU for the fallback seed, used when the instance
-/// family is unknown (unrecognized type, or detection failed / off-EC2). Chosen
-/// to match the ratio recognized network-optimized families already get
-/// (`m6idn.16xlarge`: 64 vCPU -> 250 ~= 3.9/vCPU), so an unrecognized box is
-/// seeded continuously with a recognized one rather than far below it.
-const FALLBACK_INFLIGHT_PER_VCPU: usize = 4;
+/// family is unknown (unrecognized type, or detection failed / off-EC2). Without
+/// a NIC estimate the seed can't be bandwidth-derived, so it scales concurrency
+/// directly by vCPU. In-flight requests are roughly connection-count, so the
+/// slope is kept modest; the `[FALLBACK_MIN, ABSOLUTE_MAX_CONN]` clamp keeps a
+/// small box off the floor and a large one bounded.
+const FALLBACK_INFLIGHT_PER_VCPU: usize = 5;
+
+/// Floor for the fallback seed. A small unknown box (2-6 vCPU) would otherwise
+/// seed below common general-purpose defaults (CRT's 10 Gbps target resolves to
+/// 25 connections). Floors the fallback so an unknown box gets a usable default,
+/// while the recognized-family estimate keeps its own lower `MIN_CONN` floor (a
+/// genuinely small recognized box should seed low).
+const FALLBACK_MIN: usize = 32;
 
 /// Peak network bandwidth of each EC2 instance family, as the raw spec of its
 /// largest member: `(family, max_nic_gbps, vcpus_at_that_size)`.
@@ -635,13 +643,14 @@ pub(crate) fn seed_from_gbps(gbps: f64) -> usize {
 /// Resolve the `Auto` concurrency seed from detected machine facts.
 ///
 /// Recognized family -> bandwidth estimate (`per_vcpu x vcpus`) -> connection
-/// derivation. Unknown/undetected -> `FALLBACK_INFLIGHT_PER_VCPU x vcpus`
-/// (a concurrency heuristic, not a bandwidth estimate). Both are clamped to
-/// `[MIN_CONN, ABSOLUTE_MAX_CONN]`. Pure function of its inputs.
+/// derivation, clamped `[MIN_CONN, ABSOLUTE_MAX_CONN]`. Unknown/undetected ->
+/// `FALLBACK_INFLIGHT_PER_VCPU x vcpus` (a concurrency heuristic, not a bandwidth
+/// estimate), clamped `[FALLBACK_MIN, ABSOLUTE_MAX_CONN]` so an unknown box gets a
+/// usable default. Pure function of its inputs.
 pub(crate) fn auto_concurrency_seed(instance_type: Option<&str>, vcpus: usize) -> usize {
     match instance_type.and_then(family_gbps_per_vcpu) {
         Some(per_vcpu) => seed_from_gbps(per_vcpu * vcpus as f64),
-        None => (FALLBACK_INFLIGHT_PER_VCPU * vcpus).clamp(MIN_CONN, ABSOLUTE_MAX_CONN),
+        None => (FALLBACK_INFLIGHT_PER_VCPU * vcpus).clamp(FALLBACK_MIN, ABSOLUTE_MAX_CONN),
     }
 }
 
@@ -923,7 +932,7 @@ mod tests {
         // fails if the hyphenated key stops matching (falling through to
         // fallback) rather than passing via a coincident clamp.
         // p6-b300 = 6400/192 = 33.333 Gbps/vCPU. At 24 vCPU: 800 Gbps ->
-        // ceil(800/0.4) = 2000. Fallback would be 4*24 = 96. Distinct.
+        // ceil(800/0.4) = 2000. Fallback would be 5*24 = 120. Distinct.
         assert_eq!(auto_concurrency_seed(Some("p6-b300.6xlarge"), 24), 2000);
         assert_ne!(
             auto_concurrency_seed(Some("p6-b300.6xlarge"), 24),
@@ -933,19 +942,35 @@ mod tests {
 
     #[test]
     fn test_seed_fallback_scales_with_vcpu() {
-        // Unknown family -> FALLBACK_INFLIGHT_PER_VCPU (4) * vcpus.
-        assert_eq!(auto_concurrency_seed(Some("t3.2xlarge"), 8), 32);
-        assert_eq!(auto_concurrency_seed(Some("gcp-n2-standard-64"), 64), 256);
+        // Unknown family -> FALLBACK_INFLIGHT_PER_VCPU (5) * vcpus, above the
+        // FALLBACK_MIN (32) floor.
+        assert_eq!(auto_concurrency_seed(Some("t3.2xlarge"), 8), 40);
+        assert_eq!(auto_concurrency_seed(Some("gcp-n2-standard-64"), 64), 320);
         // No detection at all falls through the same path.
-        assert_eq!(auto_concurrency_seed(None, 16), 64);
+        assert_eq!(auto_concurrency_seed(None, 16), 80);
+    }
+
+    #[test]
+    fn test_seed_fallback_floored_for_small_box() {
+        // A small unknown box would seed below the general-purpose default; the
+        // FALLBACK_MIN floor (32) lifts it. 4 vCPU * 5 = 20 -> floored to 32.
+        assert_eq!(auto_concurrency_seed(None, 4), FALLBACK_MIN);
+        assert_eq!(
+            auto_concurrency_seed(Some("gcp-n2-standard-4"), 4),
+            FALLBACK_MIN
+        );
+        // The floor governs up to 6 vCPU (6 * 5 = 30 < 32); 7 vCPU crosses it.
+        assert_eq!(auto_concurrency_seed(None, 6), FALLBACK_MIN);
+        assert_eq!(auto_concurrency_seed(None, 7), 35);
     }
 
     #[test]
     fn test_seed_clamps_to_bounds() {
-        // Tiny machine: fallback below MIN_CONN floors to MIN_CONN (10).
-        assert_eq!(auto_concurrency_seed(None, 1), MIN_CONN);
-        assert_eq!(auto_concurrency_seed(Some("t3.micro"), 2), MIN_CONN);
-        // Recognized tiny estimate also floors.
+        // Tiny unknown machine: fallback floors to FALLBACK_MIN (32).
+        assert_eq!(auto_concurrency_seed(None, 1), FALLBACK_MIN);
+        assert_eq!(auto_concurrency_seed(Some("t3.micro"), 2), FALLBACK_MIN);
+        // Recognized tiny estimate floors to the lower MIN_CONN (a genuinely
+        // small recognized box should seed low, unlike the unknown-box default).
         assert_eq!(auto_concurrency_seed(Some("i4i.large"), 2), MIN_CONN);
         // Enormous estimate caps at ABSOLUTE_MAX_CONN.
         assert_eq!(

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -13,8 +13,10 @@ use std::path::{Path, PathBuf};
 
 // Connection-cap sizing from the descriptor limit and memory budget. The
 // consumer is the managed-runtime connection pool, which caps `max_connections`
-// from these. Each item below carries `#[allow(dead_code)]` until that wiring
-// exists.
+// from these. The pool wiring does not exist yet, so the fd-budget items below
+// carry `#[allow(dead_code)]`; `MIN_CONN`/`ABSOLUTE_MAX_CONN` are already live as
+// the concurrency-seed bounds (in-flight requests are connection-bound under
+// HTTP/1, so the connection bounds bound the seed too).
 
 /// Fraction of the process file-descriptor limit the connection pool may use.
 /// The remainder is headroom for disk sinks, the directory walker, logging, and
@@ -22,14 +24,13 @@ use std::path::{Path, PathBuf};
 #[allow(dead_code)]
 const POOL_FD_BUDGET_FRACTION: f64 = 0.5;
 
-/// Ceiling on pooled connections regardless of descriptor headroom. Bounds the
-/// request fan-out against a single S3 endpoint, and is the cap on platforms
-/// with no low descriptor limit.
-#[allow(dead_code)]
+/// Ceiling on pooled connections regardless of descriptor headroom, and the
+/// upper bound on the concurrency seed. Bounds request fan-out against a single
+/// S3 endpoint, and is the cap on platforms with no low descriptor limit.
 const ABSOLUTE_MAX_CONN: usize = 10_000;
 
-/// Floor so a low descriptor limit does not cap the pool below a usable count.
-#[allow(dead_code)]
+/// Floor so a low descriptor limit does not cap the pool below a usable count,
+/// and the lower bound on the concurrency seed.
 const MIN_CONN: usize = 10;
 
 /// Global cap on pooled connections from the descriptor limit alone, used where
@@ -408,26 +409,28 @@ fn walk_paths(mount: &str, cgroup_path: &str, filename: &str) -> Vec<PathBuf> {
 // Concurrency seeding
 //
 // Resolves `ConcurrencyMode::Auto` (and `TargetThroughput`) to a fixed in-flight
-// request target for the preview, in lieu of an adaptive controller. The target
-// is derived from an estimate of the machine's network bandwidth: recognized EC2
-// instance families map to a per-vCPU Gbps rate (NIC bandwidth scales linearly
-// with vCPU count within a family), and `target = ceil(gbps / GBPS_PER_CONN)`.
+// request target, in lieu of an adaptive controller. The target is derived from
+// an estimate of the machine's network bandwidth: recognized EC2 instance
+// families map to a per-vCPU Gbps rate (NIC bandwidth scales linearly with vCPU
+// count within a family), and `target = ceil(gbps / GBPS_PER_CONN)`.
 //
-// This is `N` = target *in-flight requests* (the scheduler's `poll_work` gate),
-// not connections; the pool sizes connections separately.
+// `N` is target *in-flight requests* (the scheduler's `poll_work` gate), which
+// the pool sizes connections separately from. In-flight work is nonetheless
+// connection-bound under HTTP/1 (one request per connection on the wire), so the
+// connection bounds `[MIN_CONN, ABSOLUTE_MAX_CONN]` are the correct bounds for
+// the seed and are reused rather than duplicated.
 // ---------------------------------------------------------------------------
 
 /// Assumed goodput per in-flight request, in Gbps. Matches CRT's per-connection
 /// figure (`100 / 250`), which lines up with the measured ~250-in-flight knee at
-/// ~100 Gbps. Preview constant; a measured value may replace it later.
+/// ~100 Gbps. Estimated, not measured for this client.
 const GBPS_PER_CONN: f64 = 0.4;
 
 /// In-flight requests per vCPU for the fallback seed, used when the instance
 /// family is unknown (unrecognized type, or detection failed / off-EC2). Chosen
 /// to match the ratio recognized network-optimized families already get
 /// (`m6idn.16xlarge`: 64 vCPU -> 250 ~= 3.9/vCPU), so an unrecognized box is
-/// seeded continuously with a recognized one rather than far below it. Preview
-/// constant; a measured value may replace it later.
+/// seeded continuously with a recognized one rather than far below it.
 const FALLBACK_INFLIGHT_PER_VCPU: usize = 4;
 
 /// Peak network bandwidth of each EC2 instance family, as the raw spec of its
@@ -573,6 +576,23 @@ pub(crate) enum DmiDetection {
     Unknown,
 }
 
+/// Classify DMI reads into a [`DmiDetection`]. `vendor` is the `sys_vendor`
+/// contents; `product` is `product_name`, `None` when that read failed. Split
+/// from the file I/O so the three-state logic is testable without `/sys`.
+///
+/// A readable vendor that is not "Amazon EC2" is a definitive `NotEc2` (skip
+/// IMDS). Vendor is EC2 but product is missing/empty ⇒ `Unknown` (let IMDS try).
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn classify_dmi(vendor: &str, product: Option<&str>) -> DmiDetection {
+    if !vendor.trim().eq_ignore_ascii_case("Amazon EC2") {
+        return DmiDetection::NotEc2;
+    }
+    match product.map(str::trim) {
+        Some(ty) if !ty.is_empty() => DmiDetection::Instance(ty.to_string()),
+        _ => DmiDetection::Unknown,
+    }
+}
+
 /// Detect the EC2 instance type from DMI, without any network call.
 ///
 /// Reads `/sys/devices/virtual/dmi/id/sys_vendor` to confirm the host is EC2,
@@ -584,21 +604,8 @@ pub(crate) fn detect_instance_type_dmi() -> DmiDetection {
     let Ok(vendor) = std::fs::read_to_string("/sys/devices/virtual/dmi/id/sys_vendor") else {
         return DmiDetection::Unknown;
     };
-    if !vendor.trim().eq_ignore_ascii_case("Amazon EC2") {
-        return DmiDetection::NotEc2;
-    }
-    match std::fs::read_to_string("/sys/devices/virtual/dmi/id/product_name") {
-        Ok(product) => {
-            let ty = product.trim();
-            if ty.is_empty() {
-                // Vendor says EC2 but no product name — inconclusive, let IMDS try.
-                DmiDetection::Unknown
-            } else {
-                DmiDetection::Instance(ty.to_string())
-            }
-        }
-        Err(_) => DmiDetection::Unknown,
-    }
+    let product = std::fs::read_to_string("/sys/devices/virtual/dmi/id/product_name").ok();
+    classify_dmi(&vendor, product.as_deref())
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -910,6 +917,22 @@ mod tests {
     }
 
     #[test]
+    fn test_seed_recognizes_hyphenated_family() {
+        // The family split is on '.', so a hyphenated family (`p6-b300`) must
+        // still be recognized. Pick a vCPU count where the recognized result is
+        // distinct from BOTH the clamp ceiling and the fallback, so the test
+        // fails if the hyphenated key stops matching (falling through to
+        // fallback) rather than passing via a coincident clamp.
+        // p6-b300 = 6400/192 = 33.333 Gbps/vCPU. At 24 vCPU: 800 Gbps ->
+        // ceil(800/0.4) = 2000. Fallback would be 4*24 = 96. Distinct.
+        assert_eq!(auto_concurrency_seed(Some("p6-b300.6xlarge"), 24), 2000);
+        assert_ne!(
+            auto_concurrency_seed(Some("p6-b300.6xlarge"), 24),
+            FALLBACK_INFLIGHT_PER_VCPU * 24
+        );
+    }
+
+    #[test]
     fn test_seed_fallback_scales_with_vcpu() {
         // Unknown family -> FALLBACK_INFLIGHT_PER_VCPU (4) * vcpus.
         assert_eq!(auto_concurrency_seed(Some("t3.2xlarge"), 8), 32);
@@ -1007,5 +1030,30 @@ mod tests {
     #[test]
     fn test_dmi_detection_unknown_off_linux() {
         assert_eq!(detect_instance_type_dmi(), DmiDetection::Unknown);
+    }
+
+    #[test]
+    fn test_classify_dmi_three_states() {
+        // EC2 vendor + product -> Instance (trimmed, case-insensitive vendor).
+        assert_eq!(
+            classify_dmi("Amazon EC2\n", Some("m6idn.16xlarge\n")),
+            DmiDetection::Instance("m6idn.16xlarge".to_string())
+        );
+        assert_eq!(
+            classify_dmi("amazon ec2", Some("c7gn.16xlarge")),
+            DmiDetection::Instance("c7gn.16xlarge".to_string())
+        );
+        // Readable non-EC2 vendor -> NotEc2 (the gate that skips IMDS).
+        assert_eq!(
+            classify_dmi("QEMU", Some("Standard PC")),
+            DmiDetection::NotEc2
+        );
+        assert_eq!(classify_dmi("", Some("whatever")), DmiDetection::NotEc2);
+        // EC2 vendor but missing/empty product -> Unknown (let IMDS try).
+        assert_eq!(classify_dmi("Amazon EC2", None), DmiDetection::Unknown);
+        assert_eq!(
+            classify_dmi("Amazon EC2", Some("  ")),
+            DmiDetection::Unknown
+        );
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -409,10 +409,10 @@ fn walk_paths(mount: &str, cgroup_path: &str, filename: &str) -> Vec<PathBuf> {
 // Concurrency seeding
 //
 // Resolves `ConcurrencyMode::Auto` (and `TargetThroughput`) to a fixed in-flight
-// request target, in lieu of an adaptive controller. The target is derived from
-// an estimate of the machine's network bandwidth: recognized EC2 instance
-// families map to a per-vCPU Gbps rate (NIC bandwidth scales linearly with vCPU
-// count within a family), and `target = ceil(gbps / GBPS_PER_CONN)`.
+// request target. The target is derived from an estimate of the machine's
+// network bandwidth: recognized EC2 instance families map to a per-vCPU Gbps rate
+// (NIC bandwidth scales linearly with vCPU count within a family), and
+// `target = ceil(gbps / GBPS_PER_CONN)`.
 //
 // `N` is target *in-flight requests* (the scheduler's `poll_work` gate), which
 // the pool sizes connections separately from. In-flight work is nonetheless
@@ -422,8 +422,7 @@ fn walk_paths(mount: &str, cgroup_path: &str, filename: &str) -> Vec<PathBuf> {
 // ---------------------------------------------------------------------------
 
 /// Assumed goodput per in-flight request, in Gbps. Matches CRT's per-connection
-/// figure (`100 / 250`), which lines up with the measured ~250-in-flight knee at
-/// ~100 Gbps. Estimated, not measured for this client.
+/// figure (`100 / 250`).
 const GBPS_PER_CONN: f64 = 0.4;
 
 /// In-flight requests per vCPU for the fallback seed, used when the instance

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -402,6 +402,214 @@ fn walk_paths(mount: &str, cgroup_path: &str, filename: &str) -> Vec<PathBuf> {
     out
 }
 
+// ---------------------------------------------------------------------------
+// Concurrency seeding
+//
+// Resolves `ConcurrencyMode::Auto` (and `TargetThroughput`) to a fixed in-flight
+// request target for the preview, in lieu of an adaptive controller. The target
+// is derived from an estimate of the machine's network bandwidth: recognized EC2
+// instance families map to a per-vCPU Gbps rate (NIC bandwidth scales linearly
+// with vCPU count within a family), and `target = ceil(gbps / GBPS_PER_CONN)`.
+//
+// This is `N` = target *in-flight requests* (the scheduler's `poll_work` gate),
+// not connections; the pool sizes connections separately.
+// ---------------------------------------------------------------------------
+
+/// Assumed goodput per in-flight request, in Gbps. Matches CRT's per-connection
+/// figure (`100 / 250`), which lines up with the measured ~250-in-flight knee at
+/// ~100 Gbps. Preview constant; a measured value may replace it later.
+const GBPS_PER_CONN: f64 = 0.4;
+
+/// In-flight requests per vCPU for the fallback seed, used when the instance
+/// family is unknown (unrecognized type, or detection failed / off-EC2). Chosen
+/// to match the ratio recognized network-optimized families already get
+/// (`m6idn.16xlarge`: 64 vCPU -> 250 ~= 3.9/vCPU), so an unrecognized box is
+/// seeded continuously with a recognized one rather than far below it. Preview
+/// constant; a measured value may replace it later.
+const FALLBACK_INFLIGHT_PER_VCPU: usize = 4;
+
+/// Peak network bandwidth of each EC2 instance family, as the raw spec of its
+/// largest member: `(family, max_nic_gbps, vcpus_at_that_size)`.
+///
+/// There is no formula for a family's bandwidth — it is assigned per hardware
+/// generation and read from the published EC2 network-performance spec (e.g.
+/// c6gn tops out at 100 Gbps, c7gn at 200, same name stem). So this is a lookup
+/// table, and each row is the spec verbatim: `("m6idn", 200.0, 128)` means
+/// "m6idn's largest size delivers 200 Gbps on 128 vCPU." Storing the two source
+/// numbers (rather than a pre-divided per-vCPU rate) keeps every row directly
+/// checkable against the docs and avoids hand-computed quotients.
+///
+/// Within a family NIC bandwidth scales linearly with vCPU count, so the flagship
+/// reproduces every smaller size: `gbps = max_gbps * (local_vcpus / vcpus_at_max)`
+/// (see [`family_gbps_per_vcpu`]).
+///
+/// **Adding a family:** if a family's NIC is large enough that the seed matters,
+/// add a row with its flagship's Gbps and vCPU count from the spec. Families left
+/// out fall through to the vCPU-scaled fallback (fine — they are modest-NIC boxes
+/// where the seed is low-stakes). Sustained figures only; burstable ("up to")
+/// families are excluded so we never seed off a burst ceiling.
+const FAMILY_NIC_GBPS: &[(&str, f64, u32)] = &[
+    // Ultra-high (GPU / ML training / inference accelerators)
+    ("p6-b300", 6400.0, 192),
+    ("p5", 3200.0, 192),
+    ("p5en", 3200.0, 192),
+    ("p6-b200", 3200.0, 192),
+    ("trn1n", 1600.0, 128),
+    ("p6e-gb200", 1700.0, 144),
+    ("g7e", 1600.0, 192),
+    ("trn1", 800.0, 128),
+    ("dl1", 400.0, 96),
+    ("p4d", 400.0, 96),
+    ("p4de", 400.0, 96),
+    ("g7", 700.0, 192),
+    // Network-optimized (Graviton *gn, bandwidth-boost *gb)
+    ("c7gn", 200.0, 64),
+    ("c8gn", 600.0, 192),
+    ("m8gn", 600.0, 192),
+    ("r8gn", 600.0, 192),
+    ("hpc7g", 200.0, 64),
+    ("c8gb", 400.0, 192),
+    ("m8gb", 400.0, 192),
+    ("r8gb", 400.0, 192),
+    ("m8azn", 200.0, 96),
+    // Network-optimized *n / *dn / *idn (the S3-throughput workhorses)
+    ("c6in", 200.0, 128),
+    ("c8in", 600.0, 384),
+    ("m6idn", 200.0, 128),
+    ("m6in", 200.0, 128),
+    ("m8idn", 600.0, 384),
+    ("m8in", 600.0, 384),
+    ("r6idn", 200.0, 128),
+    ("r6in", 200.0, 128),
+    ("r8idn", 600.0, 384),
+    ("r8in", 600.0, 384),
+    ("c6gn", 100.0, 64),
+    ("im4gn", 100.0, 64),
+    ("i8ge", 300.0, 192),
+    ("c5n", 100.0, 72),
+    // 100 Gbps-class general / storage / inference / *ib bandwidth-boost
+    ("i3en", 100.0, 96),
+    ("inf1", 100.0, 96),
+    ("p3dn", 100.0, 96),
+    ("c8ib", 400.0, 384),
+    ("m8ib", 400.0, 384),
+    ("m8idb", 400.0, 384),
+    ("r8ib", 400.0, 384),
+    ("r8idb", 400.0, 384),
+    ("x2idn", 100.0, 128),
+    ("x2iedn", 100.0, 128),
+    ("i4i", 75.0, 128),
+    ("f2", 100.0, 192),
+    ("i7ie", 100.0, 192),
+    ("inf2", 100.0, 192),
+];
+
+/// Machine facts detected once, off the client-construction hot path (in the
+/// async config loader), and consumed when resolving auto-sized settings.
+#[derive(Debug, Clone)]
+pub(crate) struct MachineProfile {
+    /// EC2 instance type (e.g. `"m6idn.16xlarge"`), from DMI or IMDS. `None`
+    /// off-EC2 or when detection failed.
+    pub(crate) instance_type: Option<String>,
+    /// Usable vCPU count, honoring cgroup CPU quota and affinity.
+    pub(crate) vcpus: usize,
+}
+
+/// Usable vCPU count. `std::thread::available_parallelism` honors both the CPU
+/// affinity mask and the cgroup CPU quota (CFS bandwidth) on Linux, so a
+/// CPU-limited container reports its slice, not the host's core count. Falls
+/// back to 1 if the count can't be determined.
+pub(crate) fn local_vcpus() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+/// Outcome of local (DMI) instance-type detection. Distinguishes "known" and
+/// "definitely not EC2" from "couldn't tell" so the caller can decide whether an
+/// IMDS network fallback is worthwhile: a positive non-EC2 reading (readable DMI,
+/// vendor is not Amazon) means IMDS would fail too, so it is skipped; only an
+/// `Unknown` (unreadable DMI, e.g. a container or non-Linux) is worth an IMDS try.
+// `Instance` and `NotEc2` are only constructed on Linux (the DMI-bearing
+// target); the non-Linux stub returns `Unknown`. Allow dead code so non-Linux
+// dev builds stay warning-clean without hiding real dead code on Linux.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DmiDetection {
+    /// Instance type read from DMI.
+    Instance(String),
+    /// DMI is readable and says this host is not EC2.
+    NotEc2,
+    /// DMI could not be read (container without DMI, non-Linux); inconclusive.
+    Unknown,
+}
+
+/// Detect the EC2 instance type from DMI, without any network call.
+///
+/// Reads `/sys/devices/virtual/dmi/id/sys_vendor` to confirm the host is EC2,
+/// then `product_name` for the instance type. Mirrors the CRT S3 client's
+/// primary detection path. Returns [`DmiDetection`] so the caller can gate the
+/// IMDS fallback on `Unknown` vs `NotEc2`.
+#[cfg(target_os = "linux")]
+pub(crate) fn detect_instance_type_dmi() -> DmiDetection {
+    let Ok(vendor) = std::fs::read_to_string("/sys/devices/virtual/dmi/id/sys_vendor") else {
+        return DmiDetection::Unknown;
+    };
+    if !vendor.trim().eq_ignore_ascii_case("Amazon EC2") {
+        return DmiDetection::NotEc2;
+    }
+    match std::fs::read_to_string("/sys/devices/virtual/dmi/id/product_name") {
+        Ok(product) => {
+            let ty = product.trim();
+            if ty.is_empty() {
+                // Vendor says EC2 but no product name — inconclusive, let IMDS try.
+                DmiDetection::Unknown
+            } else {
+                DmiDetection::Instance(ty.to_string())
+            }
+        }
+        Err(_) => DmiDetection::Unknown,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn detect_instance_type_dmi() -> DmiDetection {
+    DmiDetection::Unknown
+}
+
+/// Per-vCPU Gbps for an instance type's family, or `None` if the family is not
+/// in [`FAMILY_NIC_GBPS`]. The family is the substring before the first `.`
+/// (`m6idn.16xlarge` -> `m6idn`); the rate is the flagship's
+/// `max_nic_gbps / vcpus_at_max` (the linear within-family scale).
+fn family_gbps_per_vcpu(instance_type: &str) -> Option<f64> {
+    let family = instance_type.split('.').next()?;
+    FAMILY_NIC_GBPS
+        .iter()
+        .find(|(name, _, _)| name.eq_ignore_ascii_case(family))
+        .map(|(_, max_gbps, vcpus_at_max)| max_gbps / *vcpus_at_max as f64)
+}
+
+/// In-flight-request target from a throughput estimate: `ceil(gbps /
+/// GBPS_PER_CONN)`, clamped to `[MIN_CONN, ABSOLUTE_MAX_CONN]`.
+pub(crate) fn seed_from_gbps(gbps: f64) -> usize {
+    let n = (gbps / GBPS_PER_CONN).ceil();
+    // f64 -> usize saturates negatives/NaN to 0; the clamp floor fixes that.
+    (n as usize).clamp(MIN_CONN, ABSOLUTE_MAX_CONN)
+}
+
+/// Resolve the `Auto` concurrency seed from detected machine facts.
+///
+/// Recognized family -> bandwidth estimate (`per_vcpu x vcpus`) -> connection
+/// derivation. Unknown/undetected -> `FALLBACK_INFLIGHT_PER_VCPU x vcpus`
+/// (a concurrency heuristic, not a bandwidth estimate). Both are clamped to
+/// `[MIN_CONN, ABSOLUTE_MAX_CONN]`. Pure function of its inputs.
+pub(crate) fn auto_concurrency_seed(instance_type: Option<&str>, vcpus: usize) -> usize {
+    match instance_type.and_then(family_gbps_per_vcpu) {
+        Some(per_vcpu) => seed_from_gbps(per_vcpu * vcpus as f64),
+        None => (FALLBACK_INFLIGHT_PER_VCPU * vcpus).clamp(MIN_CONN, ABSOLUTE_MAX_CONN),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -635,5 +843,117 @@ mod tests {
     fn test_available_ram_detected_on_supported_platforms() {
         // The detected machine has at least 1 GiB; guards the platform syscall.
         assert!(available_ram().expect("RAM detected") >= GIB);
+    }
+
+    // --- concurrency seeding ---
+
+    #[test]
+    fn test_family_lookup_parses_family_from_type() {
+        // Family is the prefix before the first '.'; size-independent.
+        assert_eq!(family_gbps_per_vcpu("m6idn.16xlarge"), Some(1.5625));
+        assert_eq!(family_gbps_per_vcpu("m6idn.32xlarge"), Some(1.5625));
+        assert_eq!(family_gbps_per_vcpu("m6idn.metal"), Some(1.5625));
+        // Case-insensitive.
+        assert_eq!(family_gbps_per_vcpu("C8GN.48XLARGE"), Some(3.125));
+        // Unknown family and malformed strings miss.
+        assert_eq!(family_gbps_per_vcpu("t3.large"), None);
+        assert_eq!(family_gbps_per_vcpu("nonsense"), None);
+    }
+
+    #[test]
+    fn test_seed_recognized_family_scales_with_vcpu() {
+        // m6idn: 1.5625 Gbps/vCPU, GBPS_PER_CONN=0.4.
+        // 16xlarge = 64 vCPU -> 100 Gbps -> ceil(100/0.4) = 250.
+        assert_eq!(auto_concurrency_seed(Some("m6idn.16xlarge"), 64), 250);
+        // 32xlarge = 128 vCPU -> 200 Gbps -> 500.
+        assert_eq!(auto_concurrency_seed(Some("m6idn.32xlarge"), 128), 500);
+        // c8gn: 3.125 Gbps/vCPU. 16xlarge = 64 vCPU -> 200 Gbps -> 500.
+        assert_eq!(auto_concurrency_seed(Some("c8gn.16xlarge"), 64), 500);
+    }
+
+    #[test]
+    fn test_seed_uses_realized_vcpu_not_instance_size() {
+        // A CPU-limited container on an m6idn.32xlarge reports its slice via
+        // available_parallelism. Seed scales to the slice, not the host: a
+        // 4-vCPU slice can't drive the box's 200 Gbps NIC. 4 * 1.5625 = 6.25
+        // Gbps -> ceil(6.25/0.4) = 16.
+        assert_eq!(auto_concurrency_seed(Some("m6idn.32xlarge"), 4), 16);
+    }
+
+    #[test]
+    fn test_seed_fallback_scales_with_vcpu() {
+        // Unknown family -> FALLBACK_INFLIGHT_PER_VCPU (4) * vcpus.
+        assert_eq!(auto_concurrency_seed(Some("t3.2xlarge"), 8), 32);
+        assert_eq!(auto_concurrency_seed(Some("gcp-n2-standard-64"), 64), 256);
+        // No detection at all falls through the same path.
+        assert_eq!(auto_concurrency_seed(None, 16), 64);
+    }
+
+    #[test]
+    fn test_seed_clamps_to_bounds() {
+        // Tiny machine: fallback below MIN_CONN floors to MIN_CONN (10).
+        assert_eq!(auto_concurrency_seed(None, 1), MIN_CONN);
+        assert_eq!(auto_concurrency_seed(Some("t3.micro"), 2), MIN_CONN);
+        // Recognized tiny estimate also floors.
+        assert_eq!(auto_concurrency_seed(Some("i4i.large"), 2), MIN_CONN);
+        // Enormous estimate caps at ABSOLUTE_MAX_CONN.
+        assert_eq!(
+            auto_concurrency_seed(Some("p6-b300.48xlarge"), 100_000),
+            ABSOLUTE_MAX_CONN
+        );
+    }
+
+    #[test]
+    fn test_seed_from_gbps_edges() {
+        assert_eq!(seed_from_gbps(100.0), 250);
+        assert_eq!(seed_from_gbps(0.0), MIN_CONN); // floors, no underflow
+        assert_eq!(seed_from_gbps(f64::NAN), MIN_CONN); // NaN -> 0 -> floor
+        assert_eq!(seed_from_gbps(1.0e9), ABSOLUTE_MAX_CONN); // caps
+    }
+
+    #[test]
+    fn test_family_rate_is_flagship_gbps_over_vcpu() {
+        // The per-vCPU rate is exactly the flagship spec divided out. Seeding at
+        // the flagship vCPU count reproduces the family's headline NIC number.
+        // m6idn flagship: 200 Gbps @ 128 vCPU -> ceil(200/0.4) = 500.
+        assert_eq!(auto_concurrency_seed(Some("m6idn.metal"), 128), 500);
+        // c8gn flagship: 600 Gbps @ 192 vCPU -> ceil(600/0.4) = 1500.
+        assert_eq!(auto_concurrency_seed(Some("c8gn.48xlarge"), 192), 1500);
+        // i4i flagship: 75 Gbps @ 128 vCPU -> ceil(75/0.4) = 188.
+        assert_eq!(auto_concurrency_seed(Some("i4i.32xlarge"), 128), 188);
+    }
+
+    #[test]
+    fn test_family_nic_table_is_well_formed() {
+        use std::collections::HashSet;
+        let mut seen = HashSet::new();
+        for (family, gbps, vcpus) in FAMILY_NIC_GBPS {
+            assert!(seen.insert(*family), "duplicate family entry: {family:?}");
+            assert!(!family.is_empty(), "empty family name");
+            assert!(
+                !family.contains('.'),
+                "family {family:?} must be a bare family, not an instance type"
+            );
+            assert_eq!(
+                family.to_ascii_lowercase(),
+                *family,
+                "family {family:?} must be lowercase for case-insensitive lookup"
+            );
+            // Sanity bounds: sustained NIC figures are >0 and within EC2's range,
+            // vCPU counts are plausible flagship sizes.
+            assert!(*gbps > 0.0 && *gbps <= 6400.0, "{family}: gbps {gbps}");
+            assert!(*vcpus > 0 && *vcpus <= 1024, "{family}: vcpus {vcpus}");
+        }
+    }
+
+    #[test]
+    fn test_local_vcpus_is_at_least_one() {
+        assert!(local_vcpus() >= 1);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn test_dmi_detection_unknown_off_linux() {
+        assert_eq!(detect_instance_type_dmi(), DmiDetection::Unknown);
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -105,7 +105,8 @@ const UNDETECTABLE_MEM_BYTES: usize = 2 * ByteUnit::Gibibyte.as_bytes_usize();
 /// Memory budget under `MemoryBudgetConfig::Auto`: `SAFE_MEM_FRACTION` of
 /// detected RAM, rounded to a power of two and clamped to
 /// `[MIN_BUDGET_BYTES, MAX_BUDGET_BYTES]`; `UNDETECTABLE_MEM_BYTES` when RAM is
-/// unknown.
+/// unknown. `ram_bytes` comes from the [`MachineProfile`] so detection happens
+/// once, not re-read here.
 ///
 /// The budget is a backstop, not the operating point: the concurrency
 /// controller settles at line rate well below it, and it binds only when a slow
@@ -114,8 +115,8 @@ const UNDETECTABLE_MEM_BYTES: usize = 2 * ByteUnit::Gibibyte.as_bytes_usize();
 /// is uncorrelated with RAM across instance families (m5.24xlarge and
 /// m5n.24xlarge share 384 GiB of RAM but differ 4x in bandwidth). The clamp
 /// keeps the estimate safe at both ends; NIC-aware sizing is a separate refinement.
-pub(crate) fn machine_safe_mem() -> usize {
-    auto_budget(available_ram())
+pub(crate) fn machine_safe_mem(ram_bytes: Option<usize>) -> usize {
+    auto_budget(ram_bytes)
 }
 
 /// `Auto` policy as a pure function of detected RAM.
@@ -132,15 +133,16 @@ fn auto_budget(ram: Option<usize>) -> usize {
 /// clamped to `(0.0, 1.0]` (a non-finite or non-positive value falls back to
 /// `SAFE_MEM_FRACTION`); the result is floored at `MIN_BUDGET_BYTES` but not
 /// capped — an explicit fraction is taken at the caller's word.
-/// `UNDETECTABLE_MEM_BYTES` when RAM is unknown.
-pub(crate) fn mem_for_fraction(fraction: f64) -> usize {
+/// `UNDETECTABLE_MEM_BYTES` when RAM is unknown. `ram_bytes` comes from the
+/// [`MachineProfile`].
+pub(crate) fn mem_for_fraction(ram_bytes: Option<usize>, fraction: f64) -> usize {
     if !(fraction.is_finite() && fraction > 0.0) || fraction > 1.0 {
         tracing::debug!(
             requested = fraction,
             "memory budget fraction outside (0.0, 1.0]; clamping"
         );
     }
-    mem_for_fraction_from(available_ram(), fraction)
+    mem_for_fraction_from(ram_bytes, fraction)
 }
 
 /// `Fraction` policy as a pure function of detected RAM.
@@ -186,7 +188,7 @@ fn round_pow2(n: usize) -> usize {
 /// only; `None` elsewhere or on a read failure, in which case the caller falls
 /// back to a conservative default.
 #[cfg(target_os = "linux")]
-fn available_ram() -> Option<usize> {
+pub(crate) fn available_ram() -> Option<usize> {
     match (meminfo_total(), cgroup_mem_limit()) {
         (Some(total), Some(cgroup)) => Some(total.min(cgroup)),
         (total, None) => total,
@@ -195,12 +197,12 @@ fn available_ram() -> Option<usize> {
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-fn available_ram() -> Option<usize> {
+pub(crate) fn available_ram() -> Option<usize> {
     None
 }
 
 #[cfg(target_os = "macos")]
-fn available_ram() -> Option<usize> {
+pub(crate) fn available_ram() -> Option<usize> {
     // hw.memsize is total physical memory in bytes; macOS has no cgroup.
     // Ref: sysctl(3), hw.memsize key
     // <https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sysctl.3.html>
@@ -225,7 +227,7 @@ fn available_ram() -> Option<usize> {
 }
 
 #[cfg(target_os = "windows")]
-fn available_ram() -> Option<usize> {
+pub(crate) fn available_ram() -> Option<usize> {
     use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
     // ullTotalPhys is total physical memory in bytes.
     // Ref: GlobalMemoryStatusEx / MEMORYSTATUSEX
@@ -513,6 +515,33 @@ pub(crate) struct MachineProfile {
     pub(crate) instance_type: Option<String>,
     /// Usable vCPU count, honoring cgroup CPU quota and affinity.
     pub(crate) vcpus: usize,
+    /// Usable RAM in bytes (cgroup-aware), or `None` when undetectable. Sizes the
+    /// `Auto`/`Fraction` memory budget.
+    pub(crate) ram_bytes: Option<usize>,
+}
+
+impl MachineProfile {
+    /// Detect machine facts from local sources only: DMI instance type, vCPU
+    /// count, and RAM. All are cheap pseudo-file reads (sysfs / procfs) or a
+    /// syscall — no network — so this is safe to call synchronously on the
+    /// `Client::new` path when no loader-detected profile is present.
+    ///
+    /// This does not attempt the IMDS instance-type fallback: IMDS is a network
+    /// call and belongs to the async config loader, which assembles its own
+    /// profile from these same primitives plus the IMDS step. A local DMI
+    /// `NotEc2`/`Unknown` result therefore collapses to `instance_type: None`
+    /// here — correct on the bypass path, where there is no IMDS to gate.
+    pub(crate) fn detect_local() -> Self {
+        let instance_type = match detect_instance_type_dmi() {
+            DmiDetection::Instance(ty) => Some(ty),
+            DmiDetection::NotEc2 | DmiDetection::Unknown => None,
+        };
+        Self {
+            instance_type,
+            vcpus: local_vcpus(),
+            ram_bytes: available_ram(),
+        }
+    }
 }
 
 /// Usable vCPU count. `std::thread::available_parallelism` honors both the CPU
@@ -949,6 +978,29 @@ mod tests {
     #[test]
     fn test_local_vcpus_is_at_least_one() {
         assert!(local_vcpus() >= 1);
+    }
+
+    #[cfg_attr(
+        miri,
+        ignore = "detect_local reads /sys and /proc and calls platform syscalls miri cannot emulate"
+    )]
+    #[test]
+    fn test_detect_local_fills_profile() {
+        // Local-only detection: vCPU is always present; instance_type/ram are
+        // environment-dependent (None off-EC2 / on read failure), so we only
+        // assert the always-true invariant and that it does not panic.
+        let p = MachineProfile::detect_local();
+        assert!(p.vcpus >= 1);
+        // No IMDS on this path: off-EC2, instance_type must be None (DMI-only).
+        // On EC2 it may be Some; either is valid, so this is not asserted here.
+    }
+
+    #[test]
+    fn test_machine_safe_mem_takes_ram_from_caller() {
+        // The wrapper no longer reads the environment; it sizes from the passed
+        // RAM (from the MachineProfile). 64 GiB -> 25% -> 16 GiB (pow2, in range).
+        assert_eq!(machine_safe_mem(Some(64 * GIB)), 16 * GIB);
+        assert_eq!(machine_safe_mem(None), UNDETECTABLE_MEM_BYTES);
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/aws-sdk-s3-transfer-manager/src/scheduler/concurrency.rs
+++ b/aws-sdk-s3-transfer-manager/src/scheduler/concurrency.rs
@@ -3,9 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// The adaptive controller is retained but not wired: the dev preview resolves
+// `ConcurrencyMode::Auto` to a fixed instance-aware seed (see
+// `runtime::platform` concurrency seeding). This module is the base for the
+// adaptive controller redesign (a later release), so it is kept in-tree rather
+// than deleted. `dead_code` until it is wired back as the `Auto` engine; the
+// re-export is dropped meanwhile (re-add when a consumer references it again).
+#[allow(dead_code)]
 mod adaptive;
-
-pub(crate) use adaptive::{AdaptiveConcurrencyController, AdaptiveConfig};
 
 use std::fmt;
 

--- a/aws-sdk-s3-transfer-manager/src/scheduler/concurrency.rs
+++ b/aws-sdk-s3-transfer-manager/src/scheduler/concurrency.rs
@@ -43,8 +43,9 @@ pub(crate) struct CompletionSample {
 /// The scheduler calls `target()` before generating work. Work is only
 /// generated when total in-flight + pending is below the target.
 ///
-/// Implementations: [`FixedConcurrency`] (constant target),
-/// [`AdaptiveConcurrencyController`] (adjusts based on observed throughput).
+/// Implementations: [`FixedConcurrency`] (constant target), and
+/// `adaptive::AdaptiveConcurrencyController` (adjusts based on observed
+/// throughput; retained but not currently wired).
 pub(crate) trait ConcurrencyController: Send + Sync + fmt::Debug {
     /// Current concurrency target. May change between calls.
     ///

--- a/aws-sdk-s3-transfer-manager/src/scheduler/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/scheduler/mod.rs
@@ -10,8 +10,7 @@ mod scheduler;
 mod transfer;
 
 pub(crate) use concurrency::{
-    classify_error, AdaptiveConcurrencyController, AdaptiveConfig, CompletionSample,
-    ConcurrencyController, FixedConcurrency,
+    classify_error, CompletionSample, ConcurrencyController, FixedConcurrency,
 };
 pub(crate) use scheduler::Scheduler;
 

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -67,11 +67,15 @@ pub struct MemoryBudgetSnapshot {
 }
 
 impl MemoryBudgetConfig {
-    /// Resolve to the budget capacity in bytes.
-    pub(crate) fn resolve(&self) -> usize {
+    /// Resolve to the budget capacity in bytes. `ram_bytes` is the detected
+    /// usable RAM from the [`MachineProfile`](crate::runtime::platform::MachineProfile)
+    /// (`None` when undetectable), used only by the `Auto` and `Fraction` policies.
+    pub(crate) fn resolve(&self, ram_bytes: Option<usize>) -> usize {
         match self {
-            MemoryBudgetConfig::Auto => crate::runtime::platform::machine_safe_mem(),
-            MemoryBudgetConfig::Fraction(f) => crate::runtime::platform::mem_for_fraction(*f),
+            MemoryBudgetConfig::Auto => crate::runtime::platform::machine_safe_mem(ram_bytes),
+            MemoryBudgetConfig::Fraction(f) => {
+                crate::runtime::platform::mem_for_fraction(ram_bytes, *f)
+            }
             MemoryBudgetConfig::Limit(bytes) => *bytes,
         }
     }


### PR DESCRIPTION
## Summary

`ConcurrencyMode::Auto` resolves to a fixed in-flight-request target derived from the machine's network bandwidth, instead of running the adaptive controller. The bandwidth estimate comes from the detected EC2 instance type (a per-family Gbps-per-vCPU table) times the local vCPU count; the target is `ceil(gbps / 0.4)`, clamped to `[10, 10000]`. Instance type is detected once — local DMI, falling back to IMDS — into a `MachineProfile` that also carries the vCPU count and RAM, so the memory budget sizes from the same detection. `TargetThroughput(t)` uses the same derivation from `t`; `Explicit(n)` is unchanged except `Explicit(0)` now clamps to 1 instead of tripping an assert. The adaptive controller stays in the tree, unwired.

## Why

**The adaptive controller's needs re-worked.** Adaptive controller is the right idea but the current implementation is not what I want to ship. It's too slow to ramp and was handling some issues better handled in the new connection pool. It also will benefit from better signals from the new connection pool work. So `Auto` ships a fixed seed for the next preview cut; the controller returns when the pool lands.

**Every option has to answer "what concurrency on an unknown machine," and without detection the answer is a blind constant.** CRT's client answers it from a throughput target the caller supplies (default 10 Gbps → 25 connections) and never looks at the instance; its instance-type detection feeds only query APIs the caller must invoke. Doing the detection in the engine seeds a large box correctly with no configuration.

## How it works

### The estimate

`FAMILY_NIC_GBPS` records `(family, max_nic_gbps, vcpus_at_that_size)` for each instance family, read from published EC2 network specs — one row per family, checkable against the spec sheet. A family's bandwidth has no closed form (c6gn tops at 100 Gbps, c7gn at 200), so it's a lookup; within a family it scales linearly with vCPU, so `max_gbps / vcpus_at_that_size` is the per-vCPU rate for every size. `vcpus` is `std::thread::available_parallelism()`, which honors cgroup CPU quota and affinity, so a CPU-limited container seeds from its slice rather than the host. `GBPS_PER_CONN = 0.4` is CRT's per-connection figure (100 Gbps → 250). A family absent from the table, or a machine where detection failed, falls back to `4 × vcpus` — the ratio recognized network-optimized families already get, so an unknown box seeds near a known one rather than far below it.

The target is in-flight requests, not connections. In HTTP/1 an in-flight request holds a connection, so the connection bounds `[MIN_CONN, ABSOLUTE_MAX_CONN]` = `[10, 10000]` (CRT's) are the right bounds for the seed and are reused rather than duplicated.

### Detection

`MachineProfile { instance_type, vcpus, ram_bytes }` is resolved once, in `ConfigLoader::load`. Instance type comes from DMI (`/sys/devices/virtual/dmi/id/{sys_vendor,product_name}`); a readable non-EC2 vendor is definitive and skips IMDS, an unreadable one (a container, or non-Linux) falls back to a single IMDS lookup gated on `AWS_EC2_METADATA_DISABLED`. IMDS returns only the instance-type string, so the family table is needed either way. `Client::new` reads the profile and resolves both the concurrency seed and the memory budget from it. A `Config` built directly, without the loader, has no profile; `Client::new` then detects locally (DMI + vCPU + RAM, no IMDS), so construction stays non-blocking and a container without DMI still seeds by vCPU.

### Memory budget

`MemoryBudgetConfig::resolve` and the `machine_safe_mem` / `mem_for_fraction` sizers take RAM as an argument from the profile rather than reading it themselves, so RAM is detected once alongside the instance type. The sizing arithmetic is unchanged.

## How to review

`runtime/platform.rs` is the core: the `FAMILY_NIC_GBPS` table and `auto_concurrency_seed` / `seed_from_gbps` (the estimate and clamp), `classify_dmi` (the three-state DMI gate, pure and unit-tested), and `MachineProfile`. `config/loader.rs` composes DMI with the IMDS fallback; `client.rs` has `resolve_concurrency_target` and the single-profile resolution in `Client::new`.

## Testing

Unit tests recompute the estimate for recognized families, the vCPU fallback, container-sized vCPU counts, the clamp floor and ceiling, and NaN/zero/overflow inputs; `classify_dmi` is table-tested across its three states including the non-EC2 gate. `Client::new` is checked end-to-end (seed reaches `controller.target()`) and on the no-profile bypass path. The file- and network-reading detectors are validated on real EC2: the resolved seed was confirmed by log on `m6idn.large` (2 vCPU → 10, the floor), `c6in.16xlarge` (64 → 250), and `c7gn.16xlarge` (Graviton, 64 → 500). 536 lib tests, clippy clean, fmt clean.

## Changes

```
aws-sdk-s3-transfer-manager/
  src/
    runtime/platform.rs   FAMILY_NIC_GBPS; auto_concurrency_seed / seed_from_gbps;
                          MachineProfile + detect_local; classify_dmi +
                          detect_instance_type_dmi; machine_safe_mem /
                          mem_for_fraction take ram
    config/loader.rs      detect_machine_profile (DMI, IMDS fallback); populate profile
    config.rs             MachineProfile on Config + Builder
    client.rs             resolve_concurrency_target; single-profile resolution
    types.rs              MemoryBudgetConfig::resolve takes ram_bytes
    scheduler/concurrency.rs, scheduler/mod.rs   adaptive controller unwired, kept
```

## Notes for review

- `GBPS_PER_CONN = 0.4` and the `4 × vcpus` fallback are estimates, not measured for this client; the `FAMILY_NIC_GBPS` figures are verified against the current EC2 spec sheet.
- `Auto` becoming adaptive at GA is a behavior change under a stable enum, not an API change.
- On non-Linux there's no DMI path, so `Auto` always attempts one IMDS lookup at construction; deliberate, since EC2 runs Windows and macOS and IMDS is the only detection path there.
- The DMI reads use synchronous `std::fs`: the `/sys` attributes are kernel-resident (SMBIOS parsed at boot), read once at construction, so a `spawn_blocking` hop would cost more than the read.
```
