### PR TITLE
upload: support unknown content length on streaming uploads

### DIFF
--- a/aws-sdk-s3-transfer-manager/src/io/error.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/error.rs
@@ -10,7 +10,6 @@ use tokio::task::JoinError;
 
 #[derive(Debug)]
 pub(crate) enum ErrorKind {
-    UpperBoundSizeHintRequired,
     OffsetGreaterThanFileSize,
     OffsetNotAlignedWithPartNumber(u64, u64),
     TaskFailed(JoinError),
@@ -24,9 +23,6 @@ pub struct Error {
 }
 
 impl Error {
-    pub(crate) fn upper_bound_size_hint_required() -> Error {
-        ErrorKind::UpperBoundSizeHintRequired.into()
-    }
     pub(crate) fn offset_not_aligned_with_part_number(offset: u64, part_number: u64) -> Error {
         ErrorKind::OffsetNotAlignedWithPartNumber(offset, part_number).into()
     }
@@ -46,10 +42,6 @@ impl From<StdIoError> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match &self.kind {
-            ErrorKind::UpperBoundSizeHintRequired => write!(
-                f,
-                "size hint upper bound (SizeHint::upper) is required but was None"
-            ),
             ErrorKind::OffsetGreaterThanFileSize => write!(
                 f,
                 "offset must be less than or equal to file size but was greater than"
@@ -68,7 +60,6 @@ impl fmt::Display for Error {
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match &self.kind {
-            ErrorKind::UpperBoundSizeHintRequired => None,
             ErrorKind::OffsetGreaterThanFileSize => None,
             ErrorKind::OffsetNotAlignedWithPartNumber(_, _) => None,
             ErrorKind::IoError(err) => Some(err as _),

--- a/aws-sdk-s3-transfer-manager/src/io/part_reader.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/part_reader.rs
@@ -5,6 +5,7 @@
 use std::cmp;
 use std::fs::File;
 use std::ops::DerefMut;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use bytes::{Buf, Bytes};
@@ -89,6 +90,14 @@ impl Builder {
 pub(crate) struct PartReader {
     inner: Inner,
     stream_cx: StreamContext,
+    /// Count of parts this reader has yielded (returned as `Ok(Some(..))`).
+    ///
+    /// Incremented in [`next_part`](Self::next_part) as each part is produced, so it is ordered with
+    /// the reads: end-of-stream (`Ok(None)`) is only observed after every yielded part has already
+    /// bumped this. That lets a caller driving speculative, concurrent reads decide two things
+    /// race-free — whether the stream was empty (`0` at end-of-stream) and whether it has exceeded a
+    /// part limit — without a second lock of its own that could interleave with the read.
+    parts_yielded: AtomicU64,
 }
 
 impl PartReader {
@@ -106,12 +115,21 @@ impl PartReader {
         };
 
         let stream_cx = StreamContext::new(part_size, direct_io, metrics, telemetry);
-        Ok(Self { inner, stream_cx })
+        Ok(Self {
+            inner,
+            stream_cx,
+            parts_yielded: AtomicU64::new(0),
+        })
     }
 
     #[allow(dead_code)] // TODO: re-wire upload part validation
     pub(crate) fn part_size(&self) -> usize {
         self.stream_cx.part_size()
+    }
+
+    /// Number of parts yielded so far. See the field docs on the ordering guarantee.
+    pub(crate) fn parts_yielded(&self) -> u64 {
+        self.parts_yielded.load(Ordering::Acquire)
     }
 }
 
@@ -124,10 +142,22 @@ enum Inner {
 
 impl PartReader {
     pub(crate) async fn next_part(&self) -> Result<Option<PartData>, Error> {
+        // `parts_yielded` is passed down so each reader increments it *inside the same lock that
+        // produces the part*. Incrementing here in the outer call — after the inner released its
+        // lock — would leave a window in which a concurrent reader observes end-of-stream with a
+        // stale count, which is the race this counter exists to close.
         match &self.inner {
-            Inner::Bytes(bytes) => bytes.next_part(&self.stream_cx).await,
-            Inner::Fs(path_body) => path_body.next_part(&self.stream_cx).await,
-            Inner::Dyn(part_stream) => part_stream.next_part(&self.stream_cx).await,
+            Inner::Bytes(bytes) => bytes.next_part(&self.stream_cx, &self.parts_yielded).await,
+            Inner::Fs(path_body) => {
+                path_body
+                    .next_part(&self.stream_cx, &self.parts_yielded)
+                    .await
+            }
+            Inner::Dyn(part_stream) => {
+                part_stream
+                    .next_part(&self.stream_cx, &self.parts_yielded)
+                    .await
+            }
         }
     }
 
@@ -187,7 +217,11 @@ impl BytesPartReader {
 }
 
 impl BytesPartReader {
-    async fn next_part(&self, stream_cx: &StreamContext) -> Result<Option<PartData>, Error> {
+    async fn next_part(
+        &self,
+        stream_cx: &StreamContext,
+        parts_yielded: &AtomicU64,
+    ) -> Result<Option<PartData>, Error> {
         let mut state = self.state.lock().expect("lock valid");
         if state.is_end() {
             return Ok(None);
@@ -209,6 +243,8 @@ impl BytesPartReader {
         state.offset += data.len() as u64;
         state.remaining -= data.len() as u64;
         let part = PartData::new(part_number, data).mark_last(state.is_end());
+        // Under `state` — ordered with the yield.
+        parts_yielded.fetch_add(1, Ordering::Release);
         Ok(Some(part))
     }
 }
@@ -245,16 +281,21 @@ impl PathBodyPartReader {
 }
 
 impl PathBodyPartReader {
-    async fn next_part(&self, stream_cx: &StreamContext) -> Result<Option<PartData>, Error> {
-        let (offset, part_number, part_size, is_last) = match self.advance(stream_cx)? {
-            Some(PathBodyReadCursor {
-                offset,
-                part_number,
-                part_size,
-                is_last,
-            }) => (offset, part_number, part_size, is_last),
-            None => return Ok(None),
-        };
+    async fn next_part(
+        &self,
+        stream_cx: &StreamContext,
+        parts_yielded: &AtomicU64,
+    ) -> Result<Option<PartData>, Error> {
+        let (offset, part_number, part_size, is_last) =
+            match self.advance(stream_cx, parts_yielded)? {
+                Some(PathBodyReadCursor {
+                    offset,
+                    part_number,
+                    part_size,
+                    is_last,
+                }) => (offset, part_number, part_size, is_last),
+                None => return Ok(None),
+            };
         // grab a buffer to fill from the context
         let mut dst = stream_cx.new_buffer(part_size as usize);
         // SAFETY: We set the length to capacity so the read has a full slice to fill.
@@ -286,7 +327,11 @@ impl PathBodyPartReader {
     // Advances the `PartReaderState` to the next state and returns `PathBodyReadCursor`
     // (offset, part_number, part_size, is_last), which will be used in the upcoming
     // `read_file_chunk` execution.
-    fn advance(&self, stream_cx: &StreamContext) -> Result<Option<PathBodyReadCursor>, Error> {
+    fn advance(
+        &self,
+        stream_cx: &StreamContext,
+        parts_yielded: &AtomicU64,
+    ) -> Result<Option<PathBodyReadCursor>, Error> {
         let mut state = self.state.lock().expect("lock valid");
         if state.is_end() {
             return Ok(None);
@@ -305,6 +350,10 @@ impl PathBodyPartReader {
         state.offset += part_size;
         state.part_number += 1;
         state.remaining -= part_size;
+
+        // Under `state` — ordered with the yield. A part is committed here even though the file read
+        // happens after the lock is released; `advance` returning `Some` is the yield.
+        parts_yielded.fetch_add(1, Ordering::Release);
 
         Ok(Some(PathBodyReadCursor {
             offset,
@@ -382,11 +431,23 @@ impl DynPartReader {
             inner: tokio::sync::Mutex::new(inner),
         }
     }
-    async fn next_part(&self, stream_cx: &StreamContext) -> Result<Option<PartData>, Error> {
+    async fn next_part(
+        &self,
+        stream_cx: &StreamContext,
+        parts_yielded: &AtomicU64,
+    ) -> Result<Option<PartData>, Error> {
         // TODO - can we do better than a mutex here? should we spawn a dedicated task and use channels instead
         let mut stream = self.inner.lock().await;
         match stream.next(stream_cx).await {
-            Some(result) => result.map(Some).map_err(|err| err.into()),
+            Some(Ok(part)) => {
+                // Under the stream mutex — ordered with the yield. This is the whole reason the
+                // count lives on the reader: reads here are serialized, so a caller that observes
+                // end-of-stream (the `None` arm) is guaranteed to see every prior part counted, with
+                // no separate lock of its own that could interleave between a read and the count.
+                parts_yielded.fetch_add(1, Ordering::Release);
+                Ok(Some(part))
+            }
+            Some(Err(err)) => Err(err.into()),
             None => Ok(None),
         }
     }
@@ -401,6 +462,7 @@ impl DynPartReader {
 #[cfg(test)]
 mod test {
     use std::io::Write;
+    use std::sync::atomic::AtomicU64;
     use std::task::Poll;
 
     use bytes::{Buf, Bytes};
@@ -577,9 +639,10 @@ mod test {
         let data = Bytes::from("test data for alignment error");
         let reader = BytesPartReader::new(data);
         let stream_cx = test_stream_cx(5);
+        let yielded = AtomicU64::new(0);
 
         // First call should succeed
-        let result = reader.next_part(&stream_cx).await;
+        let result = reader.next_part(&stream_cx, &yielded).await;
         assert!(result.is_ok());
 
         // Manually corrupt the offset to create misalignment
@@ -589,7 +652,7 @@ mod test {
         }
 
         // Second call should fail with offset_not_aligned_with_part_number error
-        let result = reader.next_part(&stream_cx).await;
+        let result = reader.next_part(&stream_cx, &yielded).await;
         assert!(result.is_err());
     }
 
@@ -599,8 +662,13 @@ mod test {
         let data = Bytes::from("test");
         let reader = BytesPartReader::new(data);
         let stream_cx = test_stream_cx(10);
+        let yielded = AtomicU64::new(0);
 
-        let result = reader.next_part(&stream_cx).await.unwrap().unwrap();
+        let result = reader
+            .next_part(&stream_cx, &yielded)
+            .await
+            .unwrap()
+            .unwrap();
         assert!(result.is_last.unwrap());
     }
 
@@ -616,16 +684,17 @@ mod test {
         };
         let reader = PathBodyPartReader::new(path_body).unwrap();
         let stream_cx = test_stream_cx(5);
+        let yielded = AtomicU64::new(0);
 
         // First advance should succeed
-        let result = reader.advance(&stream_cx).unwrap().unwrap();
+        let result = reader.advance(&stream_cx, &yielded).unwrap().unwrap();
         assert_eq!(result.offset, 10);
         assert_eq!(result.part_number, 1);
         assert_eq!(result.part_size, 5);
         assert!(!result.is_last);
 
         // Second advance should succeed
-        let result = reader.advance(&stream_cx).unwrap().unwrap();
+        let result = reader.advance(&stream_cx, &yielded).unwrap().unwrap();
         assert_eq!(result.offset, 15);
         assert_eq!(result.part_number, 2);
         assert_eq!(result.part_size, 5);
@@ -638,7 +707,7 @@ mod test {
         }
 
         // Third advance should fail due to misaligned offset
-        let result = reader.advance(&stream_cx);
+        let result = reader.advance(&stream_cx, &yielded);
         assert!(result.is_err());
     }
 
@@ -654,8 +723,9 @@ mod test {
         };
         let reader = PathBodyPartReader::new(path_body).unwrap();
         let stream_cx = test_stream_cx(10);
+        let yielded = AtomicU64::new(0);
 
-        let result = reader.advance(&stream_cx).unwrap().unwrap();
+        let result = reader.advance(&stream_cx, &yielded).unwrap().unwrap();
         assert!(result.is_last);
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/io/part_reader.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/part_reader.rs
@@ -115,12 +115,17 @@ impl PartReader {
         self.stream_cx.part_size()
     }
 
-    /// Number of parts yielded so far (returned as `Ok(Some(..))`).
+    /// Number of parts this reader has produced.
     ///
-    /// Each variant tracks this under the same lock that produces a part, so the count is ordered
-    /// with the reads: end-of-stream (`Ok(None)`) is only observed after every yielded part is
-    /// already counted. That lets a caller driving speculative, concurrent reads decide whether the
-    /// stream was empty (`0` at end-of-stream) without a second lock of its own to race against.
+    /// Exact for `Dyn`, and bumped inside the lock that produces the part: end-of-stream
+    /// (`Ok(None)`) is only observed once every part the stream will yield is counted, so a caller
+    /// driving speculative, concurrent reads can test emptiness (`0` at end-of-stream) without a
+    /// second lock of its own to race against. Only `Dyn` can have an unknown length, so only `Dyn`
+    /// needs that.
+    ///
+    /// `Bytes` and `Fs` derive it from their part-number cursor. `Fs` advances that cursor when it
+    /// reserves a part, so its count can lead the parts actually returned by an in-flight or failed
+    /// read.
     pub(crate) fn parts_yielded(&self) -> u64 {
         match &self.inner {
             Inner::Bytes(bytes) => bytes.parts_yielded(),
@@ -202,7 +207,6 @@ impl BytesPartReader {
 }
 
 impl BytesPartReader {
-    /// Derived from the part-number cursor, which advances under `state` as each part is produced.
     fn parts_yielded(&self) -> u64 {
         self.state.lock().expect("lock valid").part_number - 1
     }
@@ -265,7 +269,6 @@ impl PathBodyPartReader {
 }
 
 impl PathBodyPartReader {
-    /// Derived from the part-number cursor, which advances under `state` as each part is committed.
     fn parts_yielded(&self) -> u64 {
         self.state.lock().expect("lock valid").part_number - 1
     }

--- a/aws-sdk-s3-transfer-manager/src/io/part_reader.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/part_reader.rs
@@ -90,14 +90,6 @@ impl Builder {
 pub(crate) struct PartReader {
     inner: Inner,
     stream_cx: StreamContext,
-    /// Count of parts this reader has yielded (returned as `Ok(Some(..))`).
-    ///
-    /// Incremented in [`next_part`](Self::next_part) as each part is produced, so it is ordered with
-    /// the reads: end-of-stream (`Ok(None)`) is only observed after every yielded part has already
-    /// bumped this. That lets a caller driving speculative, concurrent reads decide two things
-    /// race-free — whether the stream was empty (`0` at end-of-stream) and whether it has exceeded a
-    /// part limit — without a second lock of its own that could interleave with the read.
-    parts_yielded: AtomicU64,
 }
 
 impl PartReader {
@@ -115,11 +107,7 @@ impl PartReader {
         };
 
         let stream_cx = StreamContext::new(part_size, direct_io, metrics, telemetry);
-        Ok(Self {
-            inner,
-            stream_cx,
-            parts_yielded: AtomicU64::new(0),
-        })
+        Ok(Self { inner, stream_cx })
     }
 
     #[allow(dead_code)] // TODO: re-wire upload part validation
@@ -127,9 +115,18 @@ impl PartReader {
         self.stream_cx.part_size()
     }
 
-    /// Number of parts yielded so far. See the field docs on the ordering guarantee.
+    /// Number of parts yielded so far (returned as `Ok(Some(..))`).
+    ///
+    /// Each variant tracks this under the same lock that produces a part, so the count is ordered
+    /// with the reads: end-of-stream (`Ok(None)`) is only observed after every yielded part is
+    /// already counted. That lets a caller driving speculative, concurrent reads decide whether the
+    /// stream was empty (`0` at end-of-stream) without a second lock of its own to race against.
     pub(crate) fn parts_yielded(&self) -> u64 {
-        self.parts_yielded.load(Ordering::Acquire)
+        match &self.inner {
+            Inner::Bytes(bytes) => bytes.parts_yielded(),
+            Inner::Fs(path_body) => path_body.parts_yielded(),
+            Inner::Dyn(part_stream) => part_stream.parts_yielded(),
+        }
     }
 }
 
@@ -142,22 +139,10 @@ enum Inner {
 
 impl PartReader {
     pub(crate) async fn next_part(&self) -> Result<Option<PartData>, Error> {
-        // `parts_yielded` is passed down so each reader increments it *inside the same lock that
-        // produces the part*. Incrementing here in the outer call — after the inner released its
-        // lock — would leave a window in which a concurrent reader observes end-of-stream with a
-        // stale count, which is the race this counter exists to close.
         match &self.inner {
-            Inner::Bytes(bytes) => bytes.next_part(&self.stream_cx, &self.parts_yielded).await,
-            Inner::Fs(path_body) => {
-                path_body
-                    .next_part(&self.stream_cx, &self.parts_yielded)
-                    .await
-            }
-            Inner::Dyn(part_stream) => {
-                part_stream
-                    .next_part(&self.stream_cx, &self.parts_yielded)
-                    .await
-            }
+            Inner::Bytes(bytes) => bytes.next_part(&self.stream_cx).await,
+            Inner::Fs(path_body) => path_body.next_part(&self.stream_cx).await,
+            Inner::Dyn(part_stream) => part_stream.next_part(&self.stream_cx).await,
         }
     }
 
@@ -217,11 +202,12 @@ impl BytesPartReader {
 }
 
 impl BytesPartReader {
-    async fn next_part(
-        &self,
-        stream_cx: &StreamContext,
-        parts_yielded: &AtomicU64,
-    ) -> Result<Option<PartData>, Error> {
+    /// Derived from the part-number cursor, which advances under `state` as each part is produced.
+    fn parts_yielded(&self) -> u64 {
+        self.state.lock().expect("lock valid").part_number - 1
+    }
+
+    async fn next_part(&self, stream_cx: &StreamContext) -> Result<Option<PartData>, Error> {
         let mut state = self.state.lock().expect("lock valid");
         if state.is_end() {
             return Ok(None);
@@ -243,8 +229,6 @@ impl BytesPartReader {
         state.offset += data.len() as u64;
         state.remaining -= data.len() as u64;
         let part = PartData::new(part_number, data).mark_last(state.is_end());
-        // Under `state` — ordered with the yield.
-        parts_yielded.fetch_add(1, Ordering::Release);
         Ok(Some(part))
     }
 }
@@ -281,21 +265,21 @@ impl PathBodyPartReader {
 }
 
 impl PathBodyPartReader {
-    async fn next_part(
-        &self,
-        stream_cx: &StreamContext,
-        parts_yielded: &AtomicU64,
-    ) -> Result<Option<PartData>, Error> {
-        let (offset, part_number, part_size, is_last) =
-            match self.advance(stream_cx, parts_yielded)? {
-                Some(PathBodyReadCursor {
-                    offset,
-                    part_number,
-                    part_size,
-                    is_last,
-                }) => (offset, part_number, part_size, is_last),
-                None => return Ok(None),
-            };
+    /// Derived from the part-number cursor, which advances under `state` as each part is committed.
+    fn parts_yielded(&self) -> u64 {
+        self.state.lock().expect("lock valid").part_number - 1
+    }
+
+    async fn next_part(&self, stream_cx: &StreamContext) -> Result<Option<PartData>, Error> {
+        let (offset, part_number, part_size, is_last) = match self.advance(stream_cx)? {
+            Some(PathBodyReadCursor {
+                offset,
+                part_number,
+                part_size,
+                is_last,
+            }) => (offset, part_number, part_size, is_last),
+            None => return Ok(None),
+        };
         // grab a buffer to fill from the context
         let mut dst = stream_cx.new_buffer(part_size as usize);
         // SAFETY: We set the length to capacity so the read has a full slice to fill.
@@ -327,11 +311,7 @@ impl PathBodyPartReader {
     // Advances the `PartReaderState` to the next state and returns `PathBodyReadCursor`
     // (offset, part_number, part_size, is_last), which will be used in the upcoming
     // `read_file_chunk` execution.
-    fn advance(
-        &self,
-        stream_cx: &StreamContext,
-        parts_yielded: &AtomicU64,
-    ) -> Result<Option<PathBodyReadCursor>, Error> {
+    fn advance(&self, stream_cx: &StreamContext) -> Result<Option<PathBodyReadCursor>, Error> {
         let mut state = self.state.lock().expect("lock valid");
         if state.is_end() {
             return Ok(None);
@@ -350,10 +330,6 @@ impl PathBodyPartReader {
         state.offset += part_size;
         state.part_number += 1;
         state.remaining -= part_size;
-
-        // Under `state` — ordered with the yield. A part is committed here even though the file read
-        // happens after the lock is released; `advance` returning `Some` is the yield.
-        parts_yielded.fetch_add(1, Ordering::Release);
 
         Ok(Some(PathBodyReadCursor {
             offset,
@@ -423,28 +399,31 @@ pub(crate) mod file_util {
 #[derive(Debug)]
 struct DynPartReader {
     inner: tokio::sync::Mutex<BoxStream>,
+    /// Counted explicitly: unlike the buffer and file variants, a `PartStream` carries no
+    /// part-number cursor to derive it from.
+    parts_yielded: AtomicU64,
 }
 
 impl DynPartReader {
     fn new(inner: BoxStream) -> Self {
         Self {
             inner: tokio::sync::Mutex::new(inner),
+            parts_yielded: AtomicU64::new(0),
         }
     }
-    async fn next_part(
-        &self,
-        stream_cx: &StreamContext,
-        parts_yielded: &AtomicU64,
-    ) -> Result<Option<PartData>, Error> {
+
+    fn parts_yielded(&self) -> u64 {
+        self.parts_yielded.load(Ordering::Acquire)
+    }
+
+    async fn next_part(&self, stream_cx: &StreamContext) -> Result<Option<PartData>, Error> {
         // TODO - can we do better than a mutex here? should we spawn a dedicated task and use channels instead
         let mut stream = self.inner.lock().await;
         match stream.next(stream_cx).await {
             Some(Ok(part)) => {
-                // Under the stream mutex — ordered with the yield. This is the whole reason the
-                // count lives on the reader: reads here are serialized, so a caller that observes
-                // end-of-stream (the `None` arm) is guaranteed to see every prior part counted, with
-                // no separate lock of its own that could interleave between a read and the count.
-                parts_yielded.fetch_add(1, Ordering::Release);
+                // Counted inside the lock that produces the part: a concurrent end-of-stream read
+                // must not be able to observe a stale count.
+                self.parts_yielded.fetch_add(1, Ordering::Release);
                 Ok(Some(part))
             }
             Some(Err(err)) => Err(err.into()),
@@ -462,7 +441,6 @@ impl DynPartReader {
 #[cfg(test)]
 mod test {
     use std::io::Write;
-    use std::sync::atomic::AtomicU64;
     use std::task::Poll;
 
     use bytes::{Buf, Bytes};
@@ -639,10 +617,9 @@ mod test {
         let data = Bytes::from("test data for alignment error");
         let reader = BytesPartReader::new(data);
         let stream_cx = test_stream_cx(5);
-        let yielded = AtomicU64::new(0);
 
         // First call should succeed
-        let result = reader.next_part(&stream_cx, &yielded).await;
+        let result = reader.next_part(&stream_cx).await;
         assert!(result.is_ok());
 
         // Manually corrupt the offset to create misalignment
@@ -652,7 +629,7 @@ mod test {
         }
 
         // Second call should fail with offset_not_aligned_with_part_number error
-        let result = reader.next_part(&stream_cx, &yielded).await;
+        let result = reader.next_part(&stream_cx).await;
         assert!(result.is_err());
     }
 
@@ -662,13 +639,8 @@ mod test {
         let data = Bytes::from("test");
         let reader = BytesPartReader::new(data);
         let stream_cx = test_stream_cx(10);
-        let yielded = AtomicU64::new(0);
 
-        let result = reader
-            .next_part(&stream_cx, &yielded)
-            .await
-            .unwrap()
-            .unwrap();
+        let result = reader.next_part(&stream_cx).await.unwrap().unwrap();
         assert!(result.is_last.unwrap());
     }
 
@@ -684,17 +656,16 @@ mod test {
         };
         let reader = PathBodyPartReader::new(path_body).unwrap();
         let stream_cx = test_stream_cx(5);
-        let yielded = AtomicU64::new(0);
 
         // First advance should succeed
-        let result = reader.advance(&stream_cx, &yielded).unwrap().unwrap();
+        let result = reader.advance(&stream_cx).unwrap().unwrap();
         assert_eq!(result.offset, 10);
         assert_eq!(result.part_number, 1);
         assert_eq!(result.part_size, 5);
         assert!(!result.is_last);
 
         // Second advance should succeed
-        let result = reader.advance(&stream_cx, &yielded).unwrap().unwrap();
+        let result = reader.advance(&stream_cx).unwrap().unwrap();
         assert_eq!(result.offset, 15);
         assert_eq!(result.part_number, 2);
         assert_eq!(result.part_size, 5);
@@ -707,7 +678,7 @@ mod test {
         }
 
         // Third advance should fail due to misaligned offset
-        let result = reader.advance(&stream_cx, &yielded);
+        let result = reader.advance(&stream_cx);
         assert!(result.is_err());
     }
 
@@ -723,9 +694,8 @@ mod test {
         };
         let reader = PathBodyPartReader::new(path_body).unwrap();
         let stream_cx = test_stream_cx(10);
-        let yielded = AtomicU64::new(0);
 
-        let result = reader.advance(&stream_cx, &yielded).unwrap().unwrap();
+        let result = reader.advance(&stream_cx).unwrap().unwrap();
         assert!(result.is_last);
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/io/stream.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/stream.rs
@@ -163,6 +163,19 @@ impl InputStream {
     /// NOTE: Implementing `PartStream` directly is a more advanced use case. You should reach for
     /// one of the provided implementations or adapters first if possible.
     ///
+    /// # Streams of unknown length
+    ///
+    /// A stream whose [`size_hint`](PartStream::size_hint) has no upper bound is read until it ends,
+    /// with no declared total. Prefer declaring a size when one is available, because without it:
+    ///
+    /// - The object is capped at `part_size * 10_000` — about 78 GiB at the default part size, since
+    ///   there is no total to size parts against. Exceeding it fails partway through, not up front,
+    ///   and the parts already uploaded are lost. Configure a larger part size for larger objects.
+    /// - A failure mid-stream leaves an incomplete multipart upload. Call
+    ///   [`abort`](crate::operation::upload::UploadHandle::abort), or use S3 lifecycle rules.
+    /// - `MpuObjectSize` is the size actually uploaded rather than an independently declared one, so
+    ///   it cannot detect a part this crate dropped or duplicated.
+    ///
     /// [multipart upload]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html
     pub fn from_part_stream<T: PartStream + Send + Sync + 'static>(stream: T) -> Self {
         let inner = RawInputStream::Dyn(BoxStream::new(stream));

--- a/aws-sdk-s3-transfer-manager/src/operation/upload.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload.rs
@@ -77,11 +77,6 @@ impl Upload {
 
         let stream = input.take_body();
 
-        // TODO: Relax this constraint - unknown content length implies MPU
-        if stream.size_hint().upper().is_none() {
-            return Err(crate::io::error::Error::upper_bound_size_hint_required().into());
-        }
-
         let bucket_type =
             BucketType::from_bucket_name(input.bucket().expect("bucket is available"));
 

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/context.rs
@@ -14,7 +14,6 @@ use crate::operation::upload::UploadOutputBuilder;
 ///
 /// A known length yields an exact part count up front; an unknown-length `PartStream` does not, so
 /// its parts are dispatched speculatively and the phase ends when the reader reports end-of-stream.
-/// One enum for both keeps a part count and an end-of-stream flag from coexisting.
 #[derive(Debug)]
 pub(crate) enum PartPlan {
     /// Content length known up front: dispatch until `total_parts` have been issued.

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/context.rs
@@ -16,23 +16,25 @@ use crate::operation::upload::UploadOutputBuilder;
 /// `PartStream` of unknown length does not: parts are dispatched speculatively and the phase ends
 /// when the reader reports end-of-stream. Modelling the two as one enum keeps the illegal
 /// combination — a part count *and* an end-of-stream flag — unrepresentable.
+///
+/// The unknown-length variant carries no emitted-yet / end-of-stream flags. Those questions are
+/// answered from the reader's own [`parts_yielded`](crate::io::part_reader::PartReader::parts_yielded)
+/// count, which is incremented under the read lock — so a caller driving speculative concurrent
+/// reads observes a count that is always ordered with end-of-stream, with no second lock of its own
+/// to race against. Keeping the count on the reader is what makes "was the stream empty?" and "did
+/// it exceed the part limit?" race-free.
 #[derive(Debug)]
 pub(crate) enum PartPlan {
     /// Content length known up front: dispatch until `total_parts` have been issued.
-    Known { total_parts: u64 },
-    /// Content length unknown: dispatch until the reader reports end-of-stream.
-    Unknown {
-        /// Set once a read returns end-of-stream. Gates any further dispatch.
-        eof: bool,
-        /// Whether any part has been emitted yet.
-        ///
-        /// S3 rejects a `CompleteMultipartUpload` that lists no parts, so an empty stream must
-        /// still upload one (empty) part. Several part-work items can be dispatched before any of
-        /// them reads, so more than one can observe "end-of-stream, nothing emitted"; this flag is
-        /// claimed by a check-and-set under the state lock so exactly one of them synthesizes
-        /// part 1. Data-bearing parts set it too, so a non-empty stream never synthesizes one.
-        first_part_emitted: bool,
+    Known {
+        total_parts: u64,
+        /// The size declared by the source, sent as `MpuObjectSize` on complete. It did not come
+        /// from our own part accounting, so it is an *independent* witness — it also catches a part
+        /// this crate dropped or duplicated, which a sum of what we uploaded cannot.
+        declared_object_size: u64,
     },
+    /// Content length unknown: dispatch until the reader reports end-of-stream.
+    Unknown,
 }
 
 /// State machine for tracking upload work progress.
@@ -53,16 +55,19 @@ pub(crate) enum UploadState {
         parts_dispatched: u64,
         /// How this phase decides every part has been dispatched.
         plan: PartPlan,
+        /// Unknown-length only: set once a read reports end-of-stream, to stop dispatch and let the
+        /// phase drain and complete. Its *timing* is not correctness-critical — a late set only
+        /// causes a few extra speculative reads that no-op — so it is a plain flag, not the racy
+        /// emitted-flag it replaces. Emptiness is judged from the reader's `parts_yielded()`, not
+        /// from here.
+        eof: bool,
         parts_in_flight: usize,
         completed_parts: Vec<CompletedPart>,
         response_builder: UploadOutputBuilder,
-        /// Full object size, carried through to CompleteMPU as `MpuObjectSize`.
-        ///
-        /// For [`PartPlan::Known`] this is the length declared by the source, set once at
-        /// `CreateMultipartUpload` time. For [`PartPlan::Unknown`] there is no declared length, so
-        /// it accumulates the byte length of each part actually uploaded and is exact only once
-        /// end-of-stream is reached — which is the point at which it is read.
-        object_size: u64,
+        /// Running total of bytes actually uploaded, summed as each part completes. Consistent
+        /// meaning on both paths: for `Unknown` it *is* the object size sent on complete; for
+        /// `Known` it is checked (`<=`) against the declared upper bound before completing.
+        bytes_uploaded: u64,
     },
     /// All parts done, calling CompleteMPU (MPU only)
     Completing {
@@ -71,8 +76,10 @@ pub(crate) enum UploadState {
         completed_parts: Option<Vec<CompletedPart>>,
         response_builder: Option<UploadOutputBuilder>,
         complete_in_flight: bool,
-        /// Final object size, sent as `MpuObjectSize`. See `Transferring::object_size`.
-        object_size: u64,
+        /// See [`PartPlan`] for how the `MpuObjectSize` to send is chosen from this and the plan.
+        plan: PartPlan,
+        /// Total bytes uploaded. See `Transferring::bytes_uploaded`.
+        bytes_uploaded: u64,
     },
     /// PutObject in flight (single request upload)
     PutObjectInFlight,

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/context.rs
@@ -12,29 +12,34 @@ use crate::operation::upload::UploadOutputBuilder;
 
 /// How the `Transferring` phase decides it has dispatched every part.
 ///
-/// A source with a known length (a buffer or a file) yields an exact part count up front. A
-/// `PartStream` of unknown length does not: parts are dispatched speculatively and the phase ends
-/// when the reader reports end-of-stream. Modelling the two as one enum keeps the illegal
-/// combination — a part count *and* an end-of-stream flag — unrepresentable.
-///
-/// The unknown-length variant carries no emitted-yet / end-of-stream flags. Those questions are
-/// answered from the reader's own [`parts_yielded`](crate::io::part_reader::PartReader::parts_yielded)
-/// count, which is incremented under the read lock — so a caller driving speculative concurrent
-/// reads observes a count that is always ordered with end-of-stream, with no second lock of its own
-/// to race against. Keeping the count on the reader is what makes "was the stream empty?" and "did
-/// it exceed the part limit?" race-free.
+/// A known length yields an exact part count up front; an unknown-length `PartStream` does not, so
+/// its parts are dispatched speculatively and the phase ends when the reader reports end-of-stream.
+/// One enum for both keeps a part count and an end-of-stream flag from coexisting.
 #[derive(Debug)]
 pub(crate) enum PartPlan {
     /// Content length known up front: dispatch until `total_parts` have been issued.
     Known {
         total_parts: u64,
-        /// The size declared by the source, sent as `MpuObjectSize` on complete. It did not come
-        /// from our own part accounting, so it is an *independent* witness — it also catches a part
-        /// this crate dropped or duplicated, which a sum of what we uploaded cannot.
+        /// Size declared by the source, sent as `MpuObjectSize` on complete. It does not come from
+        /// our own part accounting, so it independently catches a part dropped or duplicated here.
         declared_object_size: u64,
     },
     /// Content length unknown: dispatch until the reader reports end-of-stream.
     Unknown,
+}
+
+impl PartPlan {
+    /// Whether every part has been dispatched: a part count for `Known`, end-of-stream for
+    /// `Unknown`.
+    ///
+    /// `parts_dispatched` counts speculative dispatches, which run ahead of what the reader has
+    /// actually produced, so it answers only "is dispatch finished" — never "how many parts exist".
+    pub(crate) fn all_dispatched(&self, parts_dispatched: u64, eof: bool) -> bool {
+        match self {
+            PartPlan::Known { total_parts, .. } => parts_dispatched >= *total_parts,
+            PartPlan::Unknown => eof,
+        }
+    }
 }
 
 /// State machine for tracking upload work progress.
@@ -55,18 +60,14 @@ pub(crate) enum UploadState {
         parts_dispatched: u64,
         /// How this phase decides every part has been dispatched.
         plan: PartPlan,
-        /// Unknown-length only: set once a read reports end-of-stream, to stop dispatch and let the
-        /// phase drain and complete. Its *timing* is not correctness-critical — a late set only
-        /// causes a few extra speculative reads that no-op — so it is a plain flag, not the racy
-        /// emitted-flag it replaces. Emptiness is judged from the reader's `parts_yielded()`, not
-        /// from here.
+        /// Unknown-length only: set once a read reports end-of-stream; gates further dispatch. Its
+        /// timing is not correctness-critical — a late set only costs speculative reads that no-op.
         eof: bool,
         parts_in_flight: usize,
         completed_parts: Vec<CompletedPart>,
         response_builder: UploadOutputBuilder,
-        /// Running total of bytes actually uploaded, summed as each part completes. Consistent
-        /// meaning on both paths: for `Unknown` it *is* the object size sent on complete; for
-        /// `Known` it is checked (`<=`) against the declared upper bound before completing.
+        /// Running total of bytes uploaded, summed as each part completes. For `Unknown` this is the
+        /// object size sent on complete; for `Known` it is checked (`<=`) against the declared bound.
         bytes_uploaded: u64,
     },
     /// All parts done, calling CompleteMPU (MPU only)

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/context.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/context.rs
@@ -10,6 +10,31 @@ use crate::io::part_reader::PartReader;
 use crate::io::InputStream;
 use crate::operation::upload::UploadOutputBuilder;
 
+/// How the `Transferring` phase decides it has dispatched every part.
+///
+/// A source with a known length (a buffer or a file) yields an exact part count up front. A
+/// `PartStream` of unknown length does not: parts are dispatched speculatively and the phase ends
+/// when the reader reports end-of-stream. Modelling the two as one enum keeps the illegal
+/// combination — a part count *and* an end-of-stream flag — unrepresentable.
+#[derive(Debug)]
+pub(crate) enum PartPlan {
+    /// Content length known up front: dispatch until `total_parts` have been issued.
+    Known { total_parts: u64 },
+    /// Content length unknown: dispatch until the reader reports end-of-stream.
+    Unknown {
+        /// Set once a read returns end-of-stream. Gates any further dispatch.
+        eof: bool,
+        /// Whether any part has been emitted yet.
+        ///
+        /// S3 rejects a `CompleteMultipartUpload` that lists no parts, so an empty stream must
+        /// still upload one (empty) part. Several part-work items can be dispatched before any of
+        /// them reads, so more than one can observe "end-of-stream, nothing emitted"; this flag is
+        /// claimed by a check-and-set under the state lock so exactly one of them synthesizes
+        /// part 1. Data-bearing parts set it too, so a non-empty stream never synthesizes one.
+        first_part_emitted: bool,
+    },
+}
+
 /// State machine for tracking upload work progress.
 ///
 /// Represents the current phase of an upload operation.
@@ -26,12 +51,18 @@ pub(crate) enum UploadState {
         upload_id: String,
         part_reader: Arc<PartReader>,
         parts_dispatched: u64,
-        total_parts: u64,
+        /// How this phase decides every part has been dispatched.
+        plan: PartPlan,
         parts_in_flight: usize,
         completed_parts: Vec<CompletedPart>,
         response_builder: UploadOutputBuilder,
-        /// Full object content length, carried through to CompleteMPU as `MpuObjectSize`.
-        content_length: u64,
+        /// Full object size, carried through to CompleteMPU as `MpuObjectSize`.
+        ///
+        /// For [`PartPlan::Known`] this is the length declared by the source, set once at
+        /// `CreateMultipartUpload` time. For [`PartPlan::Unknown`] there is no declared length, so
+        /// it accumulates the byte length of each part actually uploaded and is exact only once
+        /// end-of-stream is reached — which is the point at which it is read.
+        object_size: u64,
     },
     /// All parts done, calling CompleteMPU (MPU only)
     Completing {
@@ -40,7 +71,8 @@ pub(crate) enum UploadState {
         completed_parts: Option<Vec<CompletedPart>>,
         response_builder: Option<UploadOutputBuilder>,
         complete_in_flight: bool,
-        content_length: u64,
+        /// Final object size, sent as `MpuObjectSize`. See `Transferring::object_size`.
+        object_size: u64,
     },
     /// PutObject in flight (single request upload)
     PutObjectInFlight,

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -188,12 +188,6 @@ impl UploadTransfer {
         let mut state = self.inner.state.lock().expect("lock poisoned");
 
         loop {
-            // Serve the `CompleteMPU` a transition unlocks on this same poll, rather than parking
-            // and waiting to be re-polled for work this call already knows about.
-            if try_begin_completing(&mut state) {
-                continue;
-            }
-
             match &mut *state {
                 UploadState::PendingInit {
                     init_in_flight,
@@ -236,9 +230,13 @@ impl UploadTransfer {
                     parts_in_flight,
                     ..
                 } => {
-                    // Dispatch finished here means parts are still in flight; `try_begin_completing`
-                    // above would have fired otherwise.
                     if plan.all_dispatched(*parts_dispatched, *eof) {
+                        // Last one out: transition now and serve the `CompleteMPU` it unlocks on
+                        // this same poll, rather than parking for a re-poll.
+                        if try_begin_completing(&mut state) {
+                            continue;
+                        }
+                        // Parts are still in flight; `on_part_completed` wakes this poll.
                         self.inner.ctx.set_pending();
                         return PollWork::Pending;
                     }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -443,7 +443,30 @@ impl UploadTransfer {
             Err(e) => return self.fail(e.into()),
         };
 
+        // Claim part 1 now, at read time — NOT after the send completes. A part read is what
+        // establishes that the stream is non-empty, and the send that follows can take a long time.
+        // Recording it later would let a concurrently-dispatched read that hits end-of-stream see
+        // "nothing emitted" while this part is still in flight, and synthesize a second part 1.
+        self.mark_part_emitted();
+
         self.send_part(data).await
+    }
+
+    /// Record that a part has been read from the stream, so a later end-of-stream does not treat the
+    /// stream as empty and synthesize an empty part 1.
+    ///
+    /// Called at read time rather than on send completion: see the ordering note at the call site.
+    fn mark_part_emitted(&self) {
+        let mut state = self.inner.state.lock().expect("lock poisoned");
+        if let UploadState::Transferring {
+            plan: PartPlan::Unknown {
+                first_part_emitted, ..
+            },
+            ..
+        } = &mut *state
+        {
+            *first_part_emitted = true;
+        }
     }
 
     /// Upload one part and record it, then advance the state machine.
@@ -542,15 +565,11 @@ impl UploadTransfer {
             } = &mut *state
             {
                 completed_parts.push(completed);
-                if let PartPlan::Unknown {
-                    first_part_emitted, ..
-                } = plan
-                {
-                    // A data-bearing part also claims part 1, so a stream that turned out non-empty
-                    // never synthesizes an empty one.
-                    *first_part_emitted = true;
+                if matches!(plan, PartPlan::Unknown { .. }) {
                     // No declared length to trust, so the object size is summed from what we sent.
                     // Exact once end-of-stream is reached, which is when CompleteMPU reads it.
+                    // (`first_part_emitted` is claimed at read time, not here — see
+                    // `mark_part_emitted`.)
                     *object_size += bytes_sent;
                 }
             }
@@ -1192,5 +1211,63 @@ mod tests {
         transfer.execute(&mut work).await;
 
         assert!(transfer.take_result().is_some());
+    }
+
+    /// The 10,000-part ceiling is enforced before dispatch, with an error that names the
+    /// remedy.
+    ///
+    /// An unknown-length upload has no part count to bound it, so without this guard the next
+    /// dispatch would send `PartNumber = 10001` and take S3's `InvalidArgument` — which says
+    /// nothing about part size. Reaching the ceiling through the public API would need 50 GiB
+    /// (part size is clamped to >= 5 MiB), so the plan state is driven directly here.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn test_unknown_length_part_ceiling_is_enforced() {
+        let s3_client = mock_s3_client_for_mpu();
+        let transfer = create_test_transfer(s3_client, vec![0u8; 16 * 1024 * 1024]);
+
+        // Drive through CreateMPU so the transfer is in `Transferring`.
+        let mut work = assert_ready(transfer.poll_work());
+        transfer.execute(&mut work).await;
+
+        // Pretend this is an unknown-length transfer that has already dispatched every part it
+        // is allowed to.
+        {
+            let mut state = transfer.inner.state.lock().expect("lock poisoned");
+            if let UploadState::Transferring {
+                plan,
+                parts_dispatched,
+                parts_in_flight,
+                ..
+            } = &mut *state
+            {
+                *plan = PartPlan::Unknown {
+                    eof: false,
+                    first_part_emitted: true,
+                };
+                *parts_dispatched = MAX_PARTS;
+                *parts_in_flight = 0;
+            } else {
+                panic!("expected Transferring after CreateMPU");
+            }
+        }
+
+        // The next poll must refuse to dispatch part MAX_PARTS + 1.
+        assert!(matches!(transfer.poll_work(), PollWork::Done));
+
+        let err = transfer
+            .ctx()
+            .take_error()
+            .expect("exceeding the part ceiling must record an error");
+        assert_eq!(&ErrorKind::InputInvalid, err.kind());
+        // Per this crate's convention `Display` renders the kind and the detail hangs off
+        // `source()` (see `display_omits_source_message`), so that is where the remedy must be.
+        let detail = std::error::Error::source(&err)
+            .expect("the ceiling error must carry a detail message")
+            .to_string();
+        assert!(
+            detail.contains("part size") && detail.contains("10000"),
+            "error detail must name the ceiling and the remedy, got: {detail}"
+        );
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -647,6 +647,8 @@ impl UploadTransfer {
             .take()
             .expect("stream should be present for PutObject");
 
+        // Unreachable for an unknown-length source: only a `PartStream` can omit the upper bound,
+        // and such a stream is `is_mpu_only`, so `poll_work` routes it to CreateMPU and never here.
         let content_length = stream
             .size_hint()
             .upper()

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -63,6 +63,13 @@ pub(crate) enum UploadWork {
 /// Maximum number of parts that a single S3 multipart upload supports
 const MAX_PARTS: u64 = 10_000;
 
+/// Initial capacity for the completed-part list when the content length is unknown.
+///
+/// There is no part count to size it by, so this only avoids a few early reallocations; the list
+/// grows as parts complete. Matches the CRT reference's default, which is likewise "arbitrary
+/// picked to avoid using allocations and using too much memory".
+const UNKNOWN_LENGTH_DEFAULT_NUM_PARTS: usize = 32;
+
 /// Upload transfer that generates and executes upload work.
 ///
 /// Cheap to clone - all state is behind `Arc`.
@@ -240,7 +247,7 @@ impl UploadTransfer {
                 // check at the top of the next poll reports `Done`.
                 if matches!(plan, PartPlan::Unknown { .. }) && *parts_dispatched >= MAX_PARTS {
                     drop(state);
-                    self.inner.ctx.set_failed(Error::new(
+                    self.inner.ctx.set_failed_and_signal(Error::new(
                         ErrorKind::InputInvalid,
                         format!(
                             "stream exceeds the maximum of {MAX_PARTS} parts at the current part \
@@ -248,7 +255,6 @@ impl UploadTransfer {
                              without a known content length"
                         ),
                     ));
-                    self.inner.ctx.signal_terminal();
                     return PollWork::Done;
                 }
 
@@ -374,10 +380,6 @@ impl UploadTransfer {
             },
         );
 
-        // An unknown-length upload has no part count to size the vec by; use a small default (the
-        // CRT reference uses the same, "arbitrary picked to avoid using allocations and using too
-        // much memory") and let it grow.
-        const UNKNOWN_LENGTH_DEFAULT_NUM_PARTS: usize = 32;
         let completed_parts_capacity = match &plan {
             PartPlan::Known { total_parts } => *total_parts as usize,
             PartPlan::Unknown { .. } => UNKNOWN_LENGTH_DEFAULT_NUM_PARTS,

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -41,7 +41,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use crate::error::{Error, ErrorKind};
-use crate::io::part_reader::Builder as PartReaderBuilder;
+use crate::io::part_reader::{Builder as PartReaderBuilder, PartReader};
 use crate::io::{InputStream, PartData};
 use crate::operation::upload::context::{PartPlan, UploadState};
 use crate::operation::upload::input::convert::{
@@ -62,6 +62,14 @@ pub(crate) enum UploadWork {
 
 /// Maximum number of parts that a single S3 multipart upload supports
 const MAX_PARTS: u64 = 10_000;
+
+/// The discriminant of [`PartPlan`], read without borrowing the plan's fields — used where a caller
+/// only needs to know which mode it is in (e.g. the read-time part-count guard).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PartPlanKind {
+    Known,
+    Unknown,
+}
 
 /// Initial capacity for the completed-part list when the content length is unknown.
 ///
@@ -218,14 +226,18 @@ impl UploadTransfer {
             UploadState::Transferring {
                 parts_dispatched,
                 plan,
+                eof,
                 parts_in_flight,
                 ..
             } => {
                 // Has every part been dispatched? For a known length that is a part count; for an
-                // unknown length it is the reader having reported end-of-stream.
+                // unknown length it is the reader having reported end-of-stream. The part-limit
+                // guard for unknown length lives at read time in `execute`, keyed on the reader's
+                // yielded-count, not here — `parts_dispatched` counts speculative dispatches, which
+                // run one ahead of what the reader has actually produced.
                 let all_dispatched = match plan {
-                    PartPlan::Known { total_parts } => *parts_dispatched >= *total_parts,
-                    PartPlan::Unknown { eof, .. } => *eof,
+                    PartPlan::Known { total_parts, .. } => *parts_dispatched >= *total_parts,
+                    PartPlan::Unknown => *eof,
                 };
 
                 if all_dispatched {
@@ -238,24 +250,6 @@ impl UploadTransfer {
                     drop(state);
                     self.inner.ctx.try_wake();
                     return PollWork::Pending;
-                }
-
-                // An unknown-length upload has no part count to bound it, so guard the S3 limit
-                // here: without this the next dispatch would send `PartNumber = MAX_PARTS + 1` and
-                // take S3's `InvalidArgument`, which says nothing about the remedy. Failing in
-                // `poll_work` is safe — the transfer is terminal on return, so the `is_active()`
-                // check at the top of the next poll reports `Done`.
-                if matches!(plan, PartPlan::Unknown { .. }) && *parts_dispatched >= MAX_PARTS {
-                    drop(state);
-                    self.inner.ctx.set_failed_and_signal(Error::new(
-                        ErrorKind::InputInvalid,
-                        format!(
-                            "stream exceeds the maximum of {MAX_PARTS} parts at the current part \
-                             size; configure a larger part size to upload an object this large \
-                             without a known content length"
-                        ),
-                    ));
-                    return PollWork::Done;
                 }
 
                 *parts_dispatched += 1;
@@ -357,11 +351,9 @@ impl UploadTransfer {
         let plan = match content_length {
             Some(content_length) => PartPlan::Known {
                 total_parts: content_length.div_ceil(part_size),
+                declared_object_size: content_length,
             },
-            None => PartPlan::Unknown {
-                eof: false,
-                first_part_emitted: false,
-            },
+            None => PartPlan::Unknown,
         };
 
         tracing::trace!("upload request using multipart upload with part size: {part_size} bytes");
@@ -381,8 +373,8 @@ impl UploadTransfer {
         );
 
         let completed_parts_capacity = match &plan {
-            PartPlan::Known { total_parts } => *total_parts as usize,
-            PartPlan::Unknown { .. } => UNKNOWN_LENGTH_DEFAULT_NUM_PARTS,
+            PartPlan::Known { total_parts, .. } => *total_parts as usize,
+            PartPlan::Unknown => UNKNOWN_LENGTH_DEFAULT_NUM_PARTS,
         };
 
         {
@@ -392,12 +384,11 @@ impl UploadTransfer {
                 part_reader,
                 parts_dispatched: 0,
                 plan,
+                eof: false,
                 parts_in_flight: 0,
                 completed_parts: Vec::with_capacity(completed_parts_capacity),
                 response_builder,
-                // Known: the declared length, an independent witness. Unknown: accumulated from the
-                // parts actually uploaded as they complete.
-                object_size: content_length.unwrap_or(0),
+                bytes_uploaded: 0,
             };
         }
 
@@ -428,53 +419,89 @@ impl UploadTransfer {
             Ok(Some(data)) => data,
             Ok(None) => {
                 tracing::trace!("part_reader exhausted");
-                // For an unknown-length stream this is the signal that ends the transfer, and — if
-                // nothing was ever emitted — the point at which one caller owes an empty part 1 so
-                // that an empty stream still completes as a normal (empty) object.
-                if self.set_eof_and_claim_empty_first_part() {
-                    tracing::debug!(
-                        target: crate::telemetry::TARGET_TRANSFER,
-                        "empty unknown-length stream; uploading a single empty part",
-                    );
-                    return self.send_part(PartData::new(1, Bytes::new())).await;
-                }
-                self.maybe_transition_to_completing();
-                return WorkOutcome::Success { data: None };
+                // Unknown-length end-of-stream. The reader's yielded-count is now final — it was
+                // incremented under the reader's own lock as each part was produced, so a `None`
+                // here is ordered after every part it will ever yield. That lets us decide, without
+                // a second racing lock, whether the stream was empty.
+                return self.on_end_of_stream(&part_reader).await;
             }
             Err(e) => return self.fail(e.into()),
         };
 
-        // Claim part 1 now, at read time — NOT after the send completes. A part read is what
-        // establishes that the stream is non-empty, and the send that follows can take a long time.
-        // Recording it later would let a concurrently-dispatched read that hits end-of-stream see
-        // "nothing emitted" while this part is still in flight, and synthesize a second part 1.
-        self.mark_part_emitted();
+        // Guard the S3 part-count ceiling by the number of parts the reader has actually yielded,
+        // not by speculative dispatches. Fail before sending the (MAX_PARTS + 1)-th so the caller
+        // gets an error naming the remedy instead of S3's opaque `InvalidArgument` on part 10001.
+        if matches!(self.plan_kind(), Some(PartPlanKind::Unknown))
+            && part_reader.parts_yielded() > MAX_PARTS
+        {
+            return self.fail(Error::new(
+                ErrorKind::InputInvalid,
+                format!(
+                    "stream exceeds the maximum of {MAX_PARTS} parts at the current part size; \
+                     configure a larger part size to upload an object this large without a known \
+                     content length"
+                ),
+            ));
+        }
 
         self.send_part(data).await
     }
 
-    /// Record that a part has been read from the stream, so a later end-of-stream does not treat the
-    /// stream as empty and synthesize an empty part 1.
+    /// Handle an unknown-length reader reaching end-of-stream: mark `eof`, and if the stream turned
+    /// out empty, synthesize the one zero-length part S3 requires (a multipart upload must list at
+    /// least one part).
     ///
-    /// Called at read time rather than on send completion: see the ordering note at the call site.
-    fn mark_part_emitted(&self) {
-        let mut state = self.inner.state.lock().expect("lock poisoned");
-        if let UploadState::Transferring {
-            plan: PartPlan::Unknown {
-                first_part_emitted, ..
-            },
-            ..
-        } = &mut *state
-        {
-            *first_part_emitted = true;
+    /// Emptiness is `part_reader.parts_yielded() == 0`, which is race-free: the count is bumped
+    /// under the reader's lock as each part is produced, so a `None` read is ordered after all of
+    /// them. Exactly one caller synthesizes, because only the caller that flips `eof` false→true —
+    /// a single-winner check under the state lock — takes the synthesize branch.
+    async fn on_end_of_stream(&self, part_reader: &PartReader) -> WorkOutcome {
+        let empty_and_owned = {
+            let mut state = self.inner.state.lock().expect("lock poisoned");
+            match &mut *state {
+                UploadState::Transferring { eof, .. } if !*eof => {
+                    *eof = true;
+                    // This caller flipped eof; it alone may synthesize. The reader's count is final
+                    // now, so `== 0` is an exact emptiness test.
+                    part_reader.parts_yielded() == 0
+                }
+                _ => false,
+            }
+        };
+        // `eof` may unblock a `poll_work` parked on in-flight parts, and it is set here in `execute`
+        // while the poller may already be parked — so signal the edge or the transfer hangs (see the
+        // wake protocol on `TransferContext::set_pending`).
+        self.inner.ctx.try_wake();
+
+        if empty_and_owned {
+            tracing::debug!(
+                target: crate::telemetry::TARGET_TRANSFER,
+                "empty unknown-length stream; uploading a single empty part",
+            );
+            return self.send_part(PartData::new(1, Bytes::new())).await;
+        }
+
+        self.maybe_transition_to_completing();
+        WorkOutcome::Success { data: None }
+    }
+
+    /// The kind of the current `Transferring` plan, if the transfer is transferring.
+    fn plan_kind(&self) -> Option<PartPlanKind> {
+        let state = self.inner.state.lock().expect("lock poisoned");
+        match &*state {
+            UploadState::Transferring { plan, .. } => Some(match plan {
+                PartPlan::Known { .. } => PartPlanKind::Known,
+                PartPlan::Unknown => PartPlanKind::Unknown,
+            }),
+            _ => None,
         }
     }
 
     /// Upload one part and record it, then advance the state machine.
     ///
     /// Shared by the ordinary read-a-part path and the synthesized empty part 1 (see
-    /// [`Self::set_eof_and_claim_empty_first_part`]), so both go through the same retry
-    /// classification, metrics, and completion handoff.
+    /// [`Self::on_end_of_stream`]), so both go through the same retry classification, metrics, and
+    /// completion handoff.
     async fn send_part(&self, data: PartData) -> WorkOutcome {
         // 2. Send part over network
         let upload_id = {
@@ -560,19 +587,15 @@ impl UploadTransfer {
             let mut state = self.inner.state.lock().expect("lock poisoned");
             if let UploadState::Transferring {
                 completed_parts,
-                plan,
-                object_size,
+                bytes_uploaded,
                 ..
             } = &mut *state
             {
                 completed_parts.push(completed);
-                if matches!(plan, PartPlan::Unknown { .. }) {
-                    // No declared length to trust, so the object size is summed from what we sent.
-                    // Exact once end-of-stream is reached, which is when CompleteMPU reads it.
-                    // (`first_part_emitted` is claimed at read time, not here — see
-                    // `mark_part_emitted`.)
-                    *object_size += bytes_sent;
-                }
+                // Summed on both paths so the field means one thing. For unknown length this becomes
+                // the `MpuObjectSize` sent on complete; for known length it is checked against the
+                // declared size before completing.
+                *bytes_uploaded += bytes_sent;
             }
         }
 
@@ -599,13 +622,14 @@ impl UploadTransfer {
             parts_in_flight,
             parts_dispatched,
             plan,
+            eof,
             ..
         } = &mut *state
         {
             *parts_in_flight -= 1;
             let all_dispatched = match plan {
-                PartPlan::Known { total_parts } => *parts_dispatched >= *total_parts,
-                PartPlan::Unknown { eof, .. } => *eof,
+                PartPlan::Known { total_parts, .. } => *parts_dispatched >= *total_parts,
+                PartPlan::Unknown => *eof,
             };
             all_dispatched && *parts_in_flight == 0
         } else {
@@ -617,47 +641,6 @@ impl UploadTransfer {
             drop(state);
             self.inner.ctx.try_wake();
         }
-    }
-
-    /// Record that the reader reached end-of-stream, and decide whether this caller owes an empty
-    /// part 1.
-    ///
-    /// S3 rejects a `CompleteMultipartUpload` that lists no parts, so an empty stream must still
-    /// upload one part. Because several part-work items can be dispatched before any of them reads,
-    /// more than one can see "end-of-stream with nothing emitted"; the right to synthesize part 1 is
-    /// therefore claimed by a check-and-set here, under the state lock, rather than by testing a
-    /// value the caller read earlier. Exactly one caller sees `true`.
-    ///
-    /// Returns `true` if this caller must send an empty part 1.
-    fn set_eof_and_claim_empty_first_part(&self) -> bool {
-        let mut state = self.inner.state.lock().expect("lock poisoned");
-        let claimed = match &mut *state {
-            UploadState::Transferring { plan, .. } => match plan {
-                PartPlan::Unknown {
-                    eof,
-                    first_part_emitted,
-                } => {
-                    *eof = true;
-                    if *first_part_emitted {
-                        false
-                    } else {
-                        // Claim it: no data part was emitted, so this caller owns part 1.
-                        *first_part_emitted = true;
-                        true
-                    }
-                }
-                // A known-length reader only reports end-of-stream after every counted part, so
-                // there is nothing to synthesize.
-                PartPlan::Known { .. } => false,
-            },
-            _ => false,
-        };
-        drop(state);
-        // `eof` is what unblocks a `poll_work` parked on in-flight parts. It is set here, in
-        // `execute`, while the poller may already be parked, so the edge must be signalled or the
-        // transfer hangs (see the wake protocol on `TransferContext::set_pending`).
-        self.inner.ctx.try_wake();
-        claimed
     }
 
     async fn execute_put_object(&self, stream: &mut Option<InputStream>) -> WorkOutcome {
@@ -781,7 +764,7 @@ impl UploadTransfer {
     }
 
     async fn execute_complete_mpu(&self) -> WorkOutcome {
-        let (upload_id, mut completed_parts, response_builder, part_reader, object_size) = {
+        let (upload_id, mut completed_parts, response_builder, part_reader, plan, bytes_uploaded) = {
             let mut state = self.inner.state.lock().expect("lock poisoned");
             match &mut *state {
                 UploadState::Completing {
@@ -789,7 +772,8 @@ impl UploadTransfer {
                     completed_parts,
                     response_builder,
                     part_reader,
-                    object_size,
+                    plan,
+                    bytes_uploaded,
                     ..
                 } => (
                     upload_id.take().expect("upload_id already taken"),
@@ -800,13 +784,48 @@ impl UploadTransfer {
                         .take()
                         .expect("response_builder already taken"),
                     part_reader.take().expect("part_reader already taken"),
-                    *object_size,
+                    std::mem::replace(plan, PartPlan::Unknown),
+                    *bytes_uploaded,
                 ),
                 _ => panic!("unexpected state for complete_mpu"),
             }
         };
 
         completed_parts.sort_by_key(|p| p.part_number);
+
+        // S3 sums the parts it assembled and rejects CompleteMPU when the total doesn't match the
+        // `MpuObjectSize` we send, so a dropped or duplicated part surfaces as a failed complete
+        // rather than a wrong-sized object (SEP step 7). The value differs by path:
+        //
+        // - Known: the size the source declared — an *independent* witness, since it did not come
+        //   from our own part accounting, so it also catches a part this crate dropped or a source
+        //   that delivered a different number of bytes than it declared. S3 does the comparison.
+        // - Unknown: no declared size exists, so we send what we uploaded. That still catches an
+        //   S3-side assembly mismatch, but cannot catch our own miscount — it's the same number.
+        //
+        // Do not unify the known path onto `bytes_uploaded`; that would drop the independent check.
+        let object_size = match plan {
+            PartPlan::Known {
+                declared_object_size,
+                ..
+            } => {
+                // `declared_object_size` is `size_hint().upper()` — an upper *bound*, exact for the
+                // crate's own buffer/file sources and `>=` actual for a custom `PartStream` that
+                // reports only a bound. A correct read is capped at the declared length, so uploading
+                // *more* than declared can only mean our own part accounting over-counted; assert that
+                // as a dev tripwire before we round-trip to S3. Not `==`: under-delivery against a
+                // declared upper bound is a legal input (S3 still rejects a genuine assembled-size
+                // mismatch via the value we send), and turning that into a panic is the failure mode
+                // this operation was changed to stop doing.
+                debug_assert!(
+                    bytes_uploaded <= declared_object_size,
+                    "uploaded {bytes_uploaded} bytes, more than the declared upper bound of \
+                     {declared_object_size}; part accounting over-counted"
+                );
+                declared_object_size
+            }
+            PartPlan::Unknown => bytes_uploaded,
+        };
 
         // An unknown-length transfer could not report a total while in flight (progress is genuinely
         // unknowable there). By now the stream has ended and `object_size` is exact, so final
@@ -820,16 +839,6 @@ impl UploadTransfer {
             .s3_client()
             .complete_multipart_upload()
             .upload_id(&upload_id)
-            // S3 sums the parts it assembled and rejects CompleteMPU when the
-            // total doesn't match this value, so a dropped or duplicated part
-            // surfaces as a failed complete rather than a wrong-sized object.
-            // Required by SEP step 7.
-            //
-            // For a known length this is the size declared by the source — an independent witness,
-            // so it also catches a part this crate itself dropped or duplicated. For an unknown
-            // length there is no such witness: the value is summed from the parts actually
-            // uploaded, which still catches an S3-side assembly mismatch. Do not "simplify" the
-            // known path onto the running sum; that would quietly lose the independent check.
             .mpu_object_size(object_size as i64)
             .multipart_upload(
                 CompletedMultipartUpload::builder()
@@ -897,7 +906,8 @@ fn transition_to_completing(state: &mut UploadState) {
         part_reader,
         completed_parts,
         response_builder,
-        object_size,
+        plan,
+        bytes_uploaded,
         ..
     } = std::mem::replace(state, UploadState::Done)
     {
@@ -907,7 +917,8 @@ fn transition_to_completing(state: &mut UploadState) {
             completed_parts: Some(completed_parts),
             response_builder: Some(response_builder),
             complete_in_flight: false,
-            object_size,
+            plan,
+            bytes_uploaded,
         };
     }
 }
@@ -1212,63 +1223,5 @@ mod tests {
         transfer.execute(&mut work).await;
 
         assert!(transfer.take_result().is_some());
-    }
-
-    /// The 10,000-part ceiling is enforced before dispatch, with an error that names the
-    /// remedy.
-    ///
-    /// An unknown-length upload has no part count to bound it, so without this guard the next
-    /// dispatch would send `PartNumber = 10001` and take S3's `InvalidArgument` — which says
-    /// nothing about part size. Reaching the ceiling through the public API would need 50 GiB
-    /// (part size is clamped to >= 5 MiB), so the plan state is driven directly here.
-    #[cfg_attr(miri, ignore)]
-    #[tokio::test]
-    async fn test_unknown_length_part_ceiling_is_enforced() {
-        let s3_client = mock_s3_client_for_mpu();
-        let transfer = create_test_transfer(s3_client, vec![0u8; 16 * 1024 * 1024]);
-
-        // Drive through CreateMPU so the transfer is in `Transferring`.
-        let mut work = assert_ready(transfer.poll_work());
-        transfer.execute(&mut work).await;
-
-        // Pretend this is an unknown-length transfer that has already dispatched every part it
-        // is allowed to.
-        {
-            let mut state = transfer.inner.state.lock().expect("lock poisoned");
-            if let UploadState::Transferring {
-                plan,
-                parts_dispatched,
-                parts_in_flight,
-                ..
-            } = &mut *state
-            {
-                *plan = PartPlan::Unknown {
-                    eof: false,
-                    first_part_emitted: true,
-                };
-                *parts_dispatched = MAX_PARTS;
-                *parts_in_flight = 0;
-            } else {
-                panic!("expected Transferring after CreateMPU");
-            }
-        }
-
-        // The next poll must refuse to dispatch part MAX_PARTS + 1.
-        assert!(matches!(transfer.poll_work(), PollWork::Done));
-
-        let err = transfer
-            .ctx()
-            .take_error()
-            .expect("exceeding the part ceiling must record an error");
-        assert_eq!(&ErrorKind::InputInvalid, err.kind());
-        // Per this crate's convention `Display` renders the kind and the detail hangs off
-        // `source()` (see `display_omits_source_message`), so that is where the remedy must be.
-        let detail = std::error::Error::source(&err)
-            .expect("the ceiling error must carry a detail message")
-            .to_string();
-        assert!(
-            detail.contains("part size") && detail.contains("10000"),
-            "error detail must name the ceiling and the remedy, got: {detail}"
-        );
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -236,8 +236,8 @@ impl UploadTransfer {
                     parts_in_flight,
                     ..
                 } => {
-                    // Not ready to complete (the check above returned false), so either parts remain
-                    // to dispatch, or all are dispatched and we wait for the in-flight ones to drain.
+                    // Dispatch finished here means parts are still in flight; `try_begin_completing`
+                    // above would have fired otherwise.
                     if plan.all_dispatched(*parts_dispatched, *eof) {
                         self.inner.ctx.set_pending();
                         return PollWork::Pending;
@@ -568,9 +568,6 @@ impl UploadTransfer {
             } = &mut *state
             {
                 completed_parts.push(completed);
-                // Summed on both paths so the field means one thing. For unknown length this becomes
-                // the `MpuObjectSize` sent on complete; for known length it is checked against the
-                // declared size before completing.
                 *bytes_uploaded += bytes_sent;
             }
         }
@@ -763,29 +760,17 @@ impl UploadTransfer {
         completed_parts.sort_by_key(|p| p.part_number);
 
         // S3 sums the parts it assembled and rejects CompleteMPU when the total doesn't match the
-        // `MpuObjectSize` we send, so a dropped or duplicated part surfaces as a failed complete
-        // rather than a wrong-sized object (SEP step 7). The value differs by path:
-        //
-        // - Known: the size the source declared — an *independent* witness, since it did not come
-        //   from our own part accounting, so it also catches a part this crate dropped or a source
-        //   that delivered a different number of bytes than it declared. S3 does the comparison.
-        // - Unknown: no declared size exists, so we send what we uploaded. That still catches an
-        //   S3-side assembly mismatch, but cannot catch our own miscount — it's the same number.
-        //
-        // Do not unify the known path onto `bytes_uploaded`; that would drop the independent check.
+        // `MpuObjectSize` sent, so a dropped or duplicated part fails the complete instead of
+        // silently producing a wrong-sized object (SEP step 7). Sending the source's declared size on
+        // the known path keeps that check independent of our own part accounting; the unknown path has
+        // no declared size, so its check can only catch an S3-side assembly mismatch.
         let object_size = match plan {
             PartPlan::Known {
                 declared_object_size,
                 ..
             } => {
-                // `declared_object_size` is `size_hint().upper()` — an upper *bound*, exact for the
-                // crate's own buffer/file sources and `>=` actual for a custom `PartStream` that
-                // reports only a bound. A correct read is capped at the declared length, so uploading
-                // *more* than declared can only mean our own part accounting over-counted; assert that
-                // as a dev tripwire before we round-trip to S3. Not `==`: under-delivery against a
-                // declared upper bound is a legal input (S3 still rejects a genuine assembled-size
-                // mismatch via the value we send), and turning that into a panic is the failure mode
-                // this operation was changed to stop doing.
+                // `declared_object_size` is `size_hint().upper()` — a bound, so under-delivery is
+                // legal input and only over-delivery implies we over-counted.
                 debug_assert!(
                     bytes_uploaded <= declared_object_size,
                     "uploaded {bytes_uploaded} bytes, more than the declared upper bound of \
@@ -867,12 +852,10 @@ impl UploadTransfer {
 /// If every part has been dispatched and none remain in flight, move `Transferring` → `Completing`
 /// and report that it did.
 ///
-/// The single point that begins completion. Its two callers have distinct roles: `poll_work` serves
-/// the `CompleteMPU` it unlocks on the same poll; `on_part_completed` wakes a poller parked on the
-/// drain.
+/// Returns `true` to exactly one caller: the `mem::replace` below makes that call the sole owner of
+/// the moved-out fields, so completion is set up once even when a poll and a part completion race to
+/// be last one out.
 fn try_begin_completing(state: &mut UploadState) -> bool {
-    // `mem::replace` below makes this call the single owner of the moved-out fields, so completion is
-    // set up exactly once even though both callers race to be the last one out.
     let ready = matches!(
         state,
         UploadState::Transferring { parts_dispatched, plan, eof, parts_in_flight, .. }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -205,9 +205,15 @@ impl UploadTransfer {
                         return PollWork::Pending;
                     }
 
-                    let use_mpu = stream.as_ref().is_some_and(|s| s.is_mpu_only())
-                        || content_length.unwrap_or(0)
-                            >= self.inner.ctx.handle.mpu_threshold_bytes();
+                    // The single-request path requires a content length, so a source without one has
+                    // to go multipart regardless of what the threshold comparison would say.
+                    let use_mpu = match *content_length {
+                        None => true,
+                        Some(len) => {
+                            stream.as_ref().is_some_and(|s| s.is_mpu_only())
+                                || len >= self.inner.ctx.handle.mpu_threshold_bytes()
+                        }
+                    };
                     return if use_mpu {
                         *init_in_flight = true;
                         PollWork::ready(IoRequest {
@@ -613,8 +619,8 @@ impl UploadTransfer {
             .take()
             .expect("stream should be present for PutObject");
 
-        // Unreachable for an unknown-length source: only a `PartStream` can omit the upper bound,
-        // and such a stream is `is_mpu_only`, so `poll_work` routes it to CreateMPU and never here.
+        // `poll_work` sends every source without a declared length to the multipart path, so reaching
+        // here means the length is known.
         let content_length = stream
             .size_hint()
             .upper()
@@ -865,26 +871,17 @@ impl UploadTransfer {
 /// the `CompleteMPU` it unlocks on the same poll; `on_part_completed` wakes a poller parked on the
 /// drain.
 fn try_begin_completing(state: &mut UploadState) -> bool {
-    if let UploadState::Transferring {
-        parts_dispatched,
-        plan,
-        eof,
-        parts_in_flight,
-        ..
-    } = state
-    {
-        if plan.all_dispatched(*parts_dispatched, *eof) && *parts_in_flight == 0 {
-            transition_to_completing(state);
-            return true;
-        }
+    // `mem::replace` below makes this call the single owner of the moved-out fields, so completion is
+    // set up exactly once even though both callers race to be the last one out.
+    let ready = matches!(
+        state,
+        UploadState::Transferring { parts_dispatched, plan, eof, parts_in_flight, .. }
+            if plan.all_dispatched(*parts_dispatched, *eof) && *parts_in_flight == 0
+    );
+    if !ready {
+        return false;
     }
-    false
-}
 
-/// Move a `Transferring` state to `Completing`, carrying the accumulated object size across. Only
-/// [`try_begin_completing`] calls this, once the completion condition holds. The `mem::replace`
-/// makes the caller the single owner of the moved-out fields, so completion is set up exactly once.
-fn transition_to_completing(state: &mut UploadState) {
     if let UploadState::Transferring {
         upload_id,
         part_reader,
@@ -905,6 +902,7 @@ fn transition_to_completing(state: &mut UploadState) {
             bytes_uploaded,
         };
     }
+    true
 }
 
 impl Transfer for UploadTransfer {
@@ -972,6 +970,52 @@ mod tests {
             RuleMode::MatchAny,
             &[create_mpu, upload_part, complete_mpu]
         )
+    }
+
+    /// A source with no declared length is routed to the multipart path, which is the only one that
+    /// can serve it. The stream is below the multipart threshold, so a threshold comparison against a
+    /// defaulted-to-zero length would pick the single-request path instead.
+    // FIXME: crossbeam-epoch is incompatible with miri (https://github.com/crossbeam-rs/crossbeam/issues/1181)
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn test_poll_work_unknown_length_routes_to_multipart() {
+        struct NoUpperBound;
+        impl crate::io::PartStream for NoUpperBound {
+            fn poll_part(
+                self: Pin<&mut Self>,
+                _cx: &mut std::task::Context<'_>,
+                _stream_cx: &crate::io::StreamContext,
+            ) -> std::task::Poll<Option<std::io::Result<PartData>>> {
+                std::task::Poll::Ready(None)
+            }
+            fn size_hint(&self) -> crate::io::SizeHint {
+                crate::io::SizeHint::default()
+            }
+        }
+
+        let handle = crate::client::Handle::test_handle_tokio(
+            crate::Config::builder()
+                .client(mock_client!(aws_sdk_s3, []))
+                .build(),
+        );
+        let input = UploadInput::builder()
+            .bucket("test-bucket")
+            .key("test-key")
+            .build()
+            .unwrap();
+        let (ctx, _completion_rx) = TransferContext::new(handle);
+        let transfer = UploadTransfer::new(
+            ctx,
+            BucketType::Standard,
+            input,
+            InputStream::from_part_stream(NoUpperBound),
+        );
+
+        let mut work = assert_ready(transfer.poll_work());
+        assert!(
+            matches!(work.data_mut::<UploadWork>(), UploadWork::CreateMPU),
+            "an unknown-length source must not be routed to the single-request path"
+        );
     }
 
     // FIXME: crossbeam-epoch is incompatible with miri (https://github.com/crossbeam-rs/crossbeam/issues/1181)

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -97,10 +97,9 @@ impl UploadTransfer {
         request: UploadInput,
         stream: InputStream,
     ) -> Self {
-        // `None` for a `PartStream` whose total size is not known up front (see
-        // `docs/design/unknown-length-upload.md`). Such a source is always `is_mpu_only`, so it
-        // routes through the multipart path and its parts are dispatched speculatively until the
-        // reader reports end-of-stream.
+        // `None` for a `PartStream` whose total size is not known up front. Such a source is always
+        // `is_mpu_only`, so it routes through the multipart path and its parts are dispatched
+        // speculatively until the reader reports end-of-stream (see `PartPlan`).
         let content_length = stream.size_hint().upper();
 
         // Only meaningful when the length is known; an unknown-length transfer reports

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -63,14 +63,6 @@ pub(crate) enum UploadWork {
 /// Maximum number of parts that a single S3 multipart upload supports
 const MAX_PARTS: u64 = 10_000;
 
-/// The discriminant of [`PartPlan`], read without borrowing the plan's fields — used where a caller
-/// only needs to know which mode it is in (e.g. the read-time part-count guard).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PartPlanKind {
-    Known,
-    Unknown,
-}
-
 /// Initial capacity for the completed-part list when the content length is unknown.
 ///
 /// There is no part count to size it by, so this only avoids a few early reallocations; the list
@@ -195,86 +187,80 @@ impl UploadTransfer {
 
         let mut state = self.inner.state.lock().expect("lock poisoned");
 
-        match &mut *state {
-            UploadState::PendingInit {
-                init_in_flight,
-                content_length,
-                stream,
-            } => {
-                if *init_in_flight {
-                    self.inner.ctx.set_pending();
-                    return PollWork::Pending;
-                }
-
-                let use_mpu = stream.as_ref().is_some_and(|s| s.is_mpu_only())
-                    || content_length.unwrap_or(0) >= self.inner.ctx.handle.mpu_threshold_bytes();
-                if use_mpu {
-                    *init_in_flight = true;
-                    PollWork::ready(IoRequest {
-                        data: Some(Box::new(UploadWork::CreateMPU)),
-                    })
-                } else {
-                    let taken_stream = stream.take().expect("stream already taken");
-                    *state = UploadState::PutObjectInFlight;
-                    PollWork::ready(IoRequest {
-                        data: Some(Box::new(UploadWork::PutObject {
-                            stream: Some(taken_stream),
-                        })),
-                    })
-                }
+        loop {
+            // Serve the `CompleteMPU` a transition unlocks on this same poll, rather than parking
+            // and waiting to be re-polled for work this call already knows about.
+            if try_begin_completing(&mut state) {
+                continue;
             }
-            UploadState::Transferring {
-                parts_dispatched,
-                plan,
-                eof,
-                parts_in_flight,
-                ..
-            } => {
-                // Has every part been dispatched? For a known length that is a part count; for an
-                // unknown length it is the reader having reported end-of-stream. The part-limit
-                // guard for unknown length lives at read time in `execute`, keyed on the reader's
-                // yielded-count, not here — `parts_dispatched` counts speculative dispatches, which
-                // run one ahead of what the reader has actually produced.
-                let all_dispatched = match plan {
-                    PartPlan::Known { total_parts, .. } => *parts_dispatched >= *total_parts,
-                    PartPlan::Unknown => *eof,
-                };
 
-                if all_dispatched {
-                    if *parts_in_flight > 0 {
+            match &mut *state {
+                UploadState::PendingInit {
+                    init_in_flight,
+                    content_length,
+                    stream,
+                } => {
+                    if *init_in_flight {
                         self.inner.ctx.set_pending();
                         return PollWork::Pending;
                     }
-                    // All parts sent and completed — transition to Completing
-                    transition_to_completing(&mut state);
-                    drop(state);
-                    self.inner.ctx.try_wake();
-                    return PollWork::Pending;
-                }
 
-                *parts_dispatched += 1;
-                *parts_in_flight += 1;
-                PollWork::ready(IoRequest {
-                    data: Some(Box::new(UploadWork::UploadPart)),
-                })
-            }
-            UploadState::Completing {
-                complete_in_flight, ..
-            } => {
-                if *complete_in_flight {
+                    let use_mpu = stream.as_ref().is_some_and(|s| s.is_mpu_only())
+                        || content_length.unwrap_or(0)
+                            >= self.inner.ctx.handle.mpu_threshold_bytes();
+                    return if use_mpu {
+                        *init_in_flight = true;
+                        PollWork::ready(IoRequest {
+                            data: Some(Box::new(UploadWork::CreateMPU)),
+                        })
+                    } else {
+                        let taken_stream = stream.take().expect("stream already taken");
+                        *state = UploadState::PutObjectInFlight;
+                        PollWork::ready(IoRequest {
+                            data: Some(Box::new(UploadWork::PutObject {
+                                stream: Some(taken_stream),
+                            })),
+                        })
+                    };
+                }
+                UploadState::Transferring {
+                    parts_dispatched,
+                    plan,
+                    eof,
+                    parts_in_flight,
+                    ..
+                } => {
+                    // Not ready to complete (the check above returned false), so either parts remain
+                    // to dispatch, or all are dispatched and we wait for the in-flight ones to drain.
+                    if plan.all_dispatched(*parts_dispatched, *eof) {
+                        self.inner.ctx.set_pending();
+                        return PollWork::Pending;
+                    }
+
+                    *parts_dispatched += 1;
+                    *parts_in_flight += 1;
+                    return PollWork::ready(IoRequest {
+                        data: Some(Box::new(UploadWork::UploadPart)),
+                    });
+                }
+                UploadState::Completing {
+                    complete_in_flight, ..
+                } => {
+                    if *complete_in_flight {
+                        self.inner.ctx.set_pending();
+                        return PollWork::Pending;
+                    }
+                    *complete_in_flight = true;
+                    return PollWork::ready(IoRequest {
+                        data: Some(Box::new(UploadWork::CompleteMPU)),
+                    });
+                }
+                UploadState::PutObjectInFlight => {
                     self.inner.ctx.set_pending();
                     return PollWork::Pending;
                 }
-                *complete_in_flight = true;
-                PollWork::ready(IoRequest {
-                    data: Some(Box::new(UploadWork::CompleteMPU)),
-                })
+                UploadState::Done => return PollWork::Done,
             }
-            UploadState::PutObjectInFlight => {
-                self.inner.ctx.set_pending();
-                PollWork::Pending
-            }
-            UploadState::Done => PollWork::Done,
         }
     }
 
@@ -403,10 +389,12 @@ impl UploadTransfer {
     }
 
     async fn execute_upload_part(&self) -> WorkOutcome {
-        let part_reader = {
+        let (part_reader, is_unknown) = {
             let state = self.inner.state.lock().expect("lock poisoned");
             match &*state {
-                UploadState::Transferring { part_reader, .. } => part_reader.clone(),
+                UploadState::Transferring {
+                    part_reader, plan, ..
+                } => (part_reader.clone(), matches!(plan, PartPlan::Unknown)),
                 _ => panic!("unexpected state for read_part"),
             }
         };
@@ -419,10 +407,6 @@ impl UploadTransfer {
             Ok(Some(data)) => data,
             Ok(None) => {
                 tracing::trace!("part_reader exhausted");
-                // Unknown-length end-of-stream. The reader's yielded-count is now final — it was
-                // incremented under the reader's own lock as each part was produced, so a `None`
-                // here is ordered after every part it will ever yield. That lets us decide, without
-                // a second racing lock, whether the stream was empty.
                 return self.on_end_of_stream(&part_reader).await;
             }
             Err(e) => return self.fail(e.into()),
@@ -431,9 +415,7 @@ impl UploadTransfer {
         // Guard the S3 part-count ceiling by the number of parts the reader has actually yielded,
         // not by speculative dispatches. Fail before sending the (MAX_PARTS + 1)-th so the caller
         // gets an error naming the remedy instead of S3's opaque `InvalidArgument` on part 10001.
-        if matches!(self.plan_kind(), Some(PartPlanKind::Unknown))
-            && part_reader.parts_yielded() > MAX_PARTS
-        {
+        if is_unknown && part_reader.parts_yielded() > MAX_PARTS {
             return self.fail(Error::new(
                 ErrorKind::InputInvalid,
                 format!(
@@ -451,19 +433,19 @@ impl UploadTransfer {
     /// out empty, synthesize the one zero-length part S3 requires (a multipart upload must list at
     /// least one part).
     ///
-    /// Emptiness is `part_reader.parts_yielded() == 0`, which is race-free: the count is bumped
-    /// under the reader's lock as each part is produced, so a `None` read is ordered after all of
-    /// them. Exactly one caller synthesizes, because only the caller that flips `eof` false→true —
-    /// a single-winner check under the state lock — takes the synthesize branch.
+    /// `parts_yielded()` is final at end-of-stream (see its docs for the ordering guarantee), so
+    /// `== 0` is an exact emptiness test. Exactly one caller synthesizes: only the one that flips
+    /// `eof` false→true takes that branch.
     async fn on_end_of_stream(&self, part_reader: &PartReader) -> WorkOutcome {
         let empty_and_owned = {
             let mut state = self.inner.state.lock().expect("lock poisoned");
             match &mut *state {
-                UploadState::Transferring { eof, .. } if !*eof => {
+                UploadState::Transferring { eof, plan, .. } if !*eof => {
                     *eof = true;
-                    // This caller flipped eof; it alone may synthesize. The reader's count is final
-                    // now, so `== 0` is an exact emptiness test.
-                    part_reader.parts_yielded() == 0
+                    // Gated on `Unknown`: a declared length already carries a part count, so a
+                    // source that declares a size and then delivers nothing must not have a part
+                    // invented for it — that would contradict the size it declared.
+                    matches!(plan, PartPlan::Unknown) && part_reader.parts_yielded() == 0
                 }
                 _ => false,
             }
@@ -481,20 +463,8 @@ impl UploadTransfer {
             return self.send_part(PartData::new(1, Bytes::new())).await;
         }
 
-        self.maybe_transition_to_completing();
+        self.on_part_completed();
         WorkOutcome::Success { data: None }
-    }
-
-    /// The kind of the current `Transferring` plan, if the transfer is transferring.
-    fn plan_kind(&self) -> Option<PartPlanKind> {
-        let state = self.inner.state.lock().expect("lock poisoned");
-        match &*state {
-            UploadState::Transferring { plan, .. } => Some(match plan {
-                PartPlan::Known { .. } => PartPlanKind::Known,
-                PartPlan::Unknown => PartPlanKind::Unknown,
-            }),
-            _ => None,
-        }
     }
 
     /// Upload one part and record it, then advance the state machine.
@@ -611,33 +581,26 @@ impl UploadTransfer {
             ..Default::default()
         });
 
-        self.maybe_transition_to_completing();
+        self.on_part_completed();
 
         WorkOutcome::Success { data: None }
     }
 
-    fn maybe_transition_to_completing(&self) {
+    /// Release the slot a dispatched `UploadPart` held, and hand off to `Completing` if it was the
+    /// last one out.
+    ///
+    /// Fires for every completed `UploadPart` dispatch, including one whose read only found
+    /// end-of-stream. This is the mutator side of the wake protocol: the state that could unblock a
+    /// parked `poll_work` is mutated under the lock, then the lock is dropped before signalling.
+    fn on_part_completed(&self) {
         let mut state = self.inner.state.lock().expect("lock poisoned");
-        let should_complete = if let UploadState::Transferring {
-            parts_in_flight,
-            parts_dispatched,
-            plan,
-            eof,
-            ..
+        if let UploadState::Transferring {
+            parts_in_flight, ..
         } = &mut *state
         {
             *parts_in_flight -= 1;
-            let all_dispatched = match plan {
-                PartPlan::Known { total_parts, .. } => *parts_dispatched >= *total_parts,
-                PartPlan::Unknown => *eof,
-            };
-            all_dispatched && *parts_in_flight == 0
-        } else {
-            false
-        };
-
-        if should_complete {
-            transition_to_completing(&mut state);
+        }
+        if try_begin_completing(&mut state) {
             drop(state);
             self.inner.ctx.try_wake();
         }
@@ -895,11 +858,32 @@ impl UploadTransfer {
     }
 }
 
-/// Move a `Transferring` state to `Completing`, carrying the accumulated object size across.
+/// If every part has been dispatched and none remain in flight, move `Transferring` → `Completing`
+/// and report that it did.
 ///
-/// Both the poll path (every part dispatched, nothing in flight) and the part-completion path can be
-/// the last one out, so they share this to keep the handoff identical. The `mem::replace` makes the
-/// caller the single owner of the moved-out fields, so completion is set up exactly once.
+/// The single point that begins completion. Its two callers have distinct roles: `poll_work` serves
+/// the `CompleteMPU` it unlocks on the same poll; `on_part_completed` wakes a poller parked on the
+/// drain.
+fn try_begin_completing(state: &mut UploadState) -> bool {
+    if let UploadState::Transferring {
+        parts_dispatched,
+        plan,
+        eof,
+        parts_in_flight,
+        ..
+    } = state
+    {
+        if plan.all_dispatched(*parts_dispatched, *eof) && *parts_in_flight == 0 {
+            transition_to_completing(state);
+            return true;
+        }
+    }
+    false
+}
+
+/// Move a `Transferring` state to `Completing`, carrying the accumulated object size across. Only
+/// [`try_begin_completing`] calls this, once the completion condition holds. The `mem::replace`
+/// makes the caller the single owner of the moved-out fields, so completion is set up exactly once.
 fn transition_to_completing(state: &mut UploadState) {
     if let UploadState::Transferring {
         upload_id,

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -34,16 +34,16 @@ use std::sync::{Arc, Mutex};
 
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
-use bytes::Buf;
+use bytes::{Buf, Bytes};
 use tracing::Instrument;
 
 use std::future::Future;
 use std::pin::Pin;
 
-use crate::error::Error;
+use crate::error::{Error, ErrorKind};
 use crate::io::part_reader::Builder as PartReaderBuilder;
-use crate::io::InputStream;
-use crate::operation::upload::context::UploadState;
+use crate::io::{InputStream, PartData};
+use crate::operation::upload::context::{PartPlan, UploadState};
 use crate::operation::upload::input::convert::{
     copy_fields_to_mpu_request, copy_fields_to_upload_part_request,
 };
@@ -97,19 +97,23 @@ impl UploadTransfer {
         request: UploadInput,
         stream: InputStream,
     ) -> Self {
-        // TODO: For unknown content length (streaming uploads), this will need adjustment.
-        let content_length = stream
-            .size_hint()
-            .upper()
-            .expect("content_length required; unknown length not yet supported");
+        // `None` for a `PartStream` whose total size is not known up front (see
+        // `docs/design/unknown-length-upload.md`). Such a source is always `is_mpu_only`, so it
+        // routes through the multipart path and its parts are dispatched speculatively until the
+        // reader reports end-of-stream.
+        let content_length = stream.size_hint().upper();
 
-        ctx.set_total_bytes(content_length);
+        // Only meaningful when the length is known; an unknown-length transfer reports
+        // `total_bytes: None` while in progress and sets it at end-of-stream.
+        if let Some(content_length) = content_length {
+            ctx.set_total_bytes(content_length);
+        }
 
         let inner = Arc::new(UploadTransferInner {
             ctx,
             state: Mutex::new(UploadState::PendingInit {
                 stream: Some(stream),
-                content_length: Some(content_length),
+                content_length,
                 init_in_flight: false,
             }),
             request: Arc::new(request),
@@ -207,38 +211,48 @@ impl UploadTransfer {
             }
             UploadState::Transferring {
                 parts_dispatched,
-                total_parts,
+                plan,
                 parts_in_flight,
                 ..
             } => {
-                if *parts_dispatched >= *total_parts {
+                // Has every part been dispatched? For a known length that is a part count; for an
+                // unknown length it is the reader having reported end-of-stream.
+                let all_dispatched = match plan {
+                    PartPlan::Known { total_parts } => *parts_dispatched >= *total_parts,
+                    PartPlan::Unknown { eof, .. } => *eof,
+                };
+
+                if all_dispatched {
                     if *parts_in_flight > 0 {
                         self.inner.ctx.set_pending();
                         return PollWork::Pending;
                     }
                     // All parts sent and completed — transition to Completing
-                    if let UploadState::Transferring {
-                        upload_id,
-                        part_reader,
-                        completed_parts,
-                        response_builder,
-                        content_length,
-                        ..
-                    } = std::mem::replace(&mut *state, UploadState::Done)
-                    {
-                        *state = UploadState::Completing {
-                            upload_id: Some(upload_id),
-                            part_reader: Some(part_reader),
-                            completed_parts: Some(completed_parts),
-                            response_builder: Some(response_builder),
-                            complete_in_flight: false,
-                            content_length,
-                        };
-                    }
+                    transition_to_completing(&mut state);
                     drop(state);
                     self.inner.ctx.try_wake();
                     return PollWork::Pending;
                 }
+
+                // An unknown-length upload has no part count to bound it, so guard the S3 limit
+                // here: without this the next dispatch would send `PartNumber = MAX_PARTS + 1` and
+                // take S3's `InvalidArgument`, which says nothing about the remedy. Failing in
+                // `poll_work` is safe — the transfer is terminal on return, so the `is_active()`
+                // check at the top of the next poll reports `Done`.
+                if matches!(plan, PartPlan::Unknown { .. }) && *parts_dispatched >= MAX_PARTS {
+                    drop(state);
+                    self.inner.ctx.set_failed(Error::new(
+                        ErrorKind::InputInvalid,
+                        format!(
+                            "stream exceeds the maximum of {MAX_PARTS} parts at the current part \
+                             size; configure a larger part size to upload an object this large \
+                             without a known content length"
+                        ),
+                    ));
+                    self.inner.ctx.signal_terminal();
+                    return PollWork::Done;
+                }
+
                 *parts_dispatched += 1;
                 *parts_in_flight += 1;
                 PollWork::ready(IoRequest {
@@ -318,18 +332,32 @@ impl UploadTransfer {
                     ..
                 } => (
                     stream.take().expect("stream already taken"),
-                    content_length.take().expect("content_length already taken"),
+                    content_length.take(),
                 ),
                 _ => panic!("unexpected state for create_mpu"),
             }
         };
 
-        let part_size = cmp::max(
-            self.inner.ctx.handle.upload_part_size_bytes(),
-            content_length.div_ceil(MAX_PARTS),
-        );
+        // With a known length the part size is bumped so the part count fits within `MAX_PARTS`.
+        // With an unknown length there is no total to bump against, so the configured size is used
+        // as-is and the object is bounded by `part_size * MAX_PARTS` (guarded in `poll_work`).
+        let part_size = match content_length {
+            Some(content_length) => cmp::max(
+                self.inner.ctx.handle.upload_part_size_bytes(),
+                content_length.div_ceil(MAX_PARTS),
+            ),
+            None => self.inner.ctx.handle.upload_part_size_bytes(),
+        };
 
-        let total_parts = content_length.div_ceil(part_size);
+        let plan = match content_length {
+            Some(content_length) => PartPlan::Known {
+                total_parts: content_length.div_ceil(part_size),
+            },
+            None => PartPlan::Unknown {
+                eof: false,
+                first_part_emitted: false,
+            },
+        };
 
         tracing::trace!("upload request using multipart upload with part size: {part_size} bytes");
 
@@ -347,23 +375,34 @@ impl UploadTransfer {
             },
         );
 
+        // An unknown-length upload has no part count to size the vec by; use a small default (the
+        // CRT reference uses the same, "arbitrary picked to avoid using allocations and using too
+        // much memory") and let it grow.
+        const UNKNOWN_LENGTH_DEFAULT_NUM_PARTS: usize = 32;
+        let completed_parts_capacity = match &plan {
+            PartPlan::Known { total_parts } => *total_parts as usize,
+            PartPlan::Unknown { .. } => UNKNOWN_LENGTH_DEFAULT_NUM_PARTS,
+        };
+
         {
             let mut state = self.inner.state.lock().expect("lock poisoned");
             *state = UploadState::Transferring {
                 upload_id,
                 part_reader,
                 parts_dispatched: 0,
-                total_parts,
+                plan,
                 parts_in_flight: 0,
-                completed_parts: Vec::with_capacity(total_parts as usize),
+                completed_parts: Vec::with_capacity(completed_parts_capacity),
                 response_builder,
-                content_length,
+                // Known: the declared length, an independent witness. Unknown: accumulated from the
+                // parts actually uploaded as they complete.
+                object_size: content_length.unwrap_or(0),
             };
         }
 
         tracing::debug!(
             target: crate::telemetry::TARGET_TRANSFER,
-            total_parts,
+            total_parts = content_length.map(|len| len.div_ceil(part_size)),
             part_size,
             "MPU created, transferring",
         );
@@ -388,12 +427,31 @@ impl UploadTransfer {
             Ok(Some(data)) => data,
             Ok(None) => {
                 tracing::trace!("part_reader exhausted");
+                // For an unknown-length stream this is the signal that ends the transfer, and — if
+                // nothing was ever emitted — the point at which one caller owes an empty part 1 so
+                // that an empty stream still completes as a normal (empty) object.
+                if self.set_eof_and_claim_empty_first_part() {
+                    tracing::debug!(
+                        target: crate::telemetry::TARGET_TRANSFER,
+                        "empty unknown-length stream; uploading a single empty part",
+                    );
+                    return self.send_part(PartData::new(1, Bytes::new())).await;
+                }
                 self.maybe_transition_to_completing();
                 return WorkOutcome::Success { data: None };
             }
             Err(e) => return self.fail(e.into()),
         };
 
+        self.send_part(data).await
+    }
+
+    /// Upload one part and record it, then advance the state machine.
+    ///
+    /// Shared by the ordinary read-a-part path and the synthesized empty part 1 (see
+    /// [`Self::set_eof_and_claim_empty_first_part`]), so both go through the same retry
+    /// classification, metrics, and completion handoff.
+    async fn send_part(&self, data: PartData) -> WorkOutcome {
         // 2. Send part over network
         let upload_id = {
             let state = self.inner.state.lock().expect("lock poisoned");
@@ -477,10 +535,24 @@ impl UploadTransfer {
         {
             let mut state = self.inner.state.lock().expect("lock poisoned");
             if let UploadState::Transferring {
-                completed_parts, ..
+                completed_parts,
+                plan,
+                object_size,
+                ..
             } = &mut *state
             {
                 completed_parts.push(completed);
+                if let PartPlan::Unknown {
+                    first_part_emitted, ..
+                } = plan
+                {
+                    // A data-bearing part also claims part 1, so a stream that turned out non-empty
+                    // never synthesizes an empty one.
+                    *first_part_emitted = true;
+                    // No declared length to trust, so the object size is summed from what we sent.
+                    // Exact once end-of-stream is reached, which is when CompleteMPU reads it.
+                    *object_size += bytes_sent;
+                }
             }
         }
 
@@ -506,38 +578,66 @@ impl UploadTransfer {
         let should_complete = if let UploadState::Transferring {
             parts_in_flight,
             parts_dispatched,
-            total_parts,
+            plan,
             ..
         } = &mut *state
         {
             *parts_in_flight -= 1;
-            *parts_dispatched >= *total_parts && *parts_in_flight == 0
+            let all_dispatched = match plan {
+                PartPlan::Known { total_parts } => *parts_dispatched >= *total_parts,
+                PartPlan::Unknown { eof, .. } => *eof,
+            };
+            all_dispatched && *parts_in_flight == 0
         } else {
             false
         };
 
         if should_complete {
-            if let UploadState::Transferring {
-                upload_id,
-                part_reader,
-                completed_parts,
-                response_builder,
-                content_length,
-                ..
-            } = std::mem::replace(&mut *state, UploadState::Done)
-            {
-                *state = UploadState::Completing {
-                    upload_id: Some(upload_id),
-                    part_reader: Some(part_reader),
-                    completed_parts: Some(completed_parts),
-                    response_builder: Some(response_builder),
-                    complete_in_flight: false,
-                    content_length,
-                };
-            }
+            transition_to_completing(&mut state);
             drop(state);
             self.inner.ctx.try_wake();
         }
+    }
+
+    /// Record that the reader reached end-of-stream, and decide whether this caller owes an empty
+    /// part 1.
+    ///
+    /// S3 rejects a `CompleteMultipartUpload` that lists no parts, so an empty stream must still
+    /// upload one part. Because several part-work items can be dispatched before any of them reads,
+    /// more than one can see "end-of-stream with nothing emitted"; the right to synthesize part 1 is
+    /// therefore claimed by a check-and-set here, under the state lock, rather than by testing a
+    /// value the caller read earlier. Exactly one caller sees `true`.
+    ///
+    /// Returns `true` if this caller must send an empty part 1.
+    fn set_eof_and_claim_empty_first_part(&self) -> bool {
+        let mut state = self.inner.state.lock().expect("lock poisoned");
+        let claimed = match &mut *state {
+            UploadState::Transferring { plan, .. } => match plan {
+                PartPlan::Unknown {
+                    eof,
+                    first_part_emitted,
+                } => {
+                    *eof = true;
+                    if *first_part_emitted {
+                        false
+                    } else {
+                        // Claim it: no data part was emitted, so this caller owns part 1.
+                        *first_part_emitted = true;
+                        true
+                    }
+                }
+                // A known-length reader only reports end-of-stream after every counted part, so
+                // there is nothing to synthesize.
+                PartPlan::Known { .. } => false,
+            },
+            _ => false,
+        };
+        drop(state);
+        // `eof` is what unblocks a `poll_work` parked on in-flight parts. It is set here, in
+        // `execute`, while the poller may already be parked, so the edge must be signalled or the
+        // transfer hangs (see the wake protocol on `TransferContext::set_pending`).
+        self.inner.ctx.try_wake();
+        claimed
     }
 
     async fn execute_put_object(&self, stream: &mut Option<InputStream>) -> WorkOutcome {
@@ -659,7 +759,7 @@ impl UploadTransfer {
     }
 
     async fn execute_complete_mpu(&self) -> WorkOutcome {
-        let (upload_id, mut completed_parts, response_builder, part_reader, content_length) = {
+        let (upload_id, mut completed_parts, response_builder, part_reader, object_size) = {
             let mut state = self.inner.state.lock().expect("lock poisoned");
             match &mut *state {
                 UploadState::Completing {
@@ -667,7 +767,7 @@ impl UploadTransfer {
                     completed_parts,
                     response_builder,
                     part_reader,
-                    content_length,
+                    object_size,
                     ..
                 } => (
                     upload_id.take().expect("upload_id already taken"),
@@ -678,13 +778,19 @@ impl UploadTransfer {
                         .take()
                         .expect("response_builder already taken"),
                     part_reader.take().expect("part_reader already taken"),
-                    *content_length,
+                    *object_size,
                 ),
                 _ => panic!("unexpected state for complete_mpu"),
             }
         };
 
         completed_parts.sort_by_key(|p| p.part_number);
+
+        // An unknown-length transfer could not report a total while in flight (progress is genuinely
+        // unknowable there). By now the stream has ended and `object_size` is exact, so final
+        // metrics report the true size. `set_total_bytes` is a `OnceLock` set, so this is a no-op
+        // when the length was known up front.
+        self.inner.ctx.set_total_bytes(object_size);
 
         let base_req = self
             .inner
@@ -696,7 +802,13 @@ impl UploadTransfer {
             // total doesn't match this value, so a dropped or duplicated part
             // surfaces as a failed complete rather than a wrong-sized object.
             // Required by SEP step 7.
-            .mpu_object_size(content_length as i64)
+            //
+            // For a known length this is the size declared by the source — an independent witness,
+            // so it also catches a part this crate itself dropped or duplicated. For an unknown
+            // length there is no such witness: the value is summed from the parts actually
+            // uploaded, which still catches an S3-side assembly mismatch. Do not "simplify" the
+            // known path onto the running sum; that would quietly lose the independent check.
+            .mpu_object_size(object_size as i64)
             .multipart_upload(
                 CompletedMultipartUpload::builder()
                     .set_parts(Some(completed_parts))
@@ -749,6 +861,32 @@ impl UploadTransfer {
         self.inner.ctx.set_failed(error);
         self.inner.ctx.signal_terminal();
         WorkOutcome::Failed { classification }
+    }
+}
+
+/// Move a `Transferring` state to `Completing`, carrying the accumulated object size across.
+///
+/// Both the poll path (every part dispatched, nothing in flight) and the part-completion path can be
+/// the last one out, so they share this to keep the handoff identical. The `mem::replace` makes the
+/// caller the single owner of the moved-out fields, so completion is set up exactly once.
+fn transition_to_completing(state: &mut UploadState) {
+    if let UploadState::Transferring {
+        upload_id,
+        part_reader,
+        completed_parts,
+        response_builder,
+        object_size,
+        ..
+    } = std::mem::replace(state, UploadState::Done)
+    {
+        *state = UploadState::Completing {
+            upload_id: Some(upload_id),
+            part_reader: Some(part_reader),
+            completed_parts: Some(completed_parts),
+            response_builder: Some(response_builder),
+            complete_in_flight: false,
+            object_size,
+        };
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -665,9 +665,10 @@ async fn test_upload_unknown_content_length_multipart() {
     unknown_length_round_trip(&tm, bucket_name.as_str(), key.as_str(), parts).await;
 }
 
-/// A single-part unknown-length stream (a small streamed file) round-trips. This is the
-/// case the duplicate-part-1 race lived in — one data part read while the end-of-stream
-/// read runs concurrently — so it exercises exactly the path that used to corrupt objects.
+/// A single-part unknown-length stream (a small streamed file) round-trips.
+///
+/// One data part is read while the end-of-stream read runs concurrently, so a spurious empty part 1
+/// would surface here as a wrong-sized object.
 #[tokio::test]
 async fn test_upload_unknown_content_length_single_part() {
     let _logs = show_test_logs();

--- a/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -550,3 +550,148 @@ async fn test_multi_part_upload_sends_mpu_object_size() {
         );
     }
 }
+
+/// A `PartStream` with no size-hint upper bound: the unknown-content-length case.
+///
+/// Parts are handed over a channel and closing the sender is end-of-stream, which
+/// is how a caller like Mountpoint streams an object whose final size is only
+/// known once the writer closes.
+#[derive(Debug)]
+struct UnknownLengthStream {
+    next_part_num: u64,
+    rx: tokio::sync::mpsc::Receiver<bytes::Bytes>,
+}
+
+impl UnknownLengthStream {
+    fn new(rx: tokio::sync::mpsc::Receiver<bytes::Bytes>) -> Self {
+        Self {
+            next_part_num: 1,
+            rx,
+        }
+    }
+}
+
+impl PartStream for UnknownLengthStream {
+    fn poll_part(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        _stream_cx: &StreamContext,
+    ) -> Poll<Option<std::io::Result<PartData>>> {
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(b)) => {
+                let part_num = self.next_part_num;
+                self.next_part_num += 1;
+                Poll::Ready(Some(Ok(PartData::new(part_num, b))))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    /// No upper bound — routes the upload down the unknown-length path.
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::default()
+    }
+}
+
+/// An upload from a stream with no declared content length transfers, and S3
+/// stores an object of exactly the streamed size.
+#[tokio::test]
+async fn test_upload_unknown_content_length() {
+    let _logs = show_test_logs();
+    let (tm, s3_client) = test_tm().await;
+    let (bucket_name, _) = get_bucket_names();
+    let key = generate_key("unknown-content-length");
+
+    let part_size = 8 * ByteUnit::Mebibyte.as_bytes_usize();
+    // Deliberately not a part-size multiple, so a size derived from the part count
+    // rather than the bytes actually read would not match.
+    let tail = 1024;
+    let expected_len = 2 * part_size + tail;
+
+    let (tx, rx) = tokio::sync::mpsc::channel(2);
+    let handle = tm
+        .upload()
+        .bucket(bucket_name.as_str())
+        .key(key.as_str())
+        .body(InputStream::from_part_stream(UnknownLengthStream::new(rx)))
+        .initiate()
+        .unwrap();
+
+    tokio::spawn(async move {
+        for _ in 0..2 {
+            tx.send(bytes::Bytes::from(vec![b'z'; part_size]))
+                .await
+                .unwrap();
+        }
+        tx.send(bytes::Bytes::from(vec![b'z'; tail])).await.unwrap();
+        // End of stream.
+        drop(tx);
+    });
+
+    handle
+        .join()
+        .await
+        .expect("an unknown-length stream must upload successfully");
+
+    let head = s3_client
+        .head_object()
+        .bucket(bucket_name.as_str())
+        .key(key.as_str())
+        .send()
+        .await
+        .expect("uploaded object must exist");
+    assert_eq!(
+        Some(expected_len as i64),
+        head.content_length(),
+        "stored object size must equal the number of bytes streamed"
+    );
+}
+
+/// An empty stream with no declared content length completes as a normal 0-byte
+/// object.
+///
+/// S3 rejects a CompleteMultipartUpload that lists no parts, so the transfer
+/// uploads a single empty part. This confirms against real S3 what the mock
+/// cannot: that such an upload is accepted and stores a 0-byte object.
+#[tokio::test]
+async fn test_upload_unknown_content_length_empty() {
+    let _logs = show_test_logs();
+    let (tm, s3_client) = test_tm().await;
+    let (bucket_name, _) = get_bucket_names();
+
+    for checksum in [None, Some(ChecksumStrategy::default())] {
+        let key = generate_key("unknown-content-length-empty");
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        // Empty: end-of-stream without ever sending a part.
+        drop(tx);
+
+        let handle = tm
+            .upload()
+            .bucket(bucket_name.as_str())
+            .key(key.as_str())
+            .set_checksum_strategy(checksum.clone())
+            .body(InputStream::from_part_stream(UnknownLengthStream::new(rx)))
+            .initiate()
+            .unwrap();
+
+        handle
+            .join()
+            .await
+            .expect("an empty unknown-length stream must complete as a 0-byte object");
+
+        let head = s3_client
+            .head_object()
+            .bucket(bucket_name.as_str())
+            .key(key.as_str())
+            .checksum_mode(ChecksumMode::Enabled)
+            .send()
+            .await
+            .expect("uploaded empty object must exist");
+        assert_eq!(
+            Some(0),
+            head.content_length(),
+            "an empty stream must store a 0-byte object"
+        );
+    }
+}

--- a/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/e2e_transfer_test.rs
@@ -594,39 +594,37 @@ impl PartStream for UnknownLengthStream {
     }
 }
 
-/// An upload from a stream with no declared content length transfers, and S3
-/// stores an object of exactly the streamed size.
-#[tokio::test]
-async fn test_upload_unknown_content_length() {
-    let _logs = show_test_logs();
-    let (tm, s3_client) = test_tm().await;
-    let (bucket_name, _) = get_bucket_names();
-    let key = generate_key("unknown-content-length");
+/// Stream `parts`, one message each, then end-of-stream, as an unknown-length upload;
+/// download it back and assert the bytes round-trip exactly. Returns nothing — panics on
+/// any mismatch.
+///
+/// Downloading and comparing the actual bytes (not just the size) is what catches a
+/// dropped, duplicated, or reordered part — the failure modes an unknown-length upload is
+/// most exposed to, since it has no declared size for S3 to cross-check against.
+async fn unknown_length_round_trip(
+    tm: &aws_sdk_s3_transfer_manager::Client,
+    bucket: &str,
+    key: &str,
+    parts: Vec<bytes::Bytes>,
+) {
+    let expected: Vec<u8> = parts.iter().flatten().copied().collect();
 
-    let part_size = 8 * ByteUnit::Mebibyte.as_bytes_usize();
-    // Deliberately not a part-size multiple, so a size derived from the part count
-    // rather than the bytes actually read would not match.
-    let tail = 1024;
-    let expected_len = 2 * part_size + tail;
-
-    let (tx, rx) = tokio::sync::mpsc::channel(2);
+    let (tx, rx) = tokio::sync::mpsc::channel(4);
     let handle = tm
         .upload()
-        .bucket(bucket_name.as_str())
-        .key(key.as_str())
+        .bucket(bucket)
+        .key(key)
         .body(InputStream::from_part_stream(UnknownLengthStream::new(rx)))
         .initiate()
         .unwrap();
 
     tokio::spawn(async move {
-        for _ in 0..2 {
-            tx.send(bytes::Bytes::from(vec![b'z'; part_size]))
-                .await
-                .unwrap();
+        for part in parts {
+            if tx.send(part).await.is_err() {
+                return;
+            }
         }
-        tx.send(bytes::Bytes::from(vec![b'z'; tail])).await.unwrap();
-        // End of stream.
-        drop(tx);
+        drop(tx); // end of stream
     });
 
     handle
@@ -634,33 +632,89 @@ async fn test_upload_unknown_content_length() {
         .await
         .expect("an unknown-length stream must upload successfully");
 
-    let head = s3_client
-        .head_object()
-        .bucket(bucket_name.as_str())
-        .key(key.as_str())
-        .send()
-        .await
-        .expect("uploaded object must exist");
+    let mut download = tm.download().bucket(bucket).key(key).initiate().unwrap();
+    let body = drain(&mut download).await.unwrap();
+
     assert_eq!(
-        Some(expected_len as i64),
-        head.content_length(),
-        "stored object size must equal the number of bytes streamed"
+        body.len(),
+        expected.len(),
+        "downloaded object size must equal the streamed size"
+    );
+    assert_eq!(
+        body, expected,
+        "downloaded bytes must match what was streamed, in order"
     );
 }
 
-/// An empty stream with no declared content length completes as a normal 0-byte
-/// object.
+/// A multi-part unknown-length stream round-trips byte-for-byte. The tail part is
+/// deliberately not a part-size multiple, so any size taken from a part count rather than
+/// the bytes actually read would be wrong.
+#[tokio::test]
+async fn test_upload_unknown_content_length_multipart() {
+    let _logs = show_test_logs();
+    let (tm, _) = test_tm().await;
+    let (bucket_name, _) = get_bucket_names();
+    let key = generate_key("unknown-content-length-multipart");
+
+    let part_size = 8 * ByteUnit::Mebibyte.as_bytes_usize();
+    let parts = vec![
+        bytes::Bytes::from(vec![b'a'; part_size]),
+        bytes::Bytes::from(vec![b'b'; part_size]),
+        bytes::Bytes::from(vec![b'c'; 1024]), // partial tail
+    ];
+    unknown_length_round_trip(&tm, bucket_name.as_str(), key.as_str(), parts).await;
+}
+
+/// A single-part unknown-length stream (a small streamed file) round-trips. This is the
+/// case the duplicate-part-1 race lived in — one data part read while the end-of-stream
+/// read runs concurrently — so it exercises exactly the path that used to corrupt objects.
+#[tokio::test]
+async fn test_upload_unknown_content_length_single_part() {
+    let _logs = show_test_logs();
+    let (tm, _) = test_tm().await;
+    let (bucket_name, _) = get_bucket_names();
+    let key = generate_key("unknown-content-length-single");
+
+    let parts = vec![bytes::Bytes::from(vec![b'x'; 1024])];
+    unknown_length_round_trip(&tm, bucket_name.as_str(), key.as_str(), parts).await;
+}
+
+/// Many small parts, well past the unknown-length default part-list capacity, round-trip in
+/// order. Confirms the growing part list assembles correctly on real S3.
+#[tokio::test]
+async fn test_upload_unknown_content_length_many_parts() {
+    let _logs = show_test_logs();
+    let (tm, _) = test_tm().await;
+    let (bucket_name, _) = get_bucket_names();
+    let key = generate_key("unknown-content-length-many");
+
+    // 40 full parts at the 5 MiB minimum crosses the 32 default capacity. Distinct byte per
+    // part so a reordering shows up as a content mismatch, not just a size match.
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let parts: Vec<bytes::Bytes> = (0..40u8)
+        .map(|i| bytes::Bytes::from(vec![i; part_size]))
+        .collect();
+    unknown_length_round_trip(&tm, bucket_name.as_str(), key.as_str(), parts).await;
+}
+
+/// An empty stream with no declared content length completes as a normal 0-byte object,
+/// with and without a checksum strategy.
 ///
-/// S3 rejects a CompleteMultipartUpload that lists no parts, so the transfer
-/// uploads a single empty part. This confirms against real S3 what the mock
-/// cannot: that such an upload is accepted and stores a 0-byte object.
+/// S3 rejects a CompleteMultipartUpload that lists no parts, so the transfer uploads a
+/// single empty part. This confirms against real S3 what the mock cannot: that such an
+/// upload is accepted, stores a 0-byte object, downloads back to zero bytes, and — with a
+/// checksum strategy — that the full-object checksum over zero bytes is accepted.
 #[tokio::test]
 async fn test_upload_unknown_content_length_empty() {
     let _logs = show_test_logs();
     let (tm, s3_client) = test_tm().await;
     let (bucket_name, _) = get_bucket_names();
 
-    for checksum in [None, Some(ChecksumStrategy::default())] {
+    for checksum in [
+        None,
+        Some(ChecksumStrategy::default()),
+        Some(ChecksumStrategy::with_calculated_crc32()),
+    ] {
         let key = generate_key("unknown-content-length-empty");
         let (tx, rx) = tokio::sync::mpsc::channel(1);
         // Empty: end-of-stream without ever sending a part.
@@ -693,5 +747,62 @@ async fn test_upload_unknown_content_length_empty() {
             head.content_length(),
             "an empty stream must store a 0-byte object"
         );
+
+        // And it must download back as zero bytes.
+        let mut download = tm
+            .download()
+            .bucket(bucket_name.as_str())
+            .key(key.as_str())
+            .initiate()
+            .unwrap();
+        let body = drain(&mut download).await.unwrap();
+        assert!(body.is_empty(), "empty object must download as zero bytes");
     }
+}
+
+/// An unknown-length upload that supplies a full-object checksum has it stored on the
+/// object, verified against real S3 (the mock only checks the header is sent, not that S3
+/// accepts and records it).
+#[tokio::test]
+async fn test_upload_unknown_content_length_with_checksum() {
+    let _logs = show_test_logs();
+    let (tm, s3_client) = test_tm().await;
+    let (bucket_name, _) = get_bucket_names();
+    let key = generate_key("unknown-content-length-checksum");
+
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let (tx, rx) = tokio::sync::mpsc::channel(2);
+    let handle = tm
+        .upload()
+        .bucket(bucket_name.as_str())
+        .key(key.as_str())
+        .checksum_strategy(ChecksumStrategy::with_calculated_crc32())
+        .body(InputStream::from_part_stream(UnknownLengthStream::new(rx)))
+        .initiate()
+        .unwrap();
+
+    tokio::spawn(async move {
+        for _ in 0..2 {
+            let _ = tx.send(bytes::Bytes::from(vec![b'k'; part_size])).await;
+        }
+        drop(tx);
+    });
+
+    handle
+        .join()
+        .await
+        .expect("an unknown-length upload with a checksum strategy must succeed");
+
+    let head = s3_client
+        .head_object()
+        .bucket(bucket_name.as_str())
+        .key(key.as_str())
+        .checksum_mode(ChecksumMode::Enabled)
+        .send()
+        .await
+        .expect("uploaded object must exist");
+    assert!(
+        head.checksum_crc32().is_some(),
+        "S3 must have stored the CRC32 checksum for an unknown-length upload"
+    );
 }

--- a/aws-sdk-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/upload_test.rs
@@ -11,8 +11,10 @@ use std::{task::Poll, time::Duration};
 use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadOutput;
 use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
 use aws_sdk_s3::operation::upload_part::UploadPartOutput;
+use aws_sdk_s3_transfer_manager::error::ErrorKind;
 use aws_sdk_s3_transfer_manager::io::{InputStream, PartData, PartStream, SizeHint, StreamContext};
 use aws_sdk_s3_transfer_manager::metrics::unit::ByteUnit;
+use aws_sdk_s3_transfer_manager::operation::upload::ChecksumStrategy;
 use aws_smithy_mocks::{mock, mock_client, RuleMode};
 use aws_smithy_runtime::test_util::capture_test_logs::capture_test_logs;
 use bytes::Bytes;
@@ -328,12 +330,11 @@ async fn test_complete_mpu_sends_mpu_object_size() {
         .expect("upload should succeed: CompleteMPU must carry MpuObjectSize = content length");
 }
 
-// --- Unknown content length (RUST-1228) --------------------------------------
+// --- Unknown content length --------------------------------------------------
 //
 // An unknown-length source is always a `PartStream`, which is `is_mpu_only`, so
 // these all exercise the multipart path. Termination comes from the reader
-// reporting end-of-stream rather than from a part count. See
-// `docs/design/unknown-length-upload.md`.
+// reporting end-of-stream rather than from a part count.
 
 /// A stream with no declared length uploads via multipart and completes.
 /// Previously this panicked on `content_length required`.
@@ -606,5 +607,290 @@ async fn test_unknown_length_with_data_never_sends_empty_part() {
         0,
         empty_part.num_calls(),
         "a stream that yielded data must not also send an empty part 1"
+    );
+}
+
+pin_project! {
+    /// An unknown-length `PartStream` that also supplies a full-object checksum.
+    ///
+    /// `full_object_checksum` is consulted once, after the final part, and only when the
+    /// upload uses a `FullObject` checksum strategy without a value set up front. Pairing
+    /// it with an unknown length is the combination the design flagged as needing
+    /// coverage: the size is not known when the strategy is chosen.
+    #[derive(Debug)]
+    struct UnknownLengthChecksumStream {
+        next_part_num: u64,
+        rx: mpsc::Receiver<Bytes>,
+        full_object_checksum: Option<String>,
+    }
+}
+
+impl UnknownLengthChecksumStream {
+    fn new(rx: mpsc::Receiver<Bytes>, full_object_checksum: Option<String>) -> Self {
+        Self {
+            next_part_num: 1,
+            rx,
+            full_object_checksum,
+        }
+    }
+}
+
+impl PartStream for UnknownLengthChecksumStream {
+    fn poll_part(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        _stream_cx: &StreamContext,
+    ) -> Poll<Option<std::io::Result<PartData>>> {
+        let this = self.project();
+        let data = ready!(this.rx.poll_recv(cx));
+        let part = data.map(|b| {
+            let part_num = *this.next_part_num;
+            *this.next_part_num += 1;
+            Ok(PartData::new(part_num, b))
+        });
+        Poll::Ready(part)
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::default()
+    }
+
+    fn full_object_checksum(&self) -> Option<String> {
+        self.full_object_checksum.clone()
+    }
+}
+
+/// A full-object checksum supplied by the stream must reach CompleteMultipartUpload even
+/// though the length was never declared.
+///
+/// The checksum is a property of the stream, not of any part, so it is orthogonal to the
+/// unknown-length machinery — this pins that, since the value is only produced after the
+/// final part and the transfer decides "final" from end-of-stream rather than a count.
+#[tokio::test]
+async fn test_unknown_length_forwards_full_object_checksum() {
+    let upload_id = "test-upload-id".to_owned();
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    // Base64 of a CRC32 value; the mock only checks that it is forwarded verbatim.
+    let expected_checksum = "AAAAAA==";
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+    let upload_part =
+        mock!(aws_sdk_s3::Client::upload_part).then_output(|| UploadPartOutput::builder().build());
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .match_requests(move |req| req.checksum_crc32() == Some(expected_checksum))
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[create_mpu, upload_part, complete_mpu]
+    );
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(1);
+    let stream = UnknownLengthChecksumStream::new(rx, Some(expected_checksum.to_owned()));
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .checksum_strategy(ChecksumStrategy::with_calculated_crc32())
+        .body(InputStream::from_part_stream(stream))
+        .initiate()
+        .unwrap();
+
+    tx.send(Bytes::from(vec![0u8; part_size])).await.unwrap();
+    drop(tx);
+
+    handle
+        .join()
+        .await
+        .expect("a stream-supplied full-object checksum must be sent on CompleteMPU");
+}
+
+/// An unknown-length transfer cannot report a total while in flight, but its final
+/// metrics must report the true size.
+///
+/// `total_bytes` is seeded from the size hint, which is absent here, so it is set once
+/// end-of-stream makes the summed size exact. Without that, a completed streaming upload
+/// would report `total_bytes: None` forever.
+#[tokio::test]
+async fn test_unknown_length_reports_total_bytes_after_completion() {
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let tail = 512;
+    let expected = (part_size + tail) as u64;
+
+    let client = mock_s3_client_for_multipart_upload();
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(2);
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(UnknownLengthStream::new(rx)))
+        .initiate()
+        .unwrap();
+
+    // No declared length, so nothing to report yet.
+    assert_eq!(
+        None,
+        handle.metrics().total_bytes,
+        "an unknown-length transfer must not invent a total while in flight"
+    );
+
+    tx.send(Bytes::from(vec![0u8; part_size])).await.unwrap();
+    tx.send(Bytes::from(vec![0u8; tail])).await.unwrap();
+    drop(tx);
+
+    let output = handle.join().await.expect("upload should succeed");
+
+    assert_eq!(
+        Some(expected),
+        output.metrics.total_bytes,
+        "final metrics must report the streamed size once end-of-stream makes it exact"
+    );
+    assert_eq!(
+        expected, output.metrics.network_tx,
+        "every streamed byte must be accounted for on the wire"
+    );
+}
+
+/// A reader error part-way through an unknown-length stream fails the transfer rather
+/// than being mistaken for end-of-stream.
+///
+/// `Ok(None)` means "done" and `Err` means "broken"; conflating them would silently
+/// complete a truncated object, which is the worst possible outcome for an upload.
+#[tokio::test]
+async fn test_unknown_length_reader_error_fails_transfer() {
+    let client = mock_s3_client_for_multipart_upload();
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(FailingUnknownLengthStream {
+            yielded: false,
+        }))
+        .initiate()
+        .unwrap();
+
+    let err = handle
+        .join()
+        .await
+        .expect_err("a reader error must fail the upload, not complete it");
+    assert!(
+        matches!(err.kind(), ErrorKind::IOError),
+        "expected an IO error, got {:?}",
+        err.kind()
+    );
+}
+
+/// Yields one part, then errors — never reports end-of-stream.
+#[derive(Debug)]
+struct FailingUnknownLengthStream {
+    yielded: bool,
+}
+
+impl PartStream for FailingUnknownLengthStream {
+    fn poll_part(
+        mut self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        stream_cx: &StreamContext,
+    ) -> Poll<Option<std::io::Result<PartData>>> {
+        if self.yielded {
+            return Poll::Ready(Some(Err(std::io::Error::other("simulated reader failure"))));
+        }
+        self.yielded = true;
+        let data = vec![0u8; stream_cx.part_size()];
+        Poll::Ready(Some(Ok(PartData::new(1, data))))
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::default()
+    }
+}
+
+/// A stream that yields more parts than the unknown-length default capacity must still
+/// complete with every part accounted for.
+///
+/// With no declared length there is no part count to size `completed_parts` by, so it
+/// starts at a small default (32) and grows. This walks past that boundary so a
+/// mis-sized or truncated part list would show up as a wrong `MpuObjectSize`.
+#[tokio::test]
+async fn test_unknown_length_many_parts_grows_part_list() {
+    let upload_id = "test-upload-id".to_owned();
+    // Smallest permitted part size keeps the test cheap; 40 parts crosses the 32 default.
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let num_parts = 40usize;
+    let expected_total = (part_size * num_parts) as i64;
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+    let upload_part =
+        mock!(aws_sdk_s3::Client::upload_part).then_output(|| UploadPartOutput::builder().build());
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .match_requests(move |req| req.mpu_object_size() == Some(expected_total))
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[&create_mpu, &upload_part, &complete_mpu]
+    );
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(4);
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(UnknownLengthStream::new(rx)))
+        .initiate()
+        .unwrap();
+
+    tokio::spawn(async move {
+        for _ in 0..num_parts {
+            if tx.send(Bytes::from(vec![0u8; part_size])).await.is_err() {
+                return;
+            }
+        }
+        drop(tx);
+    });
+
+    handle
+        .join()
+        .await
+        .expect("an unknown-length stream must handle more parts than the default capacity");
+
+    assert_eq!(
+        num_parts,
+        upload_part.num_calls(),
+        "every part must be uploaded exactly once"
     );
 }

--- a/aws-sdk-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/upload_test.rs
@@ -81,6 +81,49 @@ impl PartStream for TestStream {
     }
 }
 
+pin_project! {
+    /// A `PartStream` whose total size is not known up front: `size_hint` has no upper bound.
+    ///
+    /// Mirrors a caller like Mountpoint, which writes an object whose final size is only known once
+    /// the writer closes. Parts arrive over a channel; closing the sender is end-of-stream.
+    #[derive(Debug)]
+    struct UnknownLengthStream {
+        next_part_num: u64,
+        rx: mpsc::Receiver<Bytes>,
+    }
+}
+
+impl UnknownLengthStream {
+    fn new(rx: mpsc::Receiver<Bytes>) -> Self {
+        Self {
+            next_part_num: 1,
+            rx,
+        }
+    }
+}
+
+impl PartStream for UnknownLengthStream {
+    fn poll_part(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        _stream_cx: &StreamContext,
+    ) -> Poll<Option<std::io::Result<PartData>>> {
+        let this = self.project();
+        let data = ready!(this.rx.poll_recv(cx));
+        let part = data.map(|b| {
+            let part_num = *this.next_part_num;
+            *this.next_part_num += 1;
+            Ok(PartData::new(part_num, b))
+        });
+        Poll::Ready(part)
+    }
+
+    /// No upper bound — this is what routes the upload down the unknown-length path.
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::default()
+    }
+}
+
 fn mock_s3_client_for_multipart_upload() -> aws_sdk_s3::Client {
     let upload_id = "test-upload-id".to_owned();
 
@@ -283,4 +326,215 @@ async fn test_complete_mpu_sends_mpu_object_size() {
         .join()
         .await
         .expect("upload should succeed: CompleteMPU must carry MpuObjectSize = content length");
+}
+
+// --- Unknown content length (RUST-1228) --------------------------------------
+//
+// An unknown-length source is always a `PartStream`, which is `is_mpu_only`, so
+// these all exercise the multipart path. Termination comes from the reader
+// reporting end-of-stream rather than from a part count. See
+// `docs/design/unknown-length-upload.md`.
+
+/// A stream with no declared length uploads via multipart and completes.
+/// Previously this panicked on `content_length required`.
+#[tokio::test]
+async fn test_unknown_length_multipart_upload() {
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let client = mock_s3_client_for_multipart_upload();
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(2);
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(UnknownLengthStream::new(rx)))
+        .initiate()
+        .unwrap();
+
+    // Two full parts, then end-of-stream by dropping the sender.
+    for _ in 0..2 {
+        tx.send(Bytes::from(vec![0u8; part_size])).await.unwrap();
+    }
+    drop(tx);
+
+    handle
+        .join()
+        .await
+        .expect("an unknown-length stream must upload, not panic");
+}
+
+/// An empty unknown-length stream must complete as a normal 0-byte object.
+///
+/// S3 rejects a CompleteMultipartUpload that lists no parts, so "no bytes" cannot
+/// mean "no parts": the transfer synthesizes a single empty part 1. The mock
+/// asserts exactly that shape — one UploadPart, part number 1, zero bytes.
+#[tokio::test]
+async fn test_unknown_length_empty_stream() {
+    let upload_id = "test-upload-id".to_owned();
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+
+    // Matches only a zero-length part 1; anything else leaves the rule unproven.
+    let upload_part = mock!(aws_sdk_s3::Client::upload_part)
+        .match_requests(|req| req.part_number() == Some(1) && req.content_length() == Some(0))
+        .then_output(|| UploadPartOutput::builder().e_tag("empty-etag").build());
+
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .match_requests(|req| req.mpu_object_size() == Some(0))
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[&create_mpu, &upload_part, &complete_mpu]
+    );
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(1);
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(UnknownLengthStream::new(rx)))
+        .initiate()
+        .unwrap();
+
+    // Empty: end-of-stream without ever sending data.
+    drop(tx);
+
+    handle
+        .join()
+        .await
+        .expect("an empty unknown-length stream must complete as a 0-byte object");
+
+    // Exactly one part, so CompleteMPU cannot have carried a duplicate part 1.
+    assert_eq!(
+        upload_part.num_calls(),
+        1,
+        "empty stream must upload exactly one (empty) part"
+    );
+}
+
+/// `MpuObjectSize` for an unknown-length upload is the sum of the bytes actually
+/// uploaded. With no declared length there is no independent witness, but the
+/// value must still be sent so S3 can reject a mismatched assembly.
+#[tokio::test]
+async fn test_unknown_length_mpu_object_size_is_running_sum() {
+    let upload_id = "test-upload-id".to_owned();
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    // Deliberately not a part-size multiple, so a part-count-derived value wouldn't match.
+    let total = 2 * part_size + 1024;
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+    let upload_part =
+        mock!(aws_sdk_s3::Client::upload_part).then_output(|| UploadPartOutput::builder().build());
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .match_requests(move |req| req.mpu_object_size() == Some(total as i64))
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[create_mpu, upload_part, complete_mpu]
+    );
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(2);
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(UnknownLengthStream::new(rx)))
+        .initiate()
+        .unwrap();
+
+    tx.send(Bytes::from(vec![0u8; part_size])).await.unwrap();
+    tx.send(Bytes::from(vec![0u8; part_size])).await.unwrap();
+    tx.send(Bytes::from(vec![0u8; 1024])).await.unwrap();
+    drop(tx);
+
+    handle.join().await.expect(
+        "CompleteMPU must carry MpuObjectSize equal to the summed bytes of an unknown-length stream",
+    );
+}
+
+/// A known-length upload must keep sending its *declared* size as `MpuObjectSize`,
+/// not a sum accumulated from the parts it uploaded.
+///
+/// The declared length is an independent witness: it comes from the source rather
+/// than from this crate's own part accounting, so it also catches a part the crate
+/// itself dropped or duplicated. A running sum cannot. Unifying the two paths onto
+/// one accumulator would look like a simplification and would quietly lose that,
+/// so this pins the known-length path against that refactor.
+#[tokio::test]
+async fn test_known_length_sends_declared_size_not_running_sum() {
+    let upload_id = "test-upload-id".to_owned();
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+    let declared = 2 * part_size;
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+    // Drop every part on the floor: no part response contributes an ETag, so a
+    // sum-derived MpuObjectSize would be wrong while the declared one stays right.
+    let upload_part =
+        mock!(aws_sdk_s3::Client::upload_part).then_output(|| UploadPartOutput::builder().build());
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .match_requests(move |req| req.mpu_object_size() == Some(declared as i64))
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[create_mpu, upload_part, complete_mpu]
+    );
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(2);
+    let stream = TestStream::new(rx, declared, declared as u64);
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(stream))
+        .initiate()
+        .unwrap();
+    drop(tx);
+
+    handle
+        .join()
+        .await
+        .expect("a known-length upload must send its declared content length as MpuObjectSize");
 }

--- a/aws-sdk-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/upload_test.rs
@@ -337,7 +337,6 @@ async fn test_complete_mpu_sends_mpu_object_size() {
 // reporting end-of-stream rather than from a part count.
 
 /// A stream with no declared length uploads via multipart and completes.
-/// Previously this panicked on `content_length required`.
 #[tokio::test]
 async fn test_unknown_length_multipart_upload() {
     let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
@@ -892,5 +891,176 @@ async fn test_unknown_length_many_parts_grows_part_list() {
         num_parts,
         upload_part.num_calls(),
         "every part must be uploaded exactly once"
+    );
+}
+
+pin_project! {
+    /// An unknown-length `PartStream` that yields `total` one-byte parts, then end-of-stream.
+    ///
+    /// Parts are produced without waiting on a channel, so a test can drive the part count past a
+    /// limit without also taking on caller-data backpressure.
+    #[derive(Debug)]
+    struct CountingUnknownLengthStream {
+        next_part_num: u64,
+        total: u64,
+    }
+}
+
+impl PartStream for CountingUnknownLengthStream {
+    fn poll_part(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        _stream_cx: &StreamContext,
+    ) -> Poll<Option<std::io::Result<PartData>>> {
+        let this = self.project();
+        if *this.next_part_num > *this.total {
+            return Poll::Ready(None);
+        }
+        let part_number = *this.next_part_num;
+        *this.next_part_num += 1;
+        Poll::Ready(Some(Ok(PartData::new(
+            part_number,
+            Bytes::from_static(b"x"),
+        ))))
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        SizeHint::default()
+    }
+}
+
+/// A stream exceeding the S3 part limit fails with a message naming the remedy.
+///
+/// The guard keys on parts the reader actually yielded, so an exactly-`MAX_PARTS` stream must still
+/// succeed — only the part past the limit trips it. Driving this through the public API is what pins
+/// the trip point; the part size is irrelevant to the count, so one byte per part suffices.
+#[tokio::test]
+async fn test_unknown_length_exceeding_part_limit_fails() {
+    const MAX_PARTS: u64 = 10_000;
+
+    let client = mock_s3_client_for_multipart_upload();
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(CountingUnknownLengthStream {
+            next_part_num: 1,
+            total: MAX_PARTS + 1,
+        }))
+        .initiate()
+        .unwrap();
+
+    let err = handle
+        .join()
+        .await
+        .expect_err("a stream past the part limit must fail");
+
+    assert_eq!(ErrorKind::InputInvalid, *err.kind());
+    let msg = format!(
+        "{}",
+        aws_smithy_types::error::display::DisplayErrorContext(&err)
+    );
+    assert!(
+        msg.contains("maximum of 10000 parts"),
+        "error must name the part limit and the remedy, got: {msg}"
+    );
+}
+
+/// A stream of exactly `MAX_PARTS` must upload, not trip the limit.
+///
+/// End-of-stream on a custom stream is only observed on the dispatch after the last part, so a guard
+/// keyed on dispatches rather than parts actually yielded would reject this legitimate object.
+#[tokio::test]
+async fn test_unknown_length_exactly_max_parts_succeeds() {
+    const MAX_PARTS: u64 = 10_000;
+
+    let client = mock_s3_client_for_multipart_upload();
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(CountingUnknownLengthStream {
+            next_part_num: 1,
+            total: MAX_PARTS,
+        }))
+        .initiate()
+        .unwrap();
+
+    handle
+        .join()
+        .await
+        .expect("a stream of exactly the maximum part count must upload");
+}
+
+/// The synthesized empty part belongs to the unknown-length path only.
+///
+/// A declared length already gives the dispatch loop a part count, so a source that declares a size
+/// and then delivers nothing must not have a part invented on its behalf — that would upload a part
+/// the caller never produced, and one that contradicts the size it declared.
+#[tokio::test]
+async fn test_known_length_never_synthesizes_empty_part() {
+    let upload_id = "test-upload-id".to_owned();
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+
+    // Split the part rules by body size so the empty one's call count is the assertion.
+    let empty_part = mock!(aws_sdk_s3::Client::upload_part)
+        .match_requests(|req| req.content_length() == Some(0))
+        .then_output(|| UploadPartOutput::builder().e_tag("empty-etag").build());
+    let data_part = mock!(aws_sdk_s3::Client::upload_part)
+        .match_requests(|req| req.content_length() != Some(0))
+        .then_output(|| UploadPartOutput::builder().e_tag("data-etag").build());
+
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[&create_mpu, &empty_part, &data_part, &complete_mpu]
+    );
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    // `TestStream` reports an exact size hint, so this is the known-length path. Declare a size and
+    // deliver nothing, which is what drives a read to end-of-stream with no part yielded.
+    let (tx, rx) = mpsc::channel(1);
+    let declared = 5 * ByteUnit::Mebibyte.as_bytes_u64();
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(TestStream::new(
+            rx, 0, declared,
+        )))
+        .initiate()
+        .unwrap();
+
+    drop(tx);
+    let _ = handle.join().await;
+
+    assert_eq!(
+        0,
+        empty_part.num_calls(),
+        "a declared-length source must never have an empty part synthesized for it"
     );
 }

--- a/aws-sdk-s3-transfer-manager/tests/upload_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/upload_test.rs
@@ -538,3 +538,73 @@ async fn test_known_length_sends_declared_size_not_running_sum() {
         .await
         .expect("a known-length upload must send its declared content length as MpuObjectSize");
 }
+
+/// A stream that yields data must never *also* send an empty part 1.
+///
+/// The empty-part rule only applies when the stream turned out to be empty. Parts
+/// are dispatched speculatively, so the dispatch that reads end-of-stream can run
+/// while the first data part is still in flight; if "has anything been emitted" is
+/// recorded only once that send completes, the end-of-stream dispatch sees "nothing
+/// emitted" and synthesizes a *second* part 1. CompleteMultipartUpload would then
+/// list part 1 twice — and whichever write S3 kept last could truncate the object.
+#[tokio::test]
+async fn test_unknown_length_with_data_never_sends_empty_part() {
+    let upload_id = "test-upload-id".to_owned();
+    let part_size = 5 * ByteUnit::Mebibyte.as_bytes_usize();
+
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output({
+        let upload_id = upload_id.clone();
+        move || {
+            CreateMultipartUploadOutput::builder()
+                .upload_id(upload_id.clone())
+                .build()
+        }
+    });
+
+    // Split the part rules by body size so the empty one's call count is the assertion.
+    let empty_part = mock!(aws_sdk_s3::Client::upload_part)
+        .match_requests(|req| req.content_length() == Some(0))
+        .then_output(|| UploadPartOutput::builder().e_tag("empty-etag").build());
+    let data_part = mock!(aws_sdk_s3::Client::upload_part)
+        .match_requests(|req| req.content_length() != Some(0))
+        .then_output(|| UploadPartOutput::builder().e_tag("data-etag").build());
+
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[&create_mpu, &empty_part, &data_part, &complete_mpu]
+    );
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(client)
+        .build();
+    let tm = aws_sdk_s3_transfer_manager::Client::new(config);
+
+    let (tx, rx) = mpsc::channel(1);
+    let handle = tm
+        .upload()
+        .bucket("test-bucket")
+        .key("test-key")
+        .body(InputStream::from_part_stream(UnknownLengthStream::new(rx)))
+        .initiate()
+        .unwrap();
+
+    // Exactly one data part, then end-of-stream.
+    tx.send(Bytes::from(vec![0u8; part_size])).await.unwrap();
+    drop(tx);
+
+    handle.join().await.expect("upload should succeed");
+
+    assert_eq!(
+        1,
+        data_part.num_calls(),
+        "the single data part must be uploaded once"
+    );
+    assert_eq!(
+        0,
+        empty_part.num_calls(),
+        "a stream that yielded data must not also send an empty part 1"
+    );
+}


### PR DESCRIPTION
## Summary

An upload from a `PartStream` with no size-hint upper bound panicked on `content_length required` instead of transferring. Such a source is always `is_mpu_only`, so it already routes through multipart; the only assumption that did not hold was that `Transferring` knows a part count up front.

Replaces `total_parts` with a `PartPlan` enum: `Known` carries the part count, `Unknown` dispatches parts speculatively and ends when the reader reports end-of-stream. An empty stream still has to produce a part, since S3 rejects a `CompleteMultipartUpload` that lists none, so one dispatch synthesizes a zero-length part 1 — claimed by a check-and-set under the state lock, because several part-work items can be dispatched before any of them reads and more than one can observe end-of-stream with nothing emitted.

Two follow-on bits: `MpuObjectSize` (#162) has no declared length to send here, so it is summed from the parts actually uploaded — the known path keeps its declared value, which is an independent witness a sum cannot replace. And the 10,000-part ceiling now fails with an actionable error instead of letting S3 reject part 10,001.

## Test plan

- [x] fmt / clippy clean (default + `--cfg e2e_test`)
- [x] lib + upload + upload_objects + upload_checksum tests green (631 + 11 + 28 + 25)
- [x] Adversarially verified: reinstating the original flag ordering, neutering the ceiling guard, and dropping the end-of-stream `total_bytes` set each fail their test, then restored green
- [x] e2e (`test_upload_unknown_content_length`, `test_upload_unknown_content_length_empty`) run against a real bucket in the e2e job — not yet exercised locally