### PR TITLE
runtime: select the execution runtime via config

### DIFF
--- a/aws-sdk-s3-transfer-manager/examples/cp.rs
+++ b/aws-sdk-s3-transfer-manager/examples/cp.rs
@@ -71,14 +71,14 @@ enum RuntimeArg {
     #[default]
     Managed,
     /// Run on the ambient tokio multi-threaded runtime.
-    CurrentTokio,
+    MultiThreadTokio,
 }
 
 impl RuntimeArg {
     fn mode(&self) -> RuntimeMode {
         match self {
             RuntimeArg::Managed => RuntimeMode::Managed,
-            RuntimeArg::CurrentTokio => RuntimeMode::CurrentTokio,
+            RuntimeArg::MultiThreadTokio => RuntimeMode::MultiThreadTokio,
         }
     }
 }
@@ -406,15 +406,16 @@ fn main() {
     let args = Args::parse();
     // Runtime flavor must match the selected execution runtime. `Managed` spawns
     // and owns its own worker threads, so main only drives orchestration — a
-    // current-thread runtime is correct and matches prior behavior. `CurrentTokio`
-    // runs the transfer workers on THIS runtime via `tokio::spawn`, so it needs a
-    // multi-threaded runtime or all workers serialize onto one thread.
+    // current-thread runtime is correct and matches prior behavior.
+    // `MultiThreadTokio` runs the transfer workers on THIS runtime via
+    // `tokio::spawn`, so it needs a multi-threaded runtime or all workers
+    // serialize onto one thread.
     let rt = match args.runtime {
         RuntimeArg::Managed => tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .expect("build current-thread runtime"),
-        RuntimeArg::CurrentTokio => tokio::runtime::Builder::new_multi_thread()
+        RuntimeArg::MultiThreadTokio => tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .expect("build multi-thread runtime"),

--- a/aws-sdk-s3-transfer-manager/examples/cp.rs
+++ b/aws-sdk-s3-transfer-manager/examples/cp.rs
@@ -7,7 +7,7 @@ use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_sdk_s3_transfer_manager::metrics::Throughput;
 use aws_sdk_s3_transfer_manager::operation::download::Body;
 use aws_sdk_s3_transfer_manager::types::{
-    ConcurrencyMode, MemoryBudgetConfig, PartSize, TargetThroughput,
+    ConcurrencyMode, MemoryBudgetConfig, PartSize, RuntimeMode, TargetThroughput,
 };
 use aws_smithy_types::date_time::{DateTime, Format};
 use clap::{CommandFactory, Parser};
@@ -64,6 +64,25 @@ enum OutputFormat {
     Json,
 }
 
+/// Execution runtime selection, mapped to `RuntimeMode`.
+#[derive(Debug, Clone, Default, clap::ValueEnum)]
+enum RuntimeArg {
+    /// Managed OS threads owned by the transfer manager (default).
+    #[default]
+    Managed,
+    /// Run on the ambient tokio multi-threaded runtime.
+    CurrentTokio,
+}
+
+impl RuntimeArg {
+    fn mode(&self) -> RuntimeMode {
+        match self {
+            RuntimeArg::Managed => RuntimeMode::Managed,
+            RuntimeArg::CurrentTokio => RuntimeMode::CurrentTokio,
+        }
+    }
+}
+
 #[derive(Debug, Clone, clap::Parser)]
 #[command(name = "cp")]
 #[command(about = "Copies a local file or S3 object to another location locally or in S3.")]
@@ -78,6 +97,10 @@ pub struct Args {
 
     #[command(flatten)]
     concurrency: ConcurrencyModeArg,
+
+    /// Execution runtime: managed threads (default) or the ambient tokio runtime
+    #[arg(long, value_enum, default_value_t = RuntimeArg::Managed)]
+    runtime: RuntimeArg,
 
     /// Part size to use
     #[arg(long, default_value_t = 8388608)]
@@ -379,9 +402,28 @@ async fn do_manifest_upload(
     Ok(total)
 }
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
-    if let Err(e) = run().await {
+fn main() {
+    let args = Args::parse();
+    // Runtime flavor must match the selected execution runtime. `Managed` spawns
+    // and owns its own worker threads, so main only drives orchestration — a
+    // current-thread runtime is correct and matches prior behavior. `CurrentTokio`
+    // runs the transfer workers on THIS runtime via `tokio::spawn`, so it needs a
+    // multi-threaded runtime or all workers serialize onto one thread.
+    let rt = match args.runtime {
+        RuntimeArg::Managed => tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build current-thread runtime"),
+        RuntimeArg::CurrentTokio => tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("build multi-thread runtime"),
+    };
+    rt.block_on(async_main(args));
+}
+
+async fn async_main(args: Args) {
+    if let Err(e) = run(args).await {
         // The top-level Display already carries a TM error's operation, code, and
         // request ids; the source chain carries the underlying detail (SdkError
         // message, checksum values).
@@ -395,8 +437,7 @@ async fn main() {
     }
 }
 
-async fn run() -> Result<(), BoxError> {
-    let args = Args::parse();
+async fn run(args: Args) -> Result<(), BoxError> {
     if args.tokio_console {
         console_subscriber::init();
     } else {
@@ -451,6 +492,7 @@ async fn run() -> Result<(), BoxError> {
     #[allow(unused_mut)]
     let mut config_loader = aws_sdk_s3_transfer_manager::from_env()
         .concurrency(args.concurrency.mode())
+        .runtime_mode(args.runtime.mode())
         .part_size(PartSize::Target(args.part_size));
 
     // S3FIO_MEMORY_LIMIT=N caps the transfer manager's memory budget at N GiB

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -277,9 +277,26 @@ impl Client {
                     }
                     Arc::new(builder.build())
                 }
-                RuntimeMode::CurrentTokio => Arc::new(
-                    crate::runtime::TokioMultiThreadRuntime::new(weak_handle.clone()),
-                ),
+                RuntimeMode::CurrentTokio => {
+                    // CurrentTokio runs transfer workers on the caller's runtime via
+                    // `tokio::spawn`. On a current-thread runtime they all serialize onto
+                    // the one thread, collapsing throughput with no other symptom. Warn
+                    // loudly rather than let that happen silently.
+                    if matches!(
+                        tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()),
+                        Ok(tokio::runtime::RuntimeFlavor::CurrentThread)
+                    ) {
+                        tracing::warn!(
+                            target: crate::telemetry::TARGET_SCHEDULING,
+                            "RuntimeMode::CurrentTokio selected on a current-thread runtime; \
+                             transfer workers will serialize onto one thread. Use a \
+                             multi-threaded runtime or RuntimeMode::Managed."
+                        );
+                    }
+                    Arc::new(crate::runtime::TokioMultiThreadRuntime::new(
+                        weak_handle.clone(),
+                    ))
+                }
             };
 
             let s3_client = match config.take_s3_client_source() {

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -138,30 +138,17 @@ impl Handle {
         self.transfer_override(bucket)
     }
 
-    /// Create a Handle for testing with a custom scheduler factory.
+    /// Create a Handle for testing on the ambient tokio runtime with a fixed
+    /// concurrency target. The ergonomic common case; tests that need a custom
+    /// runtime or a controller they drive directly use
+    /// [`new_for_test_with_runtime`](Self::new_for_test_with_runtime).
     #[cfg(test)]
-    pub(crate) fn new_for_test(mut config: crate::Config, concurrency: usize) -> Arc<Self> {
-        Arc::new_cyclic(|weak| {
-            let scheduler = Scheduler::new(weak.clone());
-            let runtime: Arc<dyn ExecutionRuntime> =
-                Arc::new(crate::runtime::TokioMultiThreadRuntime::new(weak.clone()));
-            let s3_client = match config.take_s3_client_source() {
-                crate::config::S3ClientSource::Provided(client) => client,
-                crate::config::S3ClientSource::FromConfig(s3_config) => {
-                    aws_sdk_s3::Client::from_conf(s3_config.builder.build())
-                }
-            };
-            Self {
-                config,
-                s3_client,
-                scheduler,
-                runtime,
-                controller: Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
-                telemetry: Arc::new(Telemetry::new(std::time::Duration::from_millis(500))),
-                memory_budget: MemoryBudget::new(TEST_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
-                retry_partitions: std::sync::Mutex::new(std::collections::HashMap::new()),
-            }
-        })
+    pub(crate) fn new_for_test(config: crate::Config, concurrency: usize) -> Arc<Self> {
+        Self::new_for_test_with_runtime(
+            config,
+            Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
+            |weak| Arc::new(crate::runtime::TokioMultiThreadRuntime::new(weak)),
+        )
     }
 
     /// Test handle using the ambient tokio runtime (no OS threads spawned).
@@ -186,20 +173,27 @@ impl Handle {
     /// threads own their own runtimes independently.
     #[cfg(test)]
     pub(crate) fn test_handle_managed(config: crate::Config) -> Arc<Self> {
-        Self::new_for_test_with_runtime(config, 128, |weak| {
-            Arc::new(
-                crate::runtime::ManagedThreadRuntime::builder(weak)
-                    .topology(crate::runtime::Topology::uniform(4))
-                    .build(),
-            )
-        })
+        Self::new_for_test_with_runtime(
+            config,
+            Arc::new(crate::scheduler::FixedConcurrency::new(128)),
+            |weak| {
+                Arc::new(
+                    crate::runtime::ManagedThreadRuntime::builder(weak)
+                        .topology(crate::runtime::Topology::uniform(4))
+                        .build(),
+                )
+            },
+        )
     }
 
-    /// Create a Handle for testing with a custom runtime factory.
+    /// Create a Handle for testing with a custom concurrency controller and
+    /// runtime factory. The controller is an axis because some tests drive its
+    /// target directly (e.g. an adjustable controller); most pass a
+    /// [`FixedConcurrency`](crate::scheduler::FixedConcurrency).
     #[cfg(test)]
     pub(crate) fn new_for_test_with_runtime(
         mut config: crate::Config,
-        concurrency: usize,
+        controller: Arc<dyn ConcurrencyController>,
         runtime_factory: impl FnOnce(std::sync::Weak<Handle>) -> Arc<dyn ExecutionRuntime>,
     ) -> Arc<Self> {
         Arc::new_cyclic(|weak| {
@@ -216,7 +210,7 @@ impl Handle {
                 s3_client,
                 scheduler,
                 runtime,
-                controller: Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
+                controller,
                 telemetry: Arc::new(Telemetry::new(std::time::Duration::from_millis(500))),
                 memory_budget: MemoryBudget::new(TEST_MEMORY_BUDGET_BYTES, BUDGET_CHUNK_BYTES),
                 retry_partitions: std::sync::Mutex::new(std::collections::HashMap::new()),

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -277,26 +277,9 @@ impl Client {
                     }
                     Arc::new(builder.build())
                 }
-                RuntimeMode::CurrentTokio => {
-                    // CurrentTokio runs transfer workers on the caller's runtime via
-                    // `tokio::spawn`. On a current-thread runtime they all serialize onto
-                    // the one thread, collapsing throughput with no other symptom. Warn
-                    // loudly rather than let that happen silently.
-                    if matches!(
-                        tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()),
-                        Ok(tokio::runtime::RuntimeFlavor::CurrentThread)
-                    ) {
-                        tracing::warn!(
-                            target: crate::telemetry::TARGET_SCHEDULING,
-                            "RuntimeMode::CurrentTokio selected on a current-thread runtime; \
-                             transfer workers will serialize onto one thread. Use a \
-                             multi-threaded runtime or RuntimeMode::Managed."
-                        );
-                    }
-                    Arc::new(crate::runtime::TokioMultiThreadRuntime::new(
-                        weak_handle.clone(),
-                    ))
-                }
+                RuntimeMode::MultiThreadTokio => Arc::new(
+                    crate::runtime::TokioMultiThreadRuntime::new(weak_handle.clone()),
+                ),
             };
 
             let s3_client = match config.take_s3_client_source() {
@@ -730,11 +713,11 @@ mod tests {
     // FIXME: crossbeam-epoch is incompatible with miri (https://github.com/crossbeam-rs/crossbeam/issues/1181)
     #[cfg_attr(miri, ignore)]
     #[tokio::test(flavor = "multi_thread")]
-    async fn client_new_with_current_tokio_runtime_mode() {
+    async fn client_new_with_multi_thread_tokio_runtime_mode() {
         let s3_client = aws_smithy_mocks::mock_client!(aws_sdk_s3, []);
         let config = crate::Config::builder()
             .client(s3_client)
-            .runtime_mode(RuntimeMode::CurrentTokio)
+            .runtime_mode(RuntimeMode::MultiThreadTokio)
             .build();
         let _client = Client::new(config);
     }

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -7,7 +7,7 @@ use crate::metrics::unit::ByteUnit;
 use crate::runtime::ManagedThreadRuntime;
 use crate::scheduler::{ConcurrencyController, FixedConcurrency, Scheduler};
 use crate::telemetry::Telemetry;
-use crate::types::{ConcurrencyMode, PartSize};
+use crate::types::{ConcurrencyMode, PartSize, RuntimeMode};
 use crate::Config;
 use std::sync::Arc;
 use std::time::Duration;
@@ -267,14 +267,19 @@ impl Client {
 
         let handle = Arc::new_cyclic(|weak_handle| {
             let scheduler = Scheduler::new(weak_handle.clone());
-            let runtime: Arc<dyn ExecutionRuntime> = {
-                #[allow(unused_mut)]
-                let mut builder = ManagedThreadRuntime::builder(weak_handle.clone());
-                #[cfg(feature = "dial9")]
-                if let Some(guard) = telemetry_guard {
-                    builder = builder.telemetry_guard(guard);
+            let runtime: Arc<dyn ExecutionRuntime> = match config.runtime_mode() {
+                RuntimeMode::Managed => {
+                    #[allow(unused_mut)]
+                    let mut builder = ManagedThreadRuntime::builder(weak_handle.clone());
+                    #[cfg(feature = "dial9")]
+                    if let Some(guard) = telemetry_guard {
+                        builder = builder.telemetry_guard(guard);
+                    }
+                    Arc::new(builder.build())
                 }
-                Arc::new(builder.build())
+                RuntimeMode::CurrentTokio => Arc::new(
+                    crate::runtime::TokioMultiThreadRuntime::new(weak_handle.clone()),
+                ),
             };
 
             let s3_client = match config.take_s3_client_source() {
@@ -683,5 +688,37 @@ mod tests {
         let map = handle.retry_partitions.lock().unwrap();
         assert_eq!(map.len(), 2, "each distinct bucket caches one partition");
         assert!(map.contains_key("bucket-a") && map.contains_key("bucket-b"));
+    }
+
+    // --- runtime mode selection ---
+
+    #[test]
+    fn config_default_runtime_mode_is_managed() {
+        let config = config_with(ConcurrencyMode::Auto, None);
+        assert!(matches!(config.runtime_mode(), RuntimeMode::Managed));
+    }
+
+    // FIXME: crossbeam-epoch is incompatible with miri (https://github.com/crossbeam-rs/crossbeam/issues/1181)
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn client_new_with_managed_runtime_mode() {
+        let s3_client = aws_smithy_mocks::mock_client!(aws_sdk_s3, []);
+        let config = crate::Config::builder()
+            .client(s3_client)
+            .runtime_mode(RuntimeMode::Managed)
+            .build();
+        let _client = Client::new(config);
+    }
+
+    // FIXME: crossbeam-epoch is incompatible with miri (https://github.com/crossbeam-rs/crossbeam/issues/1181)
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn client_new_with_current_tokio_runtime_mode() {
+        let s3_client = aws_smithy_mocks::mock_client!(aws_sdk_s3, []);
+        let config = crate::Config::builder()
+            .client(s3_client)
+            .runtime_mode(RuntimeMode::CurrentTokio)
+            .build();
+        let _client = Client::new(config);
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/config.rs
@@ -7,7 +7,7 @@ use aws_runtime::user_agent::FrameworkMetadata;
 use std::cmp;
 
 use crate::metrics::unit::ByteUnit;
-use crate::types::{ConcurrencyMode, MemoryBudgetConfig, PartSize, ReadAhead};
+use crate::types::{ConcurrencyMode, MemoryBudgetConfig, PartSize, ReadAhead, RuntimeMode};
 
 pub(crate) mod loader;
 
@@ -70,6 +70,7 @@ pub struct Config {
     multipart_threshold: PartSize,
     target_part_size: PartSize,
     concurrency: ConcurrencyMode,
+    runtime_mode: RuntimeMode,
     read_ahead: ReadAhead,
     memory_budget: MemoryBudgetConfig,
     framework_metadata: Option<FrameworkMetadata>,
@@ -103,6 +104,14 @@ impl Config {
     /// This is the mode used for concurrent in-flight requests across _all_ operations.
     pub fn concurrency(&self) -> &ConcurrencyMode {
         &self.concurrency
+    }
+
+    /// Returns the execution runtime the client runs transfers on.
+    ///
+    /// See [`RuntimeMode`] for the tradeoff between managed threads and the
+    /// caller's runtime.
+    pub fn runtime_mode(&self) -> &RuntimeMode {
+        &self.runtime_mode
     }
 
     /// Returns the read-ahead mode used for downloads.
@@ -152,6 +161,7 @@ pub struct Builder {
     multipart_threshold_part_size: PartSize,
     target_part_size: PartSize,
     concurrency: ConcurrencyMode,
+    runtime_mode: RuntimeMode,
     read_ahead: ReadAhead,
     memory_budget: MemoryBudgetConfig,
     pub(crate) framework_metadata: Option<FrameworkMetadata>,
@@ -223,6 +233,14 @@ impl Builder {
     /// Default is [ConcurrencyMode::Auto].
     pub fn concurrency(mut self, mode: ConcurrencyMode) -> Self {
         self.concurrency = mode;
+        self
+    }
+
+    /// Set the execution runtime mode.
+    ///
+    /// Default is [`RuntimeMode::Managed`].
+    pub fn runtime_mode(mut self, mode: RuntimeMode) -> Self {
+        self.runtime_mode = mode;
         self
     }
 
@@ -312,6 +330,7 @@ impl Builder {
             multipart_threshold: self.multipart_threshold_part_size,
             target_part_size: self.target_part_size,
             concurrency: self.concurrency,
+            runtime_mode: self.runtime_mode,
             read_ahead: self.read_ahead,
             memory_budget: self.memory_budget,
             framework_metadata: self.framework_metadata,

--- a/aws-sdk-s3-transfer-manager/src/config/loader.rs
+++ b/aws-sdk-s3-transfer-manager/src/config/loader.rs
@@ -10,7 +10,7 @@ use aws_sdk_s3::config::{Intercept, IntoShared};
 use aws_types::os_shim_internal::Env;
 
 use crate::config::{Builder, Config};
-use crate::types::{ConcurrencyMode, MemoryBudgetConfig, PartSize};
+use crate::types::{ConcurrencyMode, MemoryBudgetConfig, PartSize, RuntimeMode};
 
 #[derive(Debug)]
 struct S3TransferManagerInterceptor {
@@ -83,6 +83,14 @@ impl ConfigLoader {
     /// Default is [ConcurrencyMode::Auto].
     pub fn concurrency(mut self, mode: ConcurrencyMode) -> Self {
         self.builder = self.builder.concurrency(mode);
+        self
+    }
+
+    /// Set the execution runtime this client should use.
+    ///
+    /// Default is [RuntimeMode::Managed].
+    pub fn runtime_mode(mut self, mode: RuntimeMode) -> Self {
+        self.builder = self.builder.runtime_mode(mode);
         self
     }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/managed.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/managed.rs
@@ -473,7 +473,7 @@ mod tests {
             crate::Config::builder()
                 .client(aws_smithy_mocks::mock_client!(aws_sdk_s3, []))
                 .build(),
-            num_cores,
+            Arc::new(crate::scheduler::FixedConcurrency::new(num_cores)),
             move |weak| {
                 let rt = Arc::new(
                     ManagedThreadRuntime::builder(weak)

--- a/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
@@ -8,7 +8,6 @@
 //! The scheduler decides WHAT to run and WHEN. The runtime decides WHERE and HOW.
 
 mod tokio_mt;
-#[cfg(test)]
 pub(crate) use tokio_mt::TokioMultiThreadRuntime;
 
 mod managed;

--- a/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt.rs
@@ -42,7 +42,12 @@ impl TokioMultiThreadRuntime {
         }
     }
 
-    /// Ensure workers are spawned. Called lazily on first dispatch.
+    /// Ensure workers are spawned on first dispatch.
+    ///
+    /// The `mark_started` CAS (AcqRel) guarantees exactly one caller wins the
+    /// genesis spawn. The subsequent `Release` store to `worker_count` publishes
+    /// `target` so that a concurrent `ensure_worker_capacity` load (Acquire)
+    /// observes the post-genesis count and does not re-spawn.
     fn ensure_workers_started(&self) {
         if self.pool.mark_started() {
             let target = self
@@ -51,32 +56,67 @@ impl TokioMultiThreadRuntime {
                 .expect("Handle dropped")
                 .controller
                 .target();
-            self.spawn_workers(target);
+
+            // Emit the current-thread guardrail warning once, at the site where
+            // workers actually execute (not at Client::new, which may observe a
+            // different runtime).
+            if matches!(
+                tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor()),
+                Ok(tokio::runtime::RuntimeFlavor::CurrentThread)
+            ) {
+                tracing::warn!(
+                    target: crate::telemetry::TARGET_SCHEDULING,
+                    "RuntimeMode::MultiThreadTokio selected on a current-thread runtime; \
+                     transfer workers will serialize onto one thread. Use a \
+                     multi-threaded runtime or RuntimeMode::Managed."
+                );
+            }
+
+            self.spawn_workers_raw(target);
+            // Release: publish the genesis count so growth-path Acquire loads see it.
+            self.worker_count.store(target, Ordering::Release);
         }
     }
 
     /// Spawn additional workers if the concurrency target has grown beyond
     /// the current worker count.
+    ///
+    /// The CAS claims the growth atomically: it publishes `target` into
+    /// `worker_count` so concurrent callers observe the new count and skip.
+    /// Only the CAS winner spawns the delta. Acquire on load pairs with the
+    /// Release in genesis and in the CAS success ordering, preventing a stale
+    /// read of 0 after genesis has completed.
     fn ensure_worker_capacity(&self) {
+        // Only attempt growth after genesis; avoids a spurious load/CAS before
+        // `mark_started` has published the initial count.
+        if !self.pool.is_started() {
+            return;
+        }
+
         let target = self
             .handle
             .upgrade()
             .expect("Handle dropped")
             .controller
             .target();
-        let current = self.worker_count.load(Ordering::Relaxed);
+        let current = self.worker_count.load(Ordering::Acquire);
         if target > current
             && self
                 .worker_count
-                .compare_exchange(current, target, Ordering::Relaxed, Ordering::Relaxed)
+                .compare_exchange(current, target, Ordering::Release, Ordering::Relaxed)
                 .is_ok()
         {
-            self.spawn_workers(target - current);
+            self.spawn_workers_raw(target - current);
             tracing::debug!(target: crate::telemetry::TARGET_SCHEDULING, old = current, new = target, "spawning additional workers");
         }
     }
 
-    fn spawn_workers(&self, count: usize) {
+    /// Spawn `count` tokio tasks that pull from the shared worker pool.
+    ///
+    /// Does NOT update `worker_count` — callers own the counter update
+    /// so each path (genesis / growth) can publish the authoritative value
+    /// without double-counting.
+    fn spawn_workers_raw(&self, count: usize) {
         for _ in 0..count {
             let pool = Arc::clone(&self.pool);
             let handle = self.handle.clone();
@@ -84,7 +124,14 @@ impl TokioMultiThreadRuntime {
                 worker_loop(pool, handle).await;
             });
         }
-        self.worker_count.fetch_add(count, Ordering::Relaxed);
+    }
+}
+
+impl TokioMultiThreadRuntime {
+    /// Current value of the worker counter. Test-only.
+    #[cfg(test)]
+    pub(crate) fn worker_count(&self) -> usize {
+        self.worker_count.load(Ordering::Acquire)
     }
 }
 
@@ -110,7 +157,7 @@ impl ExecutionRuntime for TokioMultiThreadRuntime {
     }
 }
 
-/// Worker loop — pulls work from pool and executes it.
+/// Worker loop -- pulls work from pool and executes it.
 async fn worker_loop(pool: Arc<WorkerPool>, handle: Weak<crate::client::Handle>) {
     static WORKER_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let wid = WORKER_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -167,5 +214,136 @@ async fn worker_loop(pool: Arc<WorkerPool>, handle: Weak<crate::client::Handle>)
         let elapsed = started.elapsed();
         pool.complete();
         h.scheduler.on_completion(work, outcome, elapsed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::Handle;
+    use crate::scheduler::ConcurrencyController;
+    use std::sync::atomic::AtomicUsize as StdAtomicUsize;
+    use std::sync::OnceLock;
+
+    /// Concurrency controller with a mutable target for testing growth.
+    #[derive(Debug)]
+    struct AdjustableConcurrency(StdAtomicUsize);
+
+    impl AdjustableConcurrency {
+        fn new(target: usize) -> Self {
+            Self(StdAtomicUsize::new(target))
+        }
+
+        fn set_target(&self, target: usize) {
+            self.0.store(target, std::sync::atomic::Ordering::Release);
+        }
+    }
+
+    impl ConcurrencyController for AdjustableConcurrency {
+        fn target(&self) -> usize {
+            self.0.load(std::sync::atomic::Ordering::Acquire)
+        }
+    }
+
+    fn test_config() -> crate::Config {
+        let s3_client = aws_smithy_mocks::mock_client!(aws_sdk_s3, []);
+        crate::Config::builder().client(s3_client).build()
+    }
+
+    /// Helper: builds a Handle with a TokioMultiThreadRuntime and an adjustable
+    /// concurrency controller, returning the runtime reference for counter checks.
+    fn build_handle_with_adjustable_concurrency(
+        initial_target: usize,
+    ) -> (
+        Arc<Handle>,
+        Arc<TokioMultiThreadRuntime>,
+        Arc<AdjustableConcurrency>,
+    ) {
+        let controller = Arc::new(AdjustableConcurrency::new(initial_target));
+        let controller_clone = controller.clone();
+        let slot: Arc<OnceLock<Arc<TokioMultiThreadRuntime>>> = Arc::new(OnceLock::new());
+        let slot_clone = slot.clone();
+
+        let mut config = test_config();
+        let handle = Arc::new_cyclic(|weak| {
+            let scheduler = crate::scheduler::Scheduler::new(weak.clone());
+            let rt = Arc::new(TokioMultiThreadRuntime::new(weak.clone()));
+            slot_clone.set(rt.clone()).ok();
+            let runtime: Arc<dyn crate::runtime::ExecutionRuntime> = rt;
+            let s3_client = match config.take_s3_client_source() {
+                crate::config::S3ClientSource::Provided(client) => client,
+                crate::config::S3ClientSource::FromConfig(s3_config) => {
+                    aws_sdk_s3::Client::from_conf(s3_config.builder.build())
+                }
+            };
+            Handle {
+                config,
+                s3_client,
+                scheduler,
+                runtime,
+                controller: controller_clone.clone(),
+                telemetry: Arc::new(crate::telemetry::Telemetry::new(Duration::from_millis(500))),
+                memory_budget: crate::runtime::memory::MemoryBudget::new(
+                    1024 * 1024 * 1024,
+                    8 * 1024 * 1024,
+                ),
+            }
+        });
+        let runtime = slot.get().unwrap().clone();
+        (handle, runtime, controller)
+    }
+
+    // FIXME: crossbeam-epoch is incompatible with miri
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn genesis_spawns_exact_target_workers() {
+        let (_handle, runtime, _controller) = build_handle_with_adjustable_concurrency(4);
+        assert_eq!(
+            runtime.worker_count(),
+            0,
+            "no workers before first dispatch"
+        );
+
+        // Trigger genesis via dispatch with an empty batch.
+        let sq = crate::runtime::sync::SubmissionQueue::new(8);
+        let sub = sq.enter();
+        if let Some(mut guard) = sub.submit() {
+            runtime.dispatch(&mut guard);
+        }
+
+        assert_eq!(
+            runtime.worker_count(),
+            4,
+            "genesis must spawn exactly target workers"
+        );
+    }
+
+    // FIXME: crossbeam-epoch is incompatible with miri
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn growth_does_not_double_count() {
+        let (_handle, runtime, controller) = build_handle_with_adjustable_concurrency(4);
+
+        // Genesis dispatch.
+        let sq = crate::runtime::sync::SubmissionQueue::new(8);
+        let sub = sq.enter();
+        if let Some(mut guard) = sub.submit() {
+            runtime.dispatch(&mut guard);
+        }
+        assert_eq!(runtime.worker_count(), 4);
+
+        // Grow target from 4 to 8.
+        controller.set_target(8);
+
+        // Second dispatch triggers growth.
+        let sub = sq.enter();
+        if let Some(mut guard) = sub.submit() {
+            runtime.dispatch(&mut guard);
+        }
+        assert_eq!(
+            runtime.worker_count(),
+            8,
+            "after growth 4 -> 8, counter must be 8 (not 12)"
+        );
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt.rs
@@ -24,7 +24,6 @@ use worker_pool::WorkerPool;
 ///
 /// Assumes it is running within an existing tokio multi-threaded runtime context.
 /// Workers are spawned via `tokio::spawn` and pull work from a shared queue.
-#[allow(dead_code)] // TODO: expose runtime selection on public config
 #[derive(Debug)]
 pub(crate) struct TokioMultiThreadRuntime {
     pool: Arc<WorkerPool>,
@@ -33,7 +32,6 @@ pub(crate) struct TokioMultiThreadRuntime {
     components: RuntimeComponents,
 }
 
-#[allow(dead_code)] // TODO: expose runtime selection on public config
 impl TokioMultiThreadRuntime {
     pub(crate) fn new(handle: Weak<crate::client::Handle>) -> Self {
         Self {

--- a/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt.rs
@@ -260,34 +260,13 @@ mod tests {
         Arc<AdjustableConcurrency>,
     ) {
         let controller = Arc::new(AdjustableConcurrency::new(initial_target));
-        let controller_clone = controller.clone();
         let slot: Arc<OnceLock<Arc<TokioMultiThreadRuntime>>> = Arc::new(OnceLock::new());
         let slot_clone = slot.clone();
 
-        let mut config = test_config();
-        let handle = Arc::new_cyclic(|weak| {
-            let scheduler = crate::scheduler::Scheduler::new(weak.clone());
-            let rt = Arc::new(TokioMultiThreadRuntime::new(weak.clone()));
+        let handle = Handle::new_for_test_with_runtime(test_config(), controller.clone(), |weak| {
+            let rt = Arc::new(TokioMultiThreadRuntime::new(weak));
             slot_clone.set(rt.clone()).ok();
-            let runtime: Arc<dyn crate::runtime::ExecutionRuntime> = rt;
-            let s3_client = match config.take_s3_client_source() {
-                crate::config::S3ClientSource::Provided(client) => client,
-                crate::config::S3ClientSource::FromConfig(s3_config) => {
-                    aws_sdk_s3::Client::from_conf(s3_config.builder.build())
-                }
-            };
-            Handle {
-                config,
-                s3_client,
-                scheduler,
-                runtime,
-                controller: controller_clone.clone(),
-                telemetry: Arc::new(crate::telemetry::Telemetry::new(Duration::from_millis(500))),
-                memory_budget: crate::runtime::memory::MemoryBudget::new(
-                    1024 * 1024 * 1024,
-                    8 * 1024 * 1024,
-                ),
-            }
+            rt
         });
         let runtime = slot.get().unwrap().clone();
         (handle, runtime, controller)

--- a/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt/worker_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt/worker_pool.rs
@@ -135,6 +135,11 @@ impl WorkerPool {
             .is_ok()
     }
 
+    /// Whether genesis has completed (workers have been started at least once).
+    pub(super) fn is_started(&self) -> bool {
+        self.started.load(Ordering::Acquire)
+    }
+
     /// Number of pending work items.
     #[allow(dead_code)] // TODO: runtime observability
     pub(super) fn pending_count(&self) -> usize {

--- a/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt/worker_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt/worker_pool.rs
@@ -20,7 +20,6 @@ struct WorkQueue {
     in_flight: usize,
 }
 
-#[allow(dead_code)] // TODO: expose runtime selection on public config
 impl WorkQueue {
     fn new() -> Self {
         Self {
@@ -72,7 +71,6 @@ pub(super) struct WorkerPool {
     started: AtomicBool,
 }
 
-#[allow(dead_code)] // TODO: expose runtime selection on public config
 impl WorkerPool {
     pub(super) fn new() -> Self {
         Self {
@@ -124,7 +122,6 @@ impl WorkerPool {
     }
 
     /// Signal shutdown. Workers will exit after current work.
-    #[allow(dead_code)] // TODO: scheduler observability + lifecycle
     pub(super) fn shutdown(&self) {
         self.shutdown.store(true, Ordering::Release);
         // Wake all waiting workers so they can exit

--- a/aws-sdk-s3-transfer-manager/src/scheduler/scheduler.rs
+++ b/aws-sdk-s3-transfer-manager/src/scheduler/scheduler.rs
@@ -890,13 +890,17 @@ mod tests {
     fn test_handle_managed(concurrency: usize) -> Arc<Handle> {
         let s3_client = aws_smithy_mocks::mock_client!(aws_sdk_s3, []);
         let config = crate::Config::builder().client(s3_client).build();
-        Handle::new_for_test_with_runtime(config, concurrency, |weak| {
-            Arc::new(
-                crate::runtime::ManagedThreadRuntime::builder(weak)
-                    .topology(crate::runtime::Topology::uniform(4))
-                    .build(),
-            )
-        })
+        Handle::new_for_test_with_runtime(
+            config,
+            Arc::new(crate::scheduler::FixedConcurrency::new(concurrency)),
+            |weak| {
+                Arc::new(
+                    crate::runtime::ManagedThreadRuntime::builder(weak)
+                        .topology(crate::runtime::Topology::uniform(4))
+                        .build(),
+                )
+            },
+        )
     }
 
     #[cfg_attr(miri, ignore)]

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -97,6 +97,10 @@ pub enum RuntimeMode {
     /// spawn its own OS threads. This is not a performance tuning knob —
     /// `Managed` is faster by design; prefer it unless you specifically need
     /// the transfer manager to run on your existing runtime.
+    ///
+    /// Requires a multi-threaded runtime: transfer workers run via
+    /// `tokio::spawn`, so on a current-thread runtime they serialize onto one
+    /// thread and throughput collapses.
     CurrentTokio,
 }
 

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -90,8 +90,8 @@ pub enum RuntimeMode {
     /// Spawns and owns its own worker threads; the performance path.
     #[default]
     Managed,
-    /// Run on the caller's current tokio multi-threaded runtime instead of
-    /// spawning dedicated threads.
+    /// Run on the caller's tokio multi-threaded runtime instead of spawning
+    /// dedicated threads.
     ///
     /// An escape hatch for embedding the transfer manager where it must not
     /// spawn its own OS threads. This is not a performance tuning knob —
@@ -101,7 +101,7 @@ pub enum RuntimeMode {
     /// Requires a multi-threaded runtime: transfer workers run via
     /// `tokio::spawn`, so on a current-thread runtime they serialize onto one
     /// thread and throughput collapses.
-    CurrentTokio,
+    MultiThreadTokio,
 }
 
 /// The concurrency mode the client should use for executing requests.

--- a/aws-sdk-s3-transfer-manager/src/types.rs
+++ b/aws-sdk-s3-transfer-manager/src/types.rs
@@ -81,6 +81,25 @@ impl MemoryBudgetConfig {
     }
 }
 
+/// Selects the execution runtime the transfer manager runs on.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default)]
+pub enum RuntimeMode {
+    /// Managed OS threads owned by the transfer manager (default, recommended).
+    ///
+    /// Spawns and owns its own worker threads; the performance path.
+    #[default]
+    Managed,
+    /// Run on the caller's current tokio multi-threaded runtime instead of
+    /// spawning dedicated threads.
+    ///
+    /// An escape hatch for embedding the transfer manager where it must not
+    /// spawn its own OS threads. This is not a performance tuning knob —
+    /// `Managed` is faster by design; prefer it unless you specifically need
+    /// the transfer manager to run on your existing runtime.
+    CurrentTokio,
+}
+
 /// The concurrency mode the client should use for executing requests.
 #[non_exhaustive]
 #[derive(Debug, Clone, Default)]

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -6,66 +6,23 @@
 //! Download integration tests.
 
 use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
-use aws_sdk_s3_transfer_manager::types::{ConcurrencyMode, PartSize};
-use s3_mock_server::S3MockServer;
+use aws_sdk_s3_transfer_manager::types::{ConcurrencyMode, PartSize, RuntimeMode};
 
-/// Setup transfer manager with mock server
-async fn setup() -> (
-    S3MockServer,
-    s3_mock_server::ServerHandle,
-    aws_sdk_s3_transfer_manager::Client,
-) {
-    let server = S3MockServer::builder()
-        .with_in_memory_store()
-        .build()
-        .expect("build mock server");
+use crate::harness::{mock_tm, mock_tm_with, MockTm};
 
-    let handle = server.start().await.expect("start mock server");
-    let s3_client = handle.client().await;
-
-    let tm_config = aws_sdk_s3_transfer_manager::Config::builder()
-        .client(s3_client)
-        .build();
-    let tm = aws_sdk_s3_transfer_manager::Client::new(tm_config);
-
-    (server, handle, tm)
+async fn setup() -> MockTm {
+    mock_tm(RuntimeMode::Managed).await
 }
 
-/// Setup with custom part size and concurrency
-async fn setup_concurrent(
-    part_size: usize,
-    concurrency: usize,
-) -> (
-    S3MockServer,
-    s3_mock_server::ServerHandle,
-    aws_sdk_s3_transfer_manager::Client,
-) {
-    let server = S3MockServer::builder()
-        .with_in_memory_store()
-        .build()
-        .expect("build mock server");
-
-    let handle = server.start().await.expect("start mock server");
-    let s3_client = handle.client().await;
-
-    let tm_config = aws_sdk_s3_transfer_manager::Config::builder()
-        .client(s3_client)
-        .part_size(PartSize::Target(part_size as u64))
-        .concurrency(ConcurrencyMode::Explicit(concurrency))
-        .build();
-    let tm = aws_sdk_s3_transfer_manager::Client::new(tm_config);
-
-    (server, handle, tm)
+async fn setup_concurrent(part_size: usize, concurrency: usize) -> MockTm {
+    mock_tm_with(RuntimeMode::Managed, |b| {
+        b.part_size(PartSize::Target(part_size as u64))
+            .concurrency(ConcurrencyMode::Explicit(concurrency))
+    })
+    .await
 }
 
-/// Setup with custom part size for testing ranged downloads (sequential)
-async fn setup_with_part_size(
-    part_size: usize,
-) -> (
-    S3MockServer,
-    s3_mock_server::ServerHandle,
-    aws_sdk_s3_transfer_manager::Client,
-) {
+async fn setup_with_part_size(part_size: usize) -> MockTm {
     setup_concurrent(part_size, 1).await
 }
 
@@ -85,7 +42,7 @@ async fn drain_body(
 #[tokio::test]
 async fn test_download_basic() {
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
-    let (server, server_handle, tm) = setup_with_part_size(part_size).await;
+    let m = setup_with_part_size(part_size).await;
 
     // Create test data that spans multiple parts (12MB = 3 parts at 5MB)
     let content: Vec<u8> = (0..12 * ByteUnit::Mebibyte.as_bytes_usize())
@@ -93,12 +50,13 @@ async fn test_download_basic() {
         .collect();
     let expected = content.clone();
 
-    server
+    m.server
         .add_object("test-bucket", "test-key", content, None)
         .await
         .expect("add object");
 
-    let mut handle = tm
+    let mut handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("test-key")
@@ -110,21 +68,22 @@ async fn test_download_basic() {
     assert_eq!(body.len(), expected.len(), "size mismatch");
     assert_eq!(body, expected, "data integrity check failed");
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// Test that handle can be dropped without consuming body
 #[tokio::test]
 async fn test_download_body_not_consumed() {
-    let (server, server_handle, tm) = setup().await;
+    let m = setup().await;
 
     let content = vec![0u8; 16 * ByteUnit::Mebibyte.as_bytes_usize()];
-    server
+    m.server
         .add_object("test-bucket", "test-key", content, None)
         .await
         .expect("add object");
 
-    let mut handle = tm
+    let mut handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("test-key")
@@ -136,22 +95,23 @@ async fn test_download_body_not_consumed() {
     drop(handle);
 
     // If we get here without hanging/panicking, test passes
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// Test abort cancels in-flight work
 #[tokio::test]
 async fn test_download_abort() {
     let part_size = ByteUnit::Mebibyte.as_bytes_usize();
-    let (server, server_handle, tm) = setup_with_part_size(part_size).await;
+    let m = setup_with_part_size(part_size).await;
 
     let content = vec![0u8; 25 * ByteUnit::Mebibyte.as_bytes_usize()];
-    server
+    m.server
         .add_object("test-bucket", "test-key", content, None)
         .await
         .expect("add object");
 
-    let handle = tm
+    let handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("test-key")
@@ -165,15 +125,16 @@ async fn test_download_abort() {
     handle.abort().await;
 
     // If we get here without hanging, abort worked
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// Test download of non-existent object returns error
 #[tokio::test]
 async fn test_download_not_found() {
-    let (_server, server_handle, tm) = setup().await;
+    let m = setup().await;
 
-    let mut handle = tm
+    let mut handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("non-existent-key")
@@ -183,21 +144,22 @@ async fn test_download_not_found() {
     let result = drain_body(&mut handle).await;
     assert!(result.is_err(), "should fail for non-existent object");
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// Test object metadata is available after discovery
 #[tokio::test]
 async fn test_download_object_meta() {
-    let (server, server_handle, tm) = setup().await;
+    let m = setup().await;
 
     let content = vec![42u8; ByteUnit::Mebibyte.as_bytes_usize()];
-    server
+    m.server
         .add_object("test-bucket", "test-key", content.clone(), None)
         .await
         .expect("add object");
 
-    let handle = tm
+    let handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("test-key")
@@ -211,20 +173,19 @@ async fn test_download_object_meta() {
         "content length should match"
     );
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// Test concurrent downloads
-#[tokio::test]
-async fn test_download_concurrent() {
-    let (server, server_handle, tm) = setup().await;
+async fn test_download_concurrent(rt: RuntimeMode) {
+    let m = mock_tm(rt).await;
 
     // Add multiple objects directly to server
     for i in 0..5 {
         let content: Vec<u8> = (0..2 * ByteUnit::Mebibyte.as_bytes_usize())
             .map(|j| ((i + j) % 256) as u8)
             .collect();
-        server
+        m.server
             .add_object(
                 "test-bucket",
                 &format!("concurrent-key-{}", i),
@@ -238,7 +199,8 @@ async fn test_download_concurrent() {
     // Start concurrent downloads
     let mut handles = Vec::new();
     for i in 0..5 {
-        let handle = tm
+        let handle = m
+            .client
             .download()
             .bucket("test-bucket")
             .key(format!("concurrent-key-{}", i))
@@ -258,7 +220,17 @@ async fn test_download_concurrent() {
         );
     }
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn test_download_concurrent_mock_gp() {
+    test_download_concurrent(RuntimeMode::Managed).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_download_concurrent_tokio_mt() {
+    test_download_concurrent(RuntimeMode::CurrentTokio).await;
 }
 
 /// Generate deterministic data using prime 251 to avoid alignment patterns.
@@ -271,11 +243,11 @@ fn deterministic_data(size: usize) -> Vec<u8> {
 #[tokio::test]
 async fn test_download_write_to_path() {
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
-    let (server, server_handle, tm) = setup_concurrent(part_size, 8).await;
+    let m = setup_concurrent(part_size, 8).await;
 
     let size = 100 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = deterministic_data(size);
-    server
+    m.server
         .add_object("test-bucket", "write-to-path-key", content.clone(), None)
         .await
         .expect("add object");
@@ -283,7 +255,8 @@ async fn test_download_write_to_path() {
     let dir = tempfile::tempdir().unwrap();
     let dest_path = dir.path().join("output.dat");
 
-    let handle = tm
+    let handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("write-to-path-key")
@@ -305,7 +278,7 @@ async fn test_download_write_to_path() {
         .collect();
     assert!(tmp_files.is_empty(), "leftover temp files: {:?}", tmp_files);
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// Test download to caller-provided file handle (50 MB, 5 MB parts, 8 workers).
@@ -313,11 +286,11 @@ async fn test_download_write_to_path() {
 #[tokio::test]
 async fn test_download_write_to_file() {
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
-    let (server, server_handle, tm) = setup_concurrent(part_size, 8).await;
+    let m = setup_concurrent(part_size, 8).await;
 
     let size = 50 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = deterministic_data(size);
-    server
+    m.server
         .add_object("test-bucket", "write-to-file-key", content.clone(), None)
         .await
         .expect("add object");
@@ -326,7 +299,8 @@ async fn test_download_write_to_file() {
     let file_path = dir.path().join("file_output.dat");
     let file = std::fs::File::create(&file_path).unwrap();
 
-    let handle = tm
+    let handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("write-to-file-key")
@@ -339,7 +313,7 @@ async fn test_download_write_to_file() {
     assert_eq!(written.len(), content.len(), "size mismatch");
     assert_eq!(written, content, "data integrity check failed");
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// Test ranged download to file path (bytes 10000000-59999999 of 100 MB object).
@@ -347,11 +321,11 @@ async fn test_download_write_to_file() {
 #[tokio::test]
 async fn test_download_write_to_path_ranged() {
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
-    let (server, server_handle, tm) = setup_concurrent(part_size, 8).await;
+    let m = setup_concurrent(part_size, 8).await;
 
     let size = 100 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = deterministic_data(size);
-    server
+    m.server
         .add_object("test-bucket", "ranged-key", content.clone(), None)
         .await
         .expect("add object");
@@ -359,7 +333,8 @@ async fn test_download_write_to_path_ranged() {
     let dir = tempfile::tempdir().unwrap();
     let dest_path = dir.path().join("ranged_output.dat");
 
-    let handle = tm
+    let handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("ranged-key")
@@ -379,7 +354,7 @@ async fn test_download_write_to_path_ranged() {
         "ranged data integrity check failed"
     );
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// Test single-part download to file (2 MB object, 5 MB part size — no range splitting).
@@ -387,11 +362,11 @@ async fn test_download_write_to_path_ranged() {
 #[tokio::test]
 async fn test_download_write_to_path_single_part() {
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
-    let (server, server_handle, tm) = setup_concurrent(part_size, 8).await;
+    let m = setup_concurrent(part_size, 8).await;
 
     let size = 2 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = deterministic_data(size);
-    server
+    m.server
         .add_object("test-bucket", "single-part-key", content.clone(), None)
         .await
         .expect("add object");
@@ -399,7 +374,8 @@ async fn test_download_write_to_path_single_part() {
     let dir = tempfile::tempdir().unwrap();
     let dest_path = dir.path().join("single_part.dat");
 
-    let handle = tm
+    let handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("single-part-key")
@@ -413,7 +389,7 @@ async fn test_download_write_to_path_single_part() {
     assert_eq!(written.len(), content.len(), "size mismatch");
     assert_eq!(written, content, "data integrity check failed");
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// Integrity stress test: 100 MB, 5 MB parts, 16 concurrent workers.
@@ -422,11 +398,11 @@ async fn test_download_write_to_path_single_part() {
 #[tokio::test]
 async fn test_download_write_to_path_integrity() {
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
-    let (server, server_handle, tm) = setup_concurrent(part_size, 16).await;
+    let m = setup_concurrent(part_size, 16).await;
 
     let size = 100 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = deterministic_data(size);
-    server
+    m.server
         .add_object("test-bucket", "integrity-key", content.clone(), None)
         .await
         .expect("add object");
@@ -434,7 +410,8 @@ async fn test_download_write_to_path_integrity() {
     let dir = tempfile::tempdir().unwrap();
     let dest_path = dir.path().join("integrity.dat");
 
-    let handle = tm
+    let handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("integrity-key")
@@ -448,7 +425,7 @@ async fn test_download_write_to_path_integrity() {
     assert_eq!(written.len(), content.len(), "size mismatch");
     assert_eq!(written, content, "byte-for-byte integrity check failed");
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 // TODO(vnext): integration tests to add
@@ -482,14 +459,15 @@ async fn test_download_write_to_path_integrity() {
 /// Test downloading an empty (0-byte) object completes without hanging.
 #[tokio::test]
 async fn test_download_empty_object() {
-    let (server, server_handle, tm) = setup().await;
+    let m = setup().await;
 
-    server
+    m.server
         .add_object("test-bucket", "empty-key", vec![], None)
         .await
         .expect("add object");
 
-    let mut handle = tm
+    let mut handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("empty-key")
@@ -504,7 +482,7 @@ async fn test_download_empty_object() {
 
     assert_eq!(data.len(), 0);
     handle.join().await.expect("join should succeed");
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 // ── Read-ahead window gate: slow-consumer progress ───────────────────────────
@@ -530,17 +508,18 @@ async fn test_download_slow_consumer_does_not_wedge() {
     let part_size = ByteUnit::Mebibyte.as_bytes_usize();
     // 64 parts at 1 MiB, 16-way concurrency: the issuer runs well ahead of the slow
     // in-order consumer, exercising the gate's reopen path repeatedly.
-    let (server, server_handle, tm) = setup_concurrent(part_size, 16).await;
+    let m = setup_concurrent(part_size, 16).await;
 
     let content: Vec<u8> = (0..64 * part_size).map(|i| (i % 256) as u8).collect();
     let expected = content.clone();
-    server
+    m.server
         .add_object("test-bucket", "slow-key", content, None)
         .await
         .expect("add object");
 
     let result = timeout(Duration::from_secs(30), async {
-        let mut handle = tm
+        let mut handle = m
+            .client
             .download()
             .bucket("test-bucket")
             .key("slow-key")
@@ -563,7 +542,7 @@ async fn test_download_slow_consumer_does_not_wedge() {
 
     assert_eq!(result.len(), expected.len(), "size mismatch");
     assert_eq!(result, expected, "data integrity check failed");
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// A disk download whose part count exceeds the read-ahead window must complete.
@@ -583,7 +562,7 @@ async fn test_download_to_disk_exceeding_read_ahead_window_does_not_wedge() {
     use tokio::time::timeout;
 
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
-    let (server, server_handle, tm) = setup_concurrent(part_size, 8).await;
+    let m = setup_concurrent(part_size, 8).await;
 
     // 40 parts (200 MiB) against a window of 32 (Parts(31) → 31 speculative + 1
     // demand): the gate fills and must reopen on disk drains. The window spans two
@@ -592,7 +571,7 @@ async fn test_download_to_disk_exceeding_read_ahead_window_does_not_wedge() {
     // minimum part size makes larger objects costly on the test filesystem.
     let size = 40 * part_size;
     let content = deterministic_data(size);
-    server
+    m.server
         .add_object("test-bucket", "disk-window-key", content.clone(), None)
         .await
         .expect("add object");
@@ -601,7 +580,8 @@ async fn test_download_to_disk_exceeding_read_ahead_window_does_not_wedge() {
     let dest_path = dir.path().join("output.dat");
 
     let written = timeout(Duration::from_secs(30), async {
-        let handle = tm
+        let handle = m
+            .client
             .download()
             .bucket("test-bucket")
             .key("disk-window-key")
@@ -617,7 +597,7 @@ async fn test_download_to_disk_exceeding_read_ahead_window_does_not_wedge() {
 
     assert_eq!(written.len(), content.len(), "size mismatch");
     assert_eq!(written, content, "data integrity check failed");
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 /// Disk download with a read-ahead window *below* the buffer's segment size — the
@@ -635,14 +615,14 @@ async fn test_download_to_disk_below_segment_window_drains_in_runs() {
     use tokio::time::timeout;
 
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
-    let (server, server_handle, tm) = setup_concurrent(part_size, 8).await;
+    let m = setup_concurrent(part_size, 8).await;
 
     // 40 parts against a window of 3 (Parts(2) → 2 speculative + 1 demand), far below
     // the 16-part segment. No segment ever seals within the window, so every drain is a
     // partial run; the gate must still reopen on each run drain or the transfer wedges.
     let size = 40 * part_size;
     let content = deterministic_data(size);
-    server
+    m.server
         .add_object("test-bucket", "disk-subseg-key", content.clone(), None)
         .await
         .expect("add object");
@@ -651,7 +631,8 @@ async fn test_download_to_disk_below_segment_window_drains_in_runs() {
     let dest_path = dir.path().join("output.dat");
 
     let written = timeout(Duration::from_secs(30), async {
-        let handle = tm
+        let handle = m
+            .client
             .download()
             .bucket("test-bucket")
             .key("disk-subseg-key")
@@ -667,7 +648,7 @@ async fn test_download_to_disk_below_segment_window_drains_in_runs() {
 
     assert_eq!(written.len(), content.len(), "size mismatch");
     assert_eq!(written, content, "data integrity check failed");
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 // ── Global memory budget: concurrent disk transfers below the drain batch ─────
@@ -686,8 +667,7 @@ async fn test_download_to_disk_below_segment_window_drains_in_runs() {
 /// a budget too small to hold them all at once, must all complete. A regression
 /// re-wedges and the timeout fires.
 #[cfg(any(unix, windows))]
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_concurrent_disk_downloads_under_tight_budget_do_not_wedge() {
+async fn test_concurrent_disk_downloads_under_tight_budget_do_not_wedge(rt: RuntimeMode) {
     use aws_sdk_s3_transfer_manager::types::MemoryBudgetConfig;
     use std::time::Duration;
     use tokio::time::timeout;
@@ -703,25 +683,17 @@ async fn test_concurrent_disk_downloads_under_tight_budget_do_not_wedge() {
     // reachable, while leaving room for a few resident parts per transfer.
     let budget_bytes = 8 * 8 * ByteUnit::Mebibyte.as_bytes_usize();
 
-    let server = S3MockServer::builder()
-        .with_in_memory_store()
-        .build()
-        .expect("build mock server");
-    let server_handle = server.start().await.expect("start mock server");
-    let s3_client = server_handle.client().await;
-    let tm = aws_sdk_s3_transfer_manager::Client::new(
-        aws_sdk_s3_transfer_manager::Config::builder()
-            .client(s3_client)
-            .part_size(PartSize::Target(part_size as u64))
+    let m = mock_tm_with(rt, |b| {
+        b.part_size(PartSize::Target(part_size as u64))
             .concurrency(ConcurrencyMode::Explicit(transfers))
             .memory_budget(MemoryBudgetConfig::Limit(budget_bytes))
-            .build(),
-    );
+    })
+    .await;
 
     let mut expected = Vec::with_capacity(transfers);
     for i in 0..transfers {
         let content = deterministic_data(object_size);
-        server
+        m.server
             .add_object("test-bucket", &format!("obj-{i}"), content.clone(), None)
             .await
             .expect("add object");
@@ -732,7 +704,7 @@ async fn test_concurrent_disk_downloads_under_tight_budget_do_not_wedge() {
     let results = timeout(Duration::from_secs(30), async {
         let mut tasks = Vec::with_capacity(transfers);
         for i in 0..transfers {
-            let tm = tm.clone();
+            let tm = m.client.clone();
             let dest = dir.path().join(format!("out-{i}.dat"));
             tasks.push(tokio::spawn(async move {
                 let handle = tm
@@ -762,5 +734,17 @@ async fn test_concurrent_disk_downloads_under_tight_budget_do_not_wedge() {
         assert_eq!(got.len(), want.len(), "obj-{i} size mismatch");
         assert_eq!(got, want, "obj-{i} data integrity check failed");
     }
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
+}
+
+#[cfg(any(unix, windows))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_concurrent_disk_downloads_under_tight_budget_do_not_wedge_mock_gp() {
+    test_concurrent_disk_downloads_under_tight_budget_do_not_wedge(RuntimeMode::Managed).await;
+}
+
+#[cfg(any(unix, windows))]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_concurrent_disk_downloads_under_tight_budget_do_not_wedge_tokio_mt() {
+    test_concurrent_disk_downloads_under_tight_budget_do_not_wedge(RuntimeMode::CurrentTokio).await;
 }

--- a/integration-tests/src/download.rs
+++ b/integration-tests/src/download.rs
@@ -230,7 +230,7 @@ async fn test_download_concurrent_mock_gp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_download_concurrent_tokio_mt() {
-    test_download_concurrent(RuntimeMode::CurrentTokio).await;
+    test_download_concurrent(RuntimeMode::MultiThreadTokio).await;
 }
 
 /// Generate deterministic data using prime 251 to avoid alignment patterns.
@@ -746,5 +746,6 @@ async fn test_concurrent_disk_downloads_under_tight_budget_do_not_wedge_mock_gp(
 #[cfg(any(unix, windows))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_concurrent_disk_downloads_under_tight_budget_do_not_wedge_tokio_mt() {
-    test_concurrent_disk_downloads_under_tight_budget_do_not_wedge(RuntimeMode::CurrentTokio).await;
+    test_concurrent_disk_downloads_under_tight_budget_do_not_wedge(RuntimeMode::MultiThreadTokio)
+        .await;
 }

--- a/integration-tests/src/download_objects.rs
+++ b/integration-tests/src/download_objects.rs
@@ -160,7 +160,7 @@ async fn test_download_objects_many_small_files_mock_gp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_download_objects_many_small_files_tokio_mt() {
-    test_download_objects_many_small_files(RuntimeMode::CurrentTokio).await;
+    test_download_objects_many_small_files(RuntimeMode::MultiThreadTokio).await;
 }
 
 /// Per-file byte-content integrity after download.
@@ -332,7 +332,7 @@ async fn test_download_objects_multipart_children_mock_gp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_download_objects_multipart_children_tokio_mt() {
-    test_download_objects_multipart_children(RuntimeMode::CurrentTokio).await;
+    test_download_objects_multipart_children(RuntimeMode::MultiThreadTokio).await;
 }
 
 /// Empty prefix yields zero downloads with no error.
@@ -535,7 +535,7 @@ async fn test_download_objects_listing_pagination_mock_gp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_download_objects_listing_pagination_tokio_mt() {
-    test_download_objects_listing_pagination(RuntimeMode::CurrentTokio).await;
+    test_download_objects_listing_pagination(RuntimeMode::MultiThreadTokio).await;
 }
 
 /// FailedTransferPolicy::Continue with one faulted key: the other objects
@@ -762,5 +762,5 @@ async fn test_upload_then_download_objects_roundtrip_mock_gp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_upload_then_download_objects_roundtrip_tokio_mt() {
-    test_upload_then_download_objects_roundtrip(RuntimeMode::CurrentTokio).await;
+    test_upload_then_download_objects_roundtrip(RuntimeMode::MultiThreadTokio).await;
 }

--- a/integration-tests/src/download_objects.rs
+++ b/integration-tests/src/download_objects.rs
@@ -1,0 +1,738 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Download multi-object integration tests.
+//!
+//! Exercises `download_objects` through a real HTTP mock server, covering
+//! listing pagination, key-to-path mapping, content integrity, failure
+//! policies, and path-safety invariants. Structured as the download-side
+//! mirror of `upload_objects.rs`.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use aws_sdk_s3_transfer_manager::io::walk::S3Walker;
+use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
+use aws_sdk_s3_transfer_manager::types::FailedTransferPolicy;
+use s3_mock_server::{FaultType, Occurrence, S3MockServer};
+use tokio::time::timeout;
+
+/// Default test timeout.
+const TEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Setup transfer manager with mock server.
+async fn setup() -> (
+    S3MockServer,
+    s3_mock_server::ServerHandle,
+    aws_sdk_s3_transfer_manager::Client,
+) {
+    let server = S3MockServer::builder()
+        .with_in_memory_store()
+        .build()
+        .expect("build mock server");
+
+    let handle = server.start().await.expect("start mock server");
+    let s3_client = handle.client().await;
+
+    let tm_config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(s3_client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(tm_config);
+
+    (server, handle, tm)
+}
+
+/// Seed `count` objects into the mock bucket under `prefix`, each `size` bytes.
+/// Objects are named `{prefix}{NNNN}.bin` with distinct per-index byte patterns.
+async fn seed_bucket(server: &S3MockServer, bucket: &str, prefix: &str, count: usize, size: usize) {
+    server.create_bucket(bucket).await.expect("create bucket");
+    for i in 0..count {
+        let key = format!("{prefix}{i:04}.bin");
+        let body = vec![i as u8; size];
+        server
+            .add_object(bucket, &key, body, None)
+            .await
+            .expect("seed object");
+    }
+}
+
+/// Seed objects with explicit key/content pairs.
+async fn seed_objects(server: &S3MockServer, bucket: &str, objects: &[(&str, &[u8])]) {
+    server.create_bucket(bucket).await.expect("create bucket");
+    for (key, content) in objects {
+        server
+            .add_object(bucket, key, content.to_vec(), None)
+            .await
+            .expect("seed object");
+    }
+}
+
+/// Assert that the downloaded directory contains exactly the expected files
+/// with correct byte content. `expected` maps relative paths (within the
+/// download directory) to their byte content.
+fn verify_dir(dir: &Path, expected: &HashMap<&str, Vec<u8>>) {
+    let mut found: HashMap<PathBuf, Vec<u8>> = HashMap::new();
+    collect_files(dir, dir, &mut found);
+
+    assert_eq!(
+        found.len(),
+        expected.len(),
+        "file count mismatch: found {} files, expected {}.\nFound: {:?}",
+        found.len(),
+        expected.len(),
+        found.keys().collect::<Vec<_>>()
+    );
+
+    for (rel, content) in expected {
+        let rel_path = PathBuf::from(rel);
+        let got = found
+            .get(&rel_path)
+            .unwrap_or_else(|| panic!("expected file {rel} not found in download dir"));
+        assert_eq!(got, content, "content mismatch for file {rel}");
+    }
+}
+
+/// Recursively collect files under `base`, storing their paths relative to
+/// `root` and their content.
+fn collect_files(root: &Path, dir: &Path, out: &mut HashMap<PathBuf, Vec<u8>>) {
+    for entry in std::fs::read_dir(dir).expect("read_dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(root, &path, out);
+        } else {
+            let rel = path.strip_prefix(root).expect("strip prefix").to_path_buf();
+            let content = std::fs::read(&path).expect("read file");
+            out.insert(rel, content);
+        }
+    }
+}
+
+/// Count files recursively under `dir`.
+fn count_files(dir: &Path) -> usize {
+    let mut count = 0usize;
+    count_files_inner(dir, &mut count);
+    count
+}
+
+fn count_files_inner(dir: &Path, count: &mut usize) {
+    if !dir.exists() {
+        return;
+    }
+    for entry in std::fs::read_dir(dir).expect("read_dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            count_files_inner(&path, count);
+        } else {
+            *count += 1;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PARITY SET (mirrors upload_objects.rs)
+// ---------------------------------------------------------------------------
+
+/// Seed N small objects, download them all, verify count and disk presence.
+#[tokio::test]
+async fn test_download_objects_many_small_files() {
+    timeout(TEST_TIMEOUT, async {
+        let (server, server_handle, tm) = setup().await;
+
+        let count = 500usize;
+        let size = 4 * ByteUnit::Kibibyte.as_bytes_usize();
+        let bucket = "test-bucket";
+        let prefix = "small/";
+
+        seed_bucket(&server, bucket, prefix, count, size).await;
+
+        let dest = tempfile::tempdir().expect("tempdir");
+        let handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(dest.path())
+            .key_prefix(prefix)
+            .initiate()
+            .expect("initiate download_objects");
+
+        let output = handle.join().await.expect("join download_objects");
+        assert_eq!(count as u64, output.objects_downloaded());
+        assert!(output.failed_transfers().is_empty());
+
+        let files_on_disk = count_files(dest.path());
+        assert_eq!(count, files_on_disk, "all objects should land on disk");
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_download_objects_many_small_files timed out");
+}
+
+/// Per-file byte-content integrity after download.
+#[tokio::test]
+async fn test_download_objects_flat_content_roundtrip() {
+    timeout(TEST_TIMEOUT, async {
+        let (server, server_handle, tm) = setup().await;
+
+        let count = 20usize;
+        let size = 2 * ByteUnit::Kibibyte.as_bytes_usize();
+        let bucket = "test-bucket";
+        let prefix = "roundtrip/";
+
+        server.create_bucket(bucket).await.expect("create bucket");
+        for i in 0..count {
+            let key = format!("{prefix}{i:03}.bin");
+            let body = vec![i as u8; size];
+            server
+                .add_object(bucket, &key, body, None)
+                .await
+                .expect("seed object");
+        }
+
+        let dest = tempfile::tempdir().expect("tempdir");
+        let handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(dest.path())
+            .key_prefix(prefix)
+            .initiate()
+            .expect("initiate download_objects");
+
+        let output = handle.join().await.expect("join download_objects");
+        assert_eq!(count as u64, output.objects_downloaded());
+        assert!(output.failed_transfers().is_empty());
+
+        // Verify byte content of every file.
+        for i in 0..count {
+            let file_path = dest.path().join(format!("{i:03}.bin"));
+            let got = std::fs::read(&file_path).unwrap_or_else(|_| {
+                panic!("expected file {:03}.bin not found on disk", i);
+            });
+            assert_eq!(
+                got,
+                vec![i as u8; size],
+                "content mismatch for file {:03}.bin",
+                i
+            );
+        }
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_download_objects_flat_content_roundtrip timed out");
+}
+
+/// Objects under nested prefixes download into the correct directory tree.
+#[tokio::test]
+async fn test_download_objects_nested_prefixes() {
+    timeout(TEST_TIMEOUT, async {
+        let (server, server_handle, tm) = setup().await;
+
+        let bucket = "test-bucket";
+        let prefix = "tree/";
+        let objects: &[(&str, &[u8])] = &[
+            ("tree/top.txt", b"top-level"),
+            ("tree/a/one.txt", b"a-1"),
+            ("tree/a/two.txt", b"a-2"),
+            ("tree/b/inner/deep.txt", b"deep-content"),
+            ("tree/c/1/2/3/leaf.bin", b"leaf"),
+        ];
+        seed_objects(&server, bucket, objects).await;
+
+        let dest = tempfile::tempdir().expect("tempdir");
+        let handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(dest.path())
+            .key_prefix(prefix)
+            .initiate()
+            .expect("initiate download_objects");
+
+        let output = handle.join().await.expect("join download_objects");
+        assert_eq!(objects.len() as u64, output.objects_downloaded());
+        assert!(output.failed_transfers().is_empty());
+
+        // Verify directory structure and content.
+        let mut expected: HashMap<&str, Vec<u8>> = HashMap::new();
+        expected.insert("top.txt", b"top-level".to_vec());
+        expected.insert("a/one.txt", b"a-1".to_vec());
+        expected.insert("a/two.txt", b"a-2".to_vec());
+        expected.insert("b/inner/deep.txt", b"deep-content".to_vec());
+        expected.insert("c/1/2/3/leaf.bin", b"leaf".to_vec());
+        verify_dir(dest.path(), &expected);
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_download_objects_nested_prefixes timed out");
+}
+
+/// Objects large enough to trigger multipart download, content verified.
+#[tokio::test]
+async fn test_download_objects_multipart_children() {
+    timeout(TEST_TIMEOUT, async {
+        let (server, server_handle, tm) = setup().await;
+
+        let part = 8 * ByteUnit::Mebibyte.as_bytes_usize();
+        let count = 3usize;
+        let size = 2 * part; // 16 MiB per file -> 2 parts each
+        let bucket = "test-bucket";
+        let prefix = "mpu/";
+
+        server.create_bucket(bucket).await.expect("create bucket");
+        for i in 0..count {
+            let key = format!("{prefix}{i:04}.bin");
+            // Deterministic content pattern (byte index mod 256).
+            let body: Vec<u8> = (0..size).map(|b| (b % 256) as u8).collect();
+            server
+                .add_object(bucket, &key, body, None)
+                .await
+                .expect("seed object");
+        }
+
+        let dest = tempfile::tempdir().expect("tempdir");
+        let handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(dest.path())
+            .key_prefix(prefix)
+            .initiate()
+            .expect("initiate download_objects");
+
+        let output = handle.join().await.expect("join download_objects");
+        assert_eq!(count as u64, output.objects_downloaded());
+        assert!(output.failed_transfers().is_empty());
+        assert_eq!(
+            (count * size) as u64,
+            output.metrics.network_rx,
+            "network_rx should equal sum of object sizes"
+        );
+        assert_eq!(
+            (count * size) as u64,
+            output.metrics.disk_write,
+            "disk_write should equal sum of object sizes"
+        );
+
+        // Verify content of each downloaded file.
+        let expected_body: Vec<u8> = (0..size).map(|b| (b % 256) as u8).collect();
+        for i in 0..count {
+            let file_path = dest.path().join(format!("{i:04}.bin"));
+            let got = std::fs::read(&file_path)
+                .unwrap_or_else(|_| panic!("expected file {:04}.bin not found on disk", i));
+            assert_eq!(got, expected_body, "content mismatch for {:04}.bin", i);
+        }
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_download_objects_multipart_children timed out");
+}
+
+/// Empty prefix yields zero downloads with no error.
+#[tokio::test]
+async fn test_download_objects_empty_prefix() {
+    timeout(TEST_TIMEOUT, async {
+        let (server, server_handle, tm) = setup().await;
+
+        let bucket = "test-bucket";
+        server.create_bucket(bucket).await.expect("create bucket");
+
+        let dest = tempfile::tempdir().expect("tempdir");
+        let handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(dest.path())
+            .key_prefix("nonexistent/")
+            .initiate()
+            .expect("initiate download_objects");
+
+        let output = handle.join().await.expect("join download_objects");
+        assert_eq!(0, output.objects_downloaded());
+        assert!(output.failed_transfers().is_empty());
+        assert_eq!(0, output.metrics.network_rx);
+        assert!(
+            output.metrics.finished_at.is_some(),
+            "finished_at must be set even on zero-work transfer"
+        );
+
+        let files_on_disk = count_files(dest.path());
+        assert_eq!(0, files_on_disk);
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_download_objects_empty_prefix timed out");
+}
+
+/// Deep and wide prefix tree exercises listing across many keys.
+/// Structure: 4 levels deep, 4 prefixes per level, 2 objects per prefix
+/// = 4^1 + 4^2 + 4^3 + 4^4 = 340 prefixes, 680 objects.
+#[tokio::test]
+async fn test_download_objects_deep_wide_tree() {
+    timeout(TEST_TIMEOUT, async {
+        let (server, server_handle, tm) = setup().await;
+
+        let bucket = "test-bucket";
+        let root_prefix = "deep/";
+        server.create_bucket(bucket).await.expect("create bucket");
+
+        let mut expected_count = 0u64;
+
+        // Iteratively seed a deep/wide tree to avoid recursive async lifetime issues.
+        let mut prefixes_to_seed: Vec<(String, usize)> = vec![(root_prefix.to_string(), 3)];
+        while let Some((pfx, depth)) = prefixes_to_seed.pop() {
+            for i in 0..2usize {
+                let key = format!("{pfx}f{i}.bin");
+                server
+                    .add_object(bucket, &key, vec![0u8; 64], None)
+                    .await
+                    .expect("seed");
+                expected_count += 1;
+            }
+            if depth > 0 {
+                for d in 0..4usize {
+                    let sub = format!("{pfx}d{d}/");
+                    prefixes_to_seed.push((sub, depth - 1));
+                }
+            }
+        }
+
+        let dest = tempfile::tempdir().expect("tempdir");
+        let handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(dest.path())
+            .key_prefix(root_prefix)
+            .initiate()
+            .expect("initiate");
+
+        let output = handle.join().await.expect("join");
+        assert_eq!(expected_count, output.objects_downloaded());
+        assert!(output.failed_transfers().is_empty());
+
+        let files_on_disk = count_files(dest.path());
+        assert_eq!(expected_count as usize, files_on_disk);
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_download_objects_deep_wide_tree timed out");
+}
+
+/// Abort mid-transfer terminates cleanly without deadlock.
+#[tokio::test]
+async fn test_download_objects_abort_terminates() {
+    timeout(TEST_TIMEOUT, async {
+        let (server, server_handle, tm) = setup().await;
+
+        let count = 200usize;
+        let size = 1024usize;
+        let bucket = "test-bucket";
+        let prefix = "abort/";
+
+        seed_bucket(&server, bucket, prefix, count, size).await;
+
+        // Inject faults on the first key so the download hangs/fails if not aborted.
+        server.insert_fault(
+            bucket,
+            &format!("{prefix}0000.bin"),
+            FaultType::ServiceError { status: 503 },
+            0,
+            Occurrence::Always,
+        );
+
+        let dest = tempfile::tempdir().expect("tempdir");
+        let handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(dest.path())
+            .key_prefix(prefix)
+            .failure_policy(FailedTransferPolicy::Abort)
+            .initiate()
+            .expect("initiate");
+
+        // The default Abort policy should propagate the error.
+        // Whether it auto-aborts or we abort explicitly, it should terminate.
+        let result = handle.join().await;
+        // Under Abort policy with a faulted key, join returns an error.
+        assert!(
+            result.is_err(),
+            "expected error due to faulted key under Abort policy"
+        );
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_download_objects_abort_terminates timed out");
+}
+
+// ---------------------------------------------------------------------------
+// DOWNLOAD-SPECIFIC TESTS
+// ---------------------------------------------------------------------------
+
+/// Seed enough objects to force ListObjectsV2 pagination, verify all objects
+/// across pages are discovered and downloaded. Uses `S3Walker::builder().page_size()`
+/// to force a small page size rather than seeding >1000 objects.
+#[tokio::test]
+async fn test_download_objects_listing_pagination() {
+    timeout(TEST_TIMEOUT, async {
+        let (server, server_handle, tm) = setup().await;
+
+        let count = 50usize;
+        let size = 128usize;
+        let bucket = "test-bucket";
+        let prefix = "paginated/";
+
+        seed_bucket(&server, bucket, prefix, count, size).await;
+
+        let dest = tempfile::tempdir().expect("tempdir");
+        // Force page_size=5 so that 50 objects require 10 list pages.
+        let walker = S3Walker::builder().page_size(5).build();
+        let handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(dest.path())
+            .key_prefix(prefix)
+            .walker(walker)
+            .initiate()
+            .expect("initiate download_objects");
+
+        let output = handle.join().await.expect("join download_objects");
+        assert_eq!(count as u64, output.objects_downloaded());
+        assert!(output.failed_transfers().is_empty());
+
+        let files_on_disk = count_files(dest.path());
+        assert_eq!(
+            count, files_on_disk,
+            "all paginated objects should land on disk"
+        );
+
+        // Verify content of a sample file to ensure no mix-up across pages.
+        let sample_path = dest.path().join("0025.bin");
+        let got = std::fs::read(&sample_path).expect("read sample file");
+        assert_eq!(got, vec![25u8; size], "sample content should match");
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_download_objects_listing_pagination timed out");
+}
+
+/// FailedTransferPolicy::Continue with one faulted key: the other objects
+/// succeed and the faulted key appears in `failed_transfers()`.
+#[tokio::test]
+async fn test_download_objects_continue_policy_partial_failure() {
+    timeout(TEST_TIMEOUT, async {
+        let (server, server_handle, tm) = setup().await;
+
+        let bucket = "test-bucket";
+        let prefix = "partial/";
+        let good_count = 10usize;
+        let size = 512usize;
+
+        seed_bucket(&server, bucket, prefix, good_count, size).await;
+        // Add one extra object that will be faulted.
+        let bad_key = format!("{prefix}bad.bin");
+        server
+            .add_object(bucket, &bad_key, vec![0xFFu8; size], None)
+            .await
+            .expect("seed bad object");
+
+        // Inject a permanent service error on the bad key.
+        server.insert_fault(
+            bucket,
+            &bad_key,
+            FaultType::ServiceError { status: 500 },
+            0,
+            Occurrence::Always,
+        );
+
+        let dest = tempfile::tempdir().expect("tempdir");
+        let handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(dest.path())
+            .key_prefix(prefix)
+            .failure_policy(FailedTransferPolicy::Continue)
+            .initiate()
+            .expect("initiate download_objects");
+
+        let output = handle.join().await.expect("join download_objects");
+        // The good objects should succeed.
+        assert_eq!(good_count as u64, output.objects_downloaded());
+        // Exactly one failure: the bad key.
+        assert_eq!(
+            1,
+            output.failed_transfers().len(),
+            "expected exactly one failed transfer"
+        );
+        let failed = &output.failed_transfers()[0];
+        let failed_key = failed.input().key().expect("failed input should have key");
+        assert_eq!(
+            failed_key, bad_key,
+            "failed key should be the faulted object"
+        );
+
+        // Verify good files are on disk.
+        let files_on_disk = count_files(dest.path());
+        assert_eq!(good_count, files_on_disk);
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_download_objects_continue_policy_partial_failure timed out");
+}
+
+/// SECURITY: keys with path traversal components must NOT write files outside
+/// the destination directory. The product code uses `path_clean` + validation
+/// to reject such keys. If a key resolves outside the root, it should fail
+/// rather than escape.
+#[tokio::test]
+async fn test_download_objects_key_path_safety() {
+    timeout(TEST_TIMEOUT, async {
+        let (server, server_handle, tm) = setup().await;
+
+        let bucket = "test-bucket";
+        let prefix = "safe/";
+        // Include a known-good object alongside traversal keys.
+        let objects: &[(&str, &[u8])] = &[
+            ("safe/good.txt", b"safe-content"),
+            ("safe/../escape.bin", b"escape-attempt-1"),
+            ("safe/../../etc/passwd", b"escape-attempt-2"),
+            ("safe/sub/../../other.bin", b"escape-attempt-3"),
+        ];
+        seed_objects(&server, bucket, objects).await;
+
+        let dest = tempfile::tempdir().expect("tempdir");
+        let dest_path = dest.path().to_path_buf();
+
+        // Use Continue policy so we can inspect which keys failed vs succeeded.
+        let handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(&dest_path)
+            .key_prefix(prefix)
+            .failure_policy(FailedTransferPolicy::Continue)
+            .initiate()
+            .expect("initiate download_objects");
+
+        let output = handle.join().await.expect("join download_objects");
+
+        // The good file must land on disk inside the destination.
+        let good_path = dest_path.join("good.txt");
+        assert!(good_path.exists(), "good.txt should exist on disk");
+        assert_eq!(
+            std::fs::read(&good_path).expect("read good.txt"),
+            b"safe-content"
+        );
+
+        // CRITICAL SAFETY ASSERTION: no file must exist outside the destination.
+        // Walk the parent directory of dest and check that no unexpected files landed.
+        let parent = dest_path.parent().expect("dest has parent");
+        for entry in std::fs::read_dir(parent).expect("read parent dir") {
+            let entry = entry.expect("dir entry");
+            let path = entry.path();
+            // The only entry under parent that we care about is our dest dir itself.
+            if path != dest_path {
+                // Check that no file from our traversal keys landed here.
+                if path.is_file() {
+                    let name = path.file_name().unwrap().to_string_lossy();
+                    assert!(
+                        name != "escape.bin" && name != "passwd" && name != "other.bin",
+                        "SECURITY BUG: path traversal escape detected! File landed at {path:?}"
+                    );
+                }
+            }
+        }
+
+        // The traversal keys should appear as failures (InputInvalid).
+        assert!(
+            !output.failed_transfers().is_empty(),
+            "traversal keys should fail rather than silently succeed"
+        );
+        // At minimum the good object succeeded.
+        assert!(
+            output.objects_downloaded() >= 1,
+            "at least the safe object should download"
+        );
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_download_objects_key_path_safety timed out");
+}
+
+// ---------------------------------------------------------------------------
+// ROUND-TRIP
+// ---------------------------------------------------------------------------
+
+/// Build a nested directory tree, upload it, download it to a fresh dir,
+/// and assert the two trees are byte-identical.
+#[tokio::test]
+async fn test_upload_then_download_objects_roundtrip() {
+    timeout(Duration::from_secs(120), async {
+        let (_server, server_handle, tm) = setup().await;
+
+        let bucket = "test-bucket";
+        let prefix = "rt/";
+
+        // Build a source directory tree with varied file sizes.
+        let src_dir = tempfile::tempdir().expect("tempdir");
+        let files: &[(&str, usize)] = &[
+            ("small.txt", 128),
+            ("medium.bin", 64 * 1024),
+            ("sub/nested.dat", 32 * 1024),
+            ("sub/deep/leaf.bin", 256),
+            ("another/file.txt", 1024),
+        ];
+        let mut expected_content: HashMap<&str, Vec<u8>> = HashMap::new();
+        for (rel, size) in files {
+            let path = src_dir.path().join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).expect("mkdirs");
+            let body: Vec<u8> = (0..*size).map(|i| (i % 251) as u8).collect();
+            std::fs::write(&path, &body).expect("write source file");
+            expected_content.insert(rel, body);
+        }
+
+        // Upload the directory tree.
+        use aws_sdk_s3_transfer_manager::io::walk::FsWalker;
+        let upload_handle = tm
+            .upload_objects()
+            .bucket(bucket)
+            .source(src_dir.path())
+            .walker(FsWalker::builder().recursive(true).build())
+            .key_prefix(prefix)
+            .initiate()
+            .expect("initiate upload_objects");
+
+        let upload_output = upload_handle.join().await.expect("join upload_objects");
+        assert_eq!(files.len() as u64, upload_output.objects_uploaded());
+        assert!(upload_output.failed_transfers().is_empty());
+
+        // Download to a fresh directory.
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let download_handle = tm
+            .download_objects()
+            .bucket(bucket)
+            .destination(dest_dir.path())
+            .key_prefix(prefix)
+            .initiate()
+            .expect("initiate download_objects");
+
+        let download_output = download_handle.join().await.expect("join download_objects");
+        assert_eq!(files.len() as u64, download_output.objects_downloaded());
+        assert!(download_output.failed_transfers().is_empty());
+
+        // Verify the downloaded tree matches the source tree exactly.
+        verify_dir(dest_dir.path(), &expected_content);
+
+        server_handle.shutdown().await.expect("shutdown");
+    })
+    .await
+    .expect("test_upload_then_download_objects_roundtrip timed out");
+}

--- a/integration-tests/src/download_objects.rs
+++ b/integration-tests/src/download_objects.rs
@@ -17,34 +17,14 @@ use std::time::Duration;
 
 use aws_sdk_s3_transfer_manager::io::walk::S3Walker;
 use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
-use aws_sdk_s3_transfer_manager::types::FailedTransferPolicy;
+use aws_sdk_s3_transfer_manager::types::{FailedTransferPolicy, RuntimeMode};
 use s3_mock_server::{FaultType, Occurrence, S3MockServer};
+
+use crate::harness::mock_tm;
 use tokio::time::timeout;
 
 /// Default test timeout.
 const TEST_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// Setup transfer manager with mock server.
-async fn setup() -> (
-    S3MockServer,
-    s3_mock_server::ServerHandle,
-    aws_sdk_s3_transfer_manager::Client,
-) {
-    let server = S3MockServer::builder()
-        .with_in_memory_store()
-        .build()
-        .expect("build mock server");
-
-    let handle = server.start().await.expect("start mock server");
-    let s3_client = handle.client().await;
-
-    let tm_config = aws_sdk_s3_transfer_manager::Config::builder()
-        .client(s3_client)
-        .build();
-    let tm = aws_sdk_s3_transfer_manager::Client::new(tm_config);
-
-    (server, handle, tm)
-}
 
 /// Seed `count` objects into the mock bucket under `prefix`, each `size` bytes.
 /// Objects are named `{prefix}{NNNN}.bin` with distinct per-index byte patterns.
@@ -139,20 +119,20 @@ fn count_files_inner(dir: &Path, count: &mut usize) {
 // ---------------------------------------------------------------------------
 
 /// Seed N small objects, download them all, verify count and disk presence.
-#[tokio::test]
-async fn test_download_objects_many_small_files() {
+async fn test_download_objects_many_small_files(rt: RuntimeMode) {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = mock_tm(rt).await;
 
         let count = 500usize;
         let size = 4 * ByteUnit::Kibibyte.as_bytes_usize();
         let bucket = "test-bucket";
         let prefix = "small/";
 
-        seed_bucket(&server, bucket, prefix, count, size).await;
+        seed_bucket(&m.server, bucket, prefix, count, size).await;
 
         let dest = tempfile::tempdir().expect("tempdir");
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(dest.path())
@@ -167,35 +147,46 @@ async fn test_download_objects_many_small_files() {
         let files_on_disk = count_files(dest.path());
         assert_eq!(count, files_on_disk, "all objects should land on disk");
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_download_objects_many_small_files timed out");
+}
+
+#[tokio::test]
+async fn test_download_objects_many_small_files_mock_gp() {
+    test_download_objects_many_small_files(RuntimeMode::Managed).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_download_objects_many_small_files_tokio_mt() {
+    test_download_objects_many_small_files(RuntimeMode::CurrentTokio).await;
 }
 
 /// Per-file byte-content integrity after download.
 #[tokio::test]
 async fn test_download_objects_flat_content_roundtrip() {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = mock_tm(RuntimeMode::Managed).await;
 
         let count = 20usize;
         let size = 2 * ByteUnit::Kibibyte.as_bytes_usize();
         let bucket = "test-bucket";
         let prefix = "roundtrip/";
 
-        server.create_bucket(bucket).await.expect("create bucket");
+        m.server.create_bucket(bucket).await.expect("create bucket");
         for i in 0..count {
             let key = format!("{prefix}{i:03}.bin");
             let body = vec![i as u8; size];
-            server
+            m.server
                 .add_object(bucket, &key, body, None)
                 .await
                 .expect("seed object");
         }
 
         let dest = tempfile::tempdir().expect("tempdir");
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(dest.path())
@@ -221,7 +212,7 @@ async fn test_download_objects_flat_content_roundtrip() {
             );
         }
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_download_objects_flat_content_roundtrip timed out");
@@ -231,7 +222,7 @@ async fn test_download_objects_flat_content_roundtrip() {
 #[tokio::test]
 async fn test_download_objects_nested_prefixes() {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = mock_tm(RuntimeMode::Managed).await;
 
         let bucket = "test-bucket";
         let prefix = "tree/";
@@ -242,10 +233,11 @@ async fn test_download_objects_nested_prefixes() {
             ("tree/b/inner/deep.txt", b"deep-content"),
             ("tree/c/1/2/3/leaf.bin", b"leaf"),
         ];
-        seed_objects(&server, bucket, objects).await;
+        seed_objects(&m.server, bucket, objects).await;
 
         let dest = tempfile::tempdir().expect("tempdir");
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(dest.path())
@@ -266,17 +258,16 @@ async fn test_download_objects_nested_prefixes() {
         expected.insert("c/1/2/3/leaf.bin", b"leaf".to_vec());
         verify_dir(dest.path(), &expected);
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_download_objects_nested_prefixes timed out");
 }
 
 /// Objects large enough to trigger multipart download, content verified.
-#[tokio::test]
-async fn test_download_objects_multipart_children() {
+async fn test_download_objects_multipart_children(rt: RuntimeMode) {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = mock_tm(rt).await;
 
         let part = 8 * ByteUnit::Mebibyte.as_bytes_usize();
         let count = 3usize;
@@ -284,19 +275,20 @@ async fn test_download_objects_multipart_children() {
         let bucket = "test-bucket";
         let prefix = "mpu/";
 
-        server.create_bucket(bucket).await.expect("create bucket");
+        m.server.create_bucket(bucket).await.expect("create bucket");
         for i in 0..count {
             let key = format!("{prefix}{i:04}.bin");
             // Deterministic content pattern (byte index mod 256).
             let body: Vec<u8> = (0..size).map(|b| (b % 256) as u8).collect();
-            server
+            m.server
                 .add_object(bucket, &key, body, None)
                 .await
                 .expect("seed object");
         }
 
         let dest = tempfile::tempdir().expect("tempdir");
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(dest.path())
@@ -327,23 +319,34 @@ async fn test_download_objects_multipart_children() {
             assert_eq!(got, expected_body, "content mismatch for {:04}.bin", i);
         }
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_download_objects_multipart_children timed out");
+}
+
+#[tokio::test]
+async fn test_download_objects_multipart_children_mock_gp() {
+    test_download_objects_multipart_children(RuntimeMode::Managed).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_download_objects_multipart_children_tokio_mt() {
+    test_download_objects_multipart_children(RuntimeMode::CurrentTokio).await;
 }
 
 /// Empty prefix yields zero downloads with no error.
 #[tokio::test]
 async fn test_download_objects_empty_prefix() {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = mock_tm(RuntimeMode::Managed).await;
 
         let bucket = "test-bucket";
-        server.create_bucket(bucket).await.expect("create bucket");
+        m.server.create_bucket(bucket).await.expect("create bucket");
 
         let dest = tempfile::tempdir().expect("tempdir");
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(dest.path())
@@ -363,7 +366,7 @@ async fn test_download_objects_empty_prefix() {
         let files_on_disk = count_files(dest.path());
         assert_eq!(0, files_on_disk);
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_download_objects_empty_prefix timed out");
@@ -375,11 +378,11 @@ async fn test_download_objects_empty_prefix() {
 #[tokio::test]
 async fn test_download_objects_deep_wide_tree() {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = mock_tm(RuntimeMode::Managed).await;
 
         let bucket = "test-bucket";
         let root_prefix = "deep/";
-        server.create_bucket(bucket).await.expect("create bucket");
+        m.server.create_bucket(bucket).await.expect("create bucket");
 
         let mut expected_count = 0u64;
 
@@ -388,7 +391,7 @@ async fn test_download_objects_deep_wide_tree() {
         while let Some((pfx, depth)) = prefixes_to_seed.pop() {
             for i in 0..2usize {
                 let key = format!("{pfx}f{i}.bin");
-                server
+                m.server
                     .add_object(bucket, &key, vec![0u8; 64], None)
                     .await
                     .expect("seed");
@@ -403,7 +406,8 @@ async fn test_download_objects_deep_wide_tree() {
         }
 
         let dest = tempfile::tempdir().expect("tempdir");
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(dest.path())
@@ -418,7 +422,7 @@ async fn test_download_objects_deep_wide_tree() {
         let files_on_disk = count_files(dest.path());
         assert_eq!(expected_count as usize, files_on_disk);
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_download_objects_deep_wide_tree timed out");
@@ -428,17 +432,17 @@ async fn test_download_objects_deep_wide_tree() {
 #[tokio::test]
 async fn test_download_objects_abort_terminates() {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = mock_tm(RuntimeMode::Managed).await;
 
         let count = 200usize;
         let size = 1024usize;
         let bucket = "test-bucket";
         let prefix = "abort/";
 
-        seed_bucket(&server, bucket, prefix, count, size).await;
+        seed_bucket(&m.server, bucket, prefix, count, size).await;
 
         // Inject faults on the first key so the download hangs/fails if not aborted.
-        server.insert_fault(
+        m.server.insert_fault(
             bucket,
             &format!("{prefix}0000.bin"),
             FaultType::ServiceError { status: 503 },
@@ -447,7 +451,8 @@ async fn test_download_objects_abort_terminates() {
         );
 
         let dest = tempfile::tempdir().expect("tempdir");
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(dest.path())
@@ -465,7 +470,7 @@ async fn test_download_objects_abort_terminates() {
             "expected error due to faulted key under Abort policy"
         );
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_download_objects_abort_terminates timed out");
@@ -478,22 +483,22 @@ async fn test_download_objects_abort_terminates() {
 /// Seed enough objects to force ListObjectsV2 pagination, verify all objects
 /// across pages are discovered and downloaded. Uses `S3Walker::builder().page_size()`
 /// to force a small page size rather than seeding >1000 objects.
-#[tokio::test]
-async fn test_download_objects_listing_pagination() {
+async fn test_download_objects_listing_pagination(rt: RuntimeMode) {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = mock_tm(rt).await;
 
         let count = 50usize;
         let size = 128usize;
         let bucket = "test-bucket";
         let prefix = "paginated/";
 
-        seed_bucket(&server, bucket, prefix, count, size).await;
+        seed_bucket(&m.server, bucket, prefix, count, size).await;
 
         let dest = tempfile::tempdir().expect("tempdir");
         // Force page_size=5 so that 50 objects require 10 list pages.
         let walker = S3Walker::builder().page_size(5).build();
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(dest.path())
@@ -517,10 +522,20 @@ async fn test_download_objects_listing_pagination() {
         let got = std::fs::read(&sample_path).expect("read sample file");
         assert_eq!(got, vec![25u8; size], "sample content should match");
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_download_objects_listing_pagination timed out");
+}
+
+#[tokio::test]
+async fn test_download_objects_listing_pagination_mock_gp() {
+    test_download_objects_listing_pagination(RuntimeMode::Managed).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_download_objects_listing_pagination_tokio_mt() {
+    test_download_objects_listing_pagination(RuntimeMode::CurrentTokio).await;
 }
 
 /// FailedTransferPolicy::Continue with one faulted key: the other objects
@@ -528,23 +543,23 @@ async fn test_download_objects_listing_pagination() {
 #[tokio::test]
 async fn test_download_objects_continue_policy_partial_failure() {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = mock_tm(RuntimeMode::Managed).await;
 
         let bucket = "test-bucket";
         let prefix = "partial/";
         let good_count = 10usize;
         let size = 512usize;
 
-        seed_bucket(&server, bucket, prefix, good_count, size).await;
+        seed_bucket(&m.server, bucket, prefix, good_count, size).await;
         // Add one extra object that will be faulted.
         let bad_key = format!("{prefix}bad.bin");
-        server
+        m.server
             .add_object(bucket, &bad_key, vec![0xFFu8; size], None)
             .await
             .expect("seed bad object");
 
         // Inject a permanent service error on the bad key.
-        server.insert_fault(
+        m.server.insert_fault(
             bucket,
             &bad_key,
             FaultType::ServiceError { status: 500 },
@@ -553,7 +568,8 @@ async fn test_download_objects_continue_policy_partial_failure() {
         );
 
         let dest = tempfile::tempdir().expect("tempdir");
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(dest.path())
@@ -582,7 +598,7 @@ async fn test_download_objects_continue_policy_partial_failure() {
         let files_on_disk = count_files(dest.path());
         assert_eq!(good_count, files_on_disk);
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_download_objects_continue_policy_partial_failure timed out");
@@ -595,7 +611,7 @@ async fn test_download_objects_continue_policy_partial_failure() {
 #[tokio::test]
 async fn test_download_objects_key_path_safety() {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = mock_tm(RuntimeMode::Managed).await;
 
         let bucket = "test-bucket";
         let prefix = "safe/";
@@ -606,13 +622,14 @@ async fn test_download_objects_key_path_safety() {
             ("safe/../../etc/passwd", b"escape-attempt-2"),
             ("safe/sub/../../other.bin", b"escape-attempt-3"),
         ];
-        seed_objects(&server, bucket, objects).await;
+        seed_objects(&m.server, bucket, objects).await;
 
         let dest = tempfile::tempdir().expect("tempdir");
         let dest_path = dest.path().to_path_buf();
 
         // Use Continue policy so we can inspect which keys failed vs succeeded.
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(&dest_path)
@@ -661,7 +678,7 @@ async fn test_download_objects_key_path_safety() {
             "at least the safe object should download"
         );
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_download_objects_key_path_safety timed out");
@@ -673,10 +690,9 @@ async fn test_download_objects_key_path_safety() {
 
 /// Build a nested directory tree, upload it, download it to a fresh dir,
 /// and assert the two trees are byte-identical.
-#[tokio::test]
-async fn test_upload_then_download_objects_roundtrip() {
+async fn test_upload_then_download_objects_roundtrip(rt: RuntimeMode) {
     timeout(Duration::from_secs(120), async {
-        let (_server, server_handle, tm) = setup().await;
+        let m = mock_tm(rt).await;
 
         let bucket = "test-bucket";
         let prefix = "rt/";
@@ -701,7 +717,8 @@ async fn test_upload_then_download_objects_roundtrip() {
 
         // Upload the directory tree.
         use aws_sdk_s3_transfer_manager::io::walk::FsWalker;
-        let upload_handle = tm
+        let upload_handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(src_dir.path())
@@ -716,7 +733,8 @@ async fn test_upload_then_download_objects_roundtrip() {
 
         // Download to a fresh directory.
         let dest_dir = tempfile::tempdir().expect("tempdir");
-        let download_handle = tm
+        let download_handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .destination(dest_dir.path())
@@ -731,8 +749,18 @@ async fn test_upload_then_download_objects_roundtrip() {
         // Verify the downloaded tree matches the source tree exactly.
         verify_dir(dest_dir.path(), &expected_content);
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_upload_then_download_objects_roundtrip timed out");
+}
+
+#[tokio::test]
+async fn test_upload_then_download_objects_roundtrip_mock_gp() {
+    test_upload_then_download_objects_roundtrip(RuntimeMode::Managed).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_upload_then_download_objects_roundtrip_tokio_mt() {
+    test_upload_then_download_objects_roundtrip(RuntimeMode::CurrentTokio).await;
 }

--- a/integration-tests/src/harness.rs
+++ b/integration-tests/src/harness.rs
@@ -5,15 +5,21 @@
 
 //! Test harness for driving the transfer manager against a backend.
 //!
-//! A [`Target`] is a `Backend` (mock server or real S3) crossed with a
-//! `BucketKind` (general purpose or S3 Express). [`Target::connect`] yields a
-//! [`TmTestClient`] that exposes a transfer manager wired to that backend plus
-//! the bucket name to use. The same test body runs across every target.
+//! Two ways to get a test client:
+//!
+//! - [`mock_tm`] / [`mock_tm_with`] — lightweight, mock-only. The default for
+//!   tests that only need a mock server (download_objects, upload_objects, etc.).
+//!
+//! - [`Target`] — the mock x real-S3 x bucket-kind matrix, for tests that must
+//!   run against real S3 (integrity, etc.). [`Target::connect`] yields a
+//!   [`TmTestClient`] that exposes a transfer manager wired to that backend plus
+//!   the bucket name to use.
 //!
 //! Real-S3 targets are compiled only under `--cfg e2e_test` and require the
 //! account setup the existing e2e tests use (`S3_TEST_BUCKET_NAME_RS`). Mock
 //! targets run in normal CI.
 
+use aws_sdk_s3_transfer_manager::types::RuntimeMode;
 use aws_sdk_s3_transfer_manager::Client as TmClient;
 use s3_mock_server::S3MockServer;
 
@@ -48,6 +54,55 @@ pub(crate) fn init_e2e_logs() {
             .try_init();
     });
 }
+
+// ---------------------------------------------------------------------------
+// Lightweight mock-only path
+// ---------------------------------------------------------------------------
+
+/// A transfer-manager client wired to a fresh in-memory mock server.
+///
+/// The mock-only counterpart to [`Target`]: no bucket-kind / real-S3 / express
+/// machinery, just the boilerplate every mock test repeats. Holds the server
+/// and handle (for fault injection and direct inspection) alongside the client.
+pub(crate) struct MockTm {
+    pub(crate) server: S3MockServer,
+    pub(crate) handle: s3_mock_server::ServerHandle,
+    pub(crate) client: TmClient,
+}
+
+/// Build a mock TM on the given runtime with default config.
+pub(crate) async fn mock_tm(runtime: RuntimeMode) -> MockTm {
+    mock_tm_with(runtime, |b| b).await
+}
+
+/// Build a mock TM, applying `configure` to the TM Config builder (part size,
+/// concurrency, ...). The runtime mode is set by the harness after `configure`.
+pub(crate) async fn mock_tm_with(
+    runtime: RuntimeMode,
+    configure: impl FnOnce(
+        aws_sdk_s3_transfer_manager::config::Builder,
+    ) -> aws_sdk_s3_transfer_manager::config::Builder,
+) -> MockTm {
+    init_e2e_logs();
+    let server = S3MockServer::builder()
+        .with_in_memory_store()
+        .build()
+        .expect("build mock server");
+    let handle = server.start().await.expect("start mock server");
+    let s3_client = handle.client().await;
+    let cfg = configure(aws_sdk_s3_transfer_manager::Config::builder().client(s3_client))
+        .runtime_mode(runtime)
+        .build();
+    MockTm {
+        server,
+        handle,
+        client: TmClient::new(cfg),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Target-based path (mock x real-S3 x bucket-kind matrix)
+// ---------------------------------------------------------------------------
 
 /// Which backend serves S3 requests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod assertions;
 mod download;
+mod download_objects;
 mod download_retry;
 mod harness;
 mod integrity;

--- a/integration-tests/src/metrics.rs
+++ b/integration-tests/src/metrics.rs
@@ -9,30 +9,13 @@ use std::time::Duration;
 
 use aws_sdk_s3_transfer_manager::io::InputStream;
 use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
-use aws_sdk_s3_transfer_manager::types::TransferStatus;
-use s3_mock_server::S3MockServer;
+use aws_sdk_s3_transfer_manager::types::{RuntimeMode, TransferStatus};
 use tokio::time::timeout;
 
-/// Setup transfer manager with mock server (upload-style: returns server + handle + tm).
-async fn setup() -> (
-    S3MockServer,
-    s3_mock_server::ServerHandle,
-    aws_sdk_s3_transfer_manager::Client,
-) {
-    let server = S3MockServer::builder()
-        .with_in_memory_store()
-        .build()
-        .expect("build mock server");
+use crate::harness::{mock_tm, MockTm};
 
-    let handle = server.start().await.expect("start mock server");
-    let s3_client = handle.client().await;
-
-    let tm_config = aws_sdk_s3_transfer_manager::Config::builder()
-        .client(s3_client)
-        .build();
-    let tm = aws_sdk_s3_transfer_manager::Client::new(tm_config);
-
-    (server, handle, tm)
+async fn setup() -> MockTm {
+    mock_tm(RuntimeMode::Managed).await
 }
 
 /// Poll handle status until terminal, with timeout.
@@ -51,12 +34,13 @@ async fn wait_for_terminal(status_fn: impl Fn() -> TransferStatus) {
 
 #[tokio::test]
 async fn test_upload_metrics_and_status() {
-    let (_server, server_handle, tm) = setup().await;
+    let m = setup().await;
 
     let size = 16 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = vec![0u8; size];
 
-    let handle = tm
+    let handle = m
+        .client
         .upload()
         .bucket("test-bucket")
         .key("metrics-upload")
@@ -76,12 +60,12 @@ async fn test_upload_metrics_and_status() {
     let output = handle.join().await.expect("join");
     assert_eq!(output.metrics.network_tx, size as u64);
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 #[tokio::test]
 async fn test_upload_from_file_metrics() {
-    let (_server, server_handle, tm) = setup().await;
+    let m = setup().await;
 
     let size = 16 * ByteUnit::Mebibyte.as_bytes_usize();
     let dir = tempfile::tempdir().unwrap();
@@ -90,7 +74,8 @@ async fn test_upload_from_file_metrics() {
 
     let stream = InputStream::from_path(&file_path).expect("open file");
 
-    let handle = tm
+    let handle = m
+        .client
         .upload()
         .bucket("test-bucket")
         .key("metrics-file-upload")
@@ -108,21 +93,22 @@ async fn test_upload_from_file_metrics() {
     assert_eq!(output.metrics.network_tx, size as u64);
     assert_eq!(output.metrics.disk_read, size as u64);
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 #[tokio::test]
 async fn test_download_metrics_and_status() {
-    let (server, server_handle, tm) = setup().await;
+    let m = setup().await;
 
     let size = 25 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = vec![0u8; size];
-    server
+    m.server
         .add_object("test-bucket", "metrics-download", content, None)
         .await
         .expect("add object");
 
-    let handle = tm
+    let handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("metrics-download")
@@ -147,17 +133,16 @@ async fn test_download_metrics_and_status() {
     assert_eq!(output.metrics.total_bytes, Some(size as u64));
     assert!(output.metrics.finished_at.is_some());
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 #[cfg(any(unix, windows))]
-#[tokio::test]
-async fn test_download_to_file_metrics() {
-    let (server, server_handle, tm) = setup().await;
+async fn test_download_to_file_metrics(rt: RuntimeMode) {
+    let m = mock_tm(rt).await;
 
     let size = 25 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = vec![0u8; size];
-    server
+    m.server
         .add_object("test-bucket", "metrics-file-download", content, None)
         .await
         .expect("add object");
@@ -165,7 +150,8 @@ async fn test_download_to_file_metrics() {
     let dir = tempfile::tempdir().unwrap();
     let dest_path = dir.path().join("output.dat");
 
-    let handle = tm
+    let handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("metrics-file-download")
@@ -182,17 +168,30 @@ async fn test_download_to_file_metrics() {
     assert_eq!(output.metrics.disk_write, size as u64);
     assert_eq!(output.metrics.total_bytes, Some(size as u64));
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
+}
+
+#[cfg(any(unix, windows))]
+#[tokio::test]
+async fn test_download_to_file_metrics_mock_gp() {
+    test_download_to_file_metrics(RuntimeMode::Managed).await;
+}
+
+#[cfg(any(unix, windows))]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_download_to_file_metrics_tokio_mt() {
+    test_download_to_file_metrics(RuntimeMode::CurrentTokio).await;
 }
 
 #[tokio::test]
 async fn test_upload_abort_metrics() {
-    let (_server, server_handle, tm) = setup().await;
+    let m = setup().await;
 
     let size = 16 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = vec![0u8; size];
 
-    let handle = tm
+    let handle = m
+        .client
         .upload()
         .bucket("test-bucket")
         .key("metrics-abort-upload")
@@ -211,21 +210,22 @@ async fn test_upload_abort_metrics() {
         .expect("abort timed out")
         .expect("abort");
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
 #[tokio::test]
 async fn test_download_abort_status() {
-    let (server, server_handle, tm) = setup().await;
+    let m = setup().await;
 
     let size = 100 * ByteUnit::Mebibyte.as_bytes_usize();
     let content = vec![0u8; size];
-    server
+    m.server
         .add_object("test-bucket", "metrics-abort-download", content, None)
         .await
         .expect("add object");
 
-    let handle = tm
+    let handle = m
+        .client
         .download()
         .bucket("test-bucket")
         .key("metrics-abort-download")
@@ -239,5 +239,5 @@ async fn test_download_abort_status() {
         .await
         .expect("abort timed out");
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }

--- a/integration-tests/src/metrics.rs
+++ b/integration-tests/src/metrics.rs
@@ -180,7 +180,7 @@ async fn test_download_to_file_metrics_mock_gp() {
 #[cfg(any(unix, windows))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_download_to_file_metrics_tokio_mt() {
-    test_download_to_file_metrics(RuntimeMode::CurrentTokio).await;
+    test_download_to_file_metrics(RuntimeMode::MultiThreadTokio).await;
 }
 
 #[tokio::test]

--- a/integration-tests/src/upload.rs
+++ b/integration-tests/src/upload.rs
@@ -96,7 +96,7 @@ async fn test_mpu_upload_concurrent_mock_gp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_mpu_upload_concurrent_tokio_mt() {
-    test_mpu_upload_concurrent(RuntimeMode::CurrentTokio).await;
+    test_mpu_upload_concurrent(RuntimeMode::MultiThreadTokio).await;
 }
 
 #[tokio::test]

--- a/integration-tests/src/upload.rs
+++ b/integration-tests/src/upload.rs
@@ -7,37 +7,23 @@
 
 use aws_sdk_s3_transfer_manager::io::InputStream;
 use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
-use s3_mock_server::S3MockServer;
+use aws_sdk_s3_transfer_manager::types::RuntimeMode;
 
-/// Setup transfer manager with mock server
-async fn setup() -> (
-    s3_mock_server::ServerHandle,
-    aws_sdk_s3_transfer_manager::Client,
-) {
-    let server = S3MockServer::builder()
-        .with_in_memory_store()
-        .build()
-        .expect("build mock server");
+use crate::harness::{mock_tm, MockTm};
 
-    let handle = server.start().await.expect("start mock server");
-    let s3_client = handle.client().await;
-
-    let tm_config = aws_sdk_s3_transfer_manager::Config::builder()
-        .client(s3_client)
-        .build();
-    let tm = aws_sdk_s3_transfer_manager::Client::new(tm_config);
-
-    (handle, tm)
+async fn setup() -> MockTm {
+    mock_tm(RuntimeMode::Managed).await
 }
 
 #[tokio::test]
 async fn test_mpu_upload_small_file() {
-    let (server_handle, tm) = setup().await;
+    let m = setup().await;
 
     let content = vec![0u8; 16 * ByteUnit::Mebibyte.as_bytes_usize()]; // 16MB = 2 parts at 8MB default
     let expected_content = content.clone();
 
-    let upload_handle = tm
+    let upload_handle = m
+        .client
         .upload()
         .bucket("test-bucket")
         .key("test-key")
@@ -52,9 +38,7 @@ async fn test_mpu_upload_small_file() {
         "should have upload_id for MPU"
     );
 
-    // TODO(redux): Use mock server's get_object API instead of going through S3 client
-    // once that API is available on ServerHandle
-    let s3_client = server_handle.client().await;
+    let s3_client = m.handle.client().await;
     let get_result = s3_client
         .get_object()
         .bucket("test-bucket")
@@ -66,12 +50,11 @@ async fn test_mpu_upload_small_file() {
     let body = get_result.body.collect().await.expect("collect body");
     assert_eq!(body.to_vec(), expected_content);
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }
 
-#[tokio::test]
-async fn test_mpu_upload_concurrent() {
-    let (server_handle, tm) = setup().await;
+async fn test_mpu_upload_concurrent(rt: RuntimeMode) {
+    let m = mock_tm(rt).await;
 
     let mut handles = Vec::new();
 
@@ -80,7 +63,8 @@ async fn test_mpu_upload_concurrent() {
         let content = vec![i as u8; 8 * ByteUnit::Mebibyte.as_bytes_usize()];
         let key = format!("concurrent-key-{}", i);
 
-        let upload_handle = tm
+        let upload_handle = m
+            .client
             .upload()
             .bucket("test-bucket")
             .key(&key)
@@ -102,12 +86,22 @@ async fn test_mpu_upload_concurrent() {
         );
     }
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn test_mpu_upload_concurrent_mock_gp() {
+    test_mpu_upload_concurrent(RuntimeMode::Managed).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_mpu_upload_concurrent_tokio_mt() {
+    test_mpu_upload_concurrent(RuntimeMode::CurrentTokio).await;
 }
 
 #[tokio::test]
 async fn test_upload_verify_data_integrity() {
-    let (server_handle, tm) = setup().await;
+    let m = setup().await;
 
     // Create content with recognizable pattern
     let content: Vec<u8> = (0..24 * ByteUnit::Mebibyte.as_bytes_usize()) // 24MB = 3 parts
@@ -115,7 +109,8 @@ async fn test_upload_verify_data_integrity() {
         .collect();
     let expected_content = content.clone();
 
-    let upload_handle = tm
+    let upload_handle = m
+        .client
         .upload()
         .bucket("test-bucket")
         .key("integrity-test")
@@ -125,9 +120,7 @@ async fn test_upload_verify_data_integrity() {
 
     upload_handle.join().await.expect("upload complete");
 
-    // TODO(redux): Use mock server's get_object API instead of going through S3 client
-    // once that API is available on ServerHandle
-    let s3_client = server_handle.client().await;
+    let s3_client = m.handle.client().await;
     let get_result = s3_client
         .get_object()
         .bucket("test-bucket")
@@ -143,5 +136,5 @@ async fn test_upload_verify_data_integrity() {
         "data integrity check failed"
     );
 
-    server_handle.shutdown().await.expect("shutdown");
+    m.handle.shutdown().await.expect("shutdown");
 }

--- a/integration-tests/src/upload_objects.rs
+++ b/integration-tests/src/upload_objects.rs
@@ -16,34 +16,19 @@ use std::time::Duration;
 
 use aws_sdk_s3_transfer_manager::io::walk::FsWalker;
 use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
+use aws_sdk_s3_transfer_manager::types::RuntimeMode;
 use s3_mock_server::S3MockServer;
 use tempfile::TempDir;
 use tokio::time::timeout;
+
+use crate::harness::{mock_tm, MockTm};
 
 /// Default test timeout. Any body exceeding this almost certainly
 /// reveals a hang or deadlock rather than legitimate slow work.
 const TEST_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Setup transfer manager with mock server.
-async fn setup() -> (
-    S3MockServer,
-    s3_mock_server::ServerHandle,
-    aws_sdk_s3_transfer_manager::Client,
-) {
-    let server = S3MockServer::builder()
-        .with_in_memory_store()
-        .build()
-        .expect("build mock server");
-
-    let handle = server.start().await.expect("start mock server");
-    let s3_client = handle.client().await;
-
-    let tm_config = aws_sdk_s3_transfer_manager::Config::builder()
-        .client(s3_client)
-        .build();
-    let tm = aws_sdk_s3_transfer_manager::Client::new(tm_config);
-
-    (server, handle, tm)
+async fn setup() -> MockTm {
+    mock_tm(RuntimeMode::Managed).await
 }
 
 /// Setup with an explicit concurrency limit, bounding the sustained offered load
@@ -108,17 +93,17 @@ async fn fetch_object_bytes(server: &S3MockServer, bucket: &str, key: &str) -> V
 /// s3fio benchmarks. The smithy interceptor mocks cannot reproduce this
 /// because they short-circuit above hyper; a real HTTP server exposes
 /// connection-pool and request-pipeline behavior.
-#[tokio::test]
-async fn test_upload_objects_many_small_files() {
+async fn test_upload_objects_many_small_files(rt: RuntimeMode) {
     timeout(TEST_TIMEOUT, async {
-        let (_server, server_handle, tm) = setup().await;
+        let m = mock_tm(rt).await;
 
         let count = 500usize;
         let size = 4 * ByteUnit::Kibibyte.as_bytes_usize();
         let dataset = make_flat_dataset(count, size);
 
         let bucket = "test-bucket";
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dataset.path())
@@ -136,13 +121,23 @@ async fn test_upload_objects_many_small_files() {
             "network_tx should equal sum of file sizes"
         );
 
-        let landed = count_objects(&_server, bucket, "small/").await;
+        let landed = count_objects(&m.server, bucket, "small/").await;
         assert_eq!(count, landed, "all files should land in the mock bucket");
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_upload_objects_many_small_files timed out");
+}
+
+#[tokio::test]
+async fn test_upload_objects_many_small_files_mock_gp() {
+    test_upload_objects_many_small_files(RuntimeMode::Managed).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_upload_objects_many_small_files_tokio_mt() {
+    test_upload_objects_many_small_files(RuntimeMode::CurrentTokio).await;
 }
 
 /// Flat single-directory recursive upload through the real HTTP mock
@@ -150,7 +145,7 @@ async fn test_upload_objects_many_small_files() {
 #[tokio::test]
 async fn test_upload_objects_flat_directory_content_roundtrip() {
     timeout(TEST_TIMEOUT, async {
-        let (_server, server_handle, tm) = setup().await;
+        let m = setup().await;
 
         let count = 20usize;
         let size = 2 * ByteUnit::Kibibyte.as_bytes_usize();
@@ -163,7 +158,8 @@ async fn test_upload_objects_flat_directory_content_roundtrip() {
         }
 
         let bucket = "test-bucket";
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dir.path())
@@ -179,11 +175,11 @@ async fn test_upload_objects_flat_directory_content_roundtrip() {
         // Every key should match its source file's content.
         for i in 0..count {
             let key = format!("roundtrip/{i:03}.bin");
-            let got = fetch_object_bytes(&_server, bucket, &key).await;
+            let got = fetch_object_bytes(&m.server, bucket, &key).await;
             assert_eq!(got, vec![i as u8; size], "content mismatch for key {key}");
         }
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_upload_objects_flat_directory_content_roundtrip timed out");
@@ -194,7 +190,7 @@ async fn test_upload_objects_flat_directory_content_roundtrip() {
 #[tokio::test]
 async fn test_upload_objects_nested_tree() {
     timeout(TEST_TIMEOUT, async {
-        let (_server, server_handle, tm) = setup().await;
+        let m = setup().await;
 
         let dir = tempfile::tempdir().expect("tempdir");
         let files: &[(&str, &[u8])] = &[
@@ -211,7 +207,8 @@ async fn test_upload_objects_nested_tree() {
         }
 
         let bucket = "test-bucket";
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dir.path())
@@ -226,11 +223,11 @@ async fn test_upload_objects_nested_tree() {
 
         for (rel, contents) in files {
             let key = format!("tree/{rel}");
-            let got = fetch_object_bytes(&_server, bucket, &key).await;
+            let got = fetch_object_bytes(&m.server, bucket, &key).await;
             assert_eq!(got, contents.to_vec(), "content mismatch for {key}");
         }
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_upload_objects_nested_tree timed out");
@@ -239,10 +236,9 @@ async fn test_upload_objects_nested_tree() {
 /// Files above the multipart threshold drive each child through the MPU
 /// path. Verifies that the plural state machine + child MPU uploads
 /// behave correctly against a real HTTP server.
-#[tokio::test]
-async fn test_upload_objects_multipart_children() {
+async fn test_upload_objects_multipart_children(rt: RuntimeMode) {
     timeout(TEST_TIMEOUT, async {
-        let (_server, server_handle, tm) = setup().await;
+        let m = mock_tm(rt).await;
 
         let part = 8 * ByteUnit::Mebibyte.as_bytes_usize();
         let count = 3usize;
@@ -250,7 +246,8 @@ async fn test_upload_objects_multipart_children() {
         let dataset = make_flat_dataset(count, size);
 
         let bucket = "test-bucket";
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dataset.path())
@@ -265,13 +262,23 @@ async fn test_upload_objects_multipart_children() {
         assert_eq!((count * size) as u64, output.metrics.network_tx);
         assert_eq!((count * size) as u64, output.metrics.disk_read);
 
-        let landed = count_objects(&_server, bucket, "mpu/").await;
+        let landed = count_objects(&m.server, bucket, "mpu/").await;
         assert_eq!(count, landed);
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_upload_objects_multipart_children timed out");
+}
+
+#[tokio::test]
+async fn test_upload_objects_multipart_children_mock_gp() {
+    test_upload_objects_multipart_children(RuntimeMode::Managed).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_upload_objects_multipart_children_tokio_mt() {
+    test_upload_objects_multipart_children(RuntimeMode::CurrentTokio).await;
 }
 
 /// Walker filter applied end-to-end: only matching files should land in
@@ -279,7 +286,7 @@ async fn test_upload_objects_multipart_children() {
 #[tokio::test]
 async fn test_upload_objects_walker_filter_applied() {
     timeout(TEST_TIMEOUT, async {
-        let (_server, server_handle, tm) = setup().await;
+        let m = setup().await;
 
         let dir = tempfile::tempdir().expect("tempdir");
         let entries: &[&str] = &[
@@ -297,7 +304,8 @@ async fn test_upload_objects_walker_filter_applied() {
         }
 
         let bucket = "test-bucket";
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dir.path())
@@ -316,11 +324,11 @@ async fn test_upload_objects_walker_filter_applied() {
         assert_eq!(3, output.objects_uploaded());
         assert!(output.failed_transfers().is_empty());
 
-        let landed = count_objects(&_server, bucket, "filtered/").await;
+        let landed = count_objects(&m.server, bucket, "filtered/").await;
         assert_eq!(3, landed);
 
         // Confirm none of the .log files made it.
-        let s3_client = server_handle.client().await;
+        let s3_client = m.handle.client().await;
         let logs = s3_client
             .list_objects_v2()
             .bucket(bucket)
@@ -336,7 +344,7 @@ async fn test_upload_objects_walker_filter_applied() {
             );
         }
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_upload_objects_walker_filter_applied timed out");
@@ -347,14 +355,15 @@ async fn test_upload_objects_walker_filter_applied() {
 #[tokio::test]
 async fn test_upload_objects_serial_execution() {
     timeout(TEST_TIMEOUT, async {
-        let (_server, server_handle, tm) = setup().await;
+        let m = setup().await;
 
         let count = 30usize;
         let size = 512usize;
         let dataset = make_flat_dataset(count, size);
 
         let bucket = "test-bucket";
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dataset.path())
@@ -368,10 +377,10 @@ async fn test_upload_objects_serial_execution() {
         assert_eq!(count as u64, output.objects_uploaded());
         assert!(output.failed_transfers().is_empty());
 
-        let landed = count_objects(&_server, bucket, "serial/").await;
+        let landed = count_objects(&m.server, bucket, "serial/").await;
         assert_eq!(count, landed);
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_upload_objects_serial_execution timed out");
@@ -382,16 +391,17 @@ async fn test_upload_objects_serial_execution() {
 #[tokio::test]
 async fn test_upload_objects_empty_source() {
     timeout(TEST_TIMEOUT, async {
-        let (_server, server_handle, tm) = setup().await;
+        let m = setup().await;
 
         let dir = tempfile::tempdir().expect("tempdir");
         let bucket = "test-bucket";
 
         // Create the bucket upfront since no PutObject will fire to
         // auto-create it (empty directory = zero uploads).
-        _server.create_bucket(bucket).await.expect("create bucket");
+        m.server.create_bucket(bucket).await.expect("create bucket");
 
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dir.path())
@@ -411,10 +421,10 @@ async fn test_upload_objects_empty_source() {
 
         // Create the bucket so count_objects can list it (no PutObject was
         // issued, so the mock server's auto-create-on-put never fired).
-        let landed = count_objects(&_server, bucket, "empty/").await;
+        let landed = count_objects(&m.server, bucket, "empty/").await;
         assert_eq!(0, landed);
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_upload_objects_empty_source timed out");
@@ -426,7 +436,7 @@ async fn test_upload_objects_empty_source() {
 #[tokio::test]
 async fn test_upload_objects_deep_wide_tree() {
     timeout(TEST_TIMEOUT, async {
-        let (_server, server_handle, tm) = setup().await;
+        let m = setup().await;
 
         let dir = tempfile::tempdir().expect("tempdir");
         let mut expected_files = 0u64;
@@ -455,7 +465,8 @@ async fn test_upload_objects_deep_wide_tree() {
         populate(dir.path(), 3, 2, 4, &mut expected_files);
 
         let bucket = "test-bucket";
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dir.path())
@@ -468,10 +479,10 @@ async fn test_upload_objects_deep_wide_tree() {
         assert_eq!(expected_files, output.objects_uploaded());
         assert!(output.failed_transfers().is_empty());
 
-        let landed = count_objects(&_server, bucket, "deep/").await;
+        let landed = count_objects(&m.server, bucket, "deep/").await;
         assert_eq!(expected_files as usize, landed);
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_upload_objects_deep_wide_tree timed out");
@@ -483,14 +494,15 @@ async fn test_upload_objects_deep_wide_tree() {
 #[tokio::test]
 async fn test_upload_objects_abort_terminates() {
     timeout(TEST_TIMEOUT, async {
-        let (_server, server_handle, tm) = setup().await;
+        let m = setup().await;
 
         let count = 200usize;
         let size = 1024usize;
         let dataset = make_flat_dataset(count, size);
 
         let bucket = "test-bucket";
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dataset.path())
@@ -503,7 +515,7 @@ async fn test_upload_objects_abort_terminates() {
         tokio::time::sleep(Duration::from_millis(50)).await;
         handle.abort().await;
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("test_upload_objects_abort_terminates timed out");

--- a/integration-tests/src/upload_objects.rs
+++ b/integration-tests/src/upload_objects.rs
@@ -21,7 +21,7 @@ use s3_mock_server::S3MockServer;
 use tempfile::TempDir;
 use tokio::time::timeout;
 
-use crate::harness::{mock_tm, MockTm};
+use crate::harness::{mock_tm, mock_tm_with, MockTm};
 
 /// Default test timeout. Any body exceeding this almost certainly
 /// reveals a hang or deadlock rather than legitimate slow work.
@@ -34,28 +34,11 @@ async fn setup() -> MockTm {
 /// Setup with an explicit concurrency limit, bounding the sustained offered load
 /// an installed throttle sees (so a throttled object's re-issues are not drowned
 /// out by peers retrying into the same limit).
-async fn setup_with_concurrency(
-    concurrency: usize,
-) -> (
-    S3MockServer,
-    s3_mock_server::ServerHandle,
-    aws_sdk_s3_transfer_manager::Client,
-) {
-    let server = S3MockServer::builder()
-        .with_in_memory_store()
-        .build()
-        .expect("build mock server");
-
-    let handle = server.start().await.expect("start mock server");
-    let s3_client = handle.client().await;
-
-    let tm_config = aws_sdk_s3_transfer_manager::Config::builder()
-        .client(s3_client)
-        .concurrency(aws_sdk_s3_transfer_manager::types::ConcurrencyMode::Explicit(concurrency))
-        .build();
-    let tm = aws_sdk_s3_transfer_manager::Client::new(tm_config);
-
-    (server, handle, tm)
+async fn setup_with_concurrency(concurrency: usize) -> MockTm {
+    mock_tm_with(RuntimeMode::Managed, |b| {
+        b.concurrency(aws_sdk_s3_transfer_manager::types::ConcurrencyMode::Explicit(concurrency))
+    })
+    .await
 }
 
 /// Create a flat temp directory containing `count` files, each of the
@@ -137,7 +120,7 @@ async fn test_upload_objects_many_small_files_mock_gp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_upload_objects_many_small_files_tokio_mt() {
-    test_upload_objects_many_small_files(RuntimeMode::CurrentTokio).await;
+    test_upload_objects_many_small_files(RuntimeMode::MultiThreadTokio).await;
 }
 
 /// Flat single-directory recursive upload through the real HTTP mock
@@ -278,7 +261,7 @@ async fn test_upload_objects_multipart_children_mock_gp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_upload_objects_multipart_children_tokio_mt() {
-    test_upload_objects_multipart_children(RuntimeMode::CurrentTokio).await;
+    test_upload_objects_multipart_children(RuntimeMode::MultiThreadTokio).await;
 }
 
 /// Walker filter applied end-to-end: only matching files should land in
@@ -539,7 +522,7 @@ fn _touch(_: &Path) {}
 #[tokio::test]
 async fn upload_objects_throttle_storm_aborts_transfer() {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup().await;
+        let m = setup().await;
 
         let count = 200usize;
         let size = 4 * ByteUnit::Kibibyte.as_bytes_usize();
@@ -552,7 +535,7 @@ async fn upload_objects_throttle_storm_aborts_transfer() {
         // un-retried once the bucket is drained.
         for i in 0..count {
             let key = format!("{key_prefix}{i:04}.bin");
-            server.insert_fault(
+            m.server.insert_fault(
                 bucket,
                 &key,
                 s3_mock_server::FaultType::ServiceError { status: 503 },
@@ -561,7 +544,8 @@ async fn upload_objects_throttle_storm_aborts_transfer() {
             );
         }
 
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dataset.path())
@@ -605,7 +589,7 @@ async fn upload_objects_throttle_storm_aborts_transfer() {
             "a failed_uploads entry must carry the structured ServiceError from the storm, got: {failed:?}",
         );
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("upload_objects_throttle_storm_aborts_transfer timed out");
@@ -649,7 +633,7 @@ async fn upload_objects_transient_throttle_storm_recovers() {
         // Fixed concurrency bounds the sustained offered load so throttled objects'
         // re-issues recover within the retry budget rather than being drowned out by
         // peers retrying into the same rate limit.
-        let (server, server_handle, tm) = setup_with_concurrency(16).await;
+        let m = setup_with_concurrency(16).await;
 
         let count = 200usize;
         let size = 4 * ByteUnit::Kibibyte.as_bytes_usize();
@@ -660,9 +644,10 @@ async fn upload_objects_transient_throttle_storm_recovers() {
         // past the 100 inner retries the shared SDK bucket can absorb (draining it
         // so 503s reach the TM loop); the TM's throttle backoff then paces re-issues
         // under 50/sec to recover.
-        server.set_rate_throttle(50.0, 15.0);
+        m.server.set_rate_throttle(50.0, 15.0);
 
-        let handle = tm
+        let handle = m
+            .client
             .upload_objects()
             .bucket(bucket)
             .source(dataset.path())
@@ -685,7 +670,7 @@ async fn upload_objects_transient_throttle_storm_recovers() {
             "no object should be left failed after recovery"
         );
 
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("upload_objects_transient_throttle_storm_recovers timed out");
@@ -698,7 +683,7 @@ async fn upload_objects_transient_throttle_storm_recovers() {
 #[tokio::test]
 async fn download_objects_transient_throttle_storm_recovers() {
     timeout(TEST_TIMEOUT, async {
-        let (server, server_handle, tm) = setup_with_concurrency(16).await;
+        let m = setup_with_concurrency(16).await;
         let count = 200usize;
         let size = 4 * ByteUnit::Kibibyte.as_bytes_usize();
         let bucket = "test-bucket";
@@ -706,7 +691,8 @@ async fn download_objects_transient_throttle_storm_recovers() {
 
         // Seed the store with no throttle installed.
         let dataset = make_flat_dataset(count, size);
-        tm.upload_objects()
+        m.client
+            .upload_objects()
             .bucket(bucket)
             .source(dataset.path())
             .walker(FsWalker::builder().recursive(true).build())
@@ -718,10 +704,11 @@ async fn download_objects_transient_throttle_storm_recovers() {
             .expect("seed upload must succeed");
 
         // Install the load-driven storm: every request is rate-limited server-wide.
-        server.set_rate_throttle(50.0, 15.0);
+        m.server.set_rate_throttle(50.0, 15.0);
 
         let dest = TempDir::new().expect("dest tempdir");
-        let handle = tm
+        let handle = m
+            .client
             .download_objects()
             .bucket(bucket)
             .key_prefix(prefix)
@@ -735,7 +722,7 @@ async fn download_objects_transient_throttle_storm_recovers() {
             .expect("a load-driven throttle storm on download must recover (parity with upload)");
         assert_eq!(output.objects_downloaded(), count as u64);
         assert!(output.failed_transfers().is_empty());
-        server_handle.shutdown().await.expect("shutdown");
+        m.handle.shutdown().await.expect("shutdown");
     })
     .await
     .expect("download_objects_transient_throttle_storm_recovers timed out");


### PR DESCRIPTION
## Summary

`ConcurrencyMode`-style config now selects the execution runtime: a `RuntimeMode` enum with `Managed` (default) and `CurrentTokio`, resolved once in `Client::new`. `Managed` spawns and owns worker threads as before; `CurrentTokio` runs transfer workers on the caller's existing tokio runtime via `tokio::spawn`, for embedding where the transfer manager must not spawn its own OS threads. The runtime trait, components, topology, and builders stay `pub(crate)` — the caller picks a mode and nothing else, so the runtime internals remain free to change. Alongside the selector this adds the integration coverage needed to validate a second runtime: `download_objects` (previously untested) gains a full suite, and the mock-based test files move onto a shared harness helper with dual-runtime coverage on the concurrency-exercising tests.

## Why

The transfer manager already owned two runtimes behind a private trait but only ever ran on `ManagedThreadRuntime` — `Client::new` hard-wired it, and `TokioMultiThreadRuntime` was reachable only from `#[cfg(test)]` constructors. A caller embedding the transfer manager inside an existing tokio application had no way to run transfers on that runtime instead of having the manager spawn its own threads. This exposes that choice as a narrow, opinionated config knob without exposing the runtime abstraction itself.

`CurrentTokio` is an escape hatch, not a performance tuning knob: `Managed`'s per-thread locality is faster by design, and on a network-bound download-discard workload (m6idn.16xlarge) the two are close — `Managed` leads by roughly 10-15%, concentrated on the single-stream many-parts path where a shared work queue contends. Prefer `Managed` unless you specifically need to run on your own runtime.

## How it works

### The selector

`RuntimeMode` is a `#[non_exhaustive]` public enum in `types.rs`, mirroring `ConcurrencyMode`: a `runtime_mode()` setter on the config builder (and the `from_env` loader), defaulting to `Managed`. `Client::new` matches on it at the single construction site, building `ManagedThreadRuntime` or `TokioMultiThreadRuntime`. Everything the runtime is made of — the `ExecutionRuntime` trait, `RuntimeComponents`, `Topology`, the builders — stays `pub(crate)`, so the connection-pool, NUMA, and pinning work still landing in that layer does not become public surface.

`CurrentTokio` uses the SDK's default HTTP client (the managed path's per-thread clients do not apply when the manager does not own the threads); this is intentional for the preview.

### The current-thread guard

`CurrentTokio` runs workers via `tokio::spawn`, so on a current-thread runtime they serialize onto the one thread and throughput collapses with no other symptom — a measured 6 Gbps where a multi-threaded runtime reached 66. `Client::new` checks the ambient runtime flavor when `CurrentTokio` is selected and logs a warning if it is current-thread, turning that silent cliff into a visible diagnostic. The check is best-effort and does not change the constructor's signature.

### Test harness

`harness.rs` gains a lightweight mock path — `mock_tm(runtime)` and `mock_tm_with(runtime, configure)` returning `MockTm { server, handle, client }` — beside the existing `Target` machinery, which stays for the real-S3 / bucket-kind matrix. The mock-only test files (`download`, `upload`, `upload_objects`, `metrics`, and the new `download_objects`) previously hand-rolled the same in-memory-server-to-client setup; they now share `mock_tm`, and the runtime is a parameter so a test can run on either runtime from one shared body.

Dual-runtime tests follow the existing per-variant idiom (`_mock_gp` / `_real_gp` / `_real_express`): a shared `async fn body(RuntimeMode)` plus thin `#[tokio::test]` wrappers — `_mock_gp` on the default runtime and `_tokio_mt` on a multi-threaded runtime. These are explicit named functions, not macro-generated, so each variant runs individually from an IDE. Only the tests that exercise genuine concurrent dispatch get a `_tokio_mt` sibling; runtime-agnostic tests stay single.

### download_objects coverage

The composite directory-download path had no integration tests. This adds a suite mirroring `upload_objects`, inverted to seed the mock bucket and verify files on disk: many-small-files, content roundtrip, nested prefixes, multipart children, empty prefix, deep/wide tree, and the `Abort` failure policy. It also covers paths upload cannot exercise — ListObjectsV2 pagination, the `Continue` failure policy (one faulted key fails while the rest succeed and the failure names that key), and key path-traversal safety (keys with `../` components must fail rather than write outside the destination, confirming the `path_clean` + validation guard holds) — plus an upload-then-download roundtrip asserting the two directory trees are byte-identical.

## How to review

`types.rs` and `config.rs` are the public surface (the `RuntimeMode` enum and the `runtime_mode` setter); `client.rs` is the resolution and the current-thread guard. `harness.rs` holds the `mock_tm` helper and the two-path module doc. `download_objects.rs` is the new suite; the diffs in `download.rs` / `upload.rs` / `upload_objects.rs` / `metrics.rs` are a mechanical swap of their local setup onto `mock_tm` plus the selective `_tokio_mt` splits — no test logic changed.

## Testing

Beyond the integration suite (which now exercises `CurrentTokio` on both the download_objects anchors and the per-file concurrency anchors), `CurrentTokio` was validated on real EC2 (m6idn.16xlarge) across the standard benchmark suite: it completes every workload `Managed` does and holds line rate on the concurrent max-throughput cases. This is what backs shipping a runtime that until now ran only under `#[cfg(test)]`.

## Changes

```
aws-sdk-s3-transfer-manager/
  src/
    types.rs            RuntimeMode enum (public, non_exhaustive)
    config.rs           runtime_mode on Config + Builder
    config/loader.rs    runtime_mode on the from_env loader
    client.rs           resolve runtime by mode; current-thread guard
    runtime/mod.rs, runtime/tokio_mt.rs, runtime/tokio_mt/worker_pool.rs
                        TokioMultiThreadRuntime reachable from Client::new (dead_code gates dropped)
  examples/cp.rs        --runtime flag; runtime flavor matches the selected mode
integration-tests/src/
    harness.rs          mock_tm / mock_tm_with / MockTm (lightweight mock path)
    download_objects.rs new suite (parity + pagination, partial-failure, path-safety, roundtrip)
    download.rs, upload.rs, upload_objects.rs, metrics.rs
                        moved onto mock_tm; _tokio_mt siblings on concurrency anchors
    lib.rs              register download_objects
```

## Notes for review

- `Managed` remains the default and is unchanged; `Auto` behavior and every existing test path are untouched.
- `CurrentTokio` requires a multi-threaded runtime — the current-thread guard warns, it does not error, so a caller who knows what they are doing is not blocked.
- Running the mock-only files across both runtimes exhaustively (rather than the selected concurrency anchors) is deliberately left for a follow-up; the harness now supports it uniformly.
- The `TokioMultiThreadRuntime` work queue is a single shared queue; the ~10-15% gap against `Managed` on the single-stream path is queue contention, a known and separable optimization, not a correctness issue.
