### PR TITLE
upload: conditional-write support (IfMatch/IfNoneMatch)

### DIFF
--- a/aws-sdk-s3-transfer-manager/src/error.rs
+++ b/aws-sdk-s3-transfer-manager/src/error.rs
@@ -82,14 +82,13 @@ pub enum ErrorKind {
     /// A request to S3 failed. The originating operation, service error code,
     /// message, and request ids are available via the accessors on [`Error`]
     /// ([`Error::operation_name`], [`Error::code`], [`Error::request_id`]).
+    ///
+    /// Service-specific outcomes are identified by their code rather than by a
+    /// kind of their own. A conditional write whose precondition did not hold
+    /// (`if_match` / `if_none_match` on an upload) arrives here with
+    /// [`Error::code`] of `"PreconditionFailed"`; S3 reports that code in the
+    /// response body, so it is available whatever HTTP status carries it.
     ServiceError,
-
-    /// A conditional-write precondition set on an [`upload`](crate::operation::upload)
-    /// (`If-Match` / `If-None-Match`) did not match; S3 responded with
-    /// `412 Precondition Failed`. The originating operation and service metadata
-    /// are still available via the accessors on [`Error`], the same as for a
-    /// generic [`ServiceError`](Self::ServiceError).
-    PreconditionFailed,
 
     /// Object integrity validation failed: the received bytes did not match the
     /// expected checksum. See the wrapped [`IntegrityError`] for detail.
@@ -270,21 +269,6 @@ impl Error {
         )
     }
 
-    /// Whether this error is a conditional-write precondition failure: a
-    /// caller-supplied `If-Match` / `If-None-Match` on an
-    /// [`upload`](crate::operation::upload) that S3 rejected with
-    /// `412 Precondition Failed`.
-    ///
-    /// Kept `pub(crate)` for now: the only consumer is the upload retry
-    /// classifier, and the public precondition signal callers branch on is the
-    /// [`ErrorKind::PreconditionFailed`] variant reached via [`Error::kind`].
-    /// Promoting this to `pub` later is non-breaking if a caller convenience is
-    /// wanted; adding it to the public surface now — during the 1.0 API freeze
-    /// (RUST-1202) — is the harder-to-reverse choice.
-    pub(crate) fn is_precondition_failed(&self) -> bool {
-        matches!(self.kind, ErrorKind::PreconditionFailed)
-    }
-
     /// Whether this error was a transient transport failure (connection IO error
     /// or client-side timeout) as opposed to a service response. Such failures
     /// are safe to re-issue and may not have been recovered by the SDK's own
@@ -381,12 +365,6 @@ impl fmt::Display for Error {
                     if let Some(c) = &m.code {
                         write!(f, " ({c})")?;
                     }
-                }
-            }
-            ErrorKind::PreconditionFailed => {
-                write!(f, "precondition failed")?;
-                if let Some(m) = self.service() {
-                    write!(f, " calling {}", m.operation)?;
                 }
             }
             ErrorKind::IntegrityError(ie) => {
@@ -548,19 +526,6 @@ where
     }
 }
 
-/// Whether an `SdkError` is a service response with HTTP status 412 (Precondition
-/// Failed). Used to distinguish a user-set `If-Match` / `If-None-Match`
-/// precondition failure from a generic service error, so callers can branch on
-/// [`ErrorKind::PreconditionFailed`] without string-matching a service code.
-fn sdk_err_is_precondition_failed<E>(
-    e: &SdkError<E, aws_smithy_runtime_api::client::orchestrator::HttpResponse>,
-) -> bool {
-    matches!(
-        e,
-        SdkError::ServiceError(ctx) if ctx.raw().status().as_u16() == 412
-    )
-}
-
 /// Whether a single [`ConnectorError`] frame denotes a transient transport
 /// failure: an IO error, a client-side timeout, or one the http client tagged
 /// [`RetryErrorKind::TransientError`] (an incomplete/truncated response, TLS
@@ -633,59 +598,6 @@ where
             ..Default::default()
         })),
     }
-}
-
-/// Converts an S3 `SdkError` into an [`Error`], classifying an HTTP 412 service
-/// response as [`ErrorKind::PreconditionFailed`] and everything else exactly as
-/// [`service_error`] does (yielding [`ErrorKind::ServiceError`]).
-///
-/// The resulting `Error` carries the same operation / code / request-id metadata
-/// in both arms — only the `kind` differs — so a caller that hits a 412 can
-/// branch on [`ErrorKind::PreconditionFailed`] without string-matching a service
-/// code, while still reaching the underlying `SdkError` via
-/// [`std::error::Error::source`].
-///
-/// This is the single site that classifies 412s. It is called from the upload
-/// PutObject / CompleteMultipartUpload paths, the only requests that carry
-/// caller-supplied `If-Match` / `If-None-Match` preconditions; a 412 is not
-/// expected elsewhere. No log is emitted here — the upload transfer's `fail`
-/// path already `debug!`-logs the fully-rendered error (which names the
-/// operation and request id) at the terminal boundary, and a precondition
-/// failure is a caller-requested outcome, not a degraded state that warrants
-/// `warn!`.
-fn service_error_with_precondition<E>(
-    operation: &'static str,
-    e: SdkError<E, aws_smithy_runtime_api::client::orchestrator::HttpResponse>,
-) -> Error
-where
-    E: ProvideErrorMetadata + std::error::Error + Send + Sync + 'static,
-{
-    let precondition_failed = sdk_err_is_precondition_failed(&e);
-    let mut err = service_error(operation, e);
-    if precondition_failed {
-        err.kind = ErrorKind::PreconditionFailed;
-    }
-    err
-}
-
-/// Converts a PutObject `SdkError` from the upload path, classifying a 412 as
-/// [`ErrorKind::PreconditionFailed`]. See [`service_error_with_precondition`].
-pub(crate) fn from_put_object_sdk_err(
-    e: SdkError<PutObjectError, aws_smithy_runtime_api::client::orchestrator::HttpResponse>,
-) -> Error {
-    service_error_with_precondition("PutObject", e)
-}
-
-/// Converts a CompleteMultipartUpload `SdkError` from the upload path,
-/// classifying a 412 as [`ErrorKind::PreconditionFailed`].
-/// See [`service_error_with_precondition`].
-pub(crate) fn from_complete_mpu_sdk_err(
-    e: SdkError<
-        CompleteMultipartUploadError,
-        aws_smithy_runtime_api::client::orchestrator::HttpResponse,
-    >,
-) -> Error {
-    service_error_with_precondition("CompleteMultipartUpload", e)
 }
 
 macro_rules! from_sdk_error {
@@ -947,67 +859,16 @@ mod tests {
         )));
     }
 
-    // --- 412 (precondition failed) classification -----------------------------
+    // --- conditional-write precondition failures ------------------------------
 
     use aws_smithy_runtime_api::http::StatusCode;
     use aws_smithy_types::body::SdkBody;
 
-    fn service_response<E>(status: u16, err: E) -> SdkError<E, HttpResponse>
-    where
-        E: std::error::Error + Send + Sync + 'static,
-    {
-        SdkError::service_error(
-            err,
-            HttpResponse::new(StatusCode::try_from(status).unwrap(), SdkBody::empty()),
-        )
-    }
-
-    /// Build a minimal `GetObjectError` value for status-based classification
-    /// tests — the specific variant doesn't matter, only the wrapping response.
-    fn any_get_object_error() -> GetObjectError {
-        GetObjectError::generic(
-            aws_smithy_types::error::ErrorMetadata::builder()
-                .code("PreconditionFailed")
-                .build(),
-        )
-    }
-
     #[test]
-    fn precondition_412_service_error_is_precondition_failed() {
-        let err: SdkError<GetObjectError, HttpResponse> =
-            service_response(412, any_get_object_error());
-        assert!(sdk_err_is_precondition_failed(&err));
-    }
-
-    #[test]
-    fn precondition_400_service_error_is_not_precondition_failed() {
-        // A 400 with a bogus PreconditionFailed code header is NOT a 412 —
-        // the classifier must key off the wire status, not the code string.
-        let err: SdkError<GetObjectError, HttpResponse> =
-            service_response(400, any_get_object_error());
-        assert!(!sdk_err_is_precondition_failed(&err));
-    }
-
-    #[test]
-    fn precondition_500_service_error_is_not_precondition_failed() {
-        let err: SdkError<GetObjectError, HttpResponse> =
-            service_response(500, any_get_object_error());
-        assert!(!sdk_err_is_precondition_failed(&err));
-    }
-
-    #[test]
-    fn precondition_dispatch_failure_is_not_precondition_failed() {
-        // Transport-level failure — never a 412 by construction.
-        assert!(!sdk_err_is_precondition_failed(&dispatch(
-            ConnectorError::io("reset".into())
-        )));
-    }
-
-    #[test]
-    fn service_error_with_precondition_promotes_412_and_keeps_metadata() {
-        // A 412 becomes PreconditionFailed but must retain the same service
-        // metadata (operation name, and the SdkError as source) a plain
-        // ServiceError would carry — only the kind differs.
+    fn precondition_failure_surfaces_as_service_error_with_code() {
+        // A failed `If-Match` / `If-None-Match` gets no kind of its own: callers
+        // identify it by the service code. S3 supplies that in the response body,
+        // so it is reachable whatever status the failure arrives with.
         let sdk: SdkError<PutObjectError, HttpResponse> = SdkError::service_error(
             PutObjectError::generic(
                 aws_smithy_types::error::ErrorMetadata::builder()
@@ -1016,28 +877,13 @@ mod tests {
             ),
             HttpResponse::new(StatusCode::try_from(412).unwrap(), SdkBody::empty()),
         );
-        let err = service_error_with_precondition("PutObject", sdk);
-        assert!(matches!(err.kind(), ErrorKind::PreconditionFailed));
+        let err = Error::from(sdk);
+        assert!(matches!(err.kind(), ErrorKind::ServiceError));
+        assert_eq!(err.code(), Some("PreconditionFailed"));
         assert_eq!(err.operation_name(), Some("PutObject"));
         // The underlying SdkError is preserved as the source.
         assert!(std::error::Error::source(&err)
             .and_then(|s| s.downcast_ref::<SdkError<PutObjectError, HttpResponse>>())
             .is_some());
-    }
-
-    #[test]
-    fn service_error_with_precondition_leaves_non_412_as_service_error() {
-        // A 500 stays a generic ServiceError — the promotion is 412-only.
-        let sdk: SdkError<PutObjectError, HttpResponse> = SdkError::service_error(
-            PutObjectError::generic(
-                aws_smithy_types::error::ErrorMetadata::builder()
-                    .code("InternalError")
-                    .build(),
-            ),
-            HttpResponse::new(StatusCode::try_from(500).unwrap(), SdkBody::empty()),
-        );
-        let err = service_error_with_precondition("PutObject", sdk);
-        assert!(matches!(err.kind(), ErrorKind::ServiceError));
-        assert_eq!(err.operation_name(), Some("PutObject"));
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/error.rs
+++ b/aws-sdk-s3-transfer-manager/src/error.rs
@@ -84,6 +84,13 @@ pub enum ErrorKind {
     /// ([`Error::operation_name`], [`Error::code`], [`Error::request_id`]).
     ServiceError,
 
+    /// A conditional-write precondition set on an [`upload`](crate::operation::upload)
+    /// (`If-Match` / `If-None-Match`) did not match; S3 responded with
+    /// `412 Precondition Failed`. The originating operation and service metadata
+    /// are still available via the accessors on [`Error`], the same as for a
+    /// generic [`ServiceError`](Self::ServiceError).
+    PreconditionFailed,
+
     /// Object integrity validation failed: the received bytes did not match the
     /// expected checksum. See the wrapped [`IntegrityError`] for detail.
     IntegrityError(IntegrityError),
@@ -263,6 +270,21 @@ impl Error {
         )
     }
 
+    /// Whether this error is a conditional-write precondition failure: a
+    /// caller-supplied `If-Match` / `If-None-Match` on an
+    /// [`upload`](crate::operation::upload) that S3 rejected with
+    /// `412 Precondition Failed`.
+    ///
+    /// Kept `pub(crate)` for now: the only consumer is the upload retry
+    /// classifier, and the public precondition signal callers branch on is the
+    /// [`ErrorKind::PreconditionFailed`] variant reached via [`Error::kind`].
+    /// Promoting this to `pub` later is non-breaking if a caller convenience is
+    /// wanted; adding it to the public surface now — during the 1.0 API freeze
+    /// (RUST-1202) — is the harder-to-reverse choice.
+    pub(crate) fn is_precondition_failed(&self) -> bool {
+        matches!(self.kind, ErrorKind::PreconditionFailed)
+    }
+
     /// Whether this error was a transient transport failure (connection IO error
     /// or client-side timeout) as opposed to a service response. Such failures
     /// are safe to re-issue and may not have been recovered by the SDK's own
@@ -359,6 +381,12 @@ impl fmt::Display for Error {
                     if let Some(c) = &m.code {
                         write!(f, " ({c})")?;
                     }
+                }
+            }
+            ErrorKind::PreconditionFailed => {
+                write!(f, "precondition failed")?;
+                if let Some(m) = self.service() {
+                    write!(f, " calling {}", m.operation)?;
                 }
             }
             ErrorKind::IntegrityError(ie) => {
@@ -520,6 +548,19 @@ where
     }
 }
 
+/// Whether an `SdkError` is a service response with HTTP status 412 (Precondition
+/// Failed). Used to distinguish a user-set `If-Match` / `If-None-Match`
+/// precondition failure from a generic service error, so callers can branch on
+/// [`ErrorKind::PreconditionFailed`] without string-matching a service code.
+fn sdk_err_is_precondition_failed<E>(
+    e: &SdkError<E, aws_smithy_runtime_api::client::orchestrator::HttpResponse>,
+) -> bool {
+    matches!(
+        e,
+        SdkError::ServiceError(ctx) if ctx.raw().status().as_u16() == 412
+    )
+}
+
 /// Whether a single [`ConnectorError`] frame denotes a transient transport
 /// failure: an IO error, a client-side timeout, or one the http client tagged
 /// [`RetryErrorKind::TransientError`] (an incomplete/truncated response, TLS
@@ -592,6 +633,59 @@ where
             ..Default::default()
         })),
     }
+}
+
+/// Converts an S3 `SdkError` into an [`Error`], classifying an HTTP 412 service
+/// response as [`ErrorKind::PreconditionFailed`] and everything else exactly as
+/// [`service_error`] does (yielding [`ErrorKind::ServiceError`]).
+///
+/// The resulting `Error` carries the same operation / code / request-id metadata
+/// in both arms — only the `kind` differs — so a caller that hits a 412 can
+/// branch on [`ErrorKind::PreconditionFailed`] without string-matching a service
+/// code, while still reaching the underlying `SdkError` via
+/// [`std::error::Error::source`].
+///
+/// This is the single site that classifies 412s. It is called from the upload
+/// PutObject / CompleteMultipartUpload paths, the only requests that carry
+/// caller-supplied `If-Match` / `If-None-Match` preconditions; a 412 is not
+/// expected elsewhere. No log is emitted here — the upload transfer's `fail`
+/// path already `debug!`-logs the fully-rendered error (which names the
+/// operation and request id) at the terminal boundary, and a precondition
+/// failure is a caller-requested outcome, not a degraded state that warrants
+/// `warn!`.
+fn service_error_with_precondition<E>(
+    operation: &'static str,
+    e: SdkError<E, aws_smithy_runtime_api::client::orchestrator::HttpResponse>,
+) -> Error
+where
+    E: ProvideErrorMetadata + std::error::Error + Send + Sync + 'static,
+{
+    let precondition_failed = sdk_err_is_precondition_failed(&e);
+    let mut err = service_error(operation, e);
+    if precondition_failed {
+        err.kind = ErrorKind::PreconditionFailed;
+    }
+    err
+}
+
+/// Converts a PutObject `SdkError` from the upload path, classifying a 412 as
+/// [`ErrorKind::PreconditionFailed`]. See [`service_error_with_precondition`].
+pub(crate) fn from_put_object_sdk_err(
+    e: SdkError<PutObjectError, aws_smithy_runtime_api::client::orchestrator::HttpResponse>,
+) -> Error {
+    service_error_with_precondition("PutObject", e)
+}
+
+/// Converts a CompleteMultipartUpload `SdkError` from the upload path,
+/// classifying a 412 as [`ErrorKind::PreconditionFailed`].
+/// See [`service_error_with_precondition`].
+pub(crate) fn from_complete_mpu_sdk_err(
+    e: SdkError<
+        CompleteMultipartUploadError,
+        aws_smithy_runtime_api::client::orchestrator::HttpResponse,
+    >,
+) -> Error {
+    service_error_with_precondition("CompleteMultipartUpload", e)
 }
 
 macro_rules! from_sdk_error {
@@ -851,5 +945,99 @@ mod tests {
         assert!(!is_sdk_transient_transport(&dispatch(
             ConnectorError::user("bad request".into())
         )));
+    }
+
+    // --- 412 (precondition failed) classification -----------------------------
+
+    use aws_smithy_runtime_api::http::StatusCode;
+    use aws_smithy_types::body::SdkBody;
+
+    fn service_response<E>(status: u16, err: E) -> SdkError<E, HttpResponse>
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        SdkError::service_error(
+            err,
+            HttpResponse::new(StatusCode::try_from(status).unwrap(), SdkBody::empty()),
+        )
+    }
+
+    /// Build a minimal `GetObjectError` value for status-based classification
+    /// tests — the specific variant doesn't matter, only the wrapping response.
+    fn any_get_object_error() -> GetObjectError {
+        GetObjectError::generic(
+            aws_smithy_types::error::ErrorMetadata::builder()
+                .code("PreconditionFailed")
+                .build(),
+        )
+    }
+
+    #[test]
+    fn precondition_412_service_error_is_precondition_failed() {
+        let err: SdkError<GetObjectError, HttpResponse> =
+            service_response(412, any_get_object_error());
+        assert!(sdk_err_is_precondition_failed(&err));
+    }
+
+    #[test]
+    fn precondition_400_service_error_is_not_precondition_failed() {
+        // A 400 with a bogus PreconditionFailed code header is NOT a 412 —
+        // the classifier must key off the wire status, not the code string.
+        let err: SdkError<GetObjectError, HttpResponse> =
+            service_response(400, any_get_object_error());
+        assert!(!sdk_err_is_precondition_failed(&err));
+    }
+
+    #[test]
+    fn precondition_500_service_error_is_not_precondition_failed() {
+        let err: SdkError<GetObjectError, HttpResponse> =
+            service_response(500, any_get_object_error());
+        assert!(!sdk_err_is_precondition_failed(&err));
+    }
+
+    #[test]
+    fn precondition_dispatch_failure_is_not_precondition_failed() {
+        // Transport-level failure — never a 412 by construction.
+        assert!(!sdk_err_is_precondition_failed(&dispatch(
+            ConnectorError::io("reset".into())
+        )));
+    }
+
+    #[test]
+    fn service_error_with_precondition_promotes_412_and_keeps_metadata() {
+        // A 412 becomes PreconditionFailed but must retain the same service
+        // metadata (operation name, and the SdkError as source) a plain
+        // ServiceError would carry — only the kind differs.
+        let sdk: SdkError<PutObjectError, HttpResponse> = SdkError::service_error(
+            PutObjectError::generic(
+                aws_smithy_types::error::ErrorMetadata::builder()
+                    .code("PreconditionFailed")
+                    .build(),
+            ),
+            HttpResponse::new(StatusCode::try_from(412).unwrap(), SdkBody::empty()),
+        );
+        let err = service_error_with_precondition("PutObject", sdk);
+        assert!(matches!(err.kind(), ErrorKind::PreconditionFailed));
+        assert_eq!(err.operation_name(), Some("PutObject"));
+        // The underlying SdkError is preserved as the source.
+        assert!(std::error::Error::source(&err)
+            .and_then(|s| s.downcast_ref::<SdkError<PutObjectError, HttpResponse>>())
+            .is_some());
+    }
+
+    #[test]
+    fn service_error_with_precondition_leaves_non_412_as_service_error() {
+        // A 500 stays a generic ServiceError — the promotion is 412-only.
+        let sdk: SdkError<PutObjectError, HttpResponse> = SdkError::service_error(
+            PutObjectError::generic(
+                aws_smithy_types::error::ErrorMetadata::builder()
+                    .code("InternalError")
+                    .build(),
+            ),
+            HttpResponse::new(StatusCode::try_from(500).unwrap(), SdkBody::empty()),
+        );
+        let err = service_error_with_precondition("PutObject", sdk);
+        assert!(matches!(err.kind(), ErrorKind::ServiceError));
+        assert_eq!(err.operation_name(), Some("PutObject"));
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/builders.rs
@@ -249,6 +249,50 @@ impl UploadFluentBuilder {
     pub fn get_checksum_strategy(&self) -> Option<&ChecksumStrategy> {
         self.inner.get_checksum_strategy()
     }
+
+    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn if_match(mut self, input: impl Into<String>) -> Self {
+        self.inner = self.inner.if_match(input);
+        self
+    }
+
+    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn set_if_match(mut self, input: Option<String>) -> Self {
+        self.inner = self.inner.set_if_match(input);
+        self
+    }
+
+    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn get_if_match(&self) -> Option<&str> {
+        self.inner.get_if_match()
+    }
+
+    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn if_none_match(mut self, input: impl Into<String>) -> Self {
+        self.inner = self.inner.if_none_match(input);
+        self
+    }
+
+    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn set_if_none_match(mut self, input: Option<String>) -> Self {
+        self.inner = self.inner.set_if_none_match(input);
+        self
+    }
+
+    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn get_if_none_match(&self) -> Option<&str> {
+        self.inner.get_if_none_match()
+    }
+
     /// <p>The date and time at which the object is no longer cacheable. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc7234#section-5.3">https://www.rfc-editor.org/rfc/rfc7234#section-5.3</a>.</p>
     pub fn expires(mut self, input: ::aws_smithy_types::DateTime) -> Self {
         self.inner = self.inner.expires(input);

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/builders.rs
@@ -250,45 +250,54 @@ impl UploadFluentBuilder {
         self.inner.get_checksum_strategy()
     }
 
-    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the ETag (entity tag) value provided during the WRITE operation matches the ETag of the object in S3. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the object's ETag and retry the upload.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn if_match(mut self, input: impl Into<String>) -> Self {
         self.inner = self.inner.if_match(input);
         self
     }
 
-    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the ETag (entity tag) value provided during the WRITE operation matches the ETag of the object in S3. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the object's ETag and retry the upload.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn set_if_match(mut self, input: Option<String>) -> Self {
         self.inner = self.inner.set_if_match(input);
         self
     }
 
-    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the ETag (entity tag) value provided during the WRITE operation matches the ETag of the object in S3. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the object's ETag and retry the upload.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn get_if_match(&self) -> Option<&str> {
         self.inner.get_if_match()
     }
 
-    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the object key name does not already exist in the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should retry the upload.</p>
+    /// <p>Expects the '*' (asterisk) character.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn if_none_match(mut self, input: impl Into<String>) -> Self {
         self.inner = self.inner.if_none_match(input);
         self
     }
 
-    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the object key name does not already exist in the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should retry the upload.</p>
+    /// <p>Expects the '*' (asterisk) character.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn set_if_none_match(mut self, input: Option<String>) -> Self {
         self.inner = self.inner.set_if_none_match(input);
         self
     }
 
-    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the object key name does not already exist in the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should retry the upload.</p>
+    /// <p>Expects the '*' (asterisk) character.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn get_if_none_match(&self) -> Option<&str> {
         self.inner.get_if_none_match()
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
@@ -167,9 +167,6 @@ impl UploadHandle {
             match abort_policy {
                 FailedMultipartUploadPolicy::Retain => Ok(AbortedUpload::default()),
                 FailedMultipartUploadPolicy::AbortUpload => {
-                    // AbortMultipartUpload carries no `If-Match`/`If-None-Match`
-                    // (see `copy_fields_to_abort_mpu_request`), so cleaning up
-                    // after a conditional-write failure cannot itself 412.
                     let resp = copy_fields_to_abort_mpu_request(
                         self.transfer.request(),
                         ctx.s3_client()

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
@@ -167,6 +167,9 @@ impl UploadHandle {
             match abort_policy {
                 FailedMultipartUploadPolicy::Retain => Ok(AbortedUpload::default()),
                 FailedMultipartUploadPolicy::AbortUpload => {
+                    // AbortMultipartUpload carries no `If-Match`/`If-None-Match`
+                    // (see `copy_fields_to_abort_mpu_request`), so cleaning up
+                    // after a conditional-write failure cannot itself 412.
                     let resp = copy_fields_to_abort_mpu_request(
                         self.transfer.request(),
                         ctx.s3_client()

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/input.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/input.rs
@@ -57,12 +57,15 @@ pub struct UploadInput {
     pub content_type: Option<String>,
     #[doc = std::include_str!("checksum_strategy.md")]
     pub checksum_strategy: Option<ChecksumStrategy>,
-    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>. Useful for preventing an overwrite when the caller expects the object to be in a known state.</p>
-    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the ETag (entity tag) value provided during the WRITE operation matches the ETag of the object in S3. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the object's ETag and retry the upload.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub if_match: Option<String>,
-    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>. Useful for creating an object only if the key is free.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the object key name does not already exist in the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should retry the upload.</p>
+    /// <p>Expects the '*' (asterisk) character.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub if_none_match: Option<String>,
     /// <p>The date and time at which the object is no longer cacheable. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc7234#section-5.3">https://www.rfc-editor.org/rfc/rfc7234#section-5.3</a>.</p>
     pub expires: Option<::aws_smithy_types::DateTime>,
@@ -253,14 +256,17 @@ impl UploadInput {
     pub fn checksum_strategy(&self) -> Option<&ChecksumStrategy> {
         self.checksum_strategy.as_ref()
     }
-    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the ETag (entity tag) value provided during the WRITE operation matches the ETag of the object in S3. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the object's ETag and retry the upload.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn if_match(&self) -> Option<&str> {
         self.if_match.as_deref()
     }
-    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the object key name does not already exist in the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should retry the upload.</p>
+    /// <p>Expects the '*' (asterisk) character.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn if_none_match(&self) -> Option<&str> {
         self.if_none_match.as_deref()
     }
@@ -740,40 +746,49 @@ impl UploadInputBuilder {
     pub fn get_checksum_strategy(&self) -> Option<&ChecksumStrategy> {
         self.checksum_strategy.as_ref()
     }
-    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the ETag (entity tag) value provided during the WRITE operation matches the ETag of the object in S3. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the object's ETag and retry the upload.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn if_match(mut self, input: impl Into<String>) -> Self {
         self.if_match = Some(input.into());
         self
     }
-    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the ETag (entity tag) value provided during the WRITE operation matches the ETag of the object in S3. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the object's ETag and retry the upload.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn set_if_match(mut self, input: Option<String>) -> Self {
         self.if_match = input;
         self
     }
-    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the ETag (entity tag) value provided during the WRITE operation matches the ETag of the object in S3. If the ETag values do not match, the operation returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should fetch the object's ETag and retry the upload.</p>
+    /// <p>Expects the ETag value as a string.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn get_if_match(&self) -> Option<&str> {
         self.if_match.as_deref()
     }
-    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the object key name does not already exist in the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should retry the upload.</p>
+    /// <p>Expects the '*' (asterisk) character.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn if_none_match(mut self, input: impl Into<String>) -> Self {
         self.if_none_match = Some(input.into());
         self
     }
-    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the object key name does not already exist in the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should retry the upload.</p>
+    /// <p>Expects the '*' (asterisk) character.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn set_if_none_match(mut self, input: Option<String>) -> Self {
         self.if_none_match = input;
         self
     }
-    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
-    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    /// <p>Uploads the object only if the object key name does not already exist in the bucket specified. Otherwise, Amazon S3 returns a <code>412 Precondition Failed</code> error.</p>
+    /// <p>If a conflicting operation occurs during the upload S3 returns a <code>409 ConditionalRequestConflict</code> response. On a 409 failure you should retry the upload.</p>
+    /// <p>Expects the '*' (asterisk) character.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>, or <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-requests.html">Conditional requests</a> in the <i>Amazon S3 User Guide</i>.</p>
     pub fn get_if_none_match(&self) -> Option<&str> {
         self.if_none_match.as_deref()
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/input.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/input.rs
@@ -57,6 +57,13 @@ pub struct UploadInput {
     pub content_type: Option<String>,
     #[doc = std::include_str!("checksum_strategy.md")]
     pub checksum_strategy: Option<ChecksumStrategy>,
+    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>. Useful for preventing an overwrite when the caller expects the object to be in a known state.</p>
+    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub if_match: Option<String>,
+    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>. Useful for creating an object only if the key is free.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub if_none_match: Option<String>,
     /// <p>The date and time at which the object is no longer cacheable. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc7234#section-5.3">https://www.rfc-editor.org/rfc/rfc7234#section-5.3</a>.</p>
     pub expires: Option<::aws_smithy_types::DateTime>,
     /// <p>Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.</p><note>
@@ -246,6 +253,17 @@ impl UploadInput {
     pub fn checksum_strategy(&self) -> Option<&ChecksumStrategy> {
         self.checksum_strategy.as_ref()
     }
+    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn if_match(&self) -> Option<&str> {
+        self.if_match.as_deref()
+    }
+    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn if_none_match(&self) -> Option<&str> {
+        self.if_none_match.as_deref()
+    }
     /// <p>The date and time at which the object is no longer cacheable. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc7234#section-5.3">https://www.rfc-editor.org/rfc/rfc7234#section-5.3</a>.</p>
     pub fn expires(&self) -> Option<&::aws_smithy_types::DateTime> {
         self.expires.as_ref()
@@ -424,6 +442,8 @@ impl Debug for UploadInput {
         formatter.field("content_md5", &self.content_md5);
         formatter.field("content_type", &self.content_type);
         formatter.field("checksum_strategy", &self.checksum_strategy);
+        formatter.field("if_match", &self.if_match);
+        formatter.field("if_none_match", &self.if_none_match);
         formatter.field("expires", &self.expires);
         formatter.field("grant_full_control", &self.grant_full_control);
         formatter.field("grant_read", &self.grant_read);
@@ -481,6 +501,8 @@ pub struct UploadInputBuilder {
     pub(crate) content_md5: Option<String>,
     pub(crate) content_type: Option<String>,
     pub(crate) checksum_strategy: Option<ChecksumStrategy>,
+    pub(crate) if_match: Option<String>,
+    pub(crate) if_none_match: Option<String>,
     pub(crate) expires: Option<::aws_smithy_types::DateTime>,
     pub(crate) grant_full_control: Option<String>,
     pub(crate) grant_read: Option<String>,
@@ -717,6 +739,43 @@ impl UploadInputBuilder {
     #[doc = std::include_str!("checksum_strategy.md")]
     pub fn get_checksum_strategy(&self) -> Option<&ChecksumStrategy> {
         self.checksum_strategy.as_ref()
+    }
+    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn if_match(mut self, input: impl Into<String>) -> Self {
+        self.if_match = Some(input.into());
+        self
+    }
+    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn set_if_match(mut self, input: Option<String>) -> Self {
+        self.if_match = input;
+        self
+    }
+    /// <p>Uploads the object only if the object's ETag matches the value provided; otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>Note that for a fresh key with no existing object, <code>If-Match</code> has nothing to match and S3 will fail the request; prefer [`if_none_match`](Self::if_none_match) with <code>"*"</code> for create-if-absent semantics.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn get_if_match(&self) -> Option<&str> {
+        self.if_match.as_deref()
+    }
+    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn if_none_match(mut self, input: impl Into<String>) -> Self {
+        self.if_none_match = Some(input.into());
+        self
+    }
+    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn set_if_none_match(mut self, input: Option<String>) -> Self {
+        self.if_none_match = input;
+        self
+    }
+    /// <p>Uploads the object only if no object with the same key exists (typically set to <code>"*"</code>); otherwise, S3 returns a <code>412 Precondition Failed</code> error, surfaced by the transfer manager as [`ErrorKind::PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed). Applies to both <code>PutObject</code> and <code>CompleteMultipartUpload</code>.</p>
+    /// <p>For more information about conditional requests, see <a href="https://tools.ietf.org/html/rfc7232">RFC 7232</a>.</p>
+    pub fn get_if_none_match(&self) -> Option<&str> {
+        self.if_none_match.as_deref()
     }
     /// <p>The date and time at which the object is no longer cacheable. For more information, see <a href="https://www.rfc-editor.org/rfc/rfc7234#section-5.3">https://www.rfc-editor.org/rfc/rfc7234#section-5.3</a>.</p>
     pub fn expires(mut self, input: ::aws_smithy_types::DateTime) -> Self {
@@ -1300,6 +1359,8 @@ impl UploadInputBuilder {
             content_md5: self.content_md5,
             content_type: self.content_type,
             checksum_strategy: self.checksum_strategy,
+            if_match: self.if_match,
+            if_none_match: self.if_none_match,
             expires: self.expires,
             grant_full_control: self.grant_full_control,
             grant_read: self.grant_read,
@@ -1341,6 +1402,8 @@ impl Debug for UploadInputBuilder {
         formatter.field("content_md5", &self.content_md5);
         formatter.field("content_type", &self.content_type);
         formatter.field("checksum_strategy", &self.checksum_strategy);
+        formatter.field("if_match", &self.if_match);
+        formatter.field("if_none_match", &self.if_none_match);
         formatter.field("expires", &self.expires);
         formatter.field("grant_full_control", &self.grant_full_control);
         formatter.field("grant_read", &self.grant_read);

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/input/convert.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/input/convert.rs
@@ -33,6 +33,8 @@ pub(crate) fn copy_fields_to_put_object_request(
         .set_grant_read(upload_input.grant_read.clone())
         .set_grant_read_acp(upload_input.grant_read_acp.clone())
         .set_grant_write_acp(upload_input.grant_write_acp.clone())
+        .set_if_match(upload_input.if_match.clone())
+        .set_if_none_match(upload_input.if_none_match.clone())
         .set_key(upload_input.key.clone())
         .set_metadata(upload_input.metadata.clone())
         .set_object_lock_legal_hold_status(upload_input.object_lock_legal_hold_status.clone())
@@ -176,6 +178,8 @@ where
 {
     let mut complete_mpu_builder = complete_mpu_builder
         .set_bucket(upload_input.bucket.clone())
+        .set_if_match(upload_input.if_match.clone())
+        .set_if_none_match(upload_input.if_none_match.clone())
         .set_key(upload_input.key.clone())
         .set_request_payer(upload_input.request_payer.clone())
         .set_expected_bucket_owner(upload_input.expected_bucket_owner.clone())
@@ -256,6 +260,8 @@ mod tests {
             .grant_read("test-read")
             .grant_read_acp("test-read-acp")
             .grant_write_acp("test-write-acp")
+            .if_match("\"some-etag\"")
+            .if_none_match("*")
             .key("test-key")
             .metadata("key", "value")
             .object_lock_legal_hold_status(ObjectLockLegalHoldStatus::On)
@@ -299,6 +305,8 @@ mod tests {
                         upload_req.expected_bucket_owner(),
                         put_object_req.expected_bucket_owner()
                     );
+                    assert_eq!(upload_req.if_match(), put_object_req.if_match());
+                    assert_eq!(upload_req.if_none_match(), put_object_req.if_none_match());
                     assert_eq!(upload_req.key(), put_object_req.key());
                     assert_eq!(upload_req.request_payer(), put_object_req.request_payer());
                     assert_eq!(
@@ -483,17 +491,8 @@ mod tests {
             upload_req.expected_bucket_owner(),
             complete_mpu_req.expected_bucket_owner()
         );
-        // TODO(https://github.com/awslabs/aws-s3-transfer-manager-rs/issues/117): Enable these assertions
-        /*
-        assert_eq!(
-            upload_req.if_match(),
-            complete_mpu_req.if_match()
-        );
-        assert_eq!(
-            upload_req.if_none_match(),
-            complete_mpu_req.if_none_match()
-        );
-        */
+        assert_eq!(upload_req.if_match(), complete_mpu_req.if_match());
+        assert_eq!(upload_req.if_none_match(), complete_mpu_req.if_none_match());
         assert_eq!(upload_req.key(), complete_mpu_req.key());
         assert_eq!(upload_req.request_payer(), complete_mpu_req.request_payer());
         assert_eq!(

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -602,13 +602,7 @@ impl UploadTransfer {
                     .send()
                     .instrument(tracing::debug_span!("send-put-object"))
                     .await
-                    .map_err(|e| {
-                        // Classify via from_put_object_sdk_err so a 412 (the
-                        // caller's If-Match / If-None-Match not holding) surfaces
-                        // as ErrorKind::PreconditionFailed rather than a generic
-                        // ServiceError — see the helper for the rationale.
-                        crate::retry::GuardError::Inner(crate::error::from_put_object_sdk_err(e))
-                    })
+                    .map_err(|e| crate::retry::GuardError::Inner(e.into()))
             }
         })
         .instrument(tracing::debug_span!(
@@ -729,10 +723,7 @@ impl UploadTransfer {
             .await
         {
             Ok(resp) => resp,
-            Err(e) => {
-                // Reclassify a 412 to PreconditionFailed, as execute_put_object does.
-                return self.fail(crate::error::from_complete_mpu_sdk_err(e));
-            }
+            Err(e) => return self.fail(e.into()),
         };
 
         let result = response_builder

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -602,7 +602,13 @@ impl UploadTransfer {
                     .send()
                     .instrument(tracing::debug_span!("send-put-object"))
                     .await
-                    .map_err(|e| crate::retry::GuardError::Inner(crate::error::Error::from(e)))
+                    .map_err(|e| {
+                        // Classify via from_put_object_sdk_err so a 412 (the
+                        // caller's If-Match / If-None-Match not holding) surfaces
+                        // as ErrorKind::PreconditionFailed rather than a generic
+                        // ServiceError — see the helper for the rationale.
+                        crate::retry::GuardError::Inner(crate::error::from_put_object_sdk_err(e))
+                    })
             }
         })
         .instrument(tracing::debug_span!(
@@ -723,7 +729,10 @@ impl UploadTransfer {
             .await
         {
             Ok(resp) => resp,
-            Err(e) => return self.fail(e.into()),
+            Err(e) => {
+                // Reclassify a 412 to PreconditionFailed, as execute_put_object does.
+                return self.fail(crate::error::from_complete_mpu_sdk_err(e));
+            }
         };
 
         let result = response_builder

--- a/aws-sdk-s3-transfer-manager/src/retry.rs
+++ b/aws-sdk-s3-transfer-manager/src/retry.rs
@@ -264,15 +264,9 @@ fn retry_cause(ge: &GuardError<Error>) -> String {
 /// that budget over time while the outer re-issue — bounded by [`MAX_ATTEMPTS`]
 /// and paced by the 1s throttle base — gives the service room to recover.
 ///
-/// A [`PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed) — a
-/// user-set `If-Match` / `If-None-Match` not holding — is **deterministically
-/// terminal**. Retrying cannot change the object state that caused the 412, so
-/// the loop must not consume attempt budget on it. Called out as its own arm
-/// (rather than falling into the "everything else" wildcard) to make the intent
-/// explicit and to keep this claim under test.
-///
 /// Everything else is terminal: a non-throttle modeled service error and any
-/// non-transport inner error.
+/// non-transport inner error. That includes a `412` from a user-set `If-Match` /
+/// `If-None-Match` — retrying cannot change the object state that caused it.
 ///
 /// [`GuardError::DeadlineExceeded`]: uploads carry no latency deadline (no
 /// `guarded` composition), so this arm is unreachable in practice; retained for
@@ -280,7 +274,6 @@ fn retry_cause(ge: &GuardError<Error>) -> String {
 pub(crate) fn classify_upload_part_retry(ge: &GuardError<Error>) -> RetryDecision {
     match ge {
         GuardError::DeadlineExceeded(_) => RetryDecision::NoRetry,
-        GuardError::Inner(e) if e.is_precondition_failed() => RetryDecision::NoRetry,
         GuardError::Inner(e) if e.is_transient_transport() => RetryDecision::Retry,
         GuardError::Inner(e) if is_throttle(e) => RetryDecision::RetryThrottle,
         GuardError::Inner(_) => RetryDecision::NoRetry,
@@ -732,8 +725,9 @@ mod tests {
 
     #[test]
     fn upload_non_throttle_service_error_is_terminal() {
-        // A modeled service error with no throttle code (e.g. AccessDenied) is
-        // terminal: not transient transport, not a throttle.
+        // A modeled service error with no throttle code is terminal: not transient
+        // transport, not a throttle. Covers `AccessDenied` and equally a `412` from
+        // a caller's `If-Match` / `If-None-Match`, which retrying cannot resolve.
         let err = Error::test_service_error("AccessDenied");
         assert_eq!(
             classify_upload_part_retry(&GuardError::Inner(err)),
@@ -754,19 +748,6 @@ mod tests {
     #[test]
     fn upload_other_inner_error_is_terminal() {
         let err = Error::new(ErrorKind::RuntimeError, "not a transport error");
-        assert_eq!(
-            classify_upload_part_retry(&GuardError::Inner(err)),
-            RetryDecision::NoRetry
-        );
-    }
-
-    #[test]
-    fn upload_precondition_failed_is_terminal() {
-        // A user-set If-Match / If-None-Match not holding cannot be recovered
-        // by retrying — the object state that produced the 412 is stable and
-        // consuming attempt budget is wasteful. Pinned so the classifier's
-        // explicit arm can't silently regress into the wildcard.
-        let err = Error::new(ErrorKind::PreconditionFailed, "412");
         assert_eq!(
             classify_upload_part_retry(&GuardError::Inner(err)),
             RetryDecision::NoRetry

--- a/aws-sdk-s3-transfer-manager/src/retry.rs
+++ b/aws-sdk-s3-transfer-manager/src/retry.rs
@@ -264,6 +264,13 @@ fn retry_cause(ge: &GuardError<Error>) -> String {
 /// that budget over time while the outer re-issue — bounded by [`MAX_ATTEMPTS`]
 /// and paced by the 1s throttle base — gives the service room to recover.
 ///
+/// A [`PreconditionFailed`](crate::error::ErrorKind::PreconditionFailed) — a
+/// user-set `If-Match` / `If-None-Match` not holding — is **deterministically
+/// terminal**. Retrying cannot change the object state that caused the 412, so
+/// the loop must not consume attempt budget on it. Called out as its own arm
+/// (rather than falling into the "everything else" wildcard) to make the intent
+/// explicit and to keep this claim under test.
+///
 /// Everything else is terminal: a non-throttle modeled service error and any
 /// non-transport inner error.
 ///
@@ -273,6 +280,7 @@ fn retry_cause(ge: &GuardError<Error>) -> String {
 pub(crate) fn classify_upload_part_retry(ge: &GuardError<Error>) -> RetryDecision {
     match ge {
         GuardError::DeadlineExceeded(_) => RetryDecision::NoRetry,
+        GuardError::Inner(e) if e.is_precondition_failed() => RetryDecision::NoRetry,
         GuardError::Inner(e) if e.is_transient_transport() => RetryDecision::Retry,
         GuardError::Inner(e) if is_throttle(e) => RetryDecision::RetryThrottle,
         GuardError::Inner(_) => RetryDecision::NoRetry,
@@ -746,6 +754,19 @@ mod tests {
     #[test]
     fn upload_other_inner_error_is_terminal() {
         let err = Error::new(ErrorKind::RuntimeError, "not a transport error");
+        assert_eq!(
+            classify_upload_part_retry(&GuardError::Inner(err)),
+            RetryDecision::NoRetry
+        );
+    }
+
+    #[test]
+    fn upload_precondition_failed_is_terminal() {
+        // A user-set If-Match / If-None-Match not holding cannot be recovered
+        // by retrying — the object state that produced the 412 is stable and
+        // consuming attempt budget is wasteful. Pinned so the classifier's
+        // explicit arm can't silently regress into the wildcard.
+        let err = Error::new(ErrorKind::PreconditionFailed, "412");
         assert_eq!(
             classify_upload_part_retry(&GuardError::Inner(err)),
             RetryDecision::NoRetry

--- a/aws-sdk-s3-transfer-manager/src/scheduler/scheduler.rs
+++ b/aws-sdk-s3-transfer-manager/src/scheduler/scheduler.rs
@@ -871,6 +871,10 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    // A test that returns with work still in flight leaves a strong `Handle` on the
+    // ambient runtime, so the `Handle` — and the S3 client it owns — is never dropped
+    // and shows up as a leak at process exit. Those tests are asan-gated too; see the
+    // note on `test_handle_managed` for the same root cause on managed threads.
     fn test_handle(concurrency: usize) -> Arc<Handle> {
         let s3_client = aws_smithy_mocks::mock_client!(aws_sdk_s3, []);
         let config = crate::Config::builder().client(s3_client).build();
@@ -1295,6 +1299,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(s3_tm_asan, ignore)]
     #[tokio::test]
     async fn test_panic_transfer_cleaned_up_and_error_propagated() {
         let _logs = show_test_logs();
@@ -2203,6 +2208,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(s3_tm_asan, ignore)]
     #[tokio::test]
     async fn test_panic_in_composite_poll_work() {
         let handle = test_handle(4);
@@ -2622,6 +2628,7 @@ mod tests {
     /// the IO charge; this pins that both are applied so that regression fails.
     // FIXME: crossbeam-epoch is incompatible with miri (https://github.com/crossbeam-rs/crossbeam/issues/1181)
     #[cfg_attr(miri, ignore)]
+    #[cfg_attr(s3_tm_asan, ignore)]
     #[tokio::test]
     async fn test_fused_ready_spawned_charges_both_io_and_spawn_vruntime() {
         let handle = test_handle(4);

--- a/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -615,3 +615,79 @@ async fn test_upload_if_none_match_star() {
         "real S3 must supply the service code callers identify the failure by"
     );
 }
+
+/// End-to-end: `if_match` on the object's current ETag succeeds (satisfied) and on
+/// a stale one fails (violated).
+///
+/// Covers the other conditional-write mode from [`test_upload_if_none_match_star`]:
+/// overwrite-if-unchanged, which a caller reaches by reading an ETag and writing it
+/// back. Each upload uses a different body length so a successful write moves the
+/// ETag, which is what makes the original genuinely stale rather than fabricated.
+///
+/// General-purpose bucket only, for the reason given on
+/// [`test_upload_if_none_match_star`].
+#[tokio::test]
+async fn test_upload_if_match_etag() {
+    use aws_sdk_s3_transfer_manager::error::ErrorKind;
+
+    let _logs = show_test_logs();
+    let (bucket_name, _express_bucket_name) = get_bucket_names();
+    let object_key = generate_key("if-match-etag");
+
+    let (tm, s3_client) = test_tm().await;
+
+    // Seed the key unconditionally, then read the ETag a caller would condition on.
+    perform_upload(
+        &tm,
+        &bucket_name,
+        &object_key,
+        None,
+        create_input_stream(1024),
+    )
+    .await;
+    let original_etag = s3_client
+        .head_object()
+        .bucket(&bucket_name)
+        .key(&object_key)
+        .send()
+        .await
+        .expect("head_object on the seeded key should succeed")
+        .e_tag()
+        .expect("S3 returns an ETag for a stored object")
+        .to_owned();
+
+    // 1) Satisfied: the ETag still matches, so the overwrite is allowed.
+    tm.upload()
+        .bucket(&bucket_name)
+        .key(&object_key)
+        .if_match(original_etag.as_str())
+        .body(create_input_stream(2048))
+        .initiate()
+        .expect("initiate should succeed")
+        .join()
+        .await
+        .expect("upload with If-Match on the current ETag must succeed");
+
+    // 2) Violated: that overwrite moved the ETag, so the original is now stale.
+    let err = tm
+        .upload()
+        .bucket(&bucket_name)
+        .key(&object_key)
+        .if_match(original_etag.as_str())
+        .body(create_input_stream(512))
+        .initiate()
+        .expect("initiate should succeed")
+        .join()
+        .await
+        .expect_err("upload with If-Match on a stale ETag must fail");
+    assert!(
+        matches!(err.kind(), ErrorKind::ServiceError),
+        "expected ErrorKind::ServiceError, got {:?}",
+        err.kind()
+    );
+    assert_eq!(
+        err.code(),
+        Some("PreconditionFailed"),
+        "real S3 must supply the service code callers identify the failure by"
+    );
+}

--- a/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -550,3 +550,64 @@ async fn test_multi_part_upload_sends_mpu_object_size() {
         );
     }
 }
+
+/// End-to-end: `if_none_match("*")` on a fresh key succeeds (satisfied) and on
+/// an existing key fails with [`ErrorKind::PreconditionFailed`] (violated).
+///
+/// Mock coverage in `upload_test.rs` pins the wire behavior (header forwarded,
+/// 412 mapped). This e2e adds server-side confirmation that:
+///   1. S3 accepts the header on the real request path (typos, encoding,
+///      request-signing changes would not be caught by mocks);
+///   2. a real 412 comes back with the same HTTP shape we map — i.e. the
+///      classifier is not brittle against wire-level differences between the
+///      mock and the service.
+///
+/// Runs against the general-purpose bucket only. Per the S3 conditional-writes
+/// docs, `If-None-Match` / `If-Match` are defined in terms of general-purpose
+/// (versioned / version-suspended) bucket behavior; support on S3 Express One
+/// Zone directory buckets is not affirmed there, so we don't assert it here.
+// TODO(RUST-1203): extend to the S3 Express bucket once conditional-write
+// support on directory buckets is confirmed on a real run.
+#[tokio::test]
+async fn test_upload_if_none_match_star() {
+    use aws_sdk_s3_transfer_manager::error::ErrorKind;
+
+    let _logs = show_test_logs();
+    let (bucket_name, _express_bucket_name) = get_bucket_names();
+    let object_key = generate_key("if-none-match-star");
+
+    let (tm, _) = test_tm().await;
+
+    // 1) Satisfied: no object exists at this key, so If-None-Match: "*"
+    //    (create-if-absent) is allowed.
+    tm.upload()
+        .bucket(&bucket_name)
+        .key(&object_key)
+        .if_none_match("*")
+        .body(create_input_stream(1024))
+        .initiate()
+        .expect("initiate should succeed")
+        .join()
+        .await
+        .expect("first upload with If-None-Match: * must succeed against a fresh key");
+
+    // 2) Violated: the object we just created collides with the same
+    //    precondition on the second upload. Expect PreconditionFailed —
+    //    NOT a generic ServiceError.
+    let err = tm
+        .upload()
+        .bucket(&bucket_name)
+        .key(&object_key)
+        .if_none_match("*")
+        .body(create_input_stream(1024))
+        .initiate()
+        .expect("initiate should succeed")
+        .join()
+        .await
+        .expect_err("second upload with If-None-Match: * must fail against an existing key");
+    assert!(
+        matches!(err.kind(), ErrorKind::PreconditionFailed),
+        "expected ErrorKind::PreconditionFailed, got {:?}",
+        err.kind()
+    );
+}

--- a/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -552,22 +552,22 @@ async fn test_multi_part_upload_sends_mpu_object_size() {
 }
 
 /// End-to-end: `if_none_match("*")` on a fresh key succeeds (satisfied) and on
-/// an existing key fails with [`ErrorKind::PreconditionFailed`] (violated).
+/// an existing key fails (violated).
 ///
 /// Mock coverage in `upload_test.rs` pins the wire behavior (header forwarded,
-/// 412 mapped). This e2e adds server-side confirmation that:
+/// service code surfaced). This e2e adds server-side confirmation that:
 ///   1. S3 accepts the header on the real request path (typos, encoding,
 ///      request-signing changes would not be caught by mocks);
-///   2. a real 412 comes back with the same HTTP shape we map — i.e. the
-///      classifier is not brittle against wire-level differences between the
-///      mock and the service.
+///   2. a real precondition failure carries the `PreconditionFailed` service
+///      code, so callers can identify it without wire-level assumptions the
+///      mock might not share with the service.
 ///
 /// Runs against the general-purpose bucket only. Per the S3 conditional-writes
 /// docs, `If-None-Match` / `If-Match` are defined in terms of general-purpose
 /// (versioned / version-suspended) bucket behavior; support on S3 Express One
 /// Zone directory buckets is not affirmed there, so we don't assert it here.
-// TODO(RUST-1203): extend to the S3 Express bucket once conditional-write
-// support on directory buckets is confirmed on a real run.
+// TODO: extend to the S3 Express bucket once conditional-write support on
+// directory buckets is confirmed on a real run.
 #[tokio::test]
 async fn test_upload_if_none_match_star() {
     use aws_sdk_s3_transfer_manager::error::ErrorKind;
@@ -592,8 +592,7 @@ async fn test_upload_if_none_match_star() {
         .expect("first upload with If-None-Match: * must succeed against a fresh key");
 
     // 2) Violated: the object we just created collides with the same
-    //    precondition on the second upload. Expect PreconditionFailed —
-    //    NOT a generic ServiceError.
+    //    precondition on the second upload.
     let err = tm
         .upload()
         .bucket(&bucket_name)
@@ -606,8 +605,13 @@ async fn test_upload_if_none_match_star() {
         .await
         .expect_err("second upload with If-None-Match: * must fail against an existing key");
     assert!(
-        matches!(err.kind(), ErrorKind::PreconditionFailed),
-        "expected ErrorKind::PreconditionFailed, got {:?}",
+        matches!(err.kind(), ErrorKind::ServiceError),
+        "expected ErrorKind::ServiceError, got {:?}",
         err.kind()
+    );
+    assert_eq!(
+        err.code(),
+        Some("PreconditionFailed"),
+        "real S3 must supply the service code callers identify the failure by"
     );
 }

--- a/aws-sdk-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/upload_test.rs
@@ -293,7 +293,7 @@ async fn test_complete_mpu_sends_mpu_object_size() {
         .expect("upload should succeed: CompleteMPU must carry MpuObjectSize = content length");
 }
 
-// --- Conditional-write preconditions (RUST-1203) -----------------------------
+// --- Conditional-write preconditions -----------------------------------------
 //
 // Assertion shape: use `match_requests` to fail the mock unless the request
 // carries the header we expect, so a missing/wrong precondition surfaces as a
@@ -324,13 +324,13 @@ async fn test_put_object_forwards_if_none_match() {
         .expect("PutObject must carry the caller's If-None-Match header");
 }
 
-/// When S3 returns 412 on the single-PUT path, the transfer must surface
-/// [`ErrorKind::PreconditionFailed`] — the caller's `If-Match` didn't hold, and
-/// that's semantically distinct from a generic service error. The 412 must also
-/// be terminal: neither the SDK's own retry (412 is a non-retryable 4xx) nor the
-/// TM's outer retry loop may re-issue it, so the request is sent exactly once.
+/// When S3 returns 412 on the single-PUT path, the transfer must fail with the
+/// service code reachable — that is how a caller tells a failed `If-Match` from
+/// any other service error. The 412 must also be terminal: neither the SDK's own
+/// retry (412 is a non-retryable 4xx) nor the TM's outer retry loop may re-issue
+/// it, so the request is sent exactly once.
 #[tokio::test]
-async fn test_put_object_412_maps_to_precondition_failed() {
+async fn test_put_object_412_surfaces_precondition_failed_code() {
     let put_object = mock!(aws_sdk_s3::Client::put_object).then_http_response(|| {
         HttpResponse::new(
             StatusCode::try_from(412).unwrap(),
@@ -355,9 +355,14 @@ async fn test_put_object_412_maps_to_precondition_failed() {
         .await
         .expect_err("a 412 on PutObject must fail the upload");
     assert!(
-        matches!(err.kind(), ErrorKind::PreconditionFailed),
-        "expected ErrorKind::PreconditionFailed, got {:?}",
+        matches!(err.kind(), ErrorKind::ServiceError),
+        "expected ErrorKind::ServiceError, got {:?}",
         err.kind()
+    );
+    assert_eq!(
+        err.code(),
+        Some("PreconditionFailed"),
+        "caller must be able to identify the precondition failure by service code"
     );
     // The underlying SdkError is preserved as the source for callers who want
     // the raw 412 detail.
@@ -431,10 +436,10 @@ async fn test_complete_mpu_forwards_if_match() {
 }
 
 /// When S3 rejects `CompleteMultipartUpload` with 412, the multipart path must
-/// surface [`ErrorKind::PreconditionFailed`]. Mirrors the single-PUT test but
+/// surface the same service code the single-PUT path does. Mirrors that test but
 /// exercises the MPU code path (which fails at a different site than PutObject).
 #[tokio::test]
-async fn test_complete_mpu_412_maps_to_precondition_failed() {
+async fn test_complete_mpu_412_surfaces_precondition_failed_code() {
     let upload_id = "test-upload-id".to_owned();
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
     let content_length = 2 * part_size;
@@ -484,9 +489,14 @@ async fn test_complete_mpu_412_maps_to_precondition_failed() {
         .await
         .expect_err("a 412 on CompleteMultipartUpload must fail the upload");
     assert!(
-        matches!(err.kind(), ErrorKind::PreconditionFailed),
-        "expected ErrorKind::PreconditionFailed, got {:?}",
+        matches!(err.kind(), ErrorKind::ServiceError),
+        "expected ErrorKind::ServiceError, got {:?}",
         err.kind()
+    );
+    assert_eq!(
+        err.code(),
+        Some("PreconditionFailed"),
+        "caller must be able to identify the precondition failure by service code"
     );
     let src = std::error::Error::source(&err).expect("source is set");
     assert!(

--- a/aws-sdk-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/upload_test.rs
@@ -8,13 +8,21 @@ use std::sync::Arc;
 use std::task::ready;
 use std::{task::Poll, time::Duration};
 
-use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadOutput;
+use aws_sdk_s3::operation::complete_multipart_upload::{
+    CompleteMultipartUploadError, CompleteMultipartUploadOutput,
+};
 use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
+use aws_sdk_s3::operation::put_object::{PutObjectError, PutObjectOutput};
 use aws_sdk_s3::operation::upload_part::UploadPartOutput;
+use aws_sdk_s3_transfer_manager::error::ErrorKind;
 use aws_sdk_s3_transfer_manager::io::{InputStream, PartData, PartStream, SizeHint, StreamContext};
 use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
 use aws_smithy_mocks::{mock, mock_client, RuleMode};
 use aws_smithy_runtime::test_util::capture_test_logs::capture_test_logs;
+use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
+use aws_smithy_runtime_api::client::result::SdkError;
+use aws_smithy_runtime_api::http::StatusCode;
+use aws_smithy_types::body::SdkBody;
 use bytes::Bytes;
 use pin_project_lite::pin_project;
 
@@ -283,4 +291,207 @@ async fn test_complete_mpu_sends_mpu_object_size() {
         .join()
         .await
         .expect("upload should succeed: CompleteMPU must carry MpuObjectSize = content length");
+}
+
+// --- Conditional-write preconditions (RUST-1203) -----------------------------
+//
+// Assertion shape: use `match_requests` to fail the mock unless the request
+// carries the header we expect, so a missing/wrong precondition surfaces as a
+// join failure rather than a silent pass.
+
+/// A single-PUT upload with `if_none_match("*")` must forward the header to
+/// `PutObject`. Satisfied case: the mock rule matches, upload succeeds.
+#[tokio::test]
+async fn test_put_object_forwards_if_none_match() {
+    let put_object = mock!(aws_sdk_s3::Client::put_object)
+        .match_requests(|req| req.if_none_match() == Some("*"))
+        .then_output(|| PutObjectOutput::builder().e_tag("test-etag").build());
+    let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[put_object]);
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    tm.upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .if_none_match("*")
+        .body(InputStream::from(vec![0u8; 1024]))
+        .initiate()
+        .unwrap()
+        .join()
+        .await
+        .expect("PutObject must carry the caller's If-None-Match header");
+}
+
+/// When S3 returns 412 on the single-PUT path, the transfer must surface
+/// [`ErrorKind::PreconditionFailed`] — the caller's `If-Match` didn't hold, and
+/// that's semantically distinct from a generic service error. The 412 must also
+/// be terminal: neither the SDK's own retry (412 is a non-retryable 4xx) nor the
+/// TM's outer retry loop may re-issue it, so the request is sent exactly once.
+#[tokio::test]
+async fn test_put_object_412_maps_to_precondition_failed() {
+    let put_object = mock!(aws_sdk_s3::Client::put_object).then_http_response(|| {
+        HttpResponse::new(
+            StatusCode::try_from(412).unwrap(),
+            SdkBody::from("<Error><Code>PreconditionFailed</Code></Error>"),
+        )
+    });
+    let client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[&put_object]);
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let err = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .if_match("\"stale-etag\"")
+        .body(InputStream::from(vec![0u8; 1024]))
+        .initiate()
+        .unwrap()
+        .join()
+        .await
+        .expect_err("a 412 on PutObject must fail the upload");
+    assert!(
+        matches!(err.kind(), ErrorKind::PreconditionFailed),
+        "expected ErrorKind::PreconditionFailed, got {:?}",
+        err.kind()
+    );
+    // The underlying SdkError is preserved as the source for callers who want
+    // the raw 412 detail.
+    let src = std::error::Error::source(&err).expect("source is set");
+    assert!(
+        src.downcast_ref::<SdkError<PutObjectError, HttpResponse>>()
+            .is_some(),
+        "source should be the underlying PutObject SdkError"
+    );
+    // A precondition failure is deterministic — it must not be retried.
+    assert_eq!(
+        put_object.num_calls(),
+        1,
+        "PutObject 412 must be issued exactly once (no SDK or TM retry)"
+    );
+}
+
+/// The multipart path must forward `if_match` / `if_none_match` to
+/// `CompleteMultipartUpload` (and only there — never on `CreateMultipartUpload`
+/// or `UploadPart`, where S3 doesn't accept them and mixing them in would
+/// silently drop the header at build time).
+#[tokio::test]
+async fn test_complete_mpu_forwards_if_match() {
+    let upload_id = "test-upload-id".to_owned();
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let content_length = 2 * part_size;
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+
+    let upload_part =
+        mock!(aws_sdk_s3::Client::upload_part).then_output(|| UploadPartOutput::builder().build());
+
+    let expected_etag = "\"expected-etag\"";
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .match_requests(move |req| req.if_match() == Some(expected_etag))
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[create_mpu, upload_part, complete_mpu]
+    );
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(1);
+    let stream = TestStream::new(rx, content_length, content_length as u64);
+
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .if_match(expected_etag)
+        .body(InputStream::from_part_stream(stream))
+        .initiate()
+        .unwrap();
+    drop(tx);
+    handle
+        .join()
+        .await
+        .expect("CompleteMultipartUpload must carry the caller's If-Match header");
+}
+
+/// When S3 rejects `CompleteMultipartUpload` with 412, the multipart path must
+/// surface [`ErrorKind::PreconditionFailed`]. Mirrors the single-PUT test but
+/// exercises the MPU code path (which fails at a different site than PutObject).
+#[tokio::test]
+async fn test_complete_mpu_412_maps_to_precondition_failed() {
+    let upload_id = "test-upload-id".to_owned();
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let content_length = 2 * part_size;
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+    let upload_part =
+        mock!(aws_sdk_s3::Client::upload_part).then_output(|| UploadPartOutput::builder().build());
+    let complete_mpu =
+        mock!(aws_sdk_s3::Client::complete_multipart_upload).then_http_response(|| {
+            HttpResponse::new(
+                StatusCode::try_from(412).unwrap(),
+                SdkBody::from("<Error><Code>PreconditionFailed</Code></Error>"),
+            )
+        });
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[create_mpu, upload_part, complete_mpu]
+    );
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(1);
+    let stream = TestStream::new(rx, content_length, content_length as u64);
+
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .if_match("\"stale-etag\"")
+        .body(InputStream::from_part_stream(stream))
+        .initiate()
+        .unwrap();
+    drop(tx);
+    let err = handle
+        .join()
+        .await
+        .expect_err("a 412 on CompleteMultipartUpload must fail the upload");
+    assert!(
+        matches!(err.kind(), ErrorKind::PreconditionFailed),
+        "expected ErrorKind::PreconditionFailed, got {:?}",
+        err.kind()
+    );
+    let src = std::error::Error::source(&err).expect("source is set");
+    assert!(
+        src.downcast_ref::<SdkError<CompleteMultipartUploadError, HttpResponse>>()
+            .is_some(),
+        "source should be the underlying CompleteMultipartUpload SdkError"
+    );
 }


### PR DESCRIPTION
## Summary

Adds conditional-write support to upload: callers set `if_match` / `if_none_match` on `UploadInput` ("overwrite only if unchanged" / "create only if absent"). The headers are forwarded on the two requests S3 accepts them — `PutObject` (single-PUT) and `CompleteMultipartUpload` (multipart).

A failed precondition is **not** promoted to its own error kind. It arrives as `ErrorKind::ServiceError` with `Error::code() == Some("PreconditionFailed")`, which is documented on `ServiceError` so it is discoverable. S3 reports that code in the response body, so it is reachable whatever HTTP status carries it — including the 200-with-error-XML case a status check would miss. Such a failure is terminal in the retry classifier via the existing non-throttle service-error path; no dedicated arm is needed, since it is neither transient transport nor a throttle code.

S3 doesn't accept these headers on `CreateMultipartUpload` (no builder setter), so on the multipart path they go on
[`copy_fields_to_complete_mpu_request`](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/c4e27dedf65cf98882d613234236a9b253da3637/aws-sdk-s3-transfer-manager/src/operation/upload/input/convert.rs) — which also re-enables the staged assertion. Scope is single-object upload.

New public surface: the two `UploadInput` fields.

Closes #117

## Test plan

- [x] `fmt` / `clippy` clean (default + `--cfg e2e_test`); lib + integration + doc tests green
- [x] Mocks pin both paths: header forwarded; a 412 fails the transfer with the `PreconditionFailed` service code reachable, issued exactly once
- [x] A unit test pins the classification contract end to end — kind, code, operation name, and the underlying `SdkError` preserved as the source
- [x] `test_upload_if_none_match_star` (`#[cfg(e2e_test)]`) runs against a real bucket in the e2e job, confirming real S3 supplies the code the mocks assert
