### PR TITLE
upload: set MpuObjectSize on CompleteMultipartUpload

### DIFF
--- a/aws-sdk-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/context.rs
@@ -30,6 +30,8 @@ pub(crate) enum UploadState {
         parts_in_flight: usize,
         completed_parts: Vec<CompletedPart>,
         response_builder: UploadOutputBuilder,
+        /// Full object content length, carried through to CompleteMPU as `MpuObjectSize`.
+        content_length: u64,
     },
     /// All parts done, calling CompleteMPU (MPU only)
     Completing {
@@ -38,6 +40,7 @@ pub(crate) enum UploadState {
         completed_parts: Option<Vec<CompletedPart>>,
         response_builder: Option<UploadOutputBuilder>,
         complete_in_flight: bool,
+        content_length: u64,
     },
     /// PutObject in flight (single request upload)
     PutObjectInFlight,

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -222,6 +222,7 @@ impl UploadTransfer {
                         part_reader,
                         completed_parts,
                         response_builder,
+                        content_length,
                         ..
                     } = std::mem::replace(&mut *state, UploadState::Done)
                     {
@@ -231,6 +232,7 @@ impl UploadTransfer {
                             completed_parts: Some(completed_parts),
                             response_builder: Some(response_builder),
                             complete_in_flight: false,
+                            content_length,
                         };
                     }
                     drop(state);
@@ -355,6 +357,7 @@ impl UploadTransfer {
                 parts_in_flight: 0,
                 completed_parts: Vec::with_capacity(total_parts as usize),
                 response_builder,
+                content_length,
             };
         }
 
@@ -519,6 +522,7 @@ impl UploadTransfer {
                 part_reader,
                 completed_parts,
                 response_builder,
+                content_length,
                 ..
             } = std::mem::replace(&mut *state, UploadState::Done)
             {
@@ -528,6 +532,7 @@ impl UploadTransfer {
                     completed_parts: Some(completed_parts),
                     response_builder: Some(response_builder),
                     complete_in_flight: false,
+                    content_length,
                 };
             }
             drop(state);
@@ -654,7 +659,7 @@ impl UploadTransfer {
     }
 
     async fn execute_complete_mpu(&self) -> WorkOutcome {
-        let (upload_id, mut completed_parts, response_builder, part_reader) = {
+        let (upload_id, mut completed_parts, response_builder, part_reader, content_length) = {
             let mut state = self.inner.state.lock().expect("lock poisoned");
             match &mut *state {
                 UploadState::Completing {
@@ -662,6 +667,7 @@ impl UploadTransfer {
                     completed_parts,
                     response_builder,
                     part_reader,
+                    content_length,
                     ..
                 } => (
                     upload_id.take().expect("upload_id already taken"),
@@ -672,6 +678,7 @@ impl UploadTransfer {
                         .take()
                         .expect("response_builder already taken"),
                     part_reader.take().expect("part_reader already taken"),
+                    *content_length,
                 ),
                 _ => panic!("unexpected state for complete_mpu"),
             }
@@ -685,6 +692,11 @@ impl UploadTransfer {
             .s3_client()
             .complete_multipart_upload()
             .upload_id(&upload_id)
+            // S3 sums the parts it assembled and rejects CompleteMPU when the
+            // total doesn't match this value, so a dropped or duplicated part
+            // surfaces as a failed complete rather than a wrong-sized object.
+            // Required by SEP step 7.
+            .mpu_object_size(content_length as i64)
             .multipart_upload(
                 CompletedMultipartUpload::builder()
                     .set_parts(Some(completed_parts))

--- a/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -500,3 +500,53 @@ async fn test_objects_transfer() {
         .unwrap();
     upload_handle.join().await.unwrap();
 }
+
+/// A multipart upload sets `MpuObjectSize = full content length` on
+/// CompleteMultipartUpload, and S3 accepts it and stores the correct size —
+/// covering the real-S3 half of SEP step 7's server-side enforcement.
+///
+/// A "S3 rejects a mismatch" negative path is intentionally omitted. The TM
+/// upload path derives `MpuObjectSize` from the same content length it uses
+/// to size and count the parts it sends, so it cannot naturally emit a value
+/// that disagrees with what it uploaded; a negative case would require either
+/// a test-only backdoor into production code (leaks a foot-gun into the
+/// public surface) or a hand-rolled MPU that bypasses TM entirely (tests
+/// S3, not TM). The mock-level tests in `upload_test.rs` and
+/// `upload_objects_test.rs` cover the "field must be present and correct on
+/// the emitted request" half.
+#[tokio::test]
+async fn test_multi_part_upload_sends_mpu_object_size() {
+    let _logs = show_test_logs();
+    let file_size = 20 * 1024 * 1024; // 20 MiB — above the 8 MiB default part size, so multipart
+    let object_key = generate_key("mpu-object-size");
+    let (bucket_name, express_bucket_name) = get_bucket_names();
+
+    for bucket in [bucket_name.as_str(), express_bucket_name.as_str()] {
+        let (tm, s3_client) = test_tm().await;
+
+        perform_upload(
+            &tm,
+            bucket,
+            &object_key,
+            None,
+            create_input_stream(file_size),
+        )
+        .await;
+
+        let head = s3_client
+            .head_object()
+            .bucket(bucket)
+            .key(&object_key)
+            .send()
+            .await
+            .expect("HeadObject succeeds after upload");
+        assert_eq!(
+            head.content_length(),
+            Some(file_size as i64),
+            "S3 must store the full content length; a divergence would mean either \
+             MpuObjectSize was not sent (S3 would still store the wrong size but not \
+             flag it) or was wrong and S3 rejected the complete (which surfaces as an \
+             upload failure above, not a size mismatch here)",
+        );
+    }
+}

--- a/aws-sdk-s3-transfer-manager/tests/upload_objects_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/upload_objects_test.rs
@@ -1631,3 +1631,93 @@ async fn test_stress_parent_lock_contention() {
     .await
     .expect("test_stress_parent_lock_contention timed out — single-poll exclusivity on the composite descriptor is likely broken");
 }
+
+/// Every child multipart upload spawned by `upload_objects` must send
+/// `MpuObjectSize` on CompleteMultipartUpload, so S3 can reject a request
+/// that assembled a wrong-sized object (dropped or duplicated part).
+/// Required by SEP step 7.
+///
+/// The mock matches CompleteMPU only when `mpu_object_size` equals the child's
+/// content length. With the field absent or wrong on any child, no rule matches
+/// that request and the child fails — the join below then surfaces the
+/// failure. Passing under `objects_uploaded == files.len()` is what pins the
+/// field's presence on every child.
+#[tokio::test]
+async fn test_upload_objects_children_send_mpu_object_size() {
+    timeout(TEST_TIMEOUT, async {
+        // Three files of distinct sizes, all above the multipart threshold, so
+        // a naive "always send the same value" implementation would only pass
+        // one child at a time.
+        let one_mib = ByteUnit::Mebibyte.as_bytes_u64();
+        let files = vec![
+            ("a.bin", (5 * one_mib) as usize),
+            ("b.bin", (6 * one_mib) as usize),
+            ("nested/c.bin", (7 * one_mib) as usize),
+        ];
+        let test_dir = create_test_dir(Some("test"), files.clone(), &[]);
+
+        let bucket_name = "test-bucket";
+        let upload_id = "test-upload-id".to_owned();
+
+        let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+            let upload_id = upload_id.clone();
+            move || {
+                CreateMultipartUploadOutput::builder()
+                    .upload_id(upload_id.clone())
+                    .build()
+            }
+        });
+
+        let upload_part = mock!(aws_sdk_s3::Client::upload_part)
+            .then_output(|| UploadPartOutput::builder().build());
+
+        // Match CompleteMPU only when MpuObjectSize is one of the known file
+        // sizes. The mock is size-set-aware rather than per-key because
+        // upload_objects dispatches children concurrently and there is no
+        // ordering guarantee against a specific key.
+        let expected_sizes: Vec<i64> = files
+            .iter()
+            .map(|(_, size)| *size as i64)
+            .collect();
+        let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+            .match_requests(move |req| {
+                req.mpu_object_size()
+                    .is_some_and(|n| expected_sizes.contains(&n))
+            })
+            .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+        let client = mock_client!(
+            aws_sdk_s3,
+            RuleMode::MatchAny,
+            &[create_mpu, upload_part, complete_mpu]
+        );
+
+        let config = aws_sdk_s3_transfer_manager::Config::builder()
+            .client(client)
+            .multipart_threshold(PartSize::Target(5))
+            .build();
+        let sut = aws_sdk_s3_transfer_manager::Client::new(config);
+
+        let handle = sut
+            .upload_objects()
+            .bucket(bucket_name)
+            .source(test_dir.path())
+            .walker(FsWalker::builder().recursive(true).build())
+            .initiate()
+            .unwrap();
+
+        let output = handle.join().await.unwrap();
+        assert_eq!(
+            3,
+            output.objects_uploaded(),
+            "every child must send MpuObjectSize = its content length; a child whose CompleteMPU request omits the field will not match the mock and will fail",
+        );
+        assert!(
+            output.failed_transfers().is_empty(),
+            "no child should fail: {:?}",
+            output.failed_transfers(),
+        );
+    })
+    .await
+    .expect("test_upload_objects_children_send_mpu_object_size timed out");
+}

--- a/aws-sdk-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/upload_test.rs
@@ -225,3 +225,62 @@ async fn test_large_upload_part_size_bump() {
         expected_part_size
     );
 }
+
+/// CompleteMultipartUpload must carry `MpuObjectSize` set to the full content
+/// length so S3 rejects the request if the object it assembled is a different
+/// size (a dropped or duplicated part). Required by SEP step 7.
+#[tokio::test]
+async fn test_complete_mpu_sends_mpu_object_size() {
+    let upload_id = "test-upload-id".to_owned();
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    // Two full parts plus a partial one, so the total is not a part-size multiple
+    // and a stale part-count-derived value would not match.
+    let content_length = 2 * part_size + 1024;
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+
+    let upload_part =
+        mock!(aws_sdk_s3::Client::upload_part).then_output(|| UploadPartOutput::builder().build());
+
+    // Match only when MpuObjectSize equals the full content length. With the
+    // field absent (or wrong) no rule matches and the upload fails, so the
+    // assertion below is what pins the behavior.
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .match_requests(move |req| req.mpu_object_size() == Some(content_length as i64))
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[create_mpu, upload_part, complete_mpu]
+    );
+
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(1);
+    let stream = TestStream::new(rx, content_length, content_length as u64);
+
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-mpu-object-size")
+        .body(InputStream::from_part_stream(stream))
+        .initiate()
+        .unwrap();
+
+    drop(tx);
+    handle
+        .join()
+        .await
+        .expect("upload should succeed: CompleteMPU must carry MpuObjectSize = content length");
+}


### PR DESCRIPTION
## Summary

`CompleteMultipartUpload` was sent without `MpuObjectSize`, so S3 had no client-supplied size to cross-check the assembled object against — a dropped or duplicated part completed as a wrong-sized object. 

Threads the already-known `content_length` through `Transferring → Completing` and sets it on the request, rather than summing parts at completion time (which would recompute the size from the same state that produced the
bug).

## Test plan

- [x] fmt / clippy clean (default + \`--cfg e2e_test\`)
- [x] lib + upload + upload_objects + upload_checksum tests green (630 + 25 + 28 + 2)
- [x] Both mock tests adversarially verified: stripped the fix, each test failed, restored, green
- [x] e2e (\`test_multi_part_upload_sends_mpu_object_size\`) runs in CI's \`test-hll\` step against a real bucket

```
By submitting this pull request, I confirm that you can use, modify, copy,
and redistribute this contribution, under the terms of your choice.
```