### PR TITLE
buffer pool: physical foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -274,6 +274,7 @@ dependencies = [
 name = "aws-sdk-s3-transfer-manager"
 version = "0.2.0"
 dependencies = [
+ "arc-swap",
  "aws-config",
  "aws-runtime",
  "aws-sdk-s3",
@@ -2570,9 +2571,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"

--- a/aws-sdk-s3-transfer-manager/Cargo.toml
+++ b/aws-sdk-s3-transfer-manager/Cargo.toml
@@ -40,21 +40,18 @@ hdrhistogram = "7"
 http-body-1x = { package = "http-body", version = "1" }
 same-file = "1.0.6"
 dial9-tokio-telemetry = { version = "0.3", optional = true, features = ["cpu-profiling"] }
+arc-swap = "1.9.2"
 
 [features]
 dial9 = ["dep:dial9-tokio-telemetry"]
 
 [target.'cfg(unix)'.dependencies]
+libc = "0.2.189"
 nix = { version = "0.31", features = ["uio", "fs", "resource"] }
 
-# Total physical RAM via sysctl(hw.memsize).
-[target.'cfg(target_os = "macos")'.dependencies]
-libc = "0.2"
-
-# Total physical RAM via GlobalMemoryStatusEx; descriptor limit is not low on
-# Windows, so the connection cap there is the absolute ceiling.
+# Virtual memory and total physical RAM.
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.59", features = ["Win32_System_SystemInformation"] }
+windows-sys = { version = "0.59", features = ["Win32_System_Memory", "Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 aws-sdk-s3 = { version = "1.128.0", features = ["behavior-version-latest", "test-util"] }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Fixed-size carrier geometry, virtual memory, and physical ownership.
+
+mod block;
+mod geometry;
+mod virtual_memory;
+
+/// A count of fixed-size carriers.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+struct CarrierCount(usize);
+
+impl CarrierCount {
+    /// No carriers.
+    const ZERO: Self = Self(0);
+
+    /// Wraps a carrier count.
+    fn new(value: usize) -> Self {
+        Self(value)
+    }
+
+    /// Returns the underlying count.
+    fn get(self) -> usize {
+        self.0
+    }
+
+    /// Adds two counts, returning `None` on overflow.
+    fn checked_add(self, other: Self) -> Option<Self> {
+        self.0.checked_add(other.0).map(Self)
+    }
+
+    /// Subtracts two counts, returning `None` on underflow.
+    fn checked_sub(self, other: Self) -> Option<Self> {
+        self.0.checked_sub(other.0).map(Self)
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -17,13 +17,6 @@ use super::CarrierCount;
 use crate::runtime::sync::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use crate::runtime::sync::sync::{Arc, Mutex};
 
-/// Incarnation state that permits carrier claims.
-const ACTIVE: u8 = 0;
-/// Incarnation state that rejects claims while trim confirms ownership.
-const DRAINING: u8 = 1;
-/// Incarnation state whose mapping is no longer accessible.
-const DEAD: u8 = 2;
-
 /// Failure to construct, prepare, or claim from one block.
 #[derive(Debug)]
 pub(super) enum BlockError {
@@ -81,7 +74,7 @@ pub(super) enum TrimBlocked {
     /// The slot has no prepared incarnation.
     NotPrepared,
     /// Removing the block would violate the caller's prepared-capacity floor.
-    Required,
+    FloorViolation,
     /// A carrier claim won the claim-trim gate.
     Busy,
     /// A prior trim or failed protection transition still owns the slot.
@@ -109,6 +102,62 @@ enum MappingState {
     Prepared,
     /// A protection call failed and the complete range must be recovered.
     ProtectionPending,
+}
+
+/// Claim-trim gate state for one block incarnation.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum IncarnationState {
+    /// Carrier claims may proceed.
+    Active = 0,
+    /// Trim is confirming that no carrier is owned.
+    Draining = 1,
+    /// The incarnation's mapping is inaccessible.
+    Dead = 2,
+}
+
+/// Atomic storage for [`IncarnationState`].
+struct AtomicIncarnationState(AtomicU8);
+
+impl AtomicIncarnationState {
+    /// Creates an atomic state with `value`.
+    fn new(value: IncarnationState) -> Self {
+        Self(AtomicU8::new(value as u8))
+    }
+
+    /// Loads and validates the current state.
+    fn load(&self, order: Ordering) -> IncarnationState {
+        Self::decode(self.0.load(order))
+    }
+
+    /// Stores `value` with `order`.
+    fn store(&self, value: IncarnationState, order: Ordering) {
+        self.0.store(value as u8, order);
+    }
+
+    /// Compares and exchanges two typed states.
+    fn compare_exchange(
+        &self,
+        current: IncarnationState,
+        new: IncarnationState,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<IncarnationState, IncarnationState> {
+        self.0
+            .compare_exchange(current as u8, new as u8, success, failure)
+            .map(Self::decode)
+            .map_err(Self::decode)
+    }
+
+    /// Converts a stored representation into a state.
+    fn decode(value: u8) -> IncarnationState {
+        match value {
+            value if value == IncarnationState::Active as u8 => IncarnationState::Active,
+            value if value == IncarnationState::Draining as u8 => IncarnationState::Draining,
+            value if value == IncarnationState::Dead as u8 => IncarnationState::Dead,
+            _ => invariant_violation("incarnation contains an invalid state"),
+        }
+    }
 }
 
 /// Stable identity of one carrier within an incarnation.
@@ -141,7 +190,7 @@ struct WonWord {
 /// Occupancy metadata for one activation of a stable block slot.
 struct BlockIncarnation {
     /// Claim-trim gate state.
-    state: AtomicU8,
+    state: AtomicIncarnationState,
     /// Fixed bitmap with one ownership bit per carrier.
     ///
     /// Each atomic word covers 64 carriers. Padding bits in the final word
@@ -156,7 +205,7 @@ impl BlockIncarnation {
         in_use.try_reserve_exact(bitmap_words)?;
         in_use.extend((0..bitmap_words).map(|_| AtomicU64::new(0)));
         Ok(Self {
-            state: AtomicU8::new(ACTIVE),
+            state: AtomicIncarnationState::new(IncarnationState::Active),
             in_use: in_use.into_boxed_slice(),
         })
     }
@@ -172,6 +221,8 @@ impl BlockIncarnation {
 
 #[cfg(not(all(test, s3_tm_loom)))]
 mod incarnation_cell {
+    //! Lock-free production publication for block incarnations.
+
     use arc_swap::{ArcSwapOption, Guard};
 
     use super::BlockIncarnation;
@@ -221,6 +272,8 @@ mod incarnation_cell {
 
 #[cfg(all(test, s3_tm_loom))]
 mod incarnation_cell {
+    //! Loom-instrumented publication with owned incarnation guards.
+
     use super::BlockIncarnation;
     use crate::runtime::sync::sync::{Arc, Mutex};
 
@@ -276,8 +329,6 @@ pub(super) struct BlockSlot {
     range: VirtualRange,
     /// Checked carrier and bitmap dimensions.
     geometry: PoolGeometry,
-    /// Fixed mask for the carrier bits represented by each bitmap word.
-    valid_masks: Box<[u64]>,
     /// Serialized mapping and cleanup state.
     mapping: Mutex<MappingState>,
     /// Published claimable incarnation.
@@ -285,18 +336,11 @@ pub(super) struct BlockSlot {
 }
 
 impl BlockSlot {
-    /// Reserves an inaccessible virtual range and allocates immutable masks.
+    /// Reserves an inaccessible virtual range.
     ///
-    /// Returns [`BlockError::Allocation`] if mask allocation fails or
-    /// [`BlockError::VirtualMemory`] if the address range cannot be reserved.
+    /// Returns [`BlockError::VirtualMemory`] if the address range cannot be
+    /// reserved.
     pub(super) fn new(id: u32, geometry: PoolGeometry) -> Result<Self, BlockError> {
-        let mut valid_masks = Vec::new();
-        valid_masks.try_reserve_exact(geometry.bitmap_words())?;
-        valid_masks.extend(
-            (0..geometry.bitmap_words())
-                .map(|word| geometry.valid_mask(word).expect("word belongs to geometry")),
-        );
-
         let range = VirtualRange::reserve(
             geometry.block_size(),
             NonZeroUsize::new(geometry.page_size()).expect("geometry has a nonzero page size"),
@@ -305,7 +349,6 @@ impl BlockSlot {
             id,
             range,
             geometry,
-            valid_masks: valid_masks.into_boxed_slice(),
             mapping: Mutex::new(MappingState::Reserved {
                 reclaim_pending: false,
             }),
@@ -320,9 +363,10 @@ impl BlockSlot {
 
     /// Prepares the range and makes one incarnation active.
     ///
-    /// `prepared` must be serialized with every capacity transition. The count
-    /// is incremented before `Active` becomes visible. Protection failure
-    /// leaves the slot nonclaimable and does not change `prepared`.
+    /// The caller holds the admission lock that protects the pool-wide
+    /// `prepared` count and admission floor. The count is incremented before
+    /// `Active` becomes visible. Protection failure leaves the slot
+    /// nonclaimable and does not change `prepared`.
     pub(super) fn prepare(&self, prepared: &mut CarrierCount) -> Result<(), BlockError> {
         let mut mapping = self.mapping.lock();
         let current = self.current.load();
@@ -343,7 +387,7 @@ impl BlockSlot {
 
         if let Some(incarnation) = current.as_ref() {
             if !matches!(*mapping, MappingState::ProtectionPending)
-                || incarnation.state.load(Ordering::Acquire) != DRAINING
+                || incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining
             {
                 invariant_violation("only protection recovery may retain a draining incarnation");
             }
@@ -357,7 +401,9 @@ impl BlockSlot {
         *mapping = MappingState::Prepared;
         *prepared = next_prepared;
         if let Some(incarnation) = current.as_ref() {
-            incarnation.state.store(ACTIVE, Ordering::SeqCst);
+            incarnation
+                .state
+                .store(IncarnationState::Active, Ordering::SeqCst);
         } else if self.current.swap(fresh).is_some() {
             invariant_violation("preparation replaced a current incarnation");
         }
@@ -366,9 +412,10 @@ impl BlockSlot {
 
     /// Confirms that this block may be removed from prepared capacity.
     ///
-    /// `prepared` must be serialized with every capacity transition. Success
-    /// subtracts the complete block and returns cleanup authority. A live bit
-    /// restores `Active` without changing `prepared`.
+    /// The caller holds the admission lock that protects the pool-wide
+    /// `prepared` count and admission floor. Success subtracts the complete
+    /// block and returns cleanup authority. A live bit restores `Active`
+    /// without changing `prepared`.
     pub(super) fn start_trim(
         slot: &Arc<Self>,
         prepared: &mut CarrierCount,
@@ -386,35 +433,50 @@ impl BlockSlot {
             invariant_violation("prepared mapping has no current incarnation");
         };
         match incarnation.state.load(Ordering::Acquire) {
-            ACTIVE => {}
-            DRAINING => return Err(TrimBlocked::CleanupPending),
-            DEAD => invariant_violation("prepared mapping has a dead current incarnation"),
-            _ => invariant_violation("prepared mapping has an invalid incarnation state"),
+            IncarnationState::Active => {}
+            IncarnationState::Draining => return Err(TrimBlocked::CleanupPending),
+            IncarnationState::Dead => {
+                invariant_violation("prepared mapping has a dead current incarnation")
+            }
         }
 
         let Some(next_prepared) = prepared.checked_sub(slot.carrier_count()) else {
             invariant_violation("prepared capacity excludes an active block");
         };
         if next_prepared < floor {
-            return Err(TrimBlocked::Required);
+            return Err(TrimBlocked::FloorViolation);
         }
 
         if incarnation
             .state
-            .compare_exchange(ACTIVE, DRAINING, Ordering::SeqCst, Ordering::SeqCst)
+            .compare_exchange(
+                IncarnationState::Active,
+                IncarnationState::Draining,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
             .is_err()
         {
             return Err(TrimBlocked::CleanupPending);
         }
-        model_seq_cst_store_load();
+        loom_seq_cst_fence();
 
         let busy = incarnation
             .in_use
             .iter()
-            .zip(&slot.valid_masks)
-            .any(|(word, valid)| word.load(Ordering::SeqCst) & valid != 0);
+            .enumerate()
+            .any(|(word_index, word)| {
+                let valid = if word_index + 1 == slot.geometry.bitmap_words() {
+                    slot.geometry.final_word_mask()
+                } else {
+                    u64::MAX
+                };
+                word.load(Ordering::SeqCst) & valid != 0
+            });
         if busy {
-            incarnation.state.store(ACTIVE, Ordering::SeqCst);
+            incarnation
+                .state
+                .store(IncarnationState::Active, Ordering::SeqCst);
             return Err(TrimBlocked::Busy);
         }
 
@@ -428,8 +490,10 @@ impl BlockSlot {
 
     /// Retries pending whole-range protection or backing reclaim.
     ///
-    /// A slot with no pending work returns success without changing state.
-    /// Failure leaves the slot nonclaimable and identifies the required retry.
+    /// Pool maintenance calls this after a cleanup operation records pending
+    /// work. A slot with no pending work returns success without changing
+    /// state. Failure leaves the slot nonclaimable and identifies the required
+    /// retry.
     pub(super) fn retry_cleanup(&self) -> Result<(), CleanupRetry> {
         let mut mapping = self.mapping.lock();
         match *mapping {
@@ -439,9 +503,10 @@ impl BlockSlot {
                     invariant_violation("prepared mapping has no current incarnation");
                 };
                 match incarnation.state.load(Ordering::Acquire) {
-                    ACTIVE | DRAINING => Ok(()),
-                    DEAD => invariant_violation("prepared mapping has a dead current incarnation"),
-                    _ => invariant_violation("prepared mapping has an invalid incarnation state"),
+                    IncarnationState::Active | IncarnationState::Draining => Ok(()),
+                    IncarnationState::Dead => {
+                        invariant_violation("prepared mapping has a dead current incarnation")
+                    }
                 }
             }
             MappingState::Reserved {
@@ -470,7 +535,7 @@ impl BlockSlot {
             }
             MappingState::ProtectionPending => {
                 if let Some(incarnation) = self.current.load().as_ref() {
-                    if incarnation.state.load(Ordering::Acquire) != DRAINING {
+                    if incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining {
                         invariant_violation(
                             "protection-pending mapping has a non-draining incarnation",
                         );
@@ -497,10 +562,12 @@ impl BlockSlot {
         *mapping = MappingState::Reserved { reclaim_pending };
 
         if let Some(incarnation) = self.current.load().as_ref() {
-            if incarnation.state.load(Ordering::Acquire) != DRAINING {
+            if incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining {
                 invariant_violation("cleanup found a non-draining current incarnation");
             }
-            incarnation.state.store(DEAD, Ordering::Release);
+            incarnation
+                .state
+                .store(IncarnationState::Dead, Ordering::Release);
             let removed = self
                 .current
                 .swap(None)
@@ -549,9 +616,8 @@ impl BlockSlot {
             invariant_violation("owned carriers name a different incarnation");
         }
         match current.state.load(Ordering::Acquire) {
-            ACTIVE | DRAINING => {}
-            DEAD => invariant_violation("owned carriers name a dead incarnation"),
-            _ => invariant_violation("owned carriers name an invalid incarnation state"),
+            IncarnationState::Active | IncarnationState::Draining => {}
+            IncarnationState::Dead => invariant_violation("owned carriers name a dead incarnation"),
         }
 
         for word in won {
@@ -584,8 +650,13 @@ impl BlockSlot {
                 incarnation
                     .in_use
                     .iter()
-                    .zip(&self.valid_masks)
-                    .map(|(word, valid)| {
+                    .enumerate()
+                    .map(|(word_index, word)| {
+                        let valid = if word_index + 1 == self.geometry.bitmap_words() {
+                            self.geometry.final_word_mask()
+                        } else {
+                            u64::MAX
+                        };
                         (word.load(Ordering::Acquire) & valid).count_ones() as usize
                     })
                     .sum()
@@ -594,7 +665,7 @@ impl BlockSlot {
     }
 }
 
-/// Linear cleanup authority for a confirmed trim.
+/// Single-owner cleanup token for a confirmed trim.
 ///
 /// Dropping an unfinished token performs the same cleanup attempt as
 /// [`TrimCleanup::finish`].
@@ -635,7 +706,7 @@ impl TrimCleanup {
             invariant_violation("trim cleanup lost its current incarnation");
         };
         if !Arc::ptr_eq(incarnation, &self.incarnation)
-            || incarnation.state.load(Ordering::Acquire) != DRAINING
+            || incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining
         {
             invariant_violation("trim cleanup no longer owns the draining incarnation");
         }
@@ -692,13 +763,14 @@ impl BlockClaimAttempt {
 
     /// Claims up to `count` free bits and returns the number won.
     ///
-    /// A claim may lose candidate bits after its relaxed load. For example:
+    /// A competing claim may take a candidate after the relaxed load:
     ///
     /// ```text
-    /// observed  = 0b0010
-    /// candidate = 0b0101
-    /// previous  = 0b0110  // another claim took bit 2
-    /// won       = 0b0001  // candidate & !previous
+    /// this claim loads       0b0010  // bit 1 is occupied
+    /// this claim selects     0b0101  // free bits 0 and 2
+    /// another claim sets     0b0100  // competitor wins bit 2
+    /// fetch_or returns       0b0110  // occupancy before this fetch_or
+    /// this claim wins        0b0001  // candidate & !previous
     /// ```
     fn take(&mut self, mut count: usize) -> usize {
         let incarnation = self
@@ -707,15 +779,15 @@ impl BlockClaimAttempt {
             .expect("a claim attempt protects one incarnation");
         let mut taken = 0;
 
-        for (word_index, (word, valid)) in incarnation
-            .in_use
-            .iter()
-            .zip(&self.slot.valid_masks)
-            .enumerate()
-        {
+        for (word_index, word) in incarnation.in_use.iter().enumerate() {
             if count == 0 {
                 break;
             }
+            let valid = if word_index + 1 == self.slot.geometry.bitmap_words() {
+                self.slot.geometry.final_word_mask()
+            } else {
+                u64::MAX
+            };
             let observed = word.load(Ordering::Relaxed);
             let candidate = take_lowest(!observed & valid, count);
             if candidate == 0 {
@@ -745,14 +817,13 @@ impl BlockClaimAttempt {
             .incarnation
             .as_ref()
             .expect("a claim attempt protects one incarnation");
-        model_seq_cst_store_load();
+        loom_seq_cst_fence();
         match incarnation.state.load(Ordering::SeqCst) {
-            ACTIVE => {}
-            DRAINING | DEAD => {
+            IncarnationState::Active => {}
+            IncarnationState::Draining | IncarnationState::Dead => {
                 self.rollback_original();
                 return None;
             }
-            _ => invariant_violation("claim observed an invalid incarnation state"),
         }
 
         let incarnation = BlockIncarnation::identity(incarnation);
@@ -781,7 +852,7 @@ impl Drop for BlockClaimAttempt {
     }
 }
 
-/// Linear ownership of gate-passed bits not yet converted to carriers.
+/// Single-owner set of gate-passed bits not yet converted to carriers.
 pub(super) struct ProvisionalBits {
     /// Slot containing the owned bits.
     slot: Arc<BlockSlot>,
@@ -843,7 +914,7 @@ impl Drop for ProvisionalBits {
     }
 }
 
-/// Linear physical ownership of one carrier.
+/// Single-owner physical allocation for one carrier.
 pub(super) struct CarrierAllocation {
     /// Slot that retains the carrier address.
     slot: Arc<BlockSlot>,
@@ -921,11 +992,12 @@ fn take_lowest(mut available: u64, count: usize) -> u64 {
     selected
 }
 
-/// Models the global store-load order supplied by production `SeqCst`.
+/// Supplies the store-load edge missing from Loom's atomic model.
 ///
-/// Loom 0.7 treats `SeqCst` accesses as `AcqRel`, but models a `SeqCst` fence.
+/// Production `SeqCst` operations already provide the required global order.
+/// Loom 0.7 treats those accesses as `AcqRel`, but models a `SeqCst` fence.
 #[inline]
-fn model_seq_cst_store_load() {
+fn loom_seq_cst_fence() {
     #[cfg(all(test, s3_tm_loom))]
     loom::sync::atomic::fence(Ordering::SeqCst);
 }
@@ -933,6 +1005,12 @@ fn model_seq_cst_store_load() {
 /// Stops execution after an ownership or lifecycle invariant fails.
 #[cold]
 fn invariant_violation(message: &'static str) -> ! {
+    tracing::error!(
+        target: crate::telemetry::TARGET_MEMORY,
+        reason = message,
+        "buffer-pool ownership invariant violated; aborting"
+    );
+
     #[cfg(test)]
     panic!("buffer-pool ownership invariant violated: {message}");
 
@@ -952,7 +1030,7 @@ mod tests {
 
     fn geometry(carriers: usize) -> PoolGeometry {
         let page_size = page_size().unwrap().get();
-        PoolGeometry::new(page_size, page_size, carriers).unwrap()
+        PoolGeometry::new(page_size, page_size * carriers, page_size).unwrap()
     }
 
     fn prepared_slot(carriers: usize) -> (Arc<BlockSlot>, CarrierCount) {
@@ -1053,6 +1131,23 @@ mod tests {
     }
 
     #[test]
+    fn cleanup_retry_is_a_noop_without_pending_work() {
+        let slot = Arc::new(BlockSlot::new(7, geometry(1)).unwrap());
+        let mut prepared = CarrierCount::ZERO;
+
+        slot.retry_cleanup().unwrap();
+        assert!(matches!(
+            BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO),
+            Err(TrimBlocked::NotPrepared)
+        ));
+
+        slot.prepare(&mut prepared).unwrap();
+        slot.retry_cleanup().unwrap();
+        assert_eq!(prepared, CarrierCount::new(1));
+        assert_mapping(&slot, MappingState::Prepared);
+    }
+
+    #[test]
     fn carrier_pointer_is_derived_from_live_ownership() {
         let (slot, _) = prepared_slot(1);
         let mut carriers = BlockSlot::try_claim(&slot, CarrierCount::new(1))
@@ -1122,6 +1217,34 @@ mod tests {
     }
 
     #[test]
+    fn partial_claim_crosses_a_bitmap_word_boundary() {
+        let (slot, _) = prepared_slot(66);
+        let first = BlockSlot::try_claim(&slot, CarrierCount::new(63))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+
+        let second = BlockSlot::try_claim(&slot, CarrierCount::new(3))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+
+        assert_eq!(first.last().unwrap().id.index, 62);
+        assert_eq!(
+            second
+                .iter()
+                .map(|carrier| carrier.id.index)
+                .collect::<Vec<_>>(),
+            vec![63, 64, 65]
+        );
+        drop(first);
+        drop(second);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
     fn provisional_word_bits_map_to_carrier_indices() {
         let (slot, _) = prepared_slot(68);
         let incarnation = {
@@ -1169,7 +1292,7 @@ mod tests {
 
         assert!(matches!(
             BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::new(1)),
-            Err(TrimBlocked::Required)
+            Err(TrimBlocked::FloorViolation)
         ));
         assert_eq!(prepared, CarrierCount::new(2));
 
@@ -1266,6 +1389,10 @@ mod tests {
         assert!(BlockSlot::try_claim(&slot, CarrierCount::new(1))
             .unwrap()
             .is_none());
+        assert!(matches!(
+            BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO),
+            Err(TrimBlocked::CleanupPending)
+        ));
 
         slot.prepare(&mut prepared).unwrap();
         assert_eq!(prepared, CarrierCount::new(1));
@@ -1413,6 +1540,38 @@ mod tests {
     }
 
     #[test]
+    fn slot_mismatch_stops_before_clearing() {
+        let (slot, _) = prepared_slot(1);
+        let mut carriers = BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+        let carrier = carriers.pop().unwrap();
+        let wrong = CarrierId {
+            slot: carrier.id.slot + 1,
+            ..carrier.id
+        };
+
+        let result = catch_unwind(AssertUnwindSafe(|| slot.release_one(wrong)));
+
+        assert!(result.is_err());
+        assert_eq!(slot.live_carriers(), 1);
+        drop(carrier);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn selects_only_the_requested_low_bits() {
+        assert_eq!(take_lowest(0, 8), 0);
+        assert_eq!(take_lowest(0b1011_0100, 0), 0);
+        assert_eq!(take_lowest(0b1011_0100, 1), 0b0000_0100);
+        assert_eq!(take_lowest(0b1011_0100, 3), 0b0011_0100);
+        assert_eq!(take_lowest(0b1011_0100, usize::MAX), 0b1011_0100);
+        assert_eq!(take_lowest(u64::MAX, usize::MAX), u64::MAX);
+    }
+
+    #[test]
     fn zero_claim_is_rejected_without_mutation() {
         let (slot, _) = prepared_slot(1);
 
@@ -1440,7 +1599,7 @@ mod loom_tests {
     use crate::runtime::sync::thread;
 
     fn prepared_slot() -> (Arc<BlockSlot>, CarrierCount) {
-        let geometry = PoolGeometry::new(4096, 4096, 1).unwrap();
+        let geometry = PoolGeometry::new(4096, 4096, 4096).unwrap();
         let slot = Arc::new(BlockSlot::new(0, geometry).unwrap());
         let mut prepared = CarrierCount::ZERO;
         slot.prepare(&mut prepared).unwrap();
@@ -1590,7 +1749,9 @@ mod loom_tests {
                 .current
                 .load()
                 .as_ref()
-                .map(|incarnation| incarnation.state.load(Ordering::Acquire) == ACTIVE)
+                .map(|incarnation| {
+                    incarnation.state.load(Ordering::Acquire) == IncarnationState::Active
+                })
                 .unwrap_or(false);
             if active {
                 let mut prepared = prepared.lock();
@@ -1607,6 +1768,33 @@ mod loom_tests {
                     reclaim_pending: false
                 }
             );
+        });
+    }
+
+    #[test]
+    fn two_claimants_cannot_own_one_carrier() {
+        loom::model(|| {
+            let (slot, _) = prepared_slot();
+
+            let first_slot = Arc::clone(&slot);
+            let first = thread::spawn(move || {
+                BlockSlot::try_claim(&first_slot, CarrierCount::new(1)).unwrap()
+            });
+            let second_slot = Arc::clone(&slot);
+            let second = thread::spawn(move || {
+                BlockSlot::try_claim(&second_slot, CarrierCount::new(1)).unwrap()
+            });
+
+            let first = first.join().unwrap();
+            let second = second.join().unwrap();
+            let owned = first.as_ref().map_or(0, |claim| claim.len().get())
+                + second.as_ref().map_or(0, |claim| claim.len().get());
+
+            assert_eq!(owned, 1);
+            assert_eq!(slot.live_carriers(), 1);
+            drop(first);
+            drop(second);
+            assert_eq!(slot.live_carriers(), 0);
         });
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -1,0 +1,1612 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Stable block geometry and carrier ownership.
+
+use std::collections::TryReserveError;
+use std::fmt;
+use std::mem::MaybeUninit;
+use std::num::NonZeroUsize;
+use std::ptr::NonNull;
+
+use super::geometry::PoolGeometry;
+use super::virtual_memory::{VirtualMemoryError, VirtualRange};
+use super::CarrierCount;
+use crate::runtime::sync::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use crate::runtime::sync::sync::{Arc, Mutex};
+
+/// Incarnation state that permits carrier claims.
+const ACTIVE: u8 = 0;
+/// Incarnation state that rejects claims while trim confirms ownership.
+const DRAINING: u8 = 1;
+/// Incarnation state whose mapping is no longer accessible.
+const DEAD: u8 = 2;
+
+/// Failure to construct, prepare, or claim from one block.
+#[derive(Debug)]
+pub(super) enum BlockError {
+    /// A virtual-memory operation failed.
+    VirtualMemory(VirtualMemoryError),
+    /// Ownership metadata could not be allocated.
+    Allocation(TryReserveError),
+    /// The slot already contains prepared capacity.
+    AlreadyPrepared,
+    /// Adding the block would overflow prepared-capacity accounting.
+    PreparedCapacityOverflow,
+    /// A claim requested no carriers.
+    InvalidClaimCount,
+}
+
+impl fmt::Display for BlockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::VirtualMemory(error) => error.fmt(f),
+            Self::Allocation(error) => write!(f, "block metadata allocation failed: {error}"),
+            Self::AlreadyPrepared => f.write_str("block already has a prepared incarnation"),
+            Self::PreparedCapacityOverflow => f.write_str("prepared carrier count would overflow"),
+            Self::InvalidClaimCount => f.write_str("a carrier claim must be nonzero"),
+        }
+    }
+}
+
+impl std::error::Error for BlockError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::VirtualMemory(error) => Some(error),
+            Self::Allocation(error) => Some(error),
+            Self::AlreadyPrepared | Self::PreparedCapacityOverflow | Self::InvalidClaimCount => {
+                None
+            }
+        }
+    }
+}
+
+impl From<VirtualMemoryError> for BlockError {
+    fn from(error: VirtualMemoryError) -> Self {
+        Self::VirtualMemory(error)
+    }
+}
+
+impl From<TryReserveError> for BlockError {
+    fn from(error: TryReserveError) -> Self {
+        Self::Allocation(error)
+    }
+}
+
+/// Reason one block cannot begin a trim.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum TrimBlocked {
+    /// The slot has no prepared incarnation.
+    NotPrepared,
+    /// Removing the block would violate the caller's prepared-capacity floor.
+    Required,
+    /// A carrier claim won the claim-trim gate.
+    Busy,
+    /// A prior trim or failed protection transition still owns the slot.
+    CleanupPending,
+}
+
+/// Failed cleanup work that remains safe to retry while the slot is inactive.
+#[derive(Debug)]
+pub(super) enum CleanupRetry {
+    /// Whole-range protection is unknown and must be recovered.
+    ProtectionPending(VirtualMemoryError),
+    /// The range is inaccessible, but backing may remain resident.
+    ReclaimPending(VirtualMemoryError),
+}
+
+/// Accessibility state for one stable virtual range.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MappingState {
+    /// The range is inaccessible and may need another discard attempt.
+    Reserved {
+        /// `true` when backing reclaim has not completed.
+        reclaim_pending: bool,
+    },
+    /// The complete range is readable and writable.
+    Prepared,
+    /// A protection call failed and the complete range must be recovered.
+    ProtectionPending,
+}
+
+/// Stable identity of one carrier within an incarnation.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct CarrierId {
+    /// Stable block-slot index.
+    slot: u32,
+    /// Carrier index within the slot.
+    index: u32,
+    /// Incarnation that owns the carrier bit.
+    incarnation: IncarnationIdentity,
+}
+
+/// Comparison-only identity for one block activation.
+///
+/// The live carrier bit, not this value, prevents incarnation replacement.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct IncarnationIdentity(NonZeroUsize);
+
+/// Bits won by one bitmap operation.
+#[derive(Clone, Copy, Debug)]
+struct WonWord {
+    /// Index into the incarnation bitmap.
+    word_index: usize,
+    /// Bits changed from clear to set by the operation.
+    mask: u64,
+}
+
+/// Occupancy metadata for one activation of a stable block slot.
+struct BlockIncarnation {
+    /// Claim-trim gate state.
+    state: AtomicU8,
+    /// Fixed bitmap with one ownership bit per carrier.
+    ///
+    /// Each atomic word covers 64 carriers. Padding bits in the final word
+    /// remain clear.
+    in_use: Box<[AtomicU64]>,
+}
+
+impl BlockIncarnation {
+    /// Allocates an active incarnation with every valid carrier free.
+    fn try_new(bitmap_words: usize) -> Result<Self, TryReserveError> {
+        let mut in_use = Vec::new();
+        in_use.try_reserve_exact(bitmap_words)?;
+        in_use.extend((0..bitmap_words).map(|_| AtomicU64::new(0)));
+        Ok(Self {
+            state: AtomicU8::new(ACTIVE),
+            in_use: in_use.into_boxed_slice(),
+        })
+    }
+
+    /// Returns an opaque identity for diagnostic comparisons.
+    fn identity(this: &Arc<Self>) -> IncarnationIdentity {
+        let address = Arc::as_ptr(this).addr();
+        IncarnationIdentity(
+            NonZeroUsize::new(address).expect("an allocated incarnation has a nonzero address"),
+        )
+    }
+}
+
+#[cfg(not(all(test, s3_tm_loom)))]
+mod incarnation_cell {
+    use arc_swap::{ArcSwapOption, Guard};
+
+    use super::BlockIncarnation;
+    use crate::runtime::sync::sync::Arc;
+
+    /// Atomic publication for the current block incarnation.
+    pub(super) struct IncarnationCell {
+        inner: ArcSwapOption<BlockIncarnation>,
+    }
+
+    impl IncarnationCell {
+        /// Creates an empty publication cell.
+        pub(super) fn new() -> Self {
+            Self {
+                inner: ArcSwapOption::empty(),
+            }
+        }
+
+        /// Protects the current incarnation from metadata reclamation.
+        pub(super) fn load(&self) -> IncarnationGuard {
+            IncarnationGuard {
+                inner: self.inner.load(),
+            }
+        }
+
+        /// Replaces the current incarnation and returns the previous value.
+        pub(super) fn swap(
+            &self,
+            next: Option<Arc<BlockIncarnation>>,
+        ) -> Option<Arc<BlockIncarnation>> {
+            self.inner.swap(next)
+        }
+    }
+
+    /// Protection for the incarnation loaded before a bitmap mutation.
+    pub(super) struct IncarnationGuard {
+        inner: Guard<Option<Arc<BlockIncarnation>>>,
+    }
+
+    impl IncarnationGuard {
+        /// Returns the protected incarnation, or `None` for an inactive slot.
+        pub(super) fn as_ref(&self) -> Option<&Arc<BlockIncarnation>> {
+            self.inner.as_ref()
+        }
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod incarnation_cell {
+    use super::BlockIncarnation;
+    use crate::runtime::sync::sync::{Arc, Mutex};
+
+    /// Loom-instrumented publication for the current block incarnation.
+    pub(super) struct IncarnationCell {
+        inner: Mutex<Option<Arc<BlockIncarnation>>>,
+    }
+
+    impl IncarnationCell {
+        /// Creates an empty publication cell.
+        pub(super) fn new() -> Self {
+            Self {
+                inner: Mutex::new(None),
+            }
+        }
+
+        /// Loads an owned reference to the current incarnation.
+        pub(super) fn load(&self) -> IncarnationGuard {
+            IncarnationGuard {
+                inner: self.inner.lock().clone(),
+            }
+        }
+
+        /// Replaces the current incarnation and returns the previous value.
+        pub(super) fn swap(
+            &self,
+            next: Option<Arc<BlockIncarnation>>,
+        ) -> Option<Arc<BlockIncarnation>> {
+            std::mem::replace(&mut *self.inner.lock(), next)
+        }
+    }
+
+    /// Owned protection for a Loom-loaded incarnation.
+    pub(super) struct IncarnationGuard {
+        inner: Option<Arc<BlockIncarnation>>,
+    }
+
+    impl IncarnationGuard {
+        /// Returns the protected incarnation, or `None` for an inactive slot.
+        pub(super) fn as_ref(&self) -> Option<&Arc<BlockIncarnation>> {
+            self.inner.as_ref()
+        }
+    }
+}
+
+use incarnation_cell::{IncarnationCell, IncarnationGuard};
+
+/// Stable block geometry, mapping, and replaceable ownership metadata.
+pub(super) struct BlockSlot {
+    /// Stable slot index.
+    id: u32,
+    /// Virtual range retained for the slot lifetime.
+    range: VirtualRange,
+    /// Checked carrier and bitmap dimensions.
+    geometry: PoolGeometry,
+    /// Fixed mask for the carrier bits represented by each bitmap word.
+    valid_masks: Box<[u64]>,
+    /// Serialized mapping and cleanup state.
+    mapping: Mutex<MappingState>,
+    /// Published claimable incarnation.
+    current: IncarnationCell,
+}
+
+impl BlockSlot {
+    /// Reserves an inaccessible virtual range and allocates immutable masks.
+    ///
+    /// Returns [`BlockError::Allocation`] if mask allocation fails or
+    /// [`BlockError::VirtualMemory`] if the address range cannot be reserved.
+    pub(super) fn new(id: u32, geometry: PoolGeometry) -> Result<Self, BlockError> {
+        let mut valid_masks = Vec::new();
+        valid_masks.try_reserve_exact(geometry.bitmap_words())?;
+        valid_masks.extend(
+            (0..geometry.bitmap_words())
+                .map(|word| geometry.valid_mask(word).expect("word belongs to geometry")),
+        );
+
+        let range = VirtualRange::reserve(
+            geometry.block_size(),
+            NonZeroUsize::new(geometry.page_size()).expect("geometry has a nonzero page size"),
+        )?;
+        Ok(Self {
+            id,
+            range,
+            geometry,
+            valid_masks: valid_masks.into_boxed_slice(),
+            mapping: Mutex::new(MappingState::Reserved {
+                reclaim_pending: false,
+            }),
+            current: IncarnationCell::new(),
+        })
+    }
+
+    /// Returns the number of carriers in this slot.
+    pub(super) fn carrier_count(&self) -> CarrierCount {
+        self.geometry.carriers_per_block()
+    }
+
+    /// Prepares the range and makes one incarnation active.
+    ///
+    /// `prepared` must be serialized with every capacity transition. The count
+    /// is incremented before `Active` becomes visible. Protection failure
+    /// leaves the slot nonclaimable and does not change `prepared`.
+    pub(super) fn prepare(&self, prepared: &mut CarrierCount) -> Result<(), BlockError> {
+        let mut mapping = self.mapping.lock();
+        let current = self.current.load();
+        if matches!(*mapping, MappingState::Prepared) {
+            return Err(BlockError::AlreadyPrepared);
+        }
+
+        let next_prepared = prepared
+            .checked_add(self.carrier_count())
+            .ok_or(BlockError::PreparedCapacityOverflow)?;
+        let fresh = if current.as_ref().is_none() {
+            Some(Arc::new(BlockIncarnation::try_new(
+                self.geometry.bitmap_words(),
+            )?))
+        } else {
+            None
+        };
+
+        if let Some(incarnation) = current.as_ref() {
+            if !matches!(*mapping, MappingState::ProtectionPending)
+                || incarnation.state.load(Ordering::Acquire) != DRAINING
+            {
+                invariant_violation("only protection recovery may retain a draining incarnation");
+            }
+        }
+
+        if let Err(error) = self.range.prepare() {
+            *mapping = MappingState::ProtectionPending;
+            return Err(error.into());
+        }
+
+        *mapping = MappingState::Prepared;
+        *prepared = next_prepared;
+        if let Some(incarnation) = current.as_ref() {
+            incarnation.state.store(ACTIVE, Ordering::SeqCst);
+        } else if self.current.swap(fresh).is_some() {
+            invariant_violation("preparation replaced a current incarnation");
+        }
+        Ok(())
+    }
+
+    /// Confirms that this block may be removed from prepared capacity.
+    ///
+    /// `prepared` must be serialized with every capacity transition. Success
+    /// subtracts the complete block and returns cleanup authority. A live bit
+    /// restores `Active` without changing `prepared`.
+    pub(super) fn start_trim(
+        slot: &Arc<Self>,
+        prepared: &mut CarrierCount,
+        floor: CarrierCount,
+    ) -> Result<TrimCleanup, TrimBlocked> {
+        let mapping = slot.mapping.lock();
+        match *mapping {
+            MappingState::Prepared => {}
+            MappingState::Reserved { .. } => return Err(TrimBlocked::NotPrepared),
+            MappingState::ProtectionPending => return Err(TrimBlocked::CleanupPending),
+        }
+
+        let current = slot.current.load();
+        let Some(incarnation) = current.as_ref() else {
+            invariant_violation("prepared mapping has no current incarnation");
+        };
+        match incarnation.state.load(Ordering::Acquire) {
+            ACTIVE => {}
+            DRAINING => return Err(TrimBlocked::CleanupPending),
+            DEAD => invariant_violation("prepared mapping has a dead current incarnation"),
+            _ => invariant_violation("prepared mapping has an invalid incarnation state"),
+        }
+
+        let Some(next_prepared) = prepared.checked_sub(slot.carrier_count()) else {
+            invariant_violation("prepared capacity excludes an active block");
+        };
+        if next_prepared < floor {
+            return Err(TrimBlocked::Required);
+        }
+
+        if incarnation
+            .state
+            .compare_exchange(ACTIVE, DRAINING, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return Err(TrimBlocked::CleanupPending);
+        }
+        model_seq_cst_store_load();
+
+        let busy = incarnation
+            .in_use
+            .iter()
+            .zip(&slot.valid_masks)
+            .any(|(word, valid)| word.load(Ordering::SeqCst) & valid != 0);
+        if busy {
+            incarnation.state.store(ACTIVE, Ordering::SeqCst);
+            return Err(TrimBlocked::Busy);
+        }
+
+        *prepared = next_prepared;
+        Ok(TrimCleanup {
+            slot: Arc::clone(slot),
+            incarnation: Arc::clone(incarnation),
+            consumed: false,
+        })
+    }
+
+    /// Retries pending whole-range protection or backing reclaim.
+    ///
+    /// A slot with no pending work returns success without changing state.
+    /// Failure leaves the slot nonclaimable and identifies the required retry.
+    pub(super) fn retry_cleanup(&self) -> Result<(), CleanupRetry> {
+        let mut mapping = self.mapping.lock();
+        match *mapping {
+            MappingState::Prepared => {
+                let current = self.current.load();
+                let Some(incarnation) = current.as_ref() else {
+                    invariant_violation("prepared mapping has no current incarnation");
+                };
+                match incarnation.state.load(Ordering::Acquire) {
+                    ACTIVE | DRAINING => Ok(()),
+                    DEAD => invariant_violation("prepared mapping has a dead current incarnation"),
+                    _ => invariant_violation("prepared mapping has an invalid incarnation state"),
+                }
+            }
+            MappingState::Reserved {
+                reclaim_pending: false,
+            } => {
+                if self.current.load().as_ref().is_some() {
+                    invariant_violation("inactive mapping has a current incarnation");
+                }
+                Ok(())
+            }
+            MappingState::Reserved {
+                reclaim_pending: true,
+            } => {
+                if self.current.load().as_ref().is_some() {
+                    invariant_violation("inactive reclaim has a current incarnation");
+                }
+                match self.range.discard() {
+                    Ok(()) => {
+                        *mapping = MappingState::Reserved {
+                            reclaim_pending: false,
+                        };
+                        Ok(())
+                    }
+                    Err(error) => Err(CleanupRetry::ReclaimPending(error)),
+                }
+            }
+            MappingState::ProtectionPending => {
+                if let Some(incarnation) = self.current.load().as_ref() {
+                    if incarnation.state.load(Ordering::Acquire) != DRAINING {
+                        invariant_violation(
+                            "protection-pending mapping has a non-draining incarnation",
+                        );
+                    }
+                }
+                if let Err(error) = self.range.deactivate() {
+                    return Err(CleanupRetry::ProtectionPending(error));
+                }
+                *mapping = MappingState::Reserved {
+                    reclaim_pending: false,
+                };
+                self.finish_inactive_cleanup(&mut mapping)
+            }
+        }
+    }
+
+    /// Retires a draining incarnation after the range becomes inaccessible.
+    ///
+    /// Discard failure still retires the incarnation and records pending
+    /// reclaim in `mapping`.
+    fn finish_inactive_cleanup(&self, mapping: &mut MappingState) -> Result<(), CleanupRetry> {
+        let reclaim = self.range.discard();
+        let reclaim_pending = reclaim.is_err();
+        *mapping = MappingState::Reserved { reclaim_pending };
+
+        if let Some(incarnation) = self.current.load().as_ref() {
+            if incarnation.state.load(Ordering::Acquire) != DRAINING {
+                invariant_violation("cleanup found a non-draining current incarnation");
+            }
+            incarnation.state.store(DEAD, Ordering::Release);
+            let removed = self
+                .current
+                .swap(None)
+                .unwrap_or_else(|| invariant_violation("cleanup lost its current incarnation"));
+            if !Arc::ptr_eq(&removed, incarnation) {
+                invariant_violation("cleanup removed a different incarnation");
+            }
+        }
+
+        match reclaim {
+            Ok(()) => Ok(()),
+            Err(error) => Err(CleanupRetry::ReclaimPending(error)),
+        }
+    }
+
+    /// Claims up to `count` carriers from the current active incarnation.
+    ///
+    /// Returns `None` when no incarnation is published, no bit is free, or
+    /// trim wins the state gate. Zero returns [`BlockError::InvalidClaimCount`].
+    pub(super) fn try_claim(
+        slot: &Arc<Self>,
+        count: CarrierCount,
+    ) -> Result<Option<ProvisionalBits>, BlockError> {
+        if count == CarrierCount::ZERO {
+            return Err(BlockError::InvalidClaimCount);
+        }
+        let Some(mut attempt) = BlockClaimAttempt::begin(slot)? else {
+            return Ok(None);
+        };
+        attempt.take(count.get());
+        Ok(attempt.finish())
+    }
+
+    /// Returns a set of bits from a gate-passed owner.
+    ///
+    /// Identity or ownership mismatch is fail-stop and clears no bits.
+    fn release_won(&self, incarnation: IncarnationIdentity, won: &[WonWord]) {
+        if won.iter().all(|word| word.mask == 0) {
+            return;
+        }
+        let current = self.current.load();
+        let Some(current) = current.as_ref() else {
+            invariant_violation("owned carriers have no current incarnation");
+        };
+        if BlockIncarnation::identity(current) != incarnation {
+            invariant_violation("owned carriers name a different incarnation");
+        }
+        match current.state.load(Ordering::Acquire) {
+            ACTIVE | DRAINING => {}
+            DEAD => invariant_violation("owned carriers name a dead incarnation"),
+            _ => invariant_violation("owned carriers name an invalid incarnation state"),
+        }
+
+        for word in won {
+            clear_owned_bits(&current.in_use[word.word_index], word.mask);
+        }
+    }
+
+    /// Returns one carrier identified by slot, index, and incarnation.
+    fn release_one(&self, id: CarrierId) {
+        if id.slot != self.id {
+            invariant_violation("carrier returned to a different block slot");
+        }
+        let index = id.index as usize;
+        self.release_won(
+            id.incarnation,
+            &[WonWord {
+                word_index: index / u64::BITS as usize,
+                mask: 1u64 << (index % u64::BITS as usize),
+            }],
+        );
+    }
+
+    /// Counts set valid bits in the current incarnation.
+    #[cfg(test)]
+    fn live_carriers(&self) -> usize {
+        self.current
+            .load()
+            .as_ref()
+            .map(|incarnation| {
+                incarnation
+                    .in_use
+                    .iter()
+                    .zip(&self.valid_masks)
+                    .map(|(word, valid)| {
+                        (word.load(Ordering::Acquire) & valid).count_ones() as usize
+                    })
+                    .sum()
+            })
+            .unwrap_or(0)
+    }
+}
+
+/// Linear cleanup authority for a confirmed trim.
+///
+/// Dropping an unfinished token performs the same cleanup attempt as
+/// [`TrimCleanup::finish`].
+#[must_use = "confirmed trim cleanup must be completed or dropped"]
+pub(super) struct TrimCleanup {
+    /// Slot whose prepared capacity was removed.
+    slot: Arc<BlockSlot>,
+    /// Draining incarnation confirmed free by trim.
+    incarnation: Arc<BlockIncarnation>,
+    /// `true` after cleanup has been attempted.
+    consumed: bool,
+}
+
+impl TrimCleanup {
+    /// Returns the number of carriers already removed from prepared capacity.
+    pub(super) fn carrier_count(&self) -> CarrierCount {
+        self.slot.carrier_count()
+    }
+
+    /// Makes the confirmed block inaccessible and reclaims its backing.
+    ///
+    /// Protection failure leaves the draining incarnation published.
+    /// Discard failure retires it and records pending reclaim.
+    pub(super) fn finish(mut self) -> Result<(), CleanupRetry> {
+        self.consumed = true;
+        self.finish_inner()
+    }
+
+    /// Performs the cleanup attempt after marking the token consumed.
+    fn finish_inner(&self) -> Result<(), CleanupRetry> {
+        let mut mapping = self.slot.mapping.lock();
+        if !matches!(*mapping, MappingState::Prepared) {
+            invariant_violation("trim cleanup started from a non-prepared mapping");
+        }
+
+        let current = self.slot.current.load();
+        let Some(incarnation) = current.as_ref() else {
+            invariant_violation("trim cleanup lost its current incarnation");
+        };
+        if !Arc::ptr_eq(incarnation, &self.incarnation)
+            || incarnation.state.load(Ordering::Acquire) != DRAINING
+        {
+            invariant_violation("trim cleanup no longer owns the draining incarnation");
+        }
+
+        if let Err(error) = self.slot.range.deactivate() {
+            *mapping = MappingState::ProtectionPending;
+            return Err(CleanupRetry::ProtectionPending(error));
+        }
+
+        *mapping = MappingState::Reserved {
+            reclaim_pending: false,
+        };
+        self.slot.finish_inactive_cleanup(&mut mapping)
+    }
+}
+
+impl Drop for TrimCleanup {
+    fn drop(&mut self) {
+        if !self.consumed {
+            self.consumed = true;
+            let _ = self.finish_inner();
+        }
+    }
+}
+
+/// Claim state retained through the `Active` gate.
+struct BlockClaimAttempt {
+    /// Slot whose bitmap is being claimed.
+    slot: Arc<BlockSlot>,
+    /// Incarnation protected before the first bitmap mutation.
+    incarnation: IncarnationGuard,
+    /// Bits won by this attempt.
+    won: Vec<WonWord>,
+}
+
+impl BlockClaimAttempt {
+    /// Starts a claim against the current incarnation.
+    ///
+    /// Returns `None` when the slot has no published incarnation.
+    fn begin(slot: &Arc<BlockSlot>) -> Result<Option<Self>, TryReserveError> {
+        let incarnation = slot.current.load();
+        if incarnation.as_ref().is_none() {
+            return Ok(None);
+        }
+
+        let mut won = Vec::new();
+        won.try_reserve_exact(slot.geometry.bitmap_words())?;
+        Ok(Some(Self {
+            slot: Arc::clone(slot),
+            incarnation,
+            won,
+        }))
+    }
+
+    /// Claims up to `count` free bits and returns the number won.
+    ///
+    /// A claim may lose candidate bits after its relaxed load. For example:
+    ///
+    /// ```text
+    /// observed  = 0b0010
+    /// candidate = 0b0101
+    /// previous  = 0b0110  // another claim took bit 2
+    /// won       = 0b0001  // candidate & !previous
+    /// ```
+    fn take(&mut self, mut count: usize) -> usize {
+        let incarnation = self
+            .incarnation
+            .as_ref()
+            .expect("a claim attempt protects one incarnation");
+        let mut taken = 0;
+
+        for (word_index, (word, valid)) in incarnation
+            .in_use
+            .iter()
+            .zip(&self.slot.valid_masks)
+            .enumerate()
+        {
+            if count == 0 {
+                break;
+            }
+            let observed = word.load(Ordering::Relaxed);
+            let candidate = take_lowest(!observed & valid, count);
+            if candidate == 0 {
+                continue;
+            }
+            let previous = word.fetch_or(candidate, Ordering::SeqCst);
+            let won = candidate & !previous;
+            if won != 0 {
+                let won_count = won.count_ones() as usize;
+                self.won.push(WonWord {
+                    word_index,
+                    mask: won,
+                });
+                count -= won_count;
+                taken += won_count;
+            }
+        }
+        taken
+    }
+
+    /// Passes the state gate or rolls back every bit won by this attempt.
+    fn finish(mut self) -> Option<ProvisionalBits> {
+        if self.won.is_empty() {
+            return None;
+        }
+        let incarnation = self
+            .incarnation
+            .as_ref()
+            .expect("a claim attempt protects one incarnation");
+        model_seq_cst_store_load();
+        match incarnation.state.load(Ordering::SeqCst) {
+            ACTIVE => {}
+            DRAINING | DEAD => {
+                self.rollback_original();
+                return None;
+            }
+            _ => invariant_violation("claim observed an invalid incarnation state"),
+        }
+
+        let incarnation = BlockIncarnation::identity(incarnation);
+        let won = std::mem::take(&mut self.won);
+        Some(ProvisionalBits {
+            slot: Arc::clone(&self.slot),
+            incarnation,
+            won,
+        })
+    }
+
+    /// Clears remaining bits through the originally protected incarnation.
+    fn rollback_original(&mut self) {
+        let Some(incarnation) = self.incarnation.as_ref() else {
+            return;
+        };
+        for word in self.won.drain(..) {
+            clear_owned_bits(&incarnation.in_use[word.word_index], word.mask);
+        }
+    }
+}
+
+impl Drop for BlockClaimAttempt {
+    fn drop(&mut self) {
+        self.rollback_original();
+    }
+}
+
+/// Linear ownership of gate-passed bits not yet converted to carriers.
+pub(super) struct ProvisionalBits {
+    /// Slot containing the owned bits.
+    slot: Arc<BlockSlot>,
+    /// Incarnation containing the owned bits.
+    incarnation: IncarnationIdentity,
+    /// Bits returned if this owner is dropped.
+    won: Vec<WonWord>,
+}
+
+impl ProvisionalBits {
+    /// Returns the number of provisionally owned carriers.
+    pub(super) fn len(&self) -> CarrierCount {
+        CarrierCount::new(
+            self.won
+                .iter()
+                .map(|word| word.mask.count_ones() as usize)
+                .sum(),
+        )
+    }
+
+    /// Converts every provisional bit into one carrier owner.
+    ///
+    /// Allocation failure returns every provisional bit on drop.
+    /// A carrier index is `word_index * 64 + bit_index`. Bitmap word 1 bits 1
+    /// and 3 therefore become carrier indices 65 and 67.
+    pub(super) fn into_carriers(mut self) -> Result<Vec<CarrierAllocation>, BlockError> {
+        let mut carriers = Vec::new();
+        carriers.try_reserve_exact(self.len().get())?;
+
+        for word in &mut self.won {
+            while word.mask != 0 {
+                let bit = word.mask.trailing_zeros() as usize;
+                let mask = 1u64 << bit;
+                let index = word.word_index * u64::BITS as usize + bit;
+                let index = u32::try_from(index)
+                    .unwrap_or_else(|_| invariant_violation("carrier index exceeds geometry"));
+                let carrier = CarrierAllocation {
+                    slot: Arc::clone(&self.slot),
+                    id: CarrierId {
+                        slot: self.slot.id,
+                        index,
+                        incarnation: self.incarnation,
+                    },
+                };
+
+                // Move ownership before push so unwinding leaves each bit with
+                // exactly one drop path.
+                word.mask &= !mask;
+                carriers.push(carrier);
+            }
+        }
+        Ok(carriers)
+    }
+}
+
+impl Drop for ProvisionalBits {
+    fn drop(&mut self) {
+        self.slot.release_won(self.incarnation, &self.won);
+    }
+}
+
+/// Linear physical ownership of one carrier.
+pub(super) struct CarrierAllocation {
+    /// Slot that retains the carrier address.
+    slot: Arc<BlockSlot>,
+    /// Stable carrier and incarnation identity.
+    id: CarrierId,
+}
+
+impl CarrierAllocation {
+    /// Returns the carrier capacity in bytes.
+    pub(super) fn capacity(&self) -> usize {
+        self.slot.geometry.carrier_size()
+    }
+
+    /// Returns the first byte of this carrier.
+    ///
+    /// The range remains prepared and exclusively owned while `self` lives.
+    /// Dereferencing the pointer must still obey initialization rules.
+    pub(super) fn ptr(&self) -> NonNull<MaybeUninit<u8>> {
+        let index = self.id.index as usize;
+        let offset = self
+            .slot
+            .geometry
+            .carrier_offset(index)
+            .unwrap_or_else(|| invariant_violation("carrier index is outside block geometry"));
+        // SAFETY: this allocation owns the carrier bit after passing the
+        // `Active` gate, and its Arc retains the slot for the pointer lifetime.
+        unsafe {
+            self.slot
+                .range
+                .ptr_for_range(offset, self.capacity())
+                .unwrap_or_else(|| invariant_violation("carrier range is outside its reservation"))
+        }
+    }
+}
+
+impl Drop for CarrierAllocation {
+    fn drop(&mut self) {
+        self.slot.release_one(self.id);
+    }
+}
+
+/// Clears `mask` after verifying that every bit is owned.
+fn clear_owned_bits(word: &AtomicU64, mask: u64) {
+    if mask == 0 {
+        return;
+    }
+    let mut observed = word.load(Ordering::Acquire);
+    loop {
+        if observed & mask != mask {
+            invariant_violation("bitmap release does not own every cleared bit");
+        }
+        match word.compare_exchange_weak(
+            observed,
+            observed & !mask,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => return,
+            Err(actual) => observed = actual,
+        }
+    }
+}
+
+/// Selects at most `count` least-significant bits from `available`.
+fn take_lowest(mut available: u64, count: usize) -> u64 {
+    let mut selected = 0;
+    for _ in 0..count.min(u64::BITS as usize) {
+        if available == 0 {
+            break;
+        }
+        let bit = 1u64 << available.trailing_zeros();
+        selected |= bit;
+        available &= !bit;
+    }
+    selected
+}
+
+/// Models the global store-load order supplied by production `SeqCst`.
+///
+/// Loom 0.7 treats `SeqCst` accesses as `AcqRel`, but models a `SeqCst` fence.
+#[inline]
+fn model_seq_cst_store_load() {
+    #[cfg(all(test, s3_tm_loom))]
+    loom::sync::atomic::fence(Ordering::SeqCst);
+}
+
+/// Stops execution after an ownership or lifecycle invariant fails.
+#[cold]
+fn invariant_violation(message: &'static str) -> ! {
+    #[cfg(test)]
+    panic!("buffer-pool ownership invariant violated: {message}");
+
+    #[cfg(not(test))]
+    {
+        let _ = message;
+        std::process::abort()
+    }
+}
+
+#[cfg(all(test, not(s3_tm_loom)))]
+mod tests {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    use super::super::virtual_memory::{page_size, VirtualMemoryOperation};
+    use super::*;
+
+    fn geometry(carriers: usize) -> PoolGeometry {
+        let page_size = page_size().unwrap().get();
+        PoolGeometry::new(page_size, page_size, carriers).unwrap()
+    }
+
+    fn prepared_slot(carriers: usize) -> (Arc<BlockSlot>, CarrierCount) {
+        let slot = Arc::new(BlockSlot::new(7, geometry(carriers)).unwrap());
+        let mut prepared = CarrierCount::ZERO;
+        slot.prepare(&mut prepared).unwrap();
+        (slot, prepared)
+    }
+
+    fn current_identity(slot: &BlockSlot) -> Option<IncarnationIdentity> {
+        slot.current.load().as_ref().map(BlockIncarnation::identity)
+    }
+
+    fn assert_mapping(slot: &BlockSlot, expected: MappingState) {
+        assert_eq!(*slot.mapping.lock(), expected);
+    }
+
+    #[test]
+    fn preparation_publishes_claimable_capacity() {
+        let (slot, prepared) = prepared_slot(3);
+
+        assert_eq!(prepared, CarrierCount::new(3));
+        let claimed = BlockSlot::try_claim(&slot, CarrierCount::new(3))
+            .unwrap()
+            .unwrap();
+        assert_eq!(claimed.len(), CarrierCount::new(3));
+        assert_eq!(slot.live_carriers(), 3);
+
+        drop(claimed);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn preparation_rejects_a_current_incarnation() {
+        let (slot, mut prepared) = prepared_slot(1);
+
+        assert!(matches!(
+            slot.prepare(&mut prepared),
+            Err(BlockError::AlreadyPrepared)
+        ));
+        assert_eq!(prepared, CarrierCount::new(1));
+    }
+
+    #[test]
+    fn failed_prepare_stays_nonclaimable_until_recovery() {
+        let slot = Arc::new(BlockSlot::new(7, geometry(1)).unwrap());
+        let mut prepared = CarrierCount::ZERO;
+        slot.range
+            .inject_failure_once(VirtualMemoryOperation::Prepare);
+
+        let error = slot.prepare(&mut prepared).unwrap_err();
+
+        assert!(matches!(
+            error,
+            BlockError::VirtualMemory(ref error)
+                if error.operation() == VirtualMemoryOperation::Prepare
+        ));
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert_mapping(&slot, MappingState::ProtectionPending);
+        assert!(current_identity(&slot).is_none());
+        assert!(BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .is_none());
+
+        slot.prepare(&mut prepared).unwrap();
+        assert_eq!(prepared, CarrierCount::new(1));
+        assert_mapping(&slot, MappingState::Prepared);
+        assert!(current_identity(&slot).is_some());
+    }
+
+    #[test]
+    fn cleanup_retry_restores_reserved_state_after_initial_prepare_failure() {
+        let slot = Arc::new(BlockSlot::new(7, geometry(1)).unwrap());
+        let mut prepared = CarrierCount::ZERO;
+        slot.range
+            .inject_failure_once(VirtualMemoryOperation::Prepare);
+        assert!(slot.prepare(&mut prepared).is_err());
+        assert_mapping(&slot, MappingState::ProtectionPending);
+        assert!(current_identity(&slot).is_none());
+
+        slot.retry_cleanup().unwrap();
+
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert_mapping(
+            &slot,
+            MappingState::Reserved {
+                reclaim_pending: false,
+            },
+        );
+        assert!(current_identity(&slot).is_none());
+
+        slot.prepare(&mut prepared).unwrap();
+        assert_eq!(prepared, CarrierCount::new(1));
+        let carrier = BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .expect("cleaned slot is claimable");
+        drop(carrier);
+    }
+
+    #[test]
+    fn carrier_pointer_is_derived_from_live_ownership() {
+        let (slot, _) = prepared_slot(1);
+        let mut carriers = BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+        let carrier = carriers.pop().unwrap();
+
+        assert_eq!(carrier.capacity(), geometry(1).carrier_size());
+        // SAFETY: the carrier allocation owns this complete writable byte.
+        unsafe { carrier.ptr().as_ptr().write(MaybeUninit::new(0x5a)) };
+        // SAFETY: the preceding write initialized the byte.
+        assert_eq!(unsafe { carrier.ptr().as_ptr().read().assume_init() }, 0x5a);
+
+        drop(carrier);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn claim_never_wins_padding_bits() {
+        let (slot, _) = prepared_slot(65);
+        let carriers = BlockSlot::try_claim(&slot, CarrierCount::new(65))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+
+        assert_eq!(carriers.len(), 65);
+        assert_eq!(carriers.last().unwrap().id.index, 64);
+        assert!(BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .is_none());
+
+        drop(carriers);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn dropping_provisional_bits_returns_every_word() {
+        let (slot, _) = prepared_slot(65);
+        let provisional = BlockSlot::try_claim(&slot, CarrierCount::new(65))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(slot.live_carriers(), 65);
+        drop(provisional);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn concurrent_attempts_clear_only_their_won_bits() {
+        let (slot, _) = prepared_slot(3);
+        let mut first = BlockClaimAttempt::begin(&slot).unwrap().unwrap();
+        let mut second = BlockClaimAttempt::begin(&slot).unwrap().unwrap();
+
+        assert_eq!(first.take(1), 1);
+        assert_eq!(second.take(2), 2);
+        let first = first.finish().unwrap();
+        let second = second.finish().unwrap();
+        assert_eq!(slot.live_carriers(), 3);
+
+        drop(first);
+        assert_eq!(slot.live_carriers(), 2);
+        drop(second);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn provisional_word_bits_map_to_carrier_indices() {
+        let (slot, _) = prepared_slot(68);
+        let incarnation = {
+            let current = slot.current.load();
+            let incarnation = current.as_ref().expect("slot is prepared");
+            incarnation.in_use[1].store(0b1010, Ordering::Release);
+            BlockIncarnation::identity(incarnation)
+        };
+        let provisional = ProvisionalBits {
+            slot: Arc::clone(&slot),
+            incarnation,
+            won: vec![WonWord {
+                word_index: 1,
+                mask: 0b1010,
+            }],
+        };
+
+        let carriers = provisional.into_carriers().unwrap();
+
+        assert_eq!(
+            carriers
+                .iter()
+                .map(|carrier| carrier.id.index)
+                .collect::<Vec<_>>(),
+            vec![65, 67]
+        );
+        drop(carriers);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn dropping_unfinished_attempt_returns_original_bits() {
+        let (slot, _) = prepared_slot(2);
+        let mut attempt = BlockClaimAttempt::begin(&slot).unwrap().unwrap();
+
+        assert_eq!(attempt.take(2), 2);
+        assert_eq!(slot.live_carriers(), 2);
+        drop(attempt);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn trim_preserves_floor_and_abandons_for_live_ownership() {
+        let (slot, mut prepared) = prepared_slot(2);
+
+        assert!(matches!(
+            BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::new(1)),
+            Err(TrimBlocked::Required)
+        ));
+        assert_eq!(prepared, CarrierCount::new(2));
+
+        let carriers = BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+        assert!(matches!(
+            BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO),
+            Err(TrimBlocked::Busy)
+        ));
+        assert_eq!(prepared, CarrierCount::new(2));
+        assert_mapping(&slot, MappingState::Prepared);
+
+        drop(carriers);
+    }
+
+    #[test]
+    fn successful_trim_revives_with_fresh_metadata_at_the_same_address() {
+        let (slot, mut prepared) = prepared_slot(1);
+        let original_incarnation =
+            Arc::clone(slot.current.load().as_ref().expect("slot is prepared"));
+        let original_address = slot.range.base_address();
+
+        let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
+        assert_eq!(cleanup.carrier_count(), CarrierCount::new(1));
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert!(BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .is_none());
+        cleanup.finish().unwrap();
+
+        assert_mapping(
+            &slot,
+            MappingState::Reserved {
+                reclaim_pending: false,
+            },
+        );
+        assert!(current_identity(&slot).is_none());
+
+        slot.prepare(&mut prepared).unwrap();
+        assert_eq!(prepared, CarrierCount::new(1));
+        assert_eq!(slot.range.base_address(), original_address);
+        let revived = slot.current.load();
+        assert!(!Arc::ptr_eq(
+            revived.as_ref().expect("slot was revived"),
+            &original_incarnation
+        ));
+    }
+
+    #[test]
+    fn stale_failed_gate_rolls_back_only_retired_metadata() {
+        let (slot, mut prepared) = prepared_slot(1);
+        let mut stale = BlockClaimAttempt::begin(&slot).unwrap().unwrap();
+
+        BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO)
+            .unwrap()
+            .finish()
+            .unwrap();
+        slot.prepare(&mut prepared).unwrap();
+        let current = BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+
+        assert_eq!(stale.take(1), 1);
+        assert!(stale.finish().is_none());
+        assert_eq!(slot.live_carriers(), 1);
+
+        drop(current);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn failed_deactivation_can_restore_the_draining_incarnation() {
+        let (slot, mut prepared) = prepared_slot(1);
+        let original_identity = current_identity(&slot).unwrap();
+        slot.range
+            .inject_failure_once(VirtualMemoryOperation::Deactivate);
+        let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
+
+        let error = cleanup.finish().unwrap_err();
+
+        assert!(matches!(
+            error,
+            CleanupRetry::ProtectionPending(ref error)
+                if error.operation() == VirtualMemoryOperation::Deactivate
+        ));
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert_mapping(&slot, MappingState::ProtectionPending);
+        assert_eq!(current_identity(&slot), Some(original_identity));
+        assert!(BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .is_none());
+
+        slot.prepare(&mut prepared).unwrap();
+        assert_eq!(prepared, CarrierCount::new(1));
+        assert_mapping(&slot, MappingState::Prepared);
+        assert_eq!(current_identity(&slot), Some(original_identity));
+        let carrier = BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .unwrap();
+        drop(carrier);
+    }
+
+    #[test]
+    fn protection_retry_finishes_inactive_cleanup() {
+        let (slot, mut prepared) = prepared_slot(1);
+        slot.range
+            .inject_failure_once(VirtualMemoryOperation::Deactivate);
+        let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
+        assert!(matches!(
+            cleanup.finish(),
+            Err(CleanupRetry::ProtectionPending(_))
+        ));
+
+        slot.retry_cleanup().unwrap();
+
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert_mapping(
+            &slot,
+            MappingState::Reserved {
+                reclaim_pending: false,
+            },
+        );
+        assert!(current_identity(&slot).is_none());
+    }
+
+    #[test]
+    fn failed_discard_retires_the_incarnation_and_retries_inactive() {
+        let (slot, mut prepared) = prepared_slot(1);
+        slot.range
+            .inject_failure_once(VirtualMemoryOperation::Discard);
+        let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
+
+        let error = cleanup.finish().unwrap_err();
+
+        assert!(matches!(
+            error,
+            CleanupRetry::ReclaimPending(ref error)
+                if error.operation() == VirtualMemoryOperation::Discard
+        ));
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert_mapping(
+            &slot,
+            MappingState::Reserved {
+                reclaim_pending: true,
+            },
+        );
+        assert!(current_identity(&slot).is_none());
+
+        slot.retry_cleanup().unwrap();
+        assert_mapping(
+            &slot,
+            MappingState::Reserved {
+                reclaim_pending: false,
+            },
+        );
+    }
+
+    #[test]
+    fn revival_clears_pending_reclaim_before_publication() {
+        let (slot, mut prepared) = prepared_slot(1);
+        slot.range
+            .inject_failure_once(VirtualMemoryOperation::Discard);
+        BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO)
+            .unwrap()
+            .finish()
+            .unwrap_err();
+
+        slot.prepare(&mut prepared).unwrap();
+        slot.retry_cleanup().unwrap();
+
+        assert_eq!(prepared, CarrierCount::new(1));
+        assert_mapping(&slot, MappingState::Prepared);
+        let carrier = BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .unwrap();
+        drop(carrier);
+    }
+
+    #[test]
+    fn dropped_cleanup_completes_the_confirmed_trim() {
+        let (slot, mut prepared) = prepared_slot(1);
+        let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
+
+        drop(cleanup);
+
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert_mapping(
+            &slot,
+            MappingState::Reserved {
+                reclaim_pending: false,
+            },
+        );
+        assert!(current_identity(&slot).is_none());
+    }
+
+    #[test]
+    fn dropped_cleanup_leaves_failed_protection_nonclaimable() {
+        let (slot, mut prepared) = prepared_slot(1);
+        slot.range
+            .inject_failure_once(VirtualMemoryOperation::Deactivate);
+        let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
+
+        drop(cleanup);
+
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert_mapping(&slot, MappingState::ProtectionPending);
+        assert!(current_identity(&slot).is_some());
+        assert!(BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn identity_mismatch_stops_before_clearing() {
+        let (slot, _) = prepared_slot(1);
+        let mut carriers = BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+        let carrier = carriers.pop().unwrap();
+        let wrong = CarrierId {
+            incarnation: IncarnationIdentity(
+                NonZeroUsize::new(carrier.id.incarnation.0.get().wrapping_add(1))
+                    .unwrap_or(NonZeroUsize::MIN),
+            ),
+            ..carrier.id
+        };
+
+        let result = catch_unwind(AssertUnwindSafe(|| slot.release_one(wrong)));
+
+        assert!(result.is_err());
+        assert_eq!(slot.live_carriers(), 1);
+        drop(carrier);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn zero_claim_is_rejected_without_mutation() {
+        let (slot, _) = prepared_slot(1);
+
+        assert!(matches!(
+            BlockSlot::try_claim(&slot, CarrierCount::ZERO),
+            Err(BlockError::InvalidClaimCount)
+        ));
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn ownership_spine_is_send_and_sync() {
+        assert_send_sync::<BlockSlot>();
+        assert_send_sync::<CarrierAllocation>();
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use super::super::virtual_memory::VirtualMemoryOperation;
+    use super::*;
+    use crate::runtime::sync::sync::atomic::{AtomicBool, Ordering};
+    use crate::runtime::sync::thread;
+
+    fn prepared_slot() -> (Arc<BlockSlot>, CarrierCount) {
+        let geometry = PoolGeometry::new(4096, 4096, 1).unwrap();
+        let slot = Arc::new(BlockSlot::new(0, geometry).unwrap());
+        let mut prepared = CarrierCount::ZERO;
+        slot.prepare(&mut prepared).unwrap();
+        (slot, prepared)
+    }
+
+    #[test]
+    fn stale_claim_cannot_clear_a_revived_claim() {
+        loom::model(|| {
+            let (slot, initial_prepared) = prepared_slot();
+            let loaded = Arc::new(AtomicBool::new(false));
+            let revived = Arc::new(AtomicBool::new(false));
+
+            let stale_slot = Arc::clone(&slot);
+            let stale_loaded = Arc::clone(&loaded);
+            let stale_revived = Arc::clone(&revived);
+            let stale = thread::spawn(move || {
+                let mut attempt = BlockClaimAttempt::begin(&stale_slot).unwrap().unwrap();
+                stale_loaded.store(true, Ordering::Release);
+                while !stale_revived.load(Ordering::Acquire) {
+                    loom::thread::yield_now();
+                }
+                assert_eq!(attempt.take(1), 1);
+                assert!(attempt.finish().is_none());
+            });
+
+            let current_slot = Arc::clone(&slot);
+            let current_loaded = Arc::clone(&loaded);
+            let current_revived = Arc::clone(&revived);
+            let current = thread::spawn(move || {
+                while !current_loaded.load(Ordering::Acquire) {
+                    loom::thread::yield_now();
+                }
+                let mut prepared = initial_prepared;
+                BlockSlot::start_trim(&current_slot, &mut prepared, CarrierCount::ZERO)
+                    .unwrap()
+                    .finish()
+                    .unwrap();
+                current_slot.prepare(&mut prepared).unwrap();
+                let carrier = BlockSlot::try_claim(&current_slot, CarrierCount::new(1))
+                    .unwrap()
+                    .unwrap()
+                    .into_carriers()
+                    .unwrap()
+                    .pop()
+                    .unwrap();
+                current_revived.store(true, Ordering::Release);
+                carrier
+            });
+
+            stale.join().unwrap();
+            let carrier = current.join().unwrap();
+            assert_eq!(slot.live_carriers(), 1);
+            drop(carrier);
+            assert_eq!(slot.live_carriers(), 0);
+        });
+    }
+
+    #[test]
+    fn claim_and_protection_recovery_preserve_single_ownership() {
+        loom::model(|| {
+            let (slot, mut prepared) = prepared_slot();
+            let original = Arc::clone(slot.current.load().as_ref().expect("slot is prepared"));
+
+            let mut attempt = BlockClaimAttempt::begin(&slot).unwrap().unwrap();
+            slot.range
+                .inject_failure_once(VirtualMemoryOperation::Deactivate);
+            let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
+            assert!(matches!(
+                cleanup.finish(),
+                Err(CleanupRetry::ProtectionPending(_))
+            ));
+            assert_eq!(attempt.take(1), 1);
+
+            let stale = thread::spawn(move || attempt.finish());
+            let recovery_slot = Arc::clone(&slot);
+            let recovery = thread::spawn(move || {
+                recovery_slot.prepare(&mut prepared).unwrap();
+                let current = BlockSlot::try_claim(&recovery_slot, CarrierCount::new(1)).unwrap();
+                (prepared, current)
+            });
+
+            let stale = stale.join().unwrap();
+            let (prepared, current) = recovery.join().unwrap();
+            let owned = stale
+                .as_ref()
+                .map_or(0, |claim| claim.len().get())
+                .checked_add(current.as_ref().map_or(0, |claim| claim.len().get()))
+                .unwrap();
+
+            assert_eq!(prepared, CarrierCount::new(1));
+            assert!(matches!(*slot.mapping.lock(), MappingState::Prepared));
+            let restored = slot.current.load();
+            assert!(Arc::ptr_eq(
+                restored.as_ref().expect("incarnation was restored"),
+                &original
+            ));
+            assert!(owned <= 1);
+            assert_eq!(slot.live_carriers(), owned);
+
+            drop(stale);
+            drop(current);
+            assert_eq!(slot.live_carriers(), 0);
+        });
+    }
+
+    #[test]
+    fn claim_and_trim_cannot_both_pass_the_gate() {
+        loom::model(|| {
+            let (slot, initial_prepared) = prepared_slot();
+            let prepared = Arc::new(Mutex::new(initial_prepared));
+
+            let claim_slot = Arc::clone(&slot);
+            let claim = thread::spawn(move || {
+                BlockSlot::try_claim(&claim_slot, CarrierCount::new(1))
+                    .unwrap()
+                    .map(ProvisionalBits::into_carriers)
+                    .transpose()
+                    .unwrap()
+            });
+
+            let trim_slot = Arc::clone(&slot);
+            let trim_prepared = Arc::clone(&prepared);
+            let trim = thread::spawn(move || {
+                let start = {
+                    let mut prepared = trim_prepared.lock();
+                    BlockSlot::start_trim(&trim_slot, &mut prepared, CarrierCount::ZERO)
+                };
+                match start {
+                    Ok(cleanup) => {
+                        cleanup.finish().unwrap();
+                        true
+                    }
+                    Err(TrimBlocked::Busy) => false,
+                    Err(other) => panic!("unexpected trim result: {other:?}"),
+                }
+            });
+
+            let carriers = claim.join().unwrap();
+            let trimmed = trim.join().unwrap();
+            if let Some(carriers) = carriers {
+                assert!(!trimmed);
+                drop(carriers);
+            }
+
+            let active = slot
+                .current
+                .load()
+                .as_ref()
+                .map(|incarnation| incarnation.state.load(Ordering::Acquire) == ACTIVE)
+                .unwrap_or(false);
+            if active {
+                let mut prepared = prepared.lock();
+                BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO)
+                    .unwrap()
+                    .finish()
+                    .unwrap();
+            }
+
+            assert!(slot.current.load().as_ref().is_none());
+            assert_eq!(
+                *slot.mapping.lock(),
+                MappingState::Reserved {
+                    reclaim_pending: false
+                }
+            );
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/geometry.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/geometry.rs
@@ -18,6 +18,8 @@ const BITS_PER_BITMAP_WORD: usize = u64::BITS as usize;
 pub(super) enum GeometryError {
     /// Page size is zero.
     ZeroPageSize,
+    /// Block size is zero.
+    ZeroBlockSize,
     /// Carrier size is zero.
     ZeroCarrierSize,
     /// Carrier size is not a whole number of pages.
@@ -27,17 +29,15 @@ pub(super) enum GeometryError {
         /// Runtime page size in bytes.
         page_size: usize,
     },
-    /// Block carrier count is zero.
-    ZeroCarriersPerBlock,
-    /// A carrier index cannot be represented by the stable identifier.
-    CarrierIndexOverflow {
-        /// Requested carriers per block.
-        carriers_per_block: usize,
-    },
-    /// Block byte size exceeds `usize`.
-    BlockSizeOverflow {
+    /// Block size is not a whole number of carriers.
+    BlockNotCarrierMultiple {
+        /// Requested block size in bytes.
+        block_size: usize,
         /// Requested carrier size in bytes.
         carrier_size: usize,
+    },
+    /// A carrier index cannot be represented by the stable identifier.
+    CarrierIndexOverflow {
         /// Requested carriers per block.
         carriers_per_block: usize,
     },
@@ -49,6 +49,7 @@ impl fmt::Display for GeometryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ZeroPageSize => f.write_str("page size must be nonzero"),
+            Self::ZeroBlockSize => f.write_str("block size must be nonzero"),
             Self::ZeroCarrierSize => f.write_str("carrier size must be nonzero"),
             Self::CarrierNotPageMultiple {
                 carrier_size,
@@ -57,17 +58,16 @@ impl fmt::Display for GeometryError {
                 f,
                 "carrier size {carrier_size} is not a multiple of page size {page_size}"
             ),
-            Self::ZeroCarriersPerBlock => f.write_str("a block must contain at least one carrier"),
+            Self::BlockNotCarrierMultiple {
+                block_size,
+                carrier_size,
+            } => write!(
+                f,
+                "block size {block_size} is not a multiple of carrier size {carrier_size}"
+            ),
             Self::CarrierIndexOverflow { carriers_per_block } => write!(
                 f,
                 "block carrier count {carriers_per_block} exceeds the carrier index range"
-            ),
-            Self::BlockSizeOverflow {
-                carrier_size,
-                carriers_per_block,
-            } => write!(
-                f,
-                "block size overflows for {carriers_per_block} carriers of {carrier_size} bytes"
             ),
             Self::ZeroByteRequest => f.write_str("a carrier request must be nonzero"),
         }
@@ -81,27 +81,31 @@ impl std::error::Error for GeometryError {}
 pub(super) struct PoolGeometry {
     /// Runtime page size in bytes.
     page_size: NonZeroUsize,
+    /// Number of bytes prepared and reclaimed together.
+    block_size: NonZeroUsize,
     /// Acquisition and ownership unit in bytes.
     carrier_size: NonZeroUsize,
     /// Number of carriers prepared and reclaimed together.
     carriers_per_block: NonZeroUsize,
-    /// Block size in bytes.
-    block_size: NonZeroUsize,
     /// Bitmap words required to represent every carrier.
     bitmap_words: NonZeroUsize,
+    /// Valid carrier bits in the final bitmap word.
+    final_word_mask: u64,
 }
 
 impl PoolGeometry {
-    /// Constructs checked geometry from page, carrier, and block dimensions.
+    /// Constructs checked geometry from page, block, and carrier dimensions.
     ///
-    /// Carrier size must be page-aligned. Block size and carrier indices must
-    /// fit their stored representations.
+    /// Carrier size must be page-aligned. Block size must contain a whole
+    /// number of carriers, and carrier indices must fit their stored
+    /// representation.
     pub(super) fn new(
         page_size: usize,
+        block_size: usize,
         carrier_size: usize,
-        carriers_per_block: usize,
     ) -> Result<Self, GeometryError> {
         let page_size = NonZeroUsize::new(page_size).ok_or(GeometryError::ZeroPageSize)?;
+        let block_size = NonZeroUsize::new(block_size).ok_or(GeometryError::ZeroBlockSize)?;
         let carrier_size = NonZeroUsize::new(carrier_size).ok_or(GeometryError::ZeroCarrierSize)?;
         if !carrier_size.get().is_multiple_of(page_size.get()) {
             return Err(GeometryError::CarrierNotPageMultiple {
@@ -109,39 +113,49 @@ impl PoolGeometry {
                 page_size: page_size.get(),
             });
         }
+        if !block_size.get().is_multiple_of(carrier_size.get()) {
+            return Err(GeometryError::BlockNotCarrierMultiple {
+                block_size: block_size.get(),
+                carrier_size: carrier_size.get(),
+            });
+        }
 
-        let carriers_per_block =
-            NonZeroUsize::new(carriers_per_block).ok_or(GeometryError::ZeroCarriersPerBlock)?;
+        let carriers_per_block = NonZeroUsize::new(block_size.get() / carrier_size.get())
+            .expect("a nonzero whole-carrier block contains a carrier");
         u32::try_from(carriers_per_block.get() - 1).map_err(|_| {
             GeometryError::CarrierIndexOverflow {
                 carriers_per_block: carriers_per_block.get(),
             }
         })?;
 
-        let block_size = carrier_size
-            .get()
-            .checked_mul(carriers_per_block.get())
-            .and_then(NonZeroUsize::new)
-            .ok_or(GeometryError::BlockSizeOverflow {
-                carrier_size: carrier_size.get(),
-                carriers_per_block: carriers_per_block.get(),
-            })?;
         let bitmap_words =
-            NonZeroUsize::new((carriers_per_block.get() - 1) / BITS_PER_BITMAP_WORD + 1)
+            NonZeroUsize::new(carriers_per_block.get().div_ceil(BITS_PER_BITMAP_WORD))
                 .expect("a nonzero carrier count requires a bitmap word");
+        let final_bits = carriers_per_block.get() % BITS_PER_BITMAP_WORD;
+        let final_word_mask = if final_bits == 0 {
+            u64::MAX
+        } else {
+            (1u64 << final_bits) - 1
+        };
 
         Ok(Self {
             page_size,
+            block_size,
             carrier_size,
             carriers_per_block,
-            block_size,
             bitmap_words,
+            final_word_mask,
         })
     }
 
     /// Returns the runtime page size in bytes.
     pub(super) fn page_size(self) -> usize {
         self.page_size.get()
+    }
+
+    /// Returns the block size in bytes.
+    pub(super) fn block_size(self) -> usize {
+        self.block_size.get()
     }
 
     /// Returns the carrier size in bytes.
@@ -154,14 +168,18 @@ impl PoolGeometry {
         CarrierCount::new(self.carriers_per_block.get())
     }
 
-    /// Returns the block size in bytes.
-    pub(super) fn block_size(self) -> usize {
-        self.block_size.get()
-    }
-
     /// Returns the number of ownership bitmap words.
     pub(super) fn bitmap_words(self) -> usize {
         self.bitmap_words.get()
+    }
+
+    /// Returns valid carrier bits in the final bitmap word.
+    ///
+    /// A 70-carrier block uses two words. The final mask is `0b11_1111` for
+    /// carriers 64 through 69. A block with a whole final word uses
+    /// `u64::MAX`.
+    pub(super) fn final_word_mask(self) -> u64 {
+        self.final_word_mask
     }
 
     /// Rounds a nonzero byte request up to whole carriers.
@@ -169,7 +187,7 @@ impl PoolGeometry {
         if bytes == 0 {
             return Err(GeometryError::ZeroByteRequest);
         }
-        let count = (bytes - 1) / self.carrier_size.get() + 1;
+        let count = bytes.div_ceil(self.carrier_size.get());
         Ok(CarrierCount::new(count))
     }
 
@@ -180,28 +198,6 @@ impl PoolGeometry {
         }
         index.checked_mul(self.carrier_size.get())
     }
-
-    /// Returns valid carrier bits, or `None` when the word is out of range.
-    ///
-    /// Padding bits in the final word are clear.
-    ///
-    /// A 70-carrier block has two words. Word zero uses `u64::MAX`; word one
-    /// uses `0b11_1111` for carriers 64 through 69.
-    pub(super) fn valid_mask(self, word_index: usize) -> Option<u64> {
-        if word_index >= self.bitmap_words.get() {
-            return None;
-        }
-        if word_index + 1 < self.bitmap_words.get() {
-            return Some(u64::MAX);
-        }
-
-        let final_bits = self.carriers_per_block.get() % BITS_PER_BITMAP_WORD;
-        Some(if final_bits == 0 {
-            u64::MAX
-        } else {
-            (1u64 << final_bits) - 1
-        })
-    }
 }
 
 #[cfg(test)]
@@ -211,40 +207,53 @@ mod tests {
     #[test]
     fn rejects_invalid_dimensions() {
         assert_eq!(
-            PoolGeometry::new(0, 4096, 1),
+            PoolGeometry::new(0, 4096, 4096),
             Err(GeometryError::ZeroPageSize)
         );
         assert_eq!(
-            PoolGeometry::new(4096, 0, 1),
+            PoolGeometry::new(4096, 0, 4096),
+            Err(GeometryError::ZeroBlockSize)
+        );
+        assert_eq!(
+            PoolGeometry::new(4096, 4096, 0),
             Err(GeometryError::ZeroCarrierSize)
         );
         assert_eq!(
-            PoolGeometry::new(4096, 6144, 1),
+            PoolGeometry::new(4096, 12288, 6144),
             Err(GeometryError::CarrierNotPageMultiple {
                 carrier_size: 6144,
                 page_size: 4096,
             })
         );
         assert_eq!(
-            PoolGeometry::new(4096, 4096, 0),
-            Err(GeometryError::ZeroCarriersPerBlock)
+            PoolGeometry::new(4096, 12288, 8192),
+            Err(GeometryError::BlockNotCarrierMultiple {
+                block_size: 12288,
+                carrier_size: 8192,
+            })
+        );
+        assert_eq!(
+            PoolGeometry::new(4096, 4096, 8192),
+            Err(GeometryError::BlockNotCarrierMultiple {
+                block_size: 4096,
+                carrier_size: 8192,
+            })
         );
     }
 
+    #[cfg(target_pointer_width = "64")]
     #[test]
-    fn rejects_block_size_overflow() {
+    fn rejects_carrier_index_overflow() {
+        let carriers_per_block = u32::MAX as usize + 2;
         assert_eq!(
-            PoolGeometry::new(1, usize::MAX, 2),
-            Err(GeometryError::BlockSizeOverflow {
-                carrier_size: usize::MAX,
-                carriers_per_block: 2,
-            })
+            PoolGeometry::new(1, carriers_per_block, 1),
+            Err(GeometryError::CarrierIndexOverflow { carriers_per_block })
         );
     }
 
     #[test]
     fn rounds_byte_requests_to_carriers() {
-        let geometry = PoolGeometry::new(4096, 8192, 8).unwrap();
+        let geometry = PoolGeometry::new(4096, 8192 * 8, 8192).unwrap();
 
         assert_eq!(
             geometry.carriers_for_bytes(1).unwrap(),
@@ -270,7 +279,7 @@ mod tests {
 
     #[test]
     fn computes_checked_carrier_offsets() {
-        let geometry = PoolGeometry::new(4096, 8192, 3).unwrap();
+        let geometry = PoolGeometry::new(4096, 8192 * 3, 8192).unwrap();
 
         assert_eq!(geometry.carrier_offset(0), Some(0));
         assert_eq!(geometry.carrier_offset(2), Some(16384));
@@ -280,37 +289,44 @@ mod tests {
     #[test]
     fn masks_every_partial_bitmap_width() {
         for carriers in 1..=BITS_PER_BITMAP_WORD * 3 {
-            let geometry = PoolGeometry::new(1, 1, carriers).unwrap();
-            let valid = (0..geometry.bitmap_words())
-                .map(|word| geometry.valid_mask(word).unwrap().count_ones() as usize)
-                .sum::<usize>();
+            let geometry = PoolGeometry::new(1, carriers, 1).unwrap();
+            let complete_words = geometry.bitmap_words() - 1;
+            let valid = complete_words * BITS_PER_BITMAP_WORD
+                + geometry.final_word_mask().count_ones() as usize;
 
             assert_eq!(
                 geometry.bitmap_words(),
                 carriers.div_ceil(BITS_PER_BITMAP_WORD)
             );
             assert_eq!(valid, carriers);
-            assert_eq!(geometry.valid_mask(geometry.bitmap_words()), None);
         }
     }
 
     #[test]
     fn masks_a_seventy_carrier_block() {
-        let geometry = PoolGeometry::new(1, 1, 70).unwrap();
+        let geometry = PoolGeometry::new(1, 70, 1).unwrap();
 
         assert_eq!(geometry.bitmap_words(), 2);
-        assert_eq!(geometry.valid_mask(0), Some(u64::MAX));
-        assert_eq!(geometry.valid_mask(1), Some(0b11_1111));
+        assert_eq!(geometry.final_word_mask(), 0b11_1111);
+    }
+
+    #[test]
+    fn full_final_word_uses_every_bit() {
+        let geometry = PoolGeometry::new(1, 128, 1).unwrap();
+
+        assert_eq!(geometry.bitmap_words(), 2);
+        assert_eq!(geometry.final_word_mask(), u64::MAX);
     }
 
     #[test]
     fn exposes_validated_dimensions() {
-        let geometry = PoolGeometry::new(4096, 8192, 65).unwrap();
+        let geometry = PoolGeometry::new(4096, 8192 * 65, 8192).unwrap();
 
         assert_eq!(geometry.page_size(), 4096);
+        assert_eq!(geometry.block_size(), 8192 * 65);
         assert_eq!(geometry.carrier_size(), 8192);
         assert_eq!(geometry.carriers_per_block(), CarrierCount::new(65));
-        assert_eq!(geometry.block_size(), 8192 * 65);
         assert_eq!(geometry.bitmap_words(), 2);
+        assert_eq!(geometry.final_word_mask(), 1);
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/geometry.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/geometry.rs
@@ -1,0 +1,316 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Checked physical layout for pool storage.
+
+use std::fmt;
+use std::num::NonZeroUsize;
+
+use super::CarrierCount;
+
+/// Number of carrier bits stored in each bitmap word.
+const BITS_PER_BITMAP_WORD: usize = u64::BITS as usize;
+
+/// Invalid or unrepresentable pool geometry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum GeometryError {
+    /// Page size is zero.
+    ZeroPageSize,
+    /// Carrier size is zero.
+    ZeroCarrierSize,
+    /// Carrier size is not a whole number of pages.
+    CarrierNotPageMultiple {
+        /// Requested carrier size in bytes.
+        carrier_size: usize,
+        /// Runtime page size in bytes.
+        page_size: usize,
+    },
+    /// Block carrier count is zero.
+    ZeroCarriersPerBlock,
+    /// A carrier index cannot be represented by the stable identifier.
+    CarrierIndexOverflow {
+        /// Requested carriers per block.
+        carriers_per_block: usize,
+    },
+    /// Block byte size exceeds `usize`.
+    BlockSizeOverflow {
+        /// Requested carrier size in bytes.
+        carrier_size: usize,
+        /// Requested carriers per block.
+        carriers_per_block: usize,
+    },
+    /// Byte-to-carrier conversion received zero.
+    ZeroByteRequest,
+}
+
+impl fmt::Display for GeometryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ZeroPageSize => f.write_str("page size must be nonzero"),
+            Self::ZeroCarrierSize => f.write_str("carrier size must be nonzero"),
+            Self::CarrierNotPageMultiple {
+                carrier_size,
+                page_size,
+            } => write!(
+                f,
+                "carrier size {carrier_size} is not a multiple of page size {page_size}"
+            ),
+            Self::ZeroCarriersPerBlock => f.write_str("a block must contain at least one carrier"),
+            Self::CarrierIndexOverflow { carriers_per_block } => write!(
+                f,
+                "block carrier count {carriers_per_block} exceeds the carrier index range"
+            ),
+            Self::BlockSizeOverflow {
+                carrier_size,
+                carriers_per_block,
+            } => write!(
+                f,
+                "block size overflows for {carriers_per_block} carriers of {carrier_size} bytes"
+            ),
+            Self::ZeroByteRequest => f.write_str("a carrier request must be nonzero"),
+        }
+    }
+}
+
+impl std::error::Error for GeometryError {}
+
+/// Checked page, carrier, block, and bitmap dimensions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct PoolGeometry {
+    /// Runtime page size in bytes.
+    page_size: NonZeroUsize,
+    /// Acquisition and ownership unit in bytes.
+    carrier_size: NonZeroUsize,
+    /// Number of carriers prepared and reclaimed together.
+    carriers_per_block: NonZeroUsize,
+    /// Block size in bytes.
+    block_size: NonZeroUsize,
+    /// Bitmap words required to represent every carrier.
+    bitmap_words: NonZeroUsize,
+}
+
+impl PoolGeometry {
+    /// Constructs checked geometry from page, carrier, and block dimensions.
+    ///
+    /// Carrier size must be page-aligned. Block size and carrier indices must
+    /// fit their stored representations.
+    pub(super) fn new(
+        page_size: usize,
+        carrier_size: usize,
+        carriers_per_block: usize,
+    ) -> Result<Self, GeometryError> {
+        let page_size = NonZeroUsize::new(page_size).ok_or(GeometryError::ZeroPageSize)?;
+        let carrier_size = NonZeroUsize::new(carrier_size).ok_or(GeometryError::ZeroCarrierSize)?;
+        if !carrier_size.get().is_multiple_of(page_size.get()) {
+            return Err(GeometryError::CarrierNotPageMultiple {
+                carrier_size: carrier_size.get(),
+                page_size: page_size.get(),
+            });
+        }
+
+        let carriers_per_block =
+            NonZeroUsize::new(carriers_per_block).ok_or(GeometryError::ZeroCarriersPerBlock)?;
+        u32::try_from(carriers_per_block.get() - 1).map_err(|_| {
+            GeometryError::CarrierIndexOverflow {
+                carriers_per_block: carriers_per_block.get(),
+            }
+        })?;
+
+        let block_size = carrier_size
+            .get()
+            .checked_mul(carriers_per_block.get())
+            .and_then(NonZeroUsize::new)
+            .ok_or(GeometryError::BlockSizeOverflow {
+                carrier_size: carrier_size.get(),
+                carriers_per_block: carriers_per_block.get(),
+            })?;
+        let bitmap_words =
+            NonZeroUsize::new((carriers_per_block.get() - 1) / BITS_PER_BITMAP_WORD + 1)
+                .expect("a nonzero carrier count requires a bitmap word");
+
+        Ok(Self {
+            page_size,
+            carrier_size,
+            carriers_per_block,
+            block_size,
+            bitmap_words,
+        })
+    }
+
+    /// Returns the runtime page size in bytes.
+    pub(super) fn page_size(self) -> usize {
+        self.page_size.get()
+    }
+
+    /// Returns the carrier size in bytes.
+    pub(super) fn carrier_size(self) -> usize {
+        self.carrier_size.get()
+    }
+
+    /// Returns the number of carriers in one block.
+    pub(super) fn carriers_per_block(self) -> CarrierCount {
+        CarrierCount::new(self.carriers_per_block.get())
+    }
+
+    /// Returns the block size in bytes.
+    pub(super) fn block_size(self) -> usize {
+        self.block_size.get()
+    }
+
+    /// Returns the number of ownership bitmap words.
+    pub(super) fn bitmap_words(self) -> usize {
+        self.bitmap_words.get()
+    }
+
+    /// Rounds a nonzero byte request up to whole carriers.
+    pub(super) fn carriers_for_bytes(self, bytes: usize) -> Result<CarrierCount, GeometryError> {
+        if bytes == 0 {
+            return Err(GeometryError::ZeroByteRequest);
+        }
+        let count = (bytes - 1) / self.carrier_size.get() + 1;
+        Ok(CarrierCount::new(count))
+    }
+
+    /// Returns a carrier's byte offset, or `None` when `index` is out of range.
+    pub(super) fn carrier_offset(self, index: usize) -> Option<usize> {
+        if index >= self.carriers_per_block.get() {
+            return None;
+        }
+        index.checked_mul(self.carrier_size.get())
+    }
+
+    /// Returns valid carrier bits, or `None` when the word is out of range.
+    ///
+    /// Padding bits in the final word are clear.
+    ///
+    /// A 70-carrier block has two words. Word zero uses `u64::MAX`; word one
+    /// uses `0b11_1111` for carriers 64 through 69.
+    pub(super) fn valid_mask(self, word_index: usize) -> Option<u64> {
+        if word_index >= self.bitmap_words.get() {
+            return None;
+        }
+        if word_index + 1 < self.bitmap_words.get() {
+            return Some(u64::MAX);
+        }
+
+        let final_bits = self.carriers_per_block.get() % BITS_PER_BITMAP_WORD;
+        Some(if final_bits == 0 {
+            u64::MAX
+        } else {
+            (1u64 << final_bits) - 1
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_dimensions() {
+        assert_eq!(
+            PoolGeometry::new(0, 4096, 1),
+            Err(GeometryError::ZeroPageSize)
+        );
+        assert_eq!(
+            PoolGeometry::new(4096, 0, 1),
+            Err(GeometryError::ZeroCarrierSize)
+        );
+        assert_eq!(
+            PoolGeometry::new(4096, 6144, 1),
+            Err(GeometryError::CarrierNotPageMultiple {
+                carrier_size: 6144,
+                page_size: 4096,
+            })
+        );
+        assert_eq!(
+            PoolGeometry::new(4096, 4096, 0),
+            Err(GeometryError::ZeroCarriersPerBlock)
+        );
+    }
+
+    #[test]
+    fn rejects_block_size_overflow() {
+        assert_eq!(
+            PoolGeometry::new(1, usize::MAX, 2),
+            Err(GeometryError::BlockSizeOverflow {
+                carrier_size: usize::MAX,
+                carriers_per_block: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn rounds_byte_requests_to_carriers() {
+        let geometry = PoolGeometry::new(4096, 8192, 8).unwrap();
+
+        assert_eq!(
+            geometry.carriers_for_bytes(1).unwrap(),
+            CarrierCount::new(1)
+        );
+        assert_eq!(
+            geometry.carriers_for_bytes(8192).unwrap(),
+            CarrierCount::new(1)
+        );
+        assert_eq!(
+            geometry.carriers_for_bytes(8193).unwrap(),
+            CarrierCount::new(2)
+        );
+        assert_eq!(
+            geometry.carriers_for_bytes(0),
+            Err(GeometryError::ZeroByteRequest)
+        );
+        assert_eq!(
+            geometry.carriers_for_bytes(usize::MAX).unwrap(),
+            CarrierCount::new((usize::MAX - 1) / 8192 + 1)
+        );
+    }
+
+    #[test]
+    fn computes_checked_carrier_offsets() {
+        let geometry = PoolGeometry::new(4096, 8192, 3).unwrap();
+
+        assert_eq!(geometry.carrier_offset(0), Some(0));
+        assert_eq!(geometry.carrier_offset(2), Some(16384));
+        assert_eq!(geometry.carrier_offset(3), None);
+    }
+
+    #[test]
+    fn masks_every_partial_bitmap_width() {
+        for carriers in 1..=BITS_PER_BITMAP_WORD * 3 {
+            let geometry = PoolGeometry::new(1, 1, carriers).unwrap();
+            let valid = (0..geometry.bitmap_words())
+                .map(|word| geometry.valid_mask(word).unwrap().count_ones() as usize)
+                .sum::<usize>();
+
+            assert_eq!(
+                geometry.bitmap_words(),
+                carriers.div_ceil(BITS_PER_BITMAP_WORD)
+            );
+            assert_eq!(valid, carriers);
+            assert_eq!(geometry.valid_mask(geometry.bitmap_words()), None);
+        }
+    }
+
+    #[test]
+    fn masks_a_seventy_carrier_block() {
+        let geometry = PoolGeometry::new(1, 1, 70).unwrap();
+
+        assert_eq!(geometry.bitmap_words(), 2);
+        assert_eq!(geometry.valid_mask(0), Some(u64::MAX));
+        assert_eq!(geometry.valid_mask(1), Some(0b11_1111));
+    }
+
+    #[test]
+    fn exposes_validated_dimensions() {
+        let geometry = PoolGeometry::new(4096, 8192, 65).unwrap();
+
+        assert_eq!(geometry.page_size(), 4096);
+        assert_eq!(geometry.carrier_size(), 8192);
+        assert_eq!(geometry.carriers_per_block(), CarrierCount::new(65));
+        assert_eq!(geometry.block_size(), 8192 * 65);
+        assert_eq!(geometry.bitmap_words(), 2);
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/virtual_memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/virtual_memory.rs
@@ -1,0 +1,770 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Stable virtual-address reservations with whole-range access transitions.
+
+use std::fmt;
+use std::io;
+use std::mem::MaybeUninit;
+use std::num::NonZeroUsize;
+use std::ptr::NonNull;
+
+#[cfg(test)]
+use test_support::InjectedFailures;
+
+/// Operation reported by a virtual-memory failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum VirtualMemoryOperation {
+    /// Query the runtime page size.
+    QueryPageSize,
+    /// Reserve an inaccessible address range.
+    Reserve,
+    /// Make a reserved range readable and writable.
+    Prepare,
+    /// Make a prepared range inaccessible.
+    Deactivate,
+    /// Release backing from an inaccessible range.
+    Discard,
+    /// Release the address reservation.
+    Release,
+}
+
+impl fmt::Display for VirtualMemoryOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::QueryPageSize => "page-size query",
+            Self::Reserve => "reservation",
+            Self::Prepare => "preparation",
+            Self::Deactivate => "deactivation",
+            Self::Discard => "discard",
+            Self::Release => "release",
+        })
+    }
+}
+
+/// Failure to establish or transition a stable virtual range.
+#[derive(Debug)]
+pub(super) struct VirtualMemoryError {
+    /// Operation that failed.
+    operation: VirtualMemoryOperation,
+    /// Platform error.
+    source: io::Error,
+}
+
+impl VirtualMemoryError {
+    /// Attaches operation context to a platform error.
+    fn new(operation: VirtualMemoryOperation, source: io::Error) -> Self {
+        Self { operation, source }
+    }
+
+    /// Reports an invalid reservation length.
+    fn invalid_length(len: usize, page_size: usize) -> Self {
+        Self::new(
+            VirtualMemoryOperation::Reserve,
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("range length {len} is not a nonzero multiple of page size {page_size}"),
+            ),
+        )
+    }
+
+    /// Returns the operation that failed.
+    pub(super) fn operation(&self) -> VirtualMemoryOperation {
+        self.operation
+    }
+}
+
+impl fmt::Display for VirtualMemoryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "virtual-memory {} failed: {}",
+            self.operation, self.source
+        )
+    }
+}
+
+impl std::error::Error for VirtualMemoryError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[cfg(test)]
+mod test_support {
+    use std::io;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::{VirtualMemoryError, VirtualMemoryOperation};
+
+    /// One-shot transition failures installed by a test.
+    #[derive(Debug, Default)]
+    pub(super) struct InjectedFailures {
+        /// Fails the next prepare transition when set.
+        prepare: AtomicBool,
+        /// Fails the next deactivate transition when set.
+        deactivate: AtomicBool,
+        /// Fails the next discard transition when set.
+        discard: AtomicBool,
+    }
+
+    impl InjectedFailures {
+        /// Installs one failure for `operation`.
+        ///
+        /// Panics when the operation does not support injection or already has
+        /// a pending failure.
+        pub(super) fn inject_once(&self, operation: VirtualMemoryOperation) {
+            let pending = self.pending(operation);
+            assert!(
+                !pending.swap(true, Ordering::AcqRel),
+                "{operation} already has a pending failure"
+            );
+        }
+
+        /// Consumes and reports a pending failure for `operation`.
+        pub(super) fn check(
+            &self,
+            operation: VirtualMemoryOperation,
+        ) -> Result<(), VirtualMemoryError> {
+            if self.pending(operation).swap(false, Ordering::AcqRel) {
+                Err(VirtualMemoryError::new(
+                    operation,
+                    io::Error::other(format!("injected {operation} failure")),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+
+        /// Returns the one-shot flag for an injectable transition.
+        fn pending(&self, operation: VirtualMemoryOperation) -> &AtomicBool {
+            match operation {
+                VirtualMemoryOperation::Prepare => &self.prepare,
+                VirtualMemoryOperation::Deactivate => &self.deactivate,
+                VirtualMemoryOperation::Discard => &self.discard,
+                VirtualMemoryOperation::QueryPageSize
+                | VirtualMemoryOperation::Reserve
+                | VirtualMemoryOperation::Release => {
+                    panic!("{operation} does not support failure injection")
+                }
+            }
+        }
+    }
+}
+
+/// Returns the target's runtime page size.
+///
+/// Errors report [`VirtualMemoryOperation::QueryPageSize`] when the platform
+/// query fails or returns a value that cannot be represented as nonzero
+/// `usize`.
+pub(super) fn page_size() -> Result<NonZeroUsize, VirtualMemoryError> {
+    sys::page_size()
+        .and_then(|size| {
+            usize::try_from(size)
+                .ok()
+                .and_then(NonZeroUsize::new)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("platform returned invalid page size {size}"),
+                    )
+                })
+        })
+        .map_err(|source| VirtualMemoryError::new(VirtualMemoryOperation::QueryPageSize, source))
+}
+
+/// An exclusively owned, page-aligned virtual address range.
+///
+/// The address and length remain stable until drop. Protection and backing may
+/// change without returning the address range to the operating system.
+#[derive(Debug)]
+pub(super) struct VirtualRange {
+    /// Allocation base retained until drop.
+    base: NonNull<MaybeUninit<u8>>,
+    /// Reserved length in bytes.
+    len: usize,
+    /// One-shot transition failures installed by tests.
+    #[cfg(test)]
+    injected_failures: InjectedFailures,
+}
+
+// SAFETY: the range is exclusively reserved for this object, and sharing the
+// wrapper exposes no reference or unsynchronized access to its storage.
+unsafe impl Send for VirtualRange {}
+unsafe impl Sync for VirtualRange {}
+
+impl VirtualRange {
+    /// Reserves an inaccessible page-aligned range.
+    ///
+    /// `len` must be a nonzero multiple of `page_size`. Success retains the
+    /// complete range at one address until drop.
+    pub(super) fn reserve(len: usize, page_size: NonZeroUsize) -> Result<Self, VirtualMemoryError> {
+        if len == 0 || !len.is_multiple_of(page_size.get()) {
+            return Err(VirtualMemoryError::invalid_length(len, page_size.get()));
+        }
+
+        let base = sys::reserve(len)
+            .map_err(|source| VirtualMemoryError::new(VirtualMemoryOperation::Reserve, source))?;
+        Ok(Self {
+            base,
+            len,
+            #[cfg(test)]
+            injected_failures: InjectedFailures::default(),
+        })
+    }
+
+    /// Returns the reserved length in bytes.
+    pub(super) fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns the allocation base for address comparison.
+    ///
+    /// The integer does not grant access and is never converted back to a
+    /// pointer.
+    pub(super) fn base_address(&self) -> usize {
+        self.base.as_ptr().addr()
+    }
+
+    /// Makes the complete range readable and writable.
+    ///
+    /// Failure preserves exclusive address ownership but leaves protection
+    /// unspecified. Bytes remain logically uninitialized after success.
+    pub(super) fn prepare(&self) -> Result<(), VirtualMemoryError> {
+        #[cfg(test)]
+        self.injected_failures
+            .check(VirtualMemoryOperation::Prepare)?;
+        sys::prepare(self.base, self.len)
+            .map_err(|source| VirtualMemoryError::new(VirtualMemoryOperation::Prepare, source))
+    }
+
+    /// Makes the complete range inaccessible while retaining its address.
+    ///
+    /// Failure preserves exclusive address ownership but leaves protection
+    /// unspecified.
+    pub(super) fn deactivate(&self) -> Result<(), VirtualMemoryError> {
+        #[cfg(test)]
+        self.injected_failures
+            .check(VirtualMemoryOperation::Deactivate)?;
+        sys::deactivate(self.base, self.len)
+            .map_err(|source| VirtualMemoryError::new(VirtualMemoryOperation::Deactivate, source))
+    }
+
+    /// Makes backing from an inaccessible range reclaimable.
+    ///
+    /// Failure leaves the address reserved and may leave backing resident.
+    pub(super) fn discard(&self) -> Result<(), VirtualMemoryError> {
+        #[cfg(test)]
+        self.injected_failures
+            .check(VirtualMemoryOperation::Discard)?;
+        sys::discard(self.base, self.len)
+            .map_err(|source| VirtualMemoryError::new(VirtualMemoryOperation::Discard, source))
+    }
+
+    /// Injects one failure for a supported transition.
+    ///
+    /// Panics when `operation` has no injectable transition.
+    #[cfg(test)]
+    pub(super) fn inject_failure_once(&self, operation: VirtualMemoryOperation) {
+        self.injected_failures.inject_once(operation);
+    }
+
+    /// Computes a pointer wholly contained in this range.
+    ///
+    /// # Safety
+    ///
+    /// The complete subrange must be prepared, exclusively owned by a claim
+    /// that passed the `Active` gate, and retained until the pointer is no
+    /// longer used.
+    pub(super) unsafe fn ptr_for_range(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> Option<NonNull<MaybeUninit<u8>>> {
+        let end = offset.checked_add(len)?;
+        if len == 0 || end > self.len {
+            return None;
+        }
+
+        // SAFETY: the checked nonempty subrange lies within this reservation.
+        Some(unsafe { self.base.byte_add(offset) })
+    }
+}
+
+impl Drop for VirtualRange {
+    fn drop(&mut self) {
+        // Drop cannot report a release failure. Continuing after losing the
+        // reservation invariant could permit address reuse under live owners.
+        if sys::release(self.base, self.len).is_err() {
+            std::process::abort();
+        }
+    }
+}
+
+#[cfg(not(any(miri, all(test, s3_tm_loom))))]
+mod sys {
+    //! Native virtual-memory backends.
+
+    #[cfg(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "macos"
+    ))]
+    mod platform {
+        //! Unix virtual-memory backend.
+        //!
+        //! Linux and Android follow [`mmap(2)`], [`mprotect(2)`], and
+        //! [`madvise(2)`]. FreeBSD follows its [`mmap(2)`][freebsd-mmap],
+        //! [`mprotect(2)`][freebsd-mprotect], and [`madvise(2)`][freebsd-madvise]
+        //! contracts. macOS follows the Darwin [`mmap(2)`][darwin-mmap],
+        //! [`mprotect(2)`][darwin-mprotect], and [`madvise(2)`][darwin-madvise]
+        //! manual pages.
+        //!
+        //! [`mmap(2)`]: https://man7.org/linux/man-pages/man2/mmap.2.html
+        //! [`mprotect(2)`]: https://man7.org/linux/man-pages/man2/mprotect.2.html
+        //! [`madvise(2)`]: https://man7.org/linux/man-pages/man2/madvise.2.html
+        //! [freebsd-mmap]: https://man.freebsd.org/cgi/man.cgi?query=mmap&sektion=2
+        //! [freebsd-mprotect]: https://man.freebsd.org/cgi/man.cgi?query=mprotect&sektion=2
+        //! [freebsd-madvise]: https://man.freebsd.org/cgi/man.cgi?query=madvise&sektion=2
+        //! [darwin-mmap]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/mmap.2.html
+        //! [darwin-mprotect]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/mprotect.2.html
+        //! [darwin-madvise]: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/madvise.2.html
+
+        use std::io;
+        use std::mem::MaybeUninit;
+        use std::ptr::{self, NonNull};
+
+        /// Returns `_SC_PAGESIZE` from [`sysconf()`].
+        ///
+        /// [`sysconf()`]: https://pubs.opengroup.org/onlinepubs/9799919799/functions/sysconf.html
+        pub(in super::super) fn page_size() -> io::Result<u64> {
+            // SAFETY: sysconf has no pointer preconditions.
+            let size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+            if size <= 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(size as u64)
+        }
+
+        /// Creates a private anonymous `PROT_NONE` mapping.
+        pub(in super::super) fn reserve(len: usize) -> io::Result<NonNull<MaybeUninit<u8>>> {
+            // SAFETY: a null address asks the kernel to select a fresh range.
+            // The returned mapping is owned by the caller until `release`.
+            let base = unsafe {
+                libc::mmap(
+                    ptr::null_mut(),
+                    len,
+                    libc::PROT_NONE,
+                    libc::MAP_PRIVATE | libc::MAP_ANON,
+                    -1,
+                    0,
+                )
+            };
+            if base == libc::MAP_FAILED {
+                return Err(io::Error::last_os_error());
+            }
+            if base.is_null() {
+                // SAFETY: mmap reported success for this complete mapping.
+                let released = unsafe { libc::munmap(base, len) };
+                return Err(if released == 0 {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "mmap returned a null successful mapping",
+                    )
+                } else {
+                    io::Error::last_os_error()
+                });
+            }
+            // SAFETY: MAP_FAILED and null were rejected above.
+            Ok(unsafe { NonNull::new_unchecked(base.cast()) })
+        }
+
+        /// Applies read-write protection to the complete mapping.
+        pub(in super::super) fn prepare(
+            base: NonNull<MaybeUninit<u8>>,
+            len: usize,
+        ) -> io::Result<()> {
+            // SAFETY: `VirtualRange` retains this complete mapping.
+            check_libc_result(unsafe {
+                libc::mprotect(
+                    base.as_ptr().cast(),
+                    len,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                )
+            })
+        }
+
+        /// Applies `PROT_NONE` to the complete mapping.
+        pub(in super::super) fn deactivate(
+            base: NonNull<MaybeUninit<u8>>,
+            len: usize,
+        ) -> io::Result<()> {
+            // SAFETY: the block lifecycle excludes access to this complete
+            // range.
+            check_libc_result(unsafe { libc::mprotect(base.as_ptr().cast(), len, libc::PROT_NONE) })
+        }
+
+        /// Marks inactive backing reclaimable without releasing the mapping.
+        ///
+        /// Linux and Android use `MADV_DONTNEED`; FreeBSD and macOS use
+        /// `MADV_FREE`.
+        pub(in super::super) fn discard(
+            base: NonNull<MaybeUninit<u8>>,
+            len: usize,
+        ) -> io::Result<()> {
+            #[cfg(any(target_os = "android", target_os = "linux"))]
+            let advice = libc::MADV_DONTNEED;
+            #[cfg(any(target_os = "freebsd", target_os = "macos"))]
+            let advice = libc::MADV_FREE;
+
+            // SAFETY: lifecycle serialization keeps the complete range
+            // inactive until discard and any later preparation finish.
+            check_libc_result(unsafe { libc::madvise(base.as_ptr().cast(), len, advice) })
+        }
+
+        /// Releases the complete mapping.
+        pub(in super::super) fn release(
+            base: NonNull<MaybeUninit<u8>>,
+            len: usize,
+        ) -> io::Result<()> {
+            // SAFETY: final `VirtualRange` destruction owns the complete
+            // mapping.
+            check_libc_result(unsafe { libc::munmap(base.as_ptr().cast(), len) })
+        }
+
+        /// Converts a libc result where zero indicates success.
+        fn check_libc_result(result: libc::c_int) -> io::Result<()> {
+            if result == 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    mod platform {
+        //! Windows virtual-memory backend.
+        //!
+        //! Address reservation and commit follow [`VirtualAlloc`]. Decommit and
+        //! final release follow [`VirtualFree`]. Runtime page geometry comes
+        //! from [`GetSystemInfo`].
+        //!
+        //! [`VirtualAlloc`]: https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc
+        //! [`VirtualFree`]: https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualfree
+        //! [`GetSystemInfo`]: https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsysteminfo
+
+        use std::io;
+        use std::mem::MaybeUninit;
+        use std::ptr::{self, NonNull};
+
+        use windows_sys::Win32::System::Memory::{
+            VirtualAlloc, VirtualFree, MEM_COMMIT, MEM_DECOMMIT, MEM_RELEASE, MEM_RESERVE,
+            PAGE_NOACCESS, PAGE_READWRITE,
+        };
+        use windows_sys::Win32::System::SystemInformation::{GetSystemInfo, SYSTEM_INFO};
+
+        /// Returns the system page size.
+        pub(in super::super) fn page_size() -> io::Result<u64> {
+            let mut info = MaybeUninit::<SYSTEM_INFO>::uninit();
+            // SAFETY: `info` is valid writable storage for one SYSTEM_INFO.
+            unsafe { GetSystemInfo(info.as_mut_ptr()) };
+            // SAFETY: GetSystemInfo initializes the complete output structure.
+            let info = unsafe { info.assume_init() };
+            Ok(info.dwPageSize as u64)
+        }
+
+        /// Reserves an inaccessible range without committing pages.
+        pub(in super::super) fn reserve(len: usize) -> io::Result<NonNull<MaybeUninit<u8>>> {
+            // SAFETY: a null address asks the kernel to select an exclusively
+            // reserved range, which is released by `release`.
+            let base = unsafe { VirtualAlloc(ptr::null(), len, MEM_RESERVE, PAGE_NOACCESS) };
+            NonNull::new(base.cast()).ok_or_else(io::Error::last_os_error)
+        }
+
+        /// Commits the complete range with read-write protection.
+        pub(in super::super) fn prepare(
+            base: NonNull<MaybeUninit<u8>>,
+            len: usize,
+        ) -> io::Result<()> {
+            // SAFETY: the requested range is wholly contained in one
+            // reservation.
+            let committed =
+                unsafe { VirtualAlloc(base.as_ptr().cast(), len, MEM_COMMIT, PAGE_READWRITE) };
+            let committed = NonNull::new(committed.cast()).ok_or_else(io::Error::last_os_error)?;
+            if committed.cast::<MaybeUninit<u8>>() != base {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "VirtualAlloc committed a different address",
+                ));
+            }
+            Ok(())
+        }
+
+        /// Decommits the complete range while retaining its reservation.
+        pub(in super::super) fn deactivate(
+            base: NonNull<MaybeUninit<u8>>,
+            len: usize,
+        ) -> io::Result<()> {
+            // SAFETY: the block lifecycle excludes access to the committed
+            // range.
+            check_win32_result(unsafe { VirtualFree(base.as_ptr().cast(), len, MEM_DECOMMIT) })
+        }
+
+        /// Completes reclaim already performed by `MEM_DECOMMIT`.
+        pub(in super::super) fn discard(
+            _base: NonNull<MaybeUninit<u8>>,
+            _len: usize,
+        ) -> io::Result<()> {
+            // MEM_DECOMMIT performs both deactivation and backing release.
+            Ok(())
+        }
+
+        /// Releases the complete address reservation.
+        pub(in super::super) fn release(
+            base: NonNull<MaybeUninit<u8>>,
+            _len: usize,
+        ) -> io::Result<()> {
+            // SAFETY: MEM_RELEASE requires the allocation base and a zero size.
+            check_win32_result(unsafe { VirtualFree(base.as_ptr().cast(), 0, MEM_RELEASE) })
+        }
+
+        /// Converts a Win32 result where nonzero indicates success.
+        fn check_win32_result(result: i32) -> io::Result<()> {
+            if result != 0 {
+                Ok(())
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        }
+    }
+
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "windows"
+    )))]
+    mod platform {
+        //! Unsupported-target backend.
+
+        use std::io;
+        use std::mem::MaybeUninit;
+        use std::ptr::NonNull;
+
+        /// Reports that page-size discovery is unsupported.
+        pub(in super::super) fn page_size() -> io::Result<u64> {
+            Err(unsupported())
+        }
+
+        /// Reports that virtual-range reservation is unsupported.
+        pub(in super::super) fn reserve(_len: usize) -> io::Result<NonNull<MaybeUninit<u8>>> {
+            Err(unsupported())
+        }
+
+        /// Reports that range preparation is unsupported.
+        pub(in super::super) fn prepare(
+            _base: NonNull<MaybeUninit<u8>>,
+            _len: usize,
+        ) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        /// Reports that range deactivation is unsupported.
+        pub(in super::super) fn deactivate(
+            _base: NonNull<MaybeUninit<u8>>,
+            _len: usize,
+        ) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        /// Reports that backing discard is unsupported.
+        pub(in super::super) fn discard(
+            _base: NonNull<MaybeUninit<u8>>,
+            _len: usize,
+        ) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        /// Reports that final release is unsupported.
+        pub(in super::super) fn release(
+            _base: NonNull<MaybeUninit<u8>>,
+            _len: usize,
+        ) -> io::Result<()> {
+            Err(unsupported())
+        }
+
+        /// Constructs an unsupported-target error.
+        fn unsupported() -> io::Error {
+            io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "no buffer-pool virtual-memory backend for {}",
+                    std::env::consts::OS
+                ),
+            )
+        }
+    }
+
+    pub(super) use platform::*;
+}
+
+#[cfg(any(miri, all(test, s3_tm_loom)))]
+mod sys {
+    //! Allocator-backed model for Miri and Loom.
+    //!
+    //! This backend preserves allocation ownership and pointer provenance. It
+    //! does not model operating-system access protection or backing reclaim.
+
+    use std::alloc::{alloc, dealloc, Layout};
+    use std::io;
+    use std::mem::MaybeUninit;
+    use std::ptr::NonNull;
+
+    /// Model page size and allocation alignment.
+    const PAGE_SIZE: usize = 4096;
+
+    /// Returns the model page size.
+    pub(super) fn page_size() -> io::Result<u64> {
+        Ok(PAGE_SIZE as u64)
+    }
+
+    /// Allocates a page-aligned model range.
+    pub(super) fn reserve(len: usize) -> io::Result<NonNull<MaybeUninit<u8>>> {
+        let layout = layout(len)?;
+        // SAFETY: the layout is nonzero and valid.
+        let base = unsafe { alloc(layout) };
+        NonNull::new(base.cast()).ok_or_else(|| io::Error::from(io::ErrorKind::OutOfMemory))
+    }
+
+    /// Accepts a model prepare transition.
+    pub(super) fn prepare(_base: NonNull<MaybeUninit<u8>>, _len: usize) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Accepts a model deactivate transition.
+    pub(super) fn deactivate(_base: NonNull<MaybeUninit<u8>>, _len: usize) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Accepts a model discard transition.
+    pub(super) fn discard(_base: NonNull<MaybeUninit<u8>>, _len: usize) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Deallocates the model range with its original layout.
+    pub(super) fn release(base: NonNull<MaybeUninit<u8>>, len: usize) -> io::Result<()> {
+        let layout = layout(len)?;
+        // SAFETY: `base` was allocated with this layout and remains owned.
+        unsafe { dealloc(base.as_ptr().cast(), layout) };
+        Ok(())
+    }
+
+    /// Returns the page-aligned allocation layout for `len`.
+    fn layout(len: usize) -> io::Result<Layout> {
+        Layout::from_size_align(len, PAGE_SIZE)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_zero_and_partial_pages() {
+        let page_size = NonZeroUsize::new(4096).unwrap();
+
+        assert_eq!(
+            VirtualRange::reserve(0, page_size).unwrap_err().operation(),
+            VirtualMemoryOperation::Reserve
+        );
+        assert_eq!(
+            VirtualRange::reserve(4097, page_size)
+                .unwrap_err()
+                .operation(),
+            VirtualMemoryOperation::Reserve
+        );
+    }
+
+    #[test]
+    fn range_lifecycle_preserves_address() {
+        let page_size = page_size().unwrap();
+        let range = VirtualRange::reserve(page_size.get() * 2, page_size).unwrap();
+        let base = range.base_address();
+
+        assert_eq!(range.len(), page_size.get() * 2);
+        assert_eq!(base % page_size.get(), 0);
+
+        range.prepare().unwrap();
+        // SAFETY: the prepared range is retained exclusively by this test.
+        let first = unsafe { range.ptr_for_range(0, 1).unwrap() };
+        // SAFETY: the first byte is writable and has no alias.
+        unsafe { first.as_ptr().write(MaybeUninit::new(0x5a)) };
+        // SAFETY: the preceding write initialized this byte.
+        assert_eq!(unsafe { first.as_ptr().read().assume_init() }, 0x5a);
+
+        range.deactivate().unwrap();
+        range.discard().unwrap();
+        range.prepare().unwrap();
+
+        assert_eq!(range.base_address(), base);
+        // SAFETY: revival made the retained range writable again.
+        let last = unsafe {
+            range
+                .ptr_for_range(range.len() - 1, 1)
+                .expect("last byte is within the range")
+        };
+        // SAFETY: the last byte is writable and has no alias.
+        unsafe { last.as_ptr().write(MaybeUninit::new(0xa5)) };
+        // SAFETY: the preceding write initialized this byte.
+        assert_eq!(unsafe { last.as_ptr().read().assume_init() }, 0xa5);
+    }
+
+    #[test]
+    fn injected_transition_failure_is_consumed_once() {
+        let page_size = page_size().unwrap();
+        let range = VirtualRange::reserve(page_size.get(), page_size).unwrap();
+        range.inject_failure_once(VirtualMemoryOperation::Prepare);
+
+        let error = range.prepare().unwrap_err();
+
+        assert_eq!(error.operation(), VirtualMemoryOperation::Prepare);
+        range.prepare().unwrap();
+    }
+
+    #[test]
+    fn checked_pointer_rejects_invalid_subranges() {
+        let page_size = page_size().unwrap();
+        let range = VirtualRange::reserve(page_size.get(), page_size).unwrap();
+        range.prepare().unwrap();
+
+        // SAFETY: this test only inspects pointer construction while the
+        // complete range is prepared and exclusively retained.
+        unsafe {
+            assert!(range.ptr_for_range(0, 0).is_none());
+            assert!(range.ptr_for_range(range.len(), 1).is_none());
+            assert!(range.ptr_for_range(range.len() - 1, 2).is_none());
+            assert!(range.ptr_for_range(usize::MAX, 2).is_none());
+            assert_eq!(
+                range
+                    .ptr_for_range(1, range.len() - 1)
+                    .unwrap()
+                    .addr()
+                    .get(),
+                range.base_address() + 1
+            );
+        }
+    }
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn virtual_range_is_send_and_sync() {
+        assert_send_sync::<VirtualRange>();
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/virtual_memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/virtual_memory.rs
@@ -295,9 +295,17 @@ impl VirtualRange {
 
 impl Drop for VirtualRange {
     fn drop(&mut self) {
-        // Drop cannot report a release failure. Continuing after losing the
-        // reservation invariant could permit address reuse under live owners.
-        if sys::release(self.base, self.len).is_err() {
+        // A valid reservation release cannot fail. Drop cannot return the
+        // platform error or retry after relinquishing ownership of this value.
+        if let Err(error) = sys::release(self.base, self.len) {
+            tracing::error!(
+                target: crate::telemetry::TARGET_MEMORY,
+                operation = %VirtualMemoryOperation::Release,
+                error = %error,
+                base = self.base_address(),
+                len = self.len,
+                "buffer-pool virtual range release failed; aborting"
+            );
             std::process::abort();
         }
     }
@@ -727,7 +735,7 @@ mod tests {
     }
 
     #[test]
-    fn injected_transition_failure_is_consumed_once() {
+    fn injected_transition_failures_are_consumed_once() {
         let page_size = page_size().unwrap();
         let range = VirtualRange::reserve(page_size.get(), page_size).unwrap();
         range.inject_failure_once(VirtualMemoryOperation::Prepare);
@@ -735,6 +743,21 @@ mod tests {
         let error = range.prepare().unwrap_err();
 
         assert_eq!(error.operation(), VirtualMemoryOperation::Prepare);
+        assert!(error
+            .to_string()
+            .contains("virtual-memory preparation failed"));
+        assert!(std::error::Error::source(&error).is_some());
+        range.prepare().unwrap();
+
+        range.inject_failure_once(VirtualMemoryOperation::Deactivate);
+        let error = range.deactivate().unwrap_err();
+        assert_eq!(error.operation(), VirtualMemoryOperation::Deactivate);
+        range.deactivate().unwrap();
+
+        range.inject_failure_once(VirtualMemoryOperation::Discard);
+        let error = range.discard().unwrap_err();
+        assert_eq!(error.operation(), VirtualMemoryOperation::Discard);
+        range.discard().unwrap();
         range.prepare().unwrap();
     }
 
@@ -751,6 +774,10 @@ mod tests {
             assert!(range.ptr_for_range(range.len(), 1).is_none());
             assert!(range.ptr_for_range(range.len() - 1, 2).is_none());
             assert!(range.ptr_for_range(usize::MAX, 2).is_none());
+            assert_eq!(
+                range.ptr_for_range(0, range.len()).unwrap().addr().get(),
+                range.base_address()
+            );
             assert_eq!(
                 range
                     .ptr_for_range(1, range.len() - 1)

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/virtual_memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/virtual_memory.rs
@@ -494,8 +494,9 @@ mod sys {
             // reservation.
             let committed =
                 unsafe { VirtualAlloc(base.as_ptr().cast(), len, MEM_COMMIT, PAGE_READWRITE) };
-            let committed = NonNull::new(committed.cast()).ok_or_else(io::Error::last_os_error)?;
-            if committed.cast::<MaybeUninit<u8>>() != base {
+            let committed: NonNull<MaybeUninit<u8>> =
+                NonNull::new(committed.cast()).ok_or_else(io::Error::last_os_error)?;
+            if committed != base {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "VirtualAlloc committed a different address",

--- a/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/mod.rs
@@ -16,6 +16,8 @@ pub(crate) use managed::ManagedThreadRuntime;
 mod topology;
 pub(crate) use topology::Topology;
 
+#[allow(dead_code)]
+pub(crate) mod buffer_pool;
 pub(crate) mod memory;
 pub(crate) mod platform;
 pub(crate) mod sync;

--- a/aws-sdk-s3-transfer-manager/src/scheduler/scheduler.rs
+++ b/aws-sdk-s3-transfer-manager/src/scheduler/scheduler.rs
@@ -2663,6 +2663,7 @@ mod tests {
             observed
         );
 
+        scheduler.cancel_transfer(id).wait_for_idle().await;
         handle.runtime.shutdown();
     }
 

--- a/aws-sdk-s3-transfer-manager/src/telemetry.rs
+++ b/aws-sdk-s3-transfer-manager/src/telemetry.rs
@@ -9,9 +9,10 @@
 //!
 //! ```text
 //! RUST_LOG=aws_sdk_s3_transfer_manager::concurrency=debug   # adaptive algorithm decisions
-//! RUST_LOG=aws_sdk_s3_transfer_manager::scheduling=debug    # scheduler + memory-budget capacity
+//! RUST_LOG=aws_sdk_s3_transfer_manager::scheduling=debug    # scheduler + memory-budget admission
 //! RUST_LOG=aws_sdk_s3_transfer_manager::execution=trace     # per-work-item execute/complete
 //! RUST_LOG=aws_sdk_s3_transfer_manager::transfer=debug      # transfer lifecycle events
+//! RUST_LOG=aws_sdk_s3_transfer_manager::memory=debug        # buffer-pool admission + storage
 //! ```
 
 use crate::metrics::latency::LatencyTracker;
@@ -22,9 +23,11 @@ use std::time::Duration;
 /// Adaptive concurrency controller: phase transitions, target changes, probe results.
 pub(crate) const TARGET_CONCURRENCY: &str = "aws_sdk_s3_transfer_manager::concurrency";
 
-/// Scheduler capacity decisions, worker pool growth, and memory-budget admission
-/// (reserve/grant/release flow, and saturation edges where a reserve parks).
+/// Scheduler capacity decisions, worker pool growth, and memory-budget admission.
 pub(crate) const TARGET_SCHEDULING: &str = "aws_sdk_s3_transfer_manager::scheduling";
+
+/// Buffer-pool admission, physical storage, reclamation, and fatal errors.
+pub(crate) const TARGET_MEMORY: &str = "aws_sdk_s3_transfer_manager::memory";
 
 /// Per-work-item execution: dispatch, complete, skip, panic.
 pub(crate) const TARGET_EXECUTION: &str = "aws_sdk_s3_transfer_manager::execution";

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -1262,8 +1262,6 @@ struct CarrierAllocation {
     slot: Arc<BlockSlot>,
     index: u32,
     incarnation_identity: IncarnationIdentity,
-    // Checked only after the bit passes the Active gate.
-    ptr: NonNull<MaybeUninit<u8>>,
 }
 
 struct ClaimBatch {
@@ -1309,6 +1307,10 @@ captured only as an opaque comparison token. It is never converted back into a p
 post-gate owner keeps its incarnation current through its live bit, so allocator address reuse
 cannot occur during a valid comparison. Identity remains diagnostic: bitmap ownership and the
 claim-trim gate authorize rollback, return, and pointer construction.
+
+A `CarrierAllocation` stores the block slot and carrier index rather than a derived pointer. Its
+ownership bit prevents the block mapping from being deactivated while the allocation is live. Byte
+access derives a temporary pointer from the slot's validated `VirtualRange` and carrier index.
 
 `PendingAcquisition::finish` succeeds only when `claimed == required`. It consumes the complete
 batch and matching accounting debit, converts every provisional bit to one `CarrierAllocation`, and
@@ -1611,8 +1613,9 @@ choices.
 - **P2: Physical ownership.** A set valid bit has one `ProvisionalBits` or `CarrierAllocation`
   owner. Pointer construction follows a successful `Active` gate and stays within the owning
   `VirtualRange`.
-- **P3: Activation publication.** Preparation or revival adds prepared capacity before publishing
-  `Active`, and every activation uses a fresh bitmap.
+- **P3: Activation publication.** Initial preparation or revival adds prepared capacity before
+  publishing a fresh `Active` incarnation. Protection recovery adds prepared capacity before
+  restoring its retained `Draining` incarnation to `Active` and does not reset that bitmap.
 - **P4: Claim-trim exclusion.** Claim protects its incarnation through the state gate. Claim and
   trim cannot both miss the other's publication; gate-failure rollback uses the protected
   incarnation, and a gate-passed bit prevents replacement until return.
@@ -3253,24 +3256,25 @@ section; one property may discharge several contracts.
 
 ### Physical-storage verification
 
-| Obligation | Property                                                                  | Evidence                                                 | Negative control                                               |
-| ---------- | ------------------------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------- |
-| P4         | Claim and trim cannot both pass their gate                                | Loom over one claim and one trim                         | Weaken either store-load pair to acquire/release               |
-| P3, P4     | Stale rollback cannot clear a revived carrier                             | Loom over claim, trim, revival, and new claim            | Reset and reuse one bitmap across activations                  |
-| P4         | Gate-failure rollback writes only through the protected incarnation       | Loom with removal of `current` before rollback           | Reacquire `current` for stale rollback                         |
-| P2, P5     | Post-gate batch rollback and final return clear exactly owned bits        | Loom plus multiword property tests                       | Clear the candidate mask instead of won bits                   |
-| P1         | Padding bits never become carriers or affect all-free                     | Property tests around every final-word width             | Omit `valid_masks` from claim or trim                          |
-| P1, P2     | Pool ownership spine is `Send + Sync` through `VirtualRange`              | Compile-time trait assertions and unsafe-code inspection | Store an unwrapped `NonNull` directly in `BlockSlot`           |
-| P1, P2     | Address lookup classifies only complete in-range views                    | Boundary property tests over sorted block ranges         | Classify by start address without checking the end             |
-| P6         | Fallback lock scope excludes pending finish and rollback                  | Deterministic miss-path tests plus lock assertions       | Finish or drop pending while admission remains held            |
-| P4         | Gate-failure rollback remains valid after range deactivation              | Loom over claim, trim, and delayed rollback              | Allocate incarnation metadata inside `VirtualRange`            |
-| P6         | Serialized fallback exhausts prepared capacity before growth              | Deterministic fragmented-registry tests                  | Grow after an optimistic miss without exhaustive recheck       |
-| P6         | Fresh growth reserves the fallback claimant's carriers before publication | Concurrent fallback and fast-claim test                  | Publish the free incarnation before preclaiming the batch      |
-| P7         | Protection and discard failure leave the block nonclaimable               | Failure injection at each mapping transition             | Restore `Active` from a failed platform call                   |
-| P3, P7     | Mapping failures preserve the admission floor                             | Failure injection across prepare, trim, and recovery     | Count failed preparation or subtract failed deactivation twice |
-| P8         | Idle retention does not decay within one idle epoch                       | Maintenance state-machine test over repeated scans       | Derive each retry target from current prepared capacity        |
-| P9         | Corrupt ownership state aborts before allocator mutation continues        | Fail-stop injection at each ownership check              | Clear a bit or release accounting after a failed check         |
-| A8, C3     | Shared-pool shutdown preserves other handles and final return             | Composed Loom with queue, reservation, and `Bytes`       | Drop pool state when manager-owned handles disappear           |
+| Obligation | Property                                                                  | Evidence                                                  | Negative control                                               |
+| ---------- | ------------------------------------------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------- |
+| P4         | Claim and trim cannot both pass their gate                                | Loom over one claim and one trim                          | Weaken either store-load pair to acquire/release               |
+| P3, P4     | Stale rollback cannot clear a revived carrier                             | Loom over claim, trim, revival, and new claim             | Reset and reuse one bitmap across activations                  |
+| P3, P4, P7 | Protection recovery preserves ownership in the retained incarnation       | Loom over claim, failed deactivation, recovery, and claim | Reset the retained bitmap during protection recovery           |
+| P4         | Gate-failure rollback writes only through the protected incarnation       | Loom with removal of `current` before rollback            | Reacquire `current` for stale rollback                         |
+| P2, P5     | Post-gate batch rollback and final return clear exactly owned bits        | Loom plus multiword property tests                        | Clear the candidate mask instead of won bits                   |
+| P1         | Padding bits never become carriers or affect all-free                     | Property tests around every final-word width              | Omit `valid_masks` from claim or trim                          |
+| P1, P2     | Pool ownership spine is `Send + Sync` through `VirtualRange`              | Compile-time trait assertions and unsafe-code inspection  | Store an unwrapped `NonNull` directly in `BlockSlot`           |
+| P1, P2     | Address lookup classifies only complete in-range views                    | Boundary property tests over sorted block ranges          | Classify by start address without checking the end             |
+| P6         | Fallback lock scope excludes pending finish and rollback                  | Deterministic miss-path tests plus lock assertions        | Finish or drop pending while admission remains held            |
+| P4         | Gate-failure rollback remains valid after range deactivation              | Loom over claim, trim, and delayed rollback               | Allocate incarnation metadata inside `VirtualRange`            |
+| P6         | Serialized fallback exhausts prepared capacity before growth              | Deterministic fragmented-registry tests                   | Grow after an optimistic miss without exhaustive recheck       |
+| P6         | Fresh growth reserves the fallback claimant's carriers before publication | Concurrent fallback and fast-claim test                   | Publish the free incarnation before preclaiming the batch      |
+| P7         | Protection and discard failure leave the block nonclaimable               | Failure injection at each mapping transition              | Restore `Active` from a failed platform call                   |
+| P3, P7     | Mapping failures preserve the admission floor                             | Failure injection across prepare, trim, and recovery      | Count failed preparation or subtract failed deactivation twice |
+| P8         | Idle retention does not decay within one idle epoch                       | Maintenance state-machine test over repeated scans        | Derive each retry target from current prepared capacity        |
+| P9         | Corrupt ownership state aborts before allocator mutation continues        | Fail-stop injection at each ownership check               | Clear a bit or release accounting after a failed check         |
+| A8, C3     | Shared-pool shutdown preserves other handles and final return             | Composed Loom with queue, reservation, and `Bytes`        | Drop pool state when manager-owned handles disappear           |
 
 ### Ownership verification
 

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -1555,6 +1555,24 @@ fault. Deactivation failure enters `ProtectionPending` without assuming that pri
 remains. Discard success makes backing absent or reclaimable; discard failure may retain resident
 pages but cannot make the block claimable.
 
+**Alternative: Allocator-owned blocks.** A page-aligned allocation provides the same common-path
+carrier claim, return, and reuse while retained. The standard allocator API does not provide a
+per-block operation that revokes access and makes backing reclaimable while preserving ownership of
+the allocation. Retaining idle blocks therefore leaves resident-set reduction to allocator policy.
+Deallocating them gives up the address and makes physical release behavior allocator-dependent. This
+is a viable simpler design when reuse is primary and reclamation is best effort. The selected design
+instead gives idle trim an explicit page-level operation and failure contract.
+
+**Alternative: Release and replace virtual ranges.** A pool using operating-system mappings could
+release a trimmed range and allocate a new range on later growth. This returns virtual address space
+with the backing but makes trim a topology change. Old claim attempts and registry snapshots must
+retire before the address can be reused, or every stale lookup must detect replacement. Revival also
+requires a new slot or registry publication. The selected backend can make a block inaccessible and
+discard its backing or make it reclaimable without waiting for metadata readers to quiesce. Those
+readers may still observe the retired incarnation, but cannot construct or dereference a carrier
+pointer. The cost is one retained virtual reservation per peak block slot and target-specific
+mapping and recovery state.
+
 Correctness does not assume that a failed protection call leaves the prior protection unchanged.
 
 Prepared bytes are logically uninitialized regardless of initial or recommitted contents. Physical

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -1012,8 +1012,9 @@ clears and reuses a bitmap from an earlier activation. An old claim attempt may 
 after the slot publishes incarnation B, but the two attempts mutate different bitmap objects.
 
 The block base and carrier size are page multiples, so every carrier begins on a page boundary and
-shares no page with another carrier. A final partial bitmap word is masked by immutable
-`valid_masks`; padding bits never name carriers and are never claimable.
+shares no page with another carrier. `final_word_mask` clears padding bits in a partial final bitmap
+word; padding bits never name carriers and are never claimable. Complete interior words use
+`u64::MAX` without separate stored entries.
 
 **Alternative: Multiple carrier size classes.** Rejected: multiple classes can reduce internal tail
 waste but partition reusable capacity and add size-class admission and ownership. One page-multiple
@@ -1025,14 +1026,18 @@ The pool geometry is private:
 ```rust
 struct PoolGeometry {
     page_size: NonZeroUsize,
+    block_size: NonZeroUsize,
     carrier_size: NonZeroUsize,
     carriers_per_block: NonZeroUsize,
+    bitmap_words: NonZeroUsize,
+    final_word_mask: u64,
 }
 ```
 
-Construction validates page and carrier alignment, whole-carrier block size, bitmap and valid-mask
-coverage, and every address and byte calculation. Configured capacity need not be a whole number of
-blocks; whole-block preparation may exceed configured capacity without changing admission.
+Construction accepts block size in bytes, validates page and carrier alignment and whole-carrier
+block size, then derives carrier count, bitmap size, and the final-word mask. Configured capacity
+need not be a whole number of blocks; whole-block preparation may exceed configured capacity
+without changing admission.
 
 The stable per-block state is:
 
@@ -1054,9 +1059,7 @@ unsafe impl Sync for VirtualRange {}
 struct BlockSlot {
     id: u32,
     range: VirtualRange,
-    carrier_size: usize,
-    carrier_count: CarrierCount,
-    valid_masks: Box<[u64]>,
+    geometry: PoolGeometry,
 
     // Serializes target-specific protection, discard, and revival.
     mapping: Mutex<MappingState>,
@@ -1064,8 +1067,8 @@ struct BlockSlot {
 }
 
 struct BlockIncarnation {
-    state: AtomicU8,             // Active | Draining | Dead
-    in_use: Box<[AtomicU64]>,    // one bit per carrier
+    state: AtomicIncarnationState, // Active | Draining | Dead
+    in_use: Box<[AtomicU64]>,      // one bit per carrier
 }
 ```
 
@@ -1367,7 +1370,7 @@ Trim separates the bounded admission transition from protection and discard work
 3. Scan that incarnation's bitmap.
 4. If a bit is set, restore `Active`; `prepared_capacity` has not changed.
 5. If all bits are clear, subtract the block from `prepared_capacity`.
-6. Return a linear cleanup token and release admission serialization.
+6. Return a single-owner cleanup token and release admission serialization.
 7. Make the complete range inaccessible and discard backing outside admission serialization.
 8. Publish `Dead` and clear `current`.
 
@@ -1675,7 +1678,7 @@ One completed carrier acquisition creates one `CarrierGuard`:
 struct CarrierGuard {
     // State required to validate return and release the aggregate charge.
     pool: Arc<PoolInner>,
-    // Linear physical-return capability, taken exactly once by final drop.
+    // Single-owner physical-return capability, taken once by final drop.
     allocation: Option<CarrierAllocation>,
     // Originating reservation state for a direct acquisition.
     direct: Option<Arc<ReservationState>>,
@@ -2865,9 +2868,10 @@ clearing an unexpected bit or releasing its charge.
 
 ### Carrier and block geometry
 
-Carrier size and carriers per block are measurement choices. Carrier size must be a multiple of the
-runtime page size. Smaller carriers reduce small-object and tail waste but increase bitmap
-operations, ownership transitions, scatter width, and carrier returns.
+Carrier and block sizes are measurement choices. Carrier size must be a multiple of the runtime page
+size, and block size must be a whole number of carriers. Smaller carriers reduce small-object and
+tail waste but increase bitmap operations, ownership transitions, scatter width, and carrier
+returns.
 
 Block size controls mapping amortization, all-free scan length, reclaim granularity, and how much
 capacity one long-lived carrier can keep prepared. Geometry selection must account for small
@@ -3281,7 +3285,7 @@ section; one property may discharge several contracts.
 | P3, P4, P7 | Protection recovery preserves ownership in the retained incarnation       | Loom over claim, failed deactivation, recovery, and claim | Reset the retained bitmap during protection recovery           |
 | P4         | Gate-failure rollback writes only through the protected incarnation       | Loom with removal of `current` before rollback            | Reacquire `current` for stale rollback                         |
 | P2, P5     | Post-gate batch rollback and final return clear exactly owned bits        | Loom plus multiword property tests                        | Clear the candidate mask instead of won bits                   |
-| P1         | Padding bits never become carriers or affect all-free                     | Property tests around every final-word width              | Omit `valid_masks` from claim or trim                          |
+| P1         | Padding bits never become carriers or affect all-free                     | Property tests around every final-word width              | Ignore `final_word_mask` during claim or trim                  |
 | P1, P2     | Pool ownership spine is `Send + Sync` through `VirtualRange`              | Compile-time trait assertions and unsafe-code inspection  | Store an unwrapped `NonNull` directly in `BlockSlot`           |
 | P1, P2     | Address lookup classifies only complete in-range views                    | Boundary property tests over sorted block ranges          | Classify by start address without checking the end             |
 | P6         | Fallback lock scope excludes pending finish and rollback                  | Deterministic miss-path tests plus lock assertions        | Finish or drop pending while admission remains held            |

--- a/integration-tests/src/harness.rs
+++ b/integration-tests/src/harness.rs
@@ -23,20 +23,16 @@ use aws_sdk_s3_transfer_manager::types::RuntimeMode;
 use aws_sdk_s3_transfer_manager::Client as TmClient;
 use s3_mock_server::S3MockServer;
 
-/// Install a process-global tracing subscriber for e2e diagnosis, once.
+/// Installs a process-global tracing subscriber for test diagnosis, once.
 ///
-/// A failing real-S3 test otherwise surfaces only a panic string; this makes the
-/// run debuggable from its own logs, no re-run needed. Honors `RUST_LOG`;
-/// defaults to a curated filter over the transfer manager's diagnostic targets —
-/// the adaptive concurrency target (is it ramping?), scheduler/memory-budget
-/// admission (is a reserve parking?), and transfer lifecycle. Deliberately omits
-/// the per-work-item `execution` target (768 GETs × chunks is a firehose); reach
-/// for it with `RUST_LOG` when a specific run needs it.
+/// Libtest captures events and prints them when a test fails or output capture
+/// is disabled. `RUST_LOG` overrides the curated default. The default omits the
+/// per-work-item `execution` target; enable it with `RUST_LOG` when needed.
 ///
 /// Global (not a thread-local `set_default`) so it captures events from the
 /// managed threads and tokio workers the transfer runs on, not just the test
 /// thread. Idempotent: the first call wins, later calls are no-ops.
-pub(crate) fn init_e2e_logs() {
+pub(crate) fn init_test_logs() {
     use std::sync::Once;
     static INIT: Once = Once::new();
     INIT.call_once(|| {
@@ -44,6 +40,7 @@ pub(crate) fn init_e2e_logs() {
             aws_sdk_s3_transfer_manager::concurrency=debug,\
             aws_sdk_s3_transfer_manager::scheduling=debug,\
             aws_sdk_s3_transfer_manager::transfer=debug";
+
         let filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(DEFAULT_FILTER));
         // try_init: another test (or the process) may have set a subscriber
@@ -51,6 +48,7 @@ pub(crate) fn init_e2e_logs() {
         let _ = tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_target(true)
+            .with_test_writer()
             .try_init();
     });
 }
@@ -83,7 +81,7 @@ pub(crate) async fn mock_tm_with(
         aws_sdk_s3_transfer_manager::config::Builder,
     ) -> aws_sdk_s3_transfer_manager::config::Builder,
 ) -> MockTm {
-    init_e2e_logs();
+    init_test_logs();
     let server = S3MockServer::builder()
         .with_in_memory_store()
         .build()
@@ -238,7 +236,7 @@ impl TmTestClient {
         part_size: Option<aws_sdk_s3_transfer_manager::types::PartSize>,
         configure: Option<impl FnOnce(aws_sdk_s3::config::Builder) -> aws_sdk_s3::config::Builder>,
     ) -> Self {
-        init_e2e_logs();
+        init_test_logs();
         let server = S3MockServer::builder()
             .with_in_memory_store()
             .build()
@@ -274,7 +272,7 @@ impl TmTestClient {
         kind: BucketKind,
         part_size: Option<aws_sdk_s3_transfer_manager::types::PartSize>,
     ) -> Self {
-        init_e2e_logs();
+        init_test_logs();
         let bucket_name = option_env!("S3_TEST_BUCKET_NAME_RS")
             .unwrap_or("aws-s3-transfer-manager-rs-test-bucket")
             .to_owned();


### PR DESCRIPTION
## Summary

This is the first of several implementation PRs for the [buffer-pool design](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/165). It adds the physical-storage foundation: checked geometry, stable virtual ranges, fixed-size carrier ownership, and the claim/trim protocol.

The new module remains private and disconnected from transfer-manager operation. This PR is stacked on #165 so the implementation and design corrections can be reviewed together. After #165 merges, this branch will be rebased onto `buffer-pool-main` and retargeted before merge.

## Why

The transfer manager needs reusable storage that can serve variable-size I/O without retaining its peak resident set. The pool reserves stable virtual ranges, prepares their backing storage on demand, subdivides each range into one carrier size, and later removes backing storage while retaining the virtual address range.

That lifecycle creates a claim/trim race. A claimant must not publish ownership from an incarnation that trim has made inaccessible, and recovery from a failed deactivation must preserve ownership already recorded in that incarnation. This PR implements those physical invariants before adding arena growth, admission accounting, or public buffer types.

## Overview

### Physical layout

A block slot owns one stable virtual range. Its current block incarnation owns the prepared mapping state and a bitmap with one ownership bit per carrier.

```text
BlockSlot
+-- VirtualRange: fixed base and length, reserved until drop
|   +-------------+-------------+-----+-------------+
|   |  carrier 0  |  carrier 1  | ... |  carrier N  |
|   +-------------+-------------+-----+-------------+
|
`-- current -> BlockIncarnation A
    +-- state: Active | Draining | Dead
    `-- in_use: one ownership bit per carrier
```

Checked geometry establishes the page, carrier, block, and bitmap relationships before virtual memory is reserved. The platform layer then provides the same reserve, prepare, deactivate, and release contract on Linux, macOS, and Windows.

See [Block geometry and lifetime](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/main/docs/design/memory.md#block-geometry-and-lifetime) and [Platform contract](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/main/docs/design/memory.md#platform-contract).

### Claim and return

A bitmap claim is provisional until its incarnation gate passes. Successful conversion produces a `CarrierAllocation`; dropping the final owner clears the carrier bit.

```text
free bitmap bit
      |
      v
BlockClaimAttempt
      |
      | Active gate passes
      v
ProvisionalBits
      |
      | ownership conversion
      v
CarrierAllocation
      |
      | final drop
      v
free bitmap bit
```

The allocation retains the slot and incarnation identity. It derives transient pointers from checked geometry through the virtual-range boundary rather than retaining a derived pointer.

### Trim and recovery

Claim and trim use a Dekker-style gate. A claimant records candidate ownership before checking the incarnation state. Trim publishes `Draining` before checking the ownership bitmap.

```text
claim                              trim
-----                              ----
protect current                    Active -> Draining
set candidate bits                 scan ownership bitmap
read incarnation state

Active: retain won bits            bit set: restore Active
not Active: roll back              all clear: confirm trim
```

Successful deactivation leaves the stable virtual range empty until a fresh incarnation is prepared. Failed deactivation retains the old incarnation and bitmap until recovery restores protection or finishes cleanup.

```text
Active(A)
   |
   | publish Draining; bitmap is all free
   v
Draining(A), removed from prepared capacity
   |
   +-- deactivation fails ----------> ProtectionPending(A)
   |                                      |
   |                                      +-- prepare ------> Active(A)
   |                                      |                   same bitmap
   |                                      |
   |                                      `-- retry cleanup -> current=None
   |
   `-- deactivation succeeds --------> current=None
                                          |
                                          | prepare
                                          v
                                       Active(B)
                                       fresh bitmap
```

Three Loom models exercise claim/trim exclusion, stale claims against a fresh incarnation, and failed-deactivation recovery. They model the protocol through the implementation types rather than a separate state-machine facade.

See [Claim/trim gate](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/main/docs/design/memory.md#claim-trim-gate), [Mapping and revival](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/main/docs/design/memory.md#mapping-and-revival), and [Physical-storage verification](https://github.com/awslabs/aws-s3-transfer-manager-rs/blob/main/docs/design/memory.md#physical-storage-verification).

## How to review

1. Start with `aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/geometry.rs` for the checked relationships among pages, carriers, blocks, and bitmap words.
2. Read `aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/virtual_memory.rs` for the cross-platform mapping contract and unsafe boundary.
3. Read `aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs` for incarnation publication, provisional claims, ownership conversion, trim, and recovery.
4. Review `BlockClaimAttempt`, `ProvisionalBits`, and `CarrierAllocation` together. Their ownership transitions make bitmap rollback and return explicit.
5. The unit, strict-provenance Miri, and Loom tests are colocated with the implementation they exercise.

## Changes

**Geometry**

- Validate page, carrier, block, and bitmap geometry with checked arithmetic.
- Keep carrier indexing and pointer derivation within the validated virtual range.

**Virtual memory**

- Add a platform-neutral `VirtualRange` contract.
- Implement reserve, prepare, deactivate, and release on Unix and Windows.
- Isolate test fault injection from production platform state.

**Block ownership**

- Add stable block slots and replaceable block incarnations.
- Add provisional bitmap ownership with explicit conversion and rollback.
- Implement trim, failed-deactivation recovery, and fresh-incarnation revival.
- Model the claim/trim interleavings with Loom.

**Design corrections**

- Derive carrier pointers through `VirtualRange` instead of retaining them in `CarrierAllocation`.
- Distinguish fresh-incarnation activation from protection recovery of a retained incarnation.
- Add the retained-bitmap recovery case to the physical-storage verification matrix.

## Future

The next PR adds arena acquisition, serialized fallback, and growth. Later PRs add admission accounting, public mutable and immutable buffer types, maintenance, and transfer-manager integration.

This PR provides platform implementations for Linux, macOS, and Windows. Android and FreeBSD require native qualification before they become supported targets.
