### PR TITLE
buffer pool: arena acquisition

### DIFF
--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -5,6 +5,7 @@
 
 //! Fixed-size carrier geometry, virtual memory, and physical ownership.
 
+mod arena;
 mod block;
 mod geometry;
 mod virtual_memory;

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
@@ -1,0 +1,1695 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Stable block registry and physical-allocation coordination.
+
+use std::collections::TryReserveError;
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering as DiagnosticOrdering};
+
+use super::block::{BlockError, BlockSlot, CarrierAllocation, ProvisionalBits};
+use super::geometry::PoolGeometry;
+use super::CarrierCount;
+use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
+use crate::runtime::sync::sync::{Arc, Mutex};
+
+/// Failure to configure, claim, reserve, or publish arena storage.
+#[derive(Debug)]
+pub(super) enum ArenaError {
+    /// A block operation failed.
+    Block(BlockError),
+    /// Registry metadata could not be allocated.
+    Allocation(TryReserveError),
+    /// The optimistic bitmap-word budget is zero.
+    InvalidScanBudget,
+    /// A batch claim requested no carriers.
+    InvalidClaimCount,
+    /// The flattened registry scan space cannot be represented.
+    ScanSpaceOverflow {
+        /// Slots in the registry generation.
+        slots: usize,
+        /// Bitmap words in each slot.
+        words_per_slot: usize,
+    },
+    /// Conversion was requested before the complete batch was owned.
+    IncompleteClaim {
+        /// Carriers required by the batch.
+        required: usize,
+        /// Carriers provisionally owned by the batch.
+        claimed: usize,
+    },
+    /// No stable block identifier remains.
+    SlotIdExhausted,
+    /// The registry cannot represent another slot.
+    RegistryCapacityOverflow,
+    /// A stable virtual range overflows address representation.
+    AddressOverflow {
+        /// Slot containing the invalid range.
+        slot_id: u32,
+        /// First byte of the range.
+        start: usize,
+        /// Reserved range length.
+        len: usize,
+    },
+    /// Two stable virtual ranges overlap.
+    AddressOverlap {
+        /// First overlapping range start.
+        first_start: usize,
+        /// First overlapping range end.
+        first_end: usize,
+        /// Second overlapping range start.
+        second_start: usize,
+        /// Second overlapping range end.
+        second_end: usize,
+    },
+}
+
+impl fmt::Display for ArenaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Block(error) => error.fmt(f),
+            Self::Allocation(error) => write!(f, "arena metadata allocation failed: {error}"),
+            Self::InvalidScanBudget => f.write_str("arena optimistic scan budget must be nonzero"),
+            Self::InvalidClaimCount => f.write_str("an arena claim must request carriers"),
+            Self::ScanSpaceOverflow {
+                slots,
+                words_per_slot,
+            } => write!(
+                f,
+                "arena scan space {slots} slots by {words_per_slot} words overflows"
+            ),
+            Self::IncompleteClaim { required, claimed } => write!(
+                f,
+                "cannot finish incomplete arena claim: required {required}, claimed {claimed}"
+            ),
+            Self::SlotIdExhausted => f.write_str("arena block identifier space is exhausted"),
+            Self::RegistryCapacityOverflow => f.write_str("arena registry capacity would overflow"),
+            Self::AddressOverflow {
+                slot_id,
+                start,
+                len,
+            } => write!(
+                f,
+                "block slot {slot_id} address range {start:#x}+{len:#x} overflows"
+            ),
+            Self::AddressOverlap {
+                first_start,
+                first_end,
+                second_start,
+                second_end,
+            } => write!(
+                f,
+                "block ranges {first_start:#x}..{first_end:#x} and \
+                 {second_start:#x}..{second_end:#x} overlap"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ArenaError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Block(error) => Some(error),
+            Self::Allocation(error) => Some(error),
+            Self::InvalidScanBudget
+            | Self::InvalidClaimCount
+            | Self::ScanSpaceOverflow { .. }
+            | Self::IncompleteClaim { .. }
+            | Self::SlotIdExhausted
+            | Self::RegistryCapacityOverflow
+            | Self::AddressOverflow { .. }
+            | Self::AddressOverlap { .. } => None,
+        }
+    }
+}
+
+impl From<BlockError> for ArenaError {
+    fn from(error: BlockError) -> Self {
+        Self::Block(error)
+    }
+}
+
+impl From<TryReserveError> for ArenaError {
+    fn from(error: TryReserveError) -> Self {
+        Self::Allocation(error)
+    }
+}
+
+/// Stable slots and their atomically published lookup index.
+pub(super) struct Arena {
+    /// Shared block geometry.
+    geometry: PoolGeometry,
+    /// Maximum bitmap words inspected by one optimistic claim.
+    optimistic_scan_words: usize,
+    /// Rotating flattened bitmap-word origin.
+    scan_origin: AtomicUsize,
+    /// Internal scan, growth, and rollback counters.
+    diagnostics: Arc<ArenaDiagnostics>,
+    /// Lock-free registry publication.
+    registry: BlockRegistry,
+    /// Serialized slot creation and registry rebuilding.
+    state: Mutex<ArenaState>,
+}
+
+impl Arena {
+    /// Creates an empty arena with fixed block geometry.
+    pub(super) fn new(
+        geometry: PoolGeometry,
+        optimistic_scan_words: usize,
+    ) -> Result<Self, ArenaError> {
+        if optimistic_scan_words == 0 {
+            return Err(ArenaError::InvalidScanBudget);
+        }
+        Ok(Self {
+            geometry,
+            optimistic_scan_words,
+            scan_origin: AtomicUsize::new(0),
+            diagnostics: Arc::new(ArenaDiagnostics::default()),
+            registry: BlockRegistry::new(),
+            state: Mutex::new(ArenaState {
+                slots: Vec::new(),
+                next_slot: Some(0),
+            }),
+        })
+    }
+
+    /// Reserves and publishes one inactive stable block slot.
+    ///
+    /// Failure leaves the registry and slot identifier unchanged.
+    #[cfg(test)]
+    fn reserve_slot(&self) -> Result<Arc<BlockSlot>, ArenaError> {
+        let mut state = self.state.lock();
+        self.reserve_slot_locked(&mut state)
+    }
+
+    /// Reserves and publishes one slot while holding arena serialization.
+    ///
+    /// The mutable state reference proves exclusive access without reacquiring
+    /// the mutex. Failure leaves the state and registry generation unchanged.
+    fn reserve_slot_locked(&self, state: &mut ArenaState) -> Result<Arc<BlockSlot>, ArenaError> {
+        let slot_id = state.next_slot.ok_or(ArenaError::SlotIdExhausted)?;
+
+        state.slots.try_reserve(1)?;
+        let slot = Arc::new(BlockSlot::new(slot_id, self.geometry)?);
+        let snapshot = RegistrySnapshot::try_with_slot(&state.slots, &slot)?;
+
+        state.slots.push(Arc::clone(&slot));
+        state.next_slot = slot_id.checked_add(1);
+        self.registry.publish(snapshot);
+        self.diagnostics.record_block_range_reserved();
+        Ok(slot)
+    }
+
+    /// Classifies a complete nonempty range within one stable block slot.
+    ///
+    /// Integer addresses are used only for comparison. This method does not
+    /// construct a pointer or authorize access to the classified range.
+    pub(super) fn classify_range(&self, start: usize, len: usize) -> Option<ClassifiedRange> {
+        self.registry.load().classify_range(start, len)
+    }
+
+    /// Selects one block observed active and free.
+    ///
+    /// Selection is a lock-free hint. A claim may race this scan, so the
+    /// caller must use [`BlockSlot::start_trim`] to recheck the lifecycle,
+    /// bitmap, and prepared-capacity floor under admission serialization.
+    pub(super) fn select_trim_candidate(&self) -> Option<Arc<BlockSlot>> {
+        let snapshot = self.snapshot();
+        let mut scanned = 0;
+        let candidate = snapshot.claim_slots().iter().find_map(|slot| {
+            scanned += 1;
+            slot.appears_free().then(|| Arc::clone(slot))
+        });
+        self.diagnostics.record_trim_slots_scanned(scanned);
+        candidate
+    }
+
+    /// Returns one private arena diagnostic sample.
+    pub(super) fn diagnostics(&self) -> ArenaDiagnosticSnapshot {
+        self.diagnostics.snapshot()
+    }
+
+    /// Claims a complete or partial batch within the optimistic scan budget.
+    ///
+    /// The returned batch retains every gate-passed bit. A complete batch may
+    /// be converted to carrier owners. A partial batch remains suitable for
+    /// serialized fallback and returns its bits if dropped.
+    pub(super) fn claim_optimistic(
+        &self,
+        required: CarrierCount,
+    ) -> Result<ClaimBatch, ArenaError> {
+        if required == CarrierCount::ZERO {
+            return Err(ArenaError::InvalidClaimCount);
+        }
+
+        let snapshot = self.snapshot();
+        let slots = snapshot.claim_slots();
+        let words_per_slot = self.geometry.bitmap_words();
+        let total_positions =
+            slots
+                .len()
+                .checked_mul(words_per_slot)
+                .ok_or(ArenaError::ScanSpaceOverflow {
+                    slots: slots.len(),
+                    words_per_slot,
+                })?;
+        let mut batch = ClaimBatch::new(required, Arc::clone(&self.diagnostics));
+        if total_positions == 0 {
+            self.diagnostics.record_optimistic_scan(0, true);
+            return Ok(batch);
+        }
+
+        let budget = self.optimistic_scan_words.min(total_positions);
+        let origin = self.scan_origin.fetch_add(budget, Ordering::Relaxed) % total_positions;
+        while batch.inspected_words < budget && !batch.is_complete() {
+            let position = wrapped_position(origin, batch.inspected_words, total_positions);
+            let slot_index = position / words_per_slot;
+            let start_word = position % words_per_slot;
+            let word_limit = (words_per_slot - start_word).min(budget - batch.inspected_words);
+            let claim = BlockSlot::try_claim_words(
+                &slots[slot_index],
+                start_word,
+                word_limit,
+                batch.remaining(),
+            )?;
+            let inspected = claim.inspected_words();
+            if inspected == 0 || inspected > word_limit {
+                invariant_violation("bounded block claim reported invalid scan work");
+            }
+            batch.inspected_words += inspected;
+            if let Some(provisional) = claim.into_provisional() {
+                batch.push(provisional)?;
+            }
+        }
+        self.diagnostics
+            .record_optimistic_scan(batch.inspected_words, !batch.is_complete());
+        Ok(batch)
+    }
+
+    /// Completes a partial batch through exhaustive reuse and private growth.
+    ///
+    /// The caller serializes `prepared` with the pool-wide admission floor.
+    /// This method then holds arena serialization through the full registry
+    /// recheck and every preparation. Existing inactive slots are reused
+    /// before another stable range is reserved.
+    pub(super) fn complete_claim_serialized(
+        &self,
+        prepared: &mut CarrierCount,
+        batch: &mut ClaimBatch,
+    ) -> Result<(), ArenaError> {
+        if batch.is_complete() {
+            return Ok(());
+        }
+        self.diagnostics.record_serialized_fallback();
+
+        let mut state = self.state.lock();
+        for slot in &state.slots {
+            if batch.is_complete() {
+                return Ok(());
+            }
+            if let Some(provisional) = BlockSlot::try_claim_exhaustive(slot, batch.remaining())? {
+                batch.push(provisional)?;
+            }
+        }
+
+        for slot in &state.slots {
+            if batch.is_complete() {
+                return Ok(());
+            }
+            let count = std::cmp::min(batch.remaining(), slot.carrier_count());
+            if let Some(provisional) =
+                BlockSlot::prepare_and_claim_if_inactive(slot, prepared, count)?
+            {
+                self.diagnostics.record_block_prepared();
+                batch.push(provisional)?;
+            }
+        }
+
+        while !batch.is_complete() {
+            let slot = self.reserve_slot_locked(&mut state)?;
+            let count = std::cmp::min(batch.remaining(), slot.carrier_count());
+            let provisional = BlockSlot::prepare_and_claim_if_inactive(&slot, prepared, count)?
+                .unwrap_or_else(|| {
+                    invariant_violation("new arena slot was not reusable for private growth")
+                });
+            self.diagnostics.record_block_prepared();
+            batch.push(provisional)?;
+        }
+        Ok(())
+    }
+
+    /// Protects the current immutable registry snapshot.
+    fn snapshot(&self) -> RegistryGuard {
+        self.registry.load()
+    }
+}
+
+/// Gate-passed carrier bits retained across one arena acquisition.
+#[must_use = "dropping a claim batch returns its provisional carrier bits"]
+pub(super) struct ClaimBatch {
+    /// Carriers required for a complete acquisition.
+    required: CarrierCount,
+    /// Carriers currently owned by `blocks`.
+    claimed: CarrierCount,
+    /// Bitmap-word positions charged to the optimistic scan.
+    inspected_words: usize,
+    /// Per-incarnation provisional ownership.
+    blocks: Vec<ProvisionalBits>,
+    /// Counters updated if provisional ownership rolls back.
+    diagnostics: Arc<ArenaDiagnostics>,
+}
+
+impl ClaimBatch {
+    /// Creates an empty batch for `required` carriers.
+    fn new(required: CarrierCount, diagnostics: Arc<ArenaDiagnostics>) -> Self {
+        Self {
+            required,
+            claimed: CarrierCount::ZERO,
+            inspected_words: 0,
+            blocks: Vec::new(),
+            diagnostics,
+        }
+    }
+
+    /// Returns the required carrier count.
+    pub(super) fn required(&self) -> CarrierCount {
+        self.required
+    }
+
+    /// Returns the provisionally owned carrier count.
+    pub(super) fn claimed(&self) -> CarrierCount {
+        self.claimed
+    }
+
+    /// Returns the carrier count still needed.
+    pub(super) fn remaining(&self) -> CarrierCount {
+        self.required
+            .checked_sub(self.claimed)
+            .unwrap_or_else(|| invariant_violation("arena claim exceeds its required count"))
+    }
+
+    /// Returns bitmap-word positions charged to the optimistic scan.
+    pub(super) fn inspected_words(&self) -> usize {
+        self.inspected_words
+    }
+
+    /// Returns `true` when the complete requested batch is owned.
+    pub(super) fn is_complete(&self) -> bool {
+        self.claimed == self.required
+    }
+
+    /// Retains another block's provisional ownership.
+    fn push(&mut self, provisional: ProvisionalBits) -> Result<(), ArenaError> {
+        let next_claimed = self
+            .claimed
+            .checked_add(provisional.len())
+            .unwrap_or_else(|| invariant_violation("arena claim count overflowed"));
+        if next_claimed > self.required {
+            invariant_violation("arena claim won more carriers than requested");
+        }
+
+        if let Err(error) = self.blocks.try_reserve(1) {
+            self.diagnostics
+                .record_rolled_back_carriers(provisional.len().get());
+            return Err(error.into());
+        }
+        self.blocks.push(provisional);
+        self.claimed = next_claimed;
+        Ok(())
+    }
+
+    /// Converts one complete provisional batch into carrier owners.
+    ///
+    /// An incomplete batch returns an error and releases its provisional bits.
+    /// Allocation failure drops converted owners and remaining provisional
+    /// ownership, returning every bit exactly once.
+    pub(super) fn finish(mut self) -> Result<Vec<CarrierAllocation>, ArenaError> {
+        if !self.is_complete() {
+            return Err(ArenaError::IncompleteClaim {
+                required: self.required.get(),
+                claimed: self.claimed.get(),
+            });
+        }
+
+        let mut carriers = Vec::new();
+        carriers.try_reserve_exact(self.required.get())?;
+        for provisional in self.blocks.drain(..) {
+            let mut block = provisional.into_carriers()?;
+            carriers.append(&mut block);
+        }
+        if carriers.len() != self.required.get() {
+            invariant_violation("complete arena claim converted the wrong carrier count");
+        }
+        self.claimed = CarrierCount::ZERO;
+        Ok(carriers)
+    }
+}
+
+impl Drop for ClaimBatch {
+    fn drop(&mut self) {
+        self.diagnostics
+            .record_rolled_back_carriers(self.claimed.get());
+    }
+}
+
+/// Internal arena counters that never participate in allocator decisions.
+#[derive(Default)]
+struct ArenaDiagnostics {
+    /// Bitmap words charged to completed optimistic scans.
+    optimistic_scan_words: AtomicU64,
+    /// Optimistic scans that returned incomplete ownership.
+    optimistic_misses: AtomicU64,
+    /// Partial batches that entered serialized fallback.
+    serialized_fallbacks: AtomicU64,
+    /// Successful whole-block preparation operations in fallback.
+    blocks_prepared: AtomicU64,
+    /// Stable virtual ranges added to the registry.
+    block_ranges_reserved: AtomicU64,
+    /// Provisional carriers returned without publication.
+    rolled_back_carriers: AtomicU64,
+    /// Slots inspected while selecting trim candidates.
+    trim_slots_scanned: AtomicU64,
+}
+
+impl ArenaDiagnostics {
+    /// Records one completed optimistic scan.
+    fn record_optimistic_scan(&self, words: usize, missed: bool) {
+        saturating_add(&self.optimistic_scan_words, diagnostic_count(words));
+        if missed {
+            saturating_add(&self.optimistic_misses, 1);
+        }
+    }
+
+    /// Records one serialized fallback entry.
+    fn record_serialized_fallback(&self) {
+        saturating_add(&self.serialized_fallbacks, 1);
+    }
+
+    /// Records one successful block preparation.
+    fn record_block_prepared(&self) {
+        saturating_add(&self.blocks_prepared, 1);
+    }
+
+    /// Records one stable virtual-range reservation.
+    fn record_block_range_reserved(&self) {
+        saturating_add(&self.block_ranges_reserved, 1);
+    }
+
+    /// Records provisional carrier ownership returned by rollback.
+    fn record_rolled_back_carriers(&self, carriers: usize) {
+        saturating_add(&self.rolled_back_carriers, diagnostic_count(carriers));
+    }
+
+    /// Records work spent selecting one trim candidate.
+    fn record_trim_slots_scanned(&self, slots: usize) {
+        saturating_add(&self.trim_slots_scanned, diagnostic_count(slots));
+    }
+
+    /// Loads one relaxed diagnostic sample.
+    fn snapshot(&self) -> ArenaDiagnosticSnapshot {
+        ArenaDiagnosticSnapshot {
+            optimistic_scan_words: self.optimistic_scan_words.load(DiagnosticOrdering::Relaxed),
+            optimistic_misses: self.optimistic_misses.load(DiagnosticOrdering::Relaxed),
+            serialized_fallbacks: self.serialized_fallbacks.load(DiagnosticOrdering::Relaxed),
+            blocks_prepared: self.blocks_prepared.load(DiagnosticOrdering::Relaxed),
+            block_ranges_reserved: self.block_ranges_reserved.load(DiagnosticOrdering::Relaxed),
+            rolled_back_carriers: self.rolled_back_carriers.load(DiagnosticOrdering::Relaxed),
+            trim_slots_scanned: self.trim_slots_scanned.load(DiagnosticOrdering::Relaxed),
+        }
+    }
+}
+
+/// Private snapshot of arena work and fallback behavior.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ArenaDiagnosticSnapshot {
+    /// Bitmap words charged to completed optimistic scans.
+    pub(super) optimistic_scan_words: u64,
+    /// Optimistic scans that returned incomplete ownership.
+    pub(super) optimistic_misses: u64,
+    /// Partial batches that entered serialized fallback.
+    pub(super) serialized_fallbacks: u64,
+    /// Successful whole-block preparation operations in fallback.
+    pub(super) blocks_prepared: u64,
+    /// Stable virtual ranges added to the registry.
+    pub(super) block_ranges_reserved: u64,
+    /// Provisional carriers returned without publication.
+    pub(super) rolled_back_carriers: u64,
+    /// Slots inspected while selecting trim candidates.
+    pub(super) trim_slots_scanned: u64,
+}
+
+/// Adds a diagnostic value without wrapping.
+fn saturating_add(counter: &AtomicU64, value: u64) {
+    if value == 0 {
+        return;
+    }
+    let _ = counter.fetch_update(
+        DiagnosticOrdering::Relaxed,
+        DiagnosticOrdering::Relaxed,
+        |current| Some(current.saturating_add(value)),
+    );
+}
+
+/// Converts a platform-sized work count into a saturating diagnostic count.
+fn diagnostic_count(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+/// Adds a bounded offset to an origin and wraps at `len` without overflow.
+fn wrapped_position(origin: usize, offset: usize, len: usize) -> usize {
+    let tail = len - origin;
+    if offset < tail {
+        origin + offset
+    } else {
+        offset - tail
+    }
+}
+
+/// Slot state protected by arena serialization.
+struct ArenaState {
+    /// Slots in stable claim order.
+    slots: Vec<Arc<BlockSlot>>,
+    /// Identifier assigned to the next slot, or `None` after exhaustion.
+    next_slot: Option<u32>,
+}
+
+/// Atomic publication for one coherent registry generation.
+struct BlockRegistry {
+    current: registry_cell::RegistryCell,
+}
+
+impl BlockRegistry {
+    /// Creates a registry containing no slots.
+    fn new() -> Self {
+        Self {
+            current: registry_cell::RegistryCell::new(Arc::new(RegistrySnapshot::empty())),
+        }
+    }
+
+    /// Protects the current registry generation.
+    fn load(&self) -> RegistryGuard {
+        RegistryGuard {
+            inner: self.current.load(),
+        }
+    }
+
+    /// Publishes a complete registry generation.
+    fn publish(&self, snapshot: RegistrySnapshot) {
+        self.current.store(Arc::new(snapshot));
+    }
+}
+
+/// Protected access to one immutable registry generation.
+struct RegistryGuard {
+    inner: registry_cell::RegistryCellGuard,
+}
+
+impl RegistryGuard {
+    /// Returns slots in stable physical-claim order.
+    fn claim_slots(&self) -> &[Arc<BlockSlot>] {
+        &self.inner.as_ref().claim_slots
+    }
+
+    /// Classifies a complete nonempty range within one slot.
+    fn classify_range(&self, start: usize, len: usize) -> Option<ClassifiedRange> {
+        self.inner.as_ref().classify_range(start, len)
+    }
+}
+
+/// Immutable claim and address indexes published as one generation.
+struct RegistrySnapshot {
+    /// Stable scan order for physical acquisition.
+    claim_slots: Box<[Arc<BlockSlot>]>,
+    /// Non-overlapping virtual ranges sorted by address.
+    address_ranges: Box<[AddressRange]>,
+}
+
+impl RegistrySnapshot {
+    /// Creates an empty registry generation.
+    fn empty() -> Self {
+        Self {
+            claim_slots: Box::default(),
+            address_ranges: Box::default(),
+        }
+    }
+
+    /// Builds a generation containing `slots` followed by `slot`.
+    fn try_with_slot(slots: &[Arc<BlockSlot>], slot: &Arc<BlockSlot>) -> Result<Self, ArenaError> {
+        let new_len = slots
+            .len()
+            .checked_add(1)
+            .ok_or(ArenaError::RegistryCapacityOverflow)?;
+
+        let mut claim_slots = Vec::new();
+        claim_slots.try_reserve_exact(new_len)?;
+        claim_slots.extend(slots.iter().cloned());
+        claim_slots.push(Arc::clone(slot));
+
+        let mut address_ranges = Vec::new();
+        address_ranges.try_reserve_exact(new_len)?;
+        for (slot_index, slot) in claim_slots.iter().enumerate() {
+            address_ranges.push(AddressRange::for_slot(slot, slot_index)?);
+        }
+        address_ranges.sort_unstable_by_key(|range| range.start);
+        validate_address_ranges(&address_ranges)?;
+
+        Ok(Self {
+            claim_slots: claim_slots.into_boxed_slice(),
+            address_ranges: address_ranges.into_boxed_slice(),
+        })
+    }
+
+    /// Classifies a complete nonempty range within one slot.
+    fn classify_range(&self, start: usize, len: usize) -> Option<ClassifiedRange> {
+        if len == 0 {
+            return None;
+        }
+        let end = start.checked_add(len)?;
+        let candidate = self
+            .address_ranges
+            .partition_point(|range| range.start <= start)
+            .checked_sub(1)?;
+        let range = self.address_ranges.get(candidate)?;
+        if end > range.end {
+            return None;
+        }
+        let slot =
+            Arc::clone(self.claim_slots.get(range.slot_index).unwrap_or_else(|| {
+                invariant_violation("registry range has an invalid slot index")
+            }));
+        Some(ClassifiedRange {
+            slot,
+            offset: start - range.start,
+        })
+    }
+}
+
+/// One stable virtual range in the sorted address index.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct AddressRange {
+    /// First reserved byte.
+    start: usize,
+    /// Exclusive end of the reservation.
+    end: usize,
+    /// Index into [`RegistrySnapshot::claim_slots`].
+    slot_index: usize,
+}
+
+impl AddressRange {
+    /// Constructs a checked address range for `slot`.
+    fn for_slot(slot: &BlockSlot, slot_index: usize) -> Result<Self, ArenaError> {
+        let start = slot.base_address();
+        let len = slot.reserved_len();
+        let end = start.checked_add(len).ok_or(ArenaError::AddressOverflow {
+            slot_id: slot.id(),
+            start,
+            len,
+        })?;
+        Ok(Self {
+            start,
+            end,
+            slot_index,
+        })
+    }
+
+    /// Constructs a checked synthetic range.
+    #[cfg(test)]
+    fn new(start: usize, len: usize, slot_index: usize) -> Result<Self, ArenaError> {
+        let end = start.checked_add(len).ok_or(ArenaError::AddressOverflow {
+            slot_id: u32::MAX,
+            start,
+            len,
+        })?;
+        Ok(Self {
+            start,
+            end,
+            slot_index,
+        })
+    }
+}
+
+/// Validates sorted, non-overlapping address ranges.
+fn validate_address_ranges(ranges: &[AddressRange]) -> Result<(), ArenaError> {
+    for pair in ranges.windows(2) {
+        let first = pair[0];
+        let second = pair[1];
+        if first.end > second.start {
+            return Err(ArenaError::AddressOverlap {
+                first_start: first.start,
+                first_end: first.end,
+                second_start: second.start,
+                second_end: second.end,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Classification of an integer range within one stable slot.
+pub(super) struct ClassifiedRange {
+    /// Slot containing the complete range.
+    slot: Arc<BlockSlot>,
+    /// Byte offset from the slot base.
+    offset: usize,
+}
+
+impl ClassifiedRange {
+    /// Returns the containing slot.
+    pub(super) fn slot(&self) -> &Arc<BlockSlot> {
+        &self.slot
+    }
+
+    /// Returns the byte offset from the slot base.
+    pub(super) fn offset(&self) -> usize {
+        self.offset
+    }
+}
+
+#[cfg(not(all(test, s3_tm_loom)))]
+mod registry_cell {
+    //! Lock-free production publication for registry generations.
+
+    use arc_swap::{ArcSwap, Guard};
+
+    use super::RegistrySnapshot;
+    use crate::runtime::sync::sync::Arc;
+
+    /// Atomic storage for the current registry generation.
+    pub(super) struct RegistryCell {
+        inner: ArcSwap<RegistrySnapshot>,
+    }
+
+    impl RegistryCell {
+        /// Creates a cell containing `initial`.
+        pub(super) fn new(initial: Arc<RegistrySnapshot>) -> Self {
+            Self {
+                inner: ArcSwap::from(initial),
+            }
+        }
+
+        /// Protects the current generation from reclamation.
+        pub(super) fn load(&self) -> RegistryCellGuard {
+            RegistryCellGuard {
+                inner: self.inner.load(),
+            }
+        }
+
+        /// Replaces the current generation.
+        pub(super) fn store(&self, snapshot: Arc<RegistrySnapshot>) {
+            self.inner.store(snapshot);
+        }
+    }
+
+    /// Protection for one loaded registry generation.
+    pub(super) struct RegistryCellGuard {
+        inner: Guard<Arc<RegistrySnapshot>>,
+    }
+
+    impl RegistryCellGuard {
+        /// Returns the protected generation.
+        pub(super) fn as_ref(&self) -> &RegistrySnapshot {
+            &self.inner
+        }
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod registry_cell {
+    //! Loom-instrumented publication with owned registry generations.
+
+    use super::RegistrySnapshot;
+    use crate::runtime::sync::sync::{Arc, Mutex};
+
+    /// Loom-instrumented storage for the current registry generation.
+    pub(super) struct RegistryCell {
+        inner: Mutex<Arc<RegistrySnapshot>>,
+    }
+
+    impl RegistryCell {
+        /// Creates a cell containing `initial`.
+        pub(super) fn new(initial: Arc<RegistrySnapshot>) -> Self {
+            Self {
+                inner: Mutex::new(initial),
+            }
+        }
+
+        /// Loads an owned generation.
+        pub(super) fn load(&self) -> RegistryCellGuard {
+            RegistryCellGuard {
+                inner: Arc::clone(&self.inner.lock()),
+            }
+        }
+
+        /// Replaces the current generation.
+        pub(super) fn store(&self, snapshot: Arc<RegistrySnapshot>) {
+            *self.inner.lock() = snapshot;
+        }
+    }
+
+    /// Owned protection for one loaded registry generation.
+    pub(super) struct RegistryCellGuard {
+        inner: Arc<RegistrySnapshot>,
+    }
+
+    impl RegistryCellGuard {
+        /// Returns the protected generation.
+        pub(super) fn as_ref(&self) -> &RegistrySnapshot {
+            &self.inner
+        }
+    }
+}
+
+/// Stops execution after a registry invariant fails.
+#[cold]
+fn invariant_violation(message: &'static str) -> ! {
+    tracing::error!(
+        target: crate::telemetry::TARGET_MEMORY,
+        reason = message,
+        "buffer-pool registry invariant violated; aborting"
+    );
+
+    #[cfg(test)]
+    panic!("buffer-pool registry invariant violated: {message}");
+
+    #[cfg(not(test))]
+    {
+        let _ = message;
+        std::process::abort()
+    }
+}
+
+#[cfg(all(test, not(s3_tm_loom)))]
+mod tests {
+    use std::sync::{Barrier, Mutex as StdMutex};
+    use std::thread;
+
+    use super::super::block::TrimBlocked;
+    use super::super::virtual_memory::{page_size, VirtualMemoryOperation};
+    use super::super::CarrierCount;
+    use super::*;
+
+    fn geometry() -> PoolGeometry {
+        geometry_with_carriers(4)
+    }
+
+    fn geometry_with_carriers(carriers: usize) -> PoolGeometry {
+        let page_size = page_size().unwrap().get();
+        PoolGeometry::new(
+            page_size,
+            page_size.checked_mul(carriers).unwrap(),
+            page_size,
+        )
+        .unwrap()
+    }
+
+    fn prepare_slots(arena: &Arena, count: usize) -> Vec<Arc<BlockSlot>> {
+        let mut prepared = CarrierCount::ZERO;
+        (0..count)
+            .map(|_| {
+                let slot = arena.reserve_slot().unwrap();
+                slot.prepare(&mut prepared).unwrap();
+                slot
+            })
+            .collect()
+    }
+
+    fn assert_fully_free(slot: &Arc<BlockSlot>) {
+        let all = BlockSlot::try_claim(slot, slot.carrier_count())
+            .unwrap()
+            .expect("every carrier should be free");
+        assert_eq!(all.len(), slot.carrier_count());
+        drop(all);
+    }
+
+    #[test]
+    fn empty_registry_classifies_no_range() {
+        let arena = Arena::new(geometry(), 4).unwrap();
+
+        assert!(arena.classify_range(1, 1).is_none());
+        assert!(arena.snapshot().claim_slots().is_empty());
+    }
+
+    #[test]
+    fn slot_reservation_publishes_one_coherent_generation() {
+        let arena = Arena::new(geometry(), 4).unwrap();
+        let first = arena.reserve_slot().unwrap();
+        let second = arena.reserve_slot().unwrap();
+        let snapshot = arena.snapshot();
+
+        assert_eq!(
+            snapshot
+                .claim_slots()
+                .iter()
+                .map(|slot| slot.id())
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+        assert_eq!(snapshot.inner.as_ref().address_ranges.len(), 2);
+        assert!(snapshot
+            .inner
+            .as_ref()
+            .address_ranges
+            .windows(2)
+            .all(|pair| pair[0].end <= pair[1].start));
+        assert!(snapshot
+            .claim_slots()
+            .iter()
+            .any(|slot| Arc::ptr_eq(slot, &first)));
+        assert!(snapshot
+            .claim_slots()
+            .iter()
+            .any(|slot| Arc::ptr_eq(slot, &second)));
+    }
+
+    #[test]
+    fn classification_requires_one_complete_nonempty_slot_range() {
+        let arena = Arena::new(geometry(), 4).unwrap();
+        let slot = arena.reserve_slot().unwrap();
+        let range = slot.address_range().unwrap();
+
+        let complete = arena
+            .classify_range(range.start, range.len())
+            .expect("complete slot range is classified");
+        assert!(Arc::ptr_eq(complete.slot(), &slot));
+        assert_eq!(complete.offset(), 0);
+
+        let final_byte = arena
+            .classify_range(range.end - 1, 1)
+            .expect("final byte is inside the slot");
+        assert!(Arc::ptr_eq(final_byte.slot(), &slot));
+        assert_eq!(final_byte.offset(), range.len() - 1);
+
+        assert!(arena.classify_range(range.start, 0).is_none());
+        assert!(arena.classify_range(range.end - 1, 2).is_none());
+        assert!(arena.classify_range(usize::MAX, 2).is_none());
+    }
+
+    #[test]
+    fn classification_survives_trimmed_block_backing() {
+        let arena = Arena::new(geometry(), 4).unwrap();
+        let slot = arena.reserve_slot().unwrap();
+        let range = slot.address_range().unwrap();
+        let mut prepared = CarrierCount::ZERO;
+        slot.prepare(&mut prepared).unwrap();
+
+        BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO)
+            .unwrap()
+            .finish()
+            .unwrap();
+
+        assert_eq!(prepared, CarrierCount::ZERO);
+        let classified = arena
+            .classify_range(range.start, range.len())
+            .expect("stable slot remains classified after trim");
+        assert!(Arc::ptr_eq(classified.slot(), &slot));
+    }
+
+    #[test]
+    fn address_validation_accepts_adjacency_and_rejects_overlap() {
+        let adjacent = [
+            AddressRange::new(0x1000, 0x1000, 0).unwrap(),
+            AddressRange::new(0x2000, 0x1000, 1).unwrap(),
+        ];
+        assert!(validate_address_ranges(&adjacent).is_ok());
+
+        let overlap = [
+            AddressRange::new(0x1000, 0x1001, 0).unwrap(),
+            AddressRange::new(0x2000, 0x1000, 1).unwrap(),
+        ];
+        assert!(matches!(
+            validate_address_ranges(&overlap),
+            Err(ArenaError::AddressOverlap { .. })
+        ));
+    }
+
+    #[test]
+    fn synthetic_address_overflow_is_rejected() {
+        assert!(matches!(
+            AddressRange::new(usize::MAX, 2, 0),
+            Err(ArenaError::AddressOverflow { .. })
+        ));
+    }
+
+    #[test]
+    fn exhausted_slot_ids_leave_the_registry_unchanged() {
+        let arena = Arena::new(geometry(), 4).unwrap();
+        arena.state.lock().next_slot = None;
+
+        assert!(matches!(
+            arena.reserve_slot(),
+            Err(ArenaError::SlotIdExhausted)
+        ));
+        assert!(arena.snapshot().claim_slots().is_empty());
+    }
+
+    #[test]
+    fn rejects_zero_scan_budget_and_zero_claim_count() {
+        assert!(matches!(
+            Arena::new(geometry(), 0),
+            Err(ArenaError::InvalidScanBudget)
+        ));
+
+        let arena = Arena::new(geometry(), 1).unwrap();
+        assert!(matches!(
+            arena.claim_optimistic(CarrierCount::ZERO),
+            Err(ArenaError::InvalidClaimCount)
+        ));
+    }
+
+    #[test]
+    fn empty_registry_returns_an_empty_partial_batch() {
+        let arena = Arena::new(geometry(), 2).unwrap();
+
+        let batch = arena.claim_optimistic(CarrierCount::new(2)).unwrap();
+
+        assert_eq!(batch.required(), CarrierCount::new(2));
+        assert_eq!(batch.claimed(), CarrierCount::ZERO);
+        assert_eq!(batch.remaining(), CarrierCount::new(2));
+        assert_eq!(batch.inspected_words(), 0);
+        assert!(!batch.is_complete());
+    }
+
+    #[test]
+    fn incomplete_scan_charges_the_exact_budget() {
+        let arena = Arena::new(geometry_with_carriers(130), 2).unwrap();
+        let slot = prepare_slots(&arena, 1).pop().unwrap();
+        let occupied = BlockSlot::try_claim(&slot, slot.carrier_count())
+            .unwrap()
+            .unwrap();
+
+        let batch = arena.claim_optimistic(CarrierCount::new(1)).unwrap();
+
+        assert_eq!(batch.claimed(), CarrierCount::ZERO);
+        assert_eq!(batch.inspected_words(), 2);
+        drop(batch);
+        drop(occupied);
+        assert_fully_free(&slot);
+    }
+
+    #[test]
+    fn inactive_slots_consume_scan_positions() {
+        let arena = Arena::new(geometry_with_carriers(1), 1).unwrap();
+        let inactive = arena.reserve_slot().unwrap();
+        let active = prepare_slots(&arena, 1).pop().unwrap();
+
+        let batch = arena.claim_optimistic(CarrierCount::new(1)).unwrap();
+
+        assert_eq!(batch.claimed(), CarrierCount::ZERO);
+        assert_eq!(batch.inspected_words(), 1);
+        drop(batch);
+        assert_fully_free(&active);
+        assert!(BlockSlot::try_claim(&inactive, CarrierCount::new(1))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn scan_origin_rotates_by_the_charged_budget() {
+        let arena = Arena::new(geometry_with_carriers(130), 2).unwrap();
+        let slot = prepare_slots(&arena, 1).pop().unwrap();
+        let mut indices = Vec::new();
+
+        for _ in 0..3 {
+            let carriers = arena
+                .claim_optimistic(CarrierCount::new(1))
+                .unwrap()
+                .finish()
+                .unwrap();
+            indices.push(carriers[0].carrier_index());
+            drop(carriers);
+        }
+
+        assert_eq!(indices, vec![0, 128, 64]);
+        assert_fully_free(&slot);
+    }
+
+    #[test]
+    fn scan_wraps_across_slot_and_bitmap_boundaries() {
+        let arena = Arena::new(geometry_with_carriers(65), 3).unwrap();
+        let slots = prepare_slots(&arena, 2);
+        arena.scan_origin.store(3, Ordering::Relaxed);
+
+        let batch = arena.claim_optimistic(CarrierCount::new(66)).unwrap();
+
+        assert!(batch.is_complete());
+        assert_eq!(batch.inspected_words(), 3);
+        let carriers = batch.finish().unwrap();
+        assert_eq!(
+            (carriers[0].slot_id(), carriers[0].carrier_index()),
+            (slots[1].id(), 64)
+        );
+        assert!(carriers[1..]
+            .iter()
+            .all(|carrier| carrier.slot_id() == slots[0].id()));
+        assert_eq!(carriers[1].carrier_index(), 0);
+        assert_eq!(carriers.last().unwrap().carrier_index(), 64);
+        drop(carriers);
+        assert_fully_free(&slots[0]);
+        assert_fully_free(&slots[1]);
+    }
+
+    #[test]
+    fn one_batch_accumulates_carriers_across_blocks() {
+        let arena = Arena::new(geometry_with_carriers(2), 2).unwrap();
+        let slots = prepare_slots(&arena, 2);
+
+        let batch = arena.claim_optimistic(CarrierCount::new(3)).unwrap();
+
+        assert_eq!(batch.claimed(), CarrierCount::new(3));
+        assert_eq!(batch.inspected_words(), 2);
+        let carriers = batch.finish().unwrap();
+        assert_eq!(
+            carriers
+                .iter()
+                .filter(|carrier| carrier.slot_id() == slots[0].id())
+                .count(),
+            2
+        );
+        assert_eq!(
+            carriers
+                .iter()
+                .filter(|carrier| carrier.slot_id() == slots[1].id())
+                .count(),
+            1
+        );
+        drop(carriers);
+        assert_fully_free(&slots[0]);
+        assert_fully_free(&slots[1]);
+    }
+
+    #[test]
+    fn incomplete_finish_returns_all_provisional_bits() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let slot = prepare_slots(&arena, 1).pop().unwrap();
+        let batch = arena.claim_optimistic(CarrierCount::new(3)).unwrap();
+        assert_eq!(batch.claimed(), CarrierCount::new(2));
+
+        let error = match batch.finish() {
+            Ok(_) => panic!("an incomplete batch must not expose carriers"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            ArenaError::IncompleteClaim {
+                required: 3,
+                claimed: 2
+            }
+        ));
+        assert_fully_free(&slot);
+    }
+
+    #[test]
+    fn dropping_partial_batch_returns_all_provisional_bits() {
+        let arena = Arena::new(geometry_with_carriers(65), 1).unwrap();
+        let slot = prepare_slots(&arena, 1).pop().unwrap();
+        let batch = arena.claim_optimistic(CarrierCount::new(66)).unwrap();
+        assert_eq!(batch.claimed(), CarrierCount::new(64));
+
+        drop(batch);
+
+        assert_fully_free(&slot);
+    }
+
+    #[test]
+    fn complete_batch_converts_exactly_the_requested_carriers() {
+        let arena = Arena::new(geometry_with_carriers(70), 2).unwrap();
+        let slot = prepare_slots(&arena, 1).pop().unwrap();
+
+        let carriers = arena
+            .claim_optimistic(CarrierCount::new(67))
+            .unwrap()
+            .finish()
+            .unwrap();
+
+        assert_eq!(carriers.len(), 67);
+        assert_eq!(carriers.first().unwrap().carrier_index(), 0);
+        assert_eq!(carriers.last().unwrap().carrier_index(), 66);
+        drop(carriers);
+        assert_fully_free(&slot);
+    }
+
+    #[test]
+    fn concurrent_optimistic_claimants_cannot_share_a_carrier() {
+        let arena = Arc::new(Arena::new(geometry_with_carriers(2), 1).unwrap());
+        let slot = prepare_slots(&arena, 1).pop().unwrap();
+        let start = Arc::new(Barrier::new(2));
+        let live = Arc::new(Barrier::new(2));
+
+        let claim = |arena: Arc<Arena>, start: Arc<Barrier>, live: Arc<Barrier>| {
+            thread::spawn(move || {
+                start.wait();
+                let carriers = loop {
+                    let batch = arena.claim_optimistic(CarrierCount::new(1)).unwrap();
+                    if batch.is_complete() {
+                        break batch.finish().unwrap();
+                    }
+                    thread::yield_now();
+                };
+                let id = (carriers[0].slot_id(), carriers[0].carrier_index());
+                live.wait();
+                drop(carriers);
+                id
+            })
+        };
+        let first = claim(Arc::clone(&arena), Arc::clone(&start), Arc::clone(&live));
+        let second = claim(Arc::clone(&arena), Arc::clone(&start), Arc::clone(&live));
+
+        assert_ne!(first.join().unwrap(), second.join().unwrap());
+        assert_fully_free(&slot);
+    }
+
+    #[test]
+    fn serialized_fallback_rechecks_active_capacity_before_growth() {
+        let arena = Arena::new(geometry_with_carriers(65), 1).unwrap();
+        let slot = prepare_slots(&arena, 1).pop().unwrap();
+        let occupied = BlockSlot::try_claim_words(&slot, 0, 1, CarrierCount::new(64))
+            .unwrap()
+            .into_provisional()
+            .unwrap();
+        let mut batch = arena.claim_optimistic(CarrierCount::new(1)).unwrap();
+        assert_eq!(batch.claimed(), CarrierCount::ZERO);
+        let mut prepared = CarrierCount::new(65);
+
+        arena
+            .complete_claim_serialized(&mut prepared, &mut batch)
+            .unwrap();
+
+        assert!(batch.is_complete());
+        assert_eq!(prepared, CarrierCount::new(65));
+        assert_eq!(arena.snapshot().claim_slots().len(), 1);
+        let carriers = batch.finish().unwrap();
+        assert_eq!(carriers[0].carrier_index(), 64);
+        drop(carriers);
+        drop(occupied);
+        assert_fully_free(&slot);
+    }
+
+    #[test]
+    fn serialized_fallback_exhausts_fragmented_capacity_before_growth() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let slots = prepare_slots(&arena, 3);
+        let occupied = slots
+            .iter()
+            .map(|slot| {
+                BlockSlot::try_claim(slot, CarrierCount::new(1))
+                    .unwrap()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let mut batch = arena.claim_optimistic(CarrierCount::new(3)).unwrap();
+        assert_eq!(batch.claimed(), CarrierCount::new(1));
+        let mut prepared = CarrierCount::new(6);
+
+        arena
+            .complete_claim_serialized(&mut prepared, &mut batch)
+            .unwrap();
+
+        assert!(batch.is_complete());
+        assert_eq!(prepared, CarrierCount::new(6));
+        assert_eq!(arena.snapshot().claim_slots().len(), 3);
+        let carriers = batch.finish().unwrap();
+        assert!(slots.iter().all(|slot| {
+            carriers
+                .iter()
+                .filter(|carrier| carrier.slot_id() == slot.id())
+                .count()
+                == 1
+        }));
+        drop(carriers);
+        drop(occupied);
+        for slot in &slots {
+            assert_fully_free(slot);
+        }
+    }
+
+    #[test]
+    fn serialized_fallback_reuses_inactive_slot_before_reserving() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let inactive = arena.reserve_slot().unwrap();
+        let mut batch = arena.claim_optimistic(CarrierCount::new(1)).unwrap();
+        let mut prepared = CarrierCount::ZERO;
+
+        arena
+            .complete_claim_serialized(&mut prepared, &mut batch)
+            .unwrap();
+
+        assert_eq!(prepared, CarrierCount::new(2));
+        assert_eq!(arena.snapshot().claim_slots().len(), 1);
+        let carriers = batch.finish().unwrap();
+        assert_eq!(carriers[0].slot_id(), inactive.id());
+        drop(carriers);
+        assert_fully_free(&inactive);
+    }
+
+    #[test]
+    fn serialized_fallback_grows_whole_blocks_until_complete() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let mut batch = arena.claim_optimistic(CarrierCount::new(5)).unwrap();
+        let mut prepared = CarrierCount::ZERO;
+
+        arena
+            .complete_claim_serialized(&mut prepared, &mut batch)
+            .unwrap();
+
+        assert!(batch.is_complete());
+        assert_eq!(prepared, CarrierCount::new(6));
+        assert_eq!(arena.snapshot().claim_slots().len(), 3);
+        let carriers = batch.finish().unwrap();
+        assert_eq!(carriers.len(), 5);
+        assert_eq!(
+            carriers
+                .iter()
+                .map(|carrier| carrier.slot_id())
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            3
+        );
+    }
+
+    #[test]
+    fn later_preparation_failure_preserves_earlier_capacity() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let first = arena.reserve_slot().unwrap();
+        let second = arena.reserve_slot().unwrap();
+        second.inject_failure_once(VirtualMemoryOperation::Prepare);
+        let mut batch = arena.claim_optimistic(CarrierCount::new(3)).unwrap();
+        let mut prepared = CarrierCount::ZERO;
+
+        let error = arena
+            .complete_claim_serialized(&mut prepared, &mut batch)
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ArenaError::Block(BlockError::VirtualMemory(ref error))
+                if error.operation() == VirtualMemoryOperation::Prepare
+        ));
+        assert_eq!(prepared, CarrierCount::new(2));
+        assert_eq!(batch.claimed(), CarrierCount::new(2));
+        assert!(!batch.is_complete());
+        assert_eq!(arena.snapshot().claim_slots().len(), 2);
+        drop(batch);
+        assert_fully_free(&first);
+        assert!(BlockSlot::try_claim(&second, CarrierCount::new(1))
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn serialized_growth_rejects_prepared_capacity_overflow() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let mut batch = arena.claim_optimistic(CarrierCount::new(1)).unwrap();
+        let mut prepared = CarrierCount::new(usize::MAX);
+
+        let error = arena
+            .complete_claim_serialized(&mut prepared, &mut batch)
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ArenaError::Block(BlockError::PreparedCapacityOverflow)
+        ));
+        assert_eq!(prepared, CarrierCount::new(usize::MAX));
+        assert_eq!(batch.claimed(), CarrierCount::ZERO);
+        let slots = arena.snapshot();
+        assert_eq!(slots.claim_slots().len(), 1);
+        assert!(
+            BlockSlot::try_claim(&slots.claim_slots()[0], CarrierCount::new(1))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn concurrent_serialized_fallbacks_retain_private_growth() {
+        let arena = Arc::new(Arena::new(geometry_with_carriers(2), 1).unwrap());
+        let prepared = Arc::new(StdMutex::new(CarrierCount::ZERO));
+        let start = Arc::new(Barrier::new(2));
+
+        let fallback =
+            |arena: Arc<Arena>, prepared: Arc<StdMutex<CarrierCount>>, start: Arc<Barrier>| {
+                thread::spawn(move || {
+                    let mut batch = arena.claim_optimistic(CarrierCount::new(2)).unwrap();
+                    start.wait();
+                    let mut prepared = prepared.lock().unwrap();
+                    arena
+                        .complete_claim_serialized(&mut prepared, &mut batch)
+                        .unwrap();
+                    drop(prepared);
+                    batch.finish().unwrap()
+                })
+            };
+        let first = fallback(
+            Arc::clone(&arena),
+            Arc::clone(&prepared),
+            Arc::clone(&start),
+        );
+        let second = fallback(
+            Arc::clone(&arena),
+            Arc::clone(&prepared),
+            Arc::clone(&start),
+        );
+
+        let first = first.join().unwrap();
+        let second = second.join().unwrap();
+        assert_eq!(*prepared.lock().unwrap(), CarrierCount::new(4));
+        assert_eq!(arena.snapshot().claim_slots().len(), 2);
+        assert!(first.iter().all(|left| second.iter().all(|right| {
+            (left.slot_id(), left.carrier_index()) != (right.slot_id(), right.carrier_index())
+        })));
+    }
+
+    #[test]
+    fn trim_selection_skips_inactive_and_occupied_slots() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let inactive = arena.reserve_slot().unwrap();
+        let active = prepare_slots(&arena, 2);
+        let occupied = BlockSlot::try_claim(&active[0], CarrierCount::new(1))
+            .unwrap()
+            .unwrap();
+
+        let candidate = arena
+            .select_trim_candidate()
+            .expect("one active block is free");
+
+        assert!(Arc::ptr_eq(&candidate, &active[1]));
+        assert!(!Arc::ptr_eq(&candidate, &inactive));
+        assert_eq!(arena.diagnostics().trim_slots_scanned, 3);
+        drop(occupied);
+    }
+
+    #[test]
+    fn trim_candidate_is_rechecked_after_selection() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let slot = prepare_slots(&arena, 1).pop().unwrap();
+        let candidate = arena
+            .select_trim_candidate()
+            .expect("prepared block is initially free");
+        let occupied = BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .unwrap();
+        let mut prepared = CarrierCount::new(2);
+
+        assert!(matches!(
+            BlockSlot::start_trim(&candidate, &mut prepared, CarrierCount::ZERO),
+            Err(TrimBlocked::Busy)
+        ));
+        assert_eq!(prepared, CarrierCount::new(2));
+        drop(occupied);
+    }
+
+    #[test]
+    fn trim_selection_skips_cleanup_owned_slot() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let slot = prepare_slots(&arena, 1).pop().unwrap();
+        let mut prepared = CarrierCount::new(2);
+        let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
+
+        assert!(arena.select_trim_candidate().is_none());
+        assert_eq!(arena.diagnostics().trim_slots_scanned, 1);
+
+        cleanup.finish().unwrap();
+    }
+
+    #[test]
+    fn arena_diagnostics_record_scan_growth_and_rollback() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        arena.reserve_slot().unwrap();
+        let mut batch = arena.claim_optimistic(CarrierCount::new(3)).unwrap();
+        let mut prepared = CarrierCount::ZERO;
+
+        arena
+            .complete_claim_serialized(&mut prepared, &mut batch)
+            .unwrap();
+        let before_rollback = arena.diagnostics();
+
+        assert_eq!(before_rollback.optimistic_scan_words, 1);
+        assert_eq!(before_rollback.optimistic_misses, 1);
+        assert_eq!(before_rollback.serialized_fallbacks, 1);
+        assert_eq!(before_rollback.blocks_prepared, 2);
+        assert_eq!(before_rollback.block_ranges_reserved, 2);
+        assert_eq!(before_rollback.rolled_back_carriers, 0);
+
+        drop(batch);
+        assert_eq!(arena.diagnostics().rolled_back_carriers, 3);
+    }
+
+    #[test]
+    fn completed_batch_is_not_recorded_as_rollback() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let slot = prepare_slots(&arena, 1).pop().unwrap();
+
+        let carriers = arena
+            .claim_optimistic(CarrierCount::new(1))
+            .unwrap()
+            .finish()
+            .unwrap();
+
+        assert_eq!(arena.diagnostics().rolled_back_carriers, 0);
+        drop(carriers);
+        assert_eq!(arena.diagnostics().rolled_back_carriers, 0);
+        assert_fully_free(&slot);
+    }
+
+    #[test]
+    fn arena_diagnostics_saturate() {
+        let diagnostics = ArenaDiagnostics::default();
+        diagnostics
+            .rolled_back_carriers
+            .store(u64::MAX - 1, DiagnosticOrdering::Relaxed);
+
+        diagnostics.record_rolled_back_carriers(usize::MAX);
+        diagnostics.record_rolled_back_carriers(1);
+
+        assert_eq!(diagnostics.snapshot().rolled_back_carriers, u64::MAX);
+    }
+
+    #[test]
+    fn wrapped_scan_position_does_not_overflow() {
+        assert_eq!(wrapped_position(3, 0, 4), 3);
+        assert_eq!(wrapped_position(3, 1, 4), 0);
+        assert_eq!(wrapped_position(3, 3, 4), 2);
+        assert_eq!(wrapped_position(usize::MAX - 1, 1, usize::MAX), 0);
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use super::super::virtual_memory::page_size;
+    use super::*;
+    use crate::runtime::sync::thread;
+
+    fn assert_coherent(snapshot: &RegistryGuard) {
+        let snapshot = snapshot.inner.as_ref();
+        assert_eq!(snapshot.claim_slots.len(), snapshot.address_ranges.len());
+        for range in &snapshot.address_ranges {
+            let slot = &snapshot.claim_slots[range.slot_index];
+            assert_eq!(slot.address_range(), Some(range.start..range.end));
+        }
+    }
+
+    #[test]
+    fn registry_generation_is_published_coherently() {
+        loom::model(|| {
+            let page_size = page_size().unwrap().get();
+            let geometry = PoolGeometry::new(page_size, page_size, page_size).unwrap();
+            let arena = Arc::new(Arena::new(geometry, 1).unwrap());
+            arena.reserve_slot().unwrap();
+
+            let writer_arena = Arc::clone(&arena);
+            let writer = thread::spawn(move || {
+                writer_arena.reserve_slot().unwrap();
+            });
+
+            let reader_arena = Arc::clone(&arena);
+            let reader = thread::spawn(move || {
+                assert_coherent(&reader_arena.snapshot());
+            });
+
+            writer.join().unwrap();
+            reader.join().unwrap();
+            let snapshot = arena.snapshot();
+            assert_coherent(&snapshot);
+            assert_eq!(snapshot.claim_slots().len(), 2);
+        });
+    }
+
+    #[test]
+    fn completed_concurrent_batches_cannot_own_the_same_carrier() {
+        loom::model(|| {
+            let page_size = page_size().unwrap().get();
+            let geometry = PoolGeometry::new(page_size, page_size * 2, page_size).unwrap();
+            let arena = Arc::new(Arena::new(geometry, 1).unwrap());
+            let slot = arena.reserve_slot().unwrap();
+            let mut prepared = CarrierCount::ZERO;
+            slot.prepare(&mut prepared).unwrap();
+
+            let claim = |arena: Arc<Arena>| {
+                thread::spawn(move || {
+                    let batch = arena.claim_optimistic(CarrierCount::new(1)).unwrap();
+                    if batch.is_complete() {
+                        Some(batch.finish().unwrap())
+                    } else {
+                        None
+                    }
+                })
+            };
+            let first = claim(Arc::clone(&arena));
+            let second = claim(Arc::clone(&arena));
+
+            let first = first.join().unwrap();
+            let second = second.join().unwrap();
+            assert!(first.is_some() || second.is_some());
+            if let (Some(first), Some(second)) = (&first, &second) {
+                assert_ne!(first[0].carrier_index(), second[0].carrier_index());
+            }
+        });
+    }
+
+    #[test]
+    fn private_growth_cannot_be_stolen_by_an_optimistic_claim() {
+        loom::model(|| {
+            let page_size = page_size().unwrap().get();
+            let geometry = PoolGeometry::new(page_size, page_size * 2, page_size).unwrap();
+            let arena = Arc::new(Arena::new(geometry, 1).unwrap());
+
+            let fallback_arena = Arc::clone(&arena);
+            let fallback = thread::spawn(move || {
+                let mut batch = fallback_arena
+                    .claim_optimistic(CarrierCount::new(1))
+                    .unwrap();
+                let mut prepared = CarrierCount::ZERO;
+                fallback_arena
+                    .complete_claim_serialized(&mut prepared, &mut batch)
+                    .unwrap();
+                assert_eq!(prepared, CarrierCount::new(2));
+                batch.finish().unwrap()
+            });
+
+            let optimistic_arena = Arc::clone(&arena);
+            let optimistic = thread::spawn(move || {
+                let batch = optimistic_arena
+                    .claim_optimistic(CarrierCount::new(1))
+                    .unwrap();
+                if batch.is_complete() {
+                    Some(batch.finish().unwrap())
+                } else {
+                    None
+                }
+            });
+
+            let fallback = fallback.join().unwrap();
+            let optimistic = optimistic.join().unwrap();
+            assert_eq!(fallback.len(), 1);
+            if let Some(optimistic) = optimistic {
+                assert_ne!(
+                    (fallback[0].slot_id(), fallback[0].carrier_index()),
+                    (optimistic[0].slot_id(), optimistic[0].carrier_index())
+                );
+            }
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
@@ -374,6 +374,7 @@ impl ClaimBatch {
     }
 
     /// Returns the required carrier count.
+    #[cfg(test)]
     pub(super) fn required(&self) -> CarrierCount {
         self.required
     }
@@ -467,7 +468,7 @@ struct ArenaDiagnostics {
     blocks_prepared: AtomicU64,
     /// Stable virtual ranges added to the registry.
     block_ranges_reserved: AtomicU64,
-    /// Provisional carriers returned without publication.
+    /// Carriers returned because a claim batch ended without publication.
     rolled_back_carriers: AtomicU64,
     /// Slots inspected while selecting trim candidates.
     trim_slots_scanned: AtomicU64,
@@ -497,7 +498,7 @@ impl ArenaDiagnostics {
         saturating_add(&self.block_ranges_reserved, 1);
     }
 
-    /// Records provisional carrier ownership returned by rollback.
+    /// Records carriers returned when a claim batch ends without publication.
     fn record_rolled_back_carriers(&self, carriers: usize) {
         saturating_add(&self.rolled_back_carriers, diagnostic_count(carriers));
     }
@@ -534,7 +535,7 @@ pub(super) struct ArenaDiagnosticSnapshot {
     pub(super) blocks_prepared: u64,
     /// Stable virtual ranges added to the registry.
     pub(super) block_ranges_reserved: u64,
-    /// Provisional carriers returned without publication.
+    /// Carriers returned because a claim batch ended without publication.
     pub(super) rolled_back_carriers: u64,
     /// Slots inspected while selecting trim candidates.
     pub(super) trim_slots_scanned: u64,

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
@@ -3,7 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Stable block registry and physical-allocation coordination.
+//! Multi-block carrier acquisition and stable-range lookup.
+//!
+//! [`Arena`] publishes immutable registry generations for lock-free optimistic
+//! scans and address classification. A miss enters serialized fallback, which
+//! exhausts reusable capacity before preparing another block. The arena owns
+//! physical topology and claims; admission policy and byte presentation remain
+//! in higher layers.
 
 use std::collections::TryReserveError;
 use std::fmt;
@@ -14,6 +20,215 @@ use super::geometry::PoolGeometry;
 use super::CarrierCount;
 use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
 use crate::runtime::sync::sync::{Arc, Mutex};
+
+/// Stable slots and their atomically published lookup index.
+pub(super) struct Arena {
+    /// Shared block geometry.
+    geometry: PoolGeometry,
+    /// Maximum bitmap words inspected by one optimistic claim.
+    optimistic_scan_words: usize,
+    /// Rotating flattened bitmap-word origin.
+    scan_origin: AtomicUsize,
+    /// Internal scan, growth, and rollback counters.
+    diagnostics: Arc<ArenaDiagnostics>,
+    /// Lock-free registry publication.
+    registry: BlockRegistry,
+    /// Serialized slot creation and registry rebuilding.
+    state: Mutex<ArenaState>,
+}
+
+impl Arena {
+    /// Creates an empty arena with fixed block geometry.
+    pub(super) fn new(
+        geometry: PoolGeometry,
+        optimistic_scan_words: usize,
+    ) -> Result<Self, ArenaError> {
+        if optimistic_scan_words == 0 {
+            return Err(ArenaError::InvalidScanBudget);
+        }
+        Ok(Self {
+            geometry,
+            optimistic_scan_words,
+            scan_origin: AtomicUsize::new(0),
+            diagnostics: Arc::new(ArenaDiagnostics::default()),
+            registry: BlockRegistry::new(),
+            state: Mutex::new(ArenaState {
+                slots: Vec::new(),
+                next_slot: Some(0),
+            }),
+        })
+    }
+
+    /// Reserves and publishes one inactive stable block slot.
+    ///
+    /// Failure leaves the registry and slot identifier unchanged.
+    #[cfg(test)]
+    fn reserve_slot(&self) -> Result<Arc<BlockSlot>, ArenaError> {
+        let mut state = self.state.lock();
+        self.reserve_slot_locked(&mut state)
+    }
+
+    /// Reserves and publishes one slot while holding arena serialization.
+    ///
+    /// The mutable state reference proves exclusive access without reacquiring
+    /// the mutex. Failure leaves the state and registry generation unchanged.
+    fn reserve_slot_locked(&self, state: &mut ArenaState) -> Result<Arc<BlockSlot>, ArenaError> {
+        let slot_id = state.next_slot.ok_or(ArenaError::SlotIdExhausted)?;
+
+        state.slots.try_reserve(1)?;
+        let slot = Arc::new(BlockSlot::new(slot_id, self.geometry)?);
+        let generation = RegistryGeneration::try_with_slot(&state.slots, &slot)?;
+
+        state.slots.push(Arc::clone(&slot));
+        state.next_slot = slot_id.checked_add(1);
+        self.registry.publish(generation);
+        self.diagnostics.record_block_range_reserved();
+        Ok(slot)
+    }
+
+    /// Classifies a complete nonempty range within one stable block slot.
+    ///
+    /// Integer addresses are used only for comparison. This method does not
+    /// construct a pointer or authorize access to the classified range.
+    pub(super) fn classify_range(&self, start: usize, len: usize) -> Option<ClassifiedRange> {
+        self.registry.load().classify_range(start, len)
+    }
+
+    /// Selects one block observed active and free.
+    ///
+    /// Selection is a lock-free hint. A claim may race this scan, so the
+    /// caller must use [`BlockSlot::start_trim`] to recheck the lifecycle,
+    /// bitmap, and prepared-capacity floor under admission serialization.
+    pub(super) fn select_trim_candidate(&self) -> Option<Arc<BlockSlot>> {
+        let generation = self.registry_generation();
+        let mut scanned = 0;
+        let candidate = generation.slots_in_claim_order().iter().find_map(|slot| {
+            scanned += 1;
+            slot.appears_free().then(|| Arc::clone(slot))
+        });
+        self.diagnostics.record_trim_slots_scanned(scanned);
+        candidate
+    }
+
+    /// Returns one private arena diagnostic sample.
+    pub(super) fn diagnostics(&self) -> ArenaDiagnosticSnapshot {
+        self.diagnostics.snapshot()
+    }
+
+    /// Claims a complete or partial batch within the optimistic scan budget.
+    ///
+    /// The returned batch retains every gate-passed bit. A complete batch may
+    /// be converted to carrier owners. A partial batch remains suitable for
+    /// serialized fallback and returns its bits if dropped.
+    pub(super) fn claim_optimistic(
+        &self,
+        required: CarrierCount,
+    ) -> Result<ClaimBatch, ArenaError> {
+        if required == CarrierCount::ZERO {
+            return Err(ArenaError::InvalidClaimCount);
+        }
+
+        let generation = self.registry_generation();
+        let slots = generation.slots_in_claim_order();
+        let words_per_slot = self.geometry.bitmap_words();
+        let total_positions =
+            slots
+                .len()
+                .checked_mul(words_per_slot)
+                .ok_or(ArenaError::ScanSpaceOverflow {
+                    slots: slots.len(),
+                    words_per_slot,
+                })?;
+        let mut batch = ClaimBatch::new(required, Arc::clone(&self.diagnostics));
+        if total_positions == 0 {
+            self.diagnostics.record_optimistic_scan(0, true);
+            return Ok(batch);
+        }
+
+        let budget = self.optimistic_scan_words.min(total_positions);
+        let origin = self.scan_origin.fetch_add(budget, Ordering::Relaxed) % total_positions;
+        while batch.inspected_words < budget && !batch.is_complete() {
+            let position = wrapped_position(origin, batch.inspected_words, total_positions);
+            let slot_index = position / words_per_slot;
+            let start_word = position % words_per_slot;
+            let word_limit = (words_per_slot - start_word).min(budget - batch.inspected_words);
+            let claim = BlockSlot::try_claim_words(
+                &slots[slot_index],
+                start_word,
+                word_limit,
+                batch.remaining(),
+            )?;
+            let inspected = claim.inspected_words();
+            if inspected == 0 || inspected > word_limit {
+                invariant_violation("bounded block claim reported invalid scan work");
+            }
+            batch.inspected_words += inspected;
+            if let Some(provisional) = claim.into_provisional() {
+                batch.push(provisional)?;
+            }
+        }
+        self.diagnostics
+            .record_optimistic_scan(batch.inspected_words, !batch.is_complete());
+        Ok(batch)
+    }
+
+    /// Completes a partial batch through exhaustive reuse and private growth.
+    ///
+    /// The caller serializes `prepared` with the pool-wide admission floor.
+    /// This method then holds arena serialization through the full registry
+    /// recheck and every preparation. Existing inactive slots are reused
+    /// before another stable range is reserved.
+    pub(super) fn complete_claim_serialized(
+        &self,
+        prepared: &mut CarrierCount,
+        batch: &mut ClaimBatch,
+    ) -> Result<(), ArenaError> {
+        if batch.is_complete() {
+            return Ok(());
+        }
+        self.diagnostics.record_serialized_fallback();
+
+        let mut state = self.state.lock();
+        for slot in &state.slots {
+            if batch.is_complete() {
+                return Ok(());
+            }
+            if let Some(provisional) = BlockSlot::try_claim_exhaustive(slot, batch.remaining())? {
+                batch.push(provisional)?;
+            }
+        }
+
+        for slot in &state.slots {
+            if batch.is_complete() {
+                return Ok(());
+            }
+            let count = std::cmp::min(batch.remaining(), slot.carrier_count());
+            if let Some(provisional) =
+                BlockSlot::prepare_and_claim_if_inactive(slot, prepared, count)?
+            {
+                self.diagnostics.record_block_prepared();
+                batch.push(provisional)?;
+            }
+        }
+
+        while !batch.is_complete() {
+            let slot = self.reserve_slot_locked(&mut state)?;
+            let count = std::cmp::min(batch.remaining(), slot.carrier_count());
+            let provisional = BlockSlot::prepare_and_claim_if_inactive(&slot, prepared, count)?
+                .unwrap_or_else(|| {
+                    invariant_violation("new arena slot was not reusable for private growth")
+                });
+            self.diagnostics.record_block_prepared();
+            batch.push(provisional)?;
+        }
+        Ok(())
+    }
+
+    /// Protects the current immutable registry generation.
+    fn registry_generation(&self) -> RegistryGenerationGuard {
+        self.registry.load()
+    }
+}
 
 /// Failure to configure, claim, reserve, or publish arena storage.
 #[derive(Debug)]
@@ -134,215 +349,6 @@ impl From<BlockError> for ArenaError {
 impl From<TryReserveError> for ArenaError {
     fn from(error: TryReserveError) -> Self {
         Self::Allocation(error)
-    }
-}
-
-/// Stable slots and their atomically published lookup index.
-pub(super) struct Arena {
-    /// Shared block geometry.
-    geometry: PoolGeometry,
-    /// Maximum bitmap words inspected by one optimistic claim.
-    optimistic_scan_words: usize,
-    /// Rotating flattened bitmap-word origin.
-    scan_origin: AtomicUsize,
-    /// Internal scan, growth, and rollback counters.
-    diagnostics: Arc<ArenaDiagnostics>,
-    /// Lock-free registry publication.
-    registry: BlockRegistry,
-    /// Serialized slot creation and registry rebuilding.
-    state: Mutex<ArenaState>,
-}
-
-impl Arena {
-    /// Creates an empty arena with fixed block geometry.
-    pub(super) fn new(
-        geometry: PoolGeometry,
-        optimistic_scan_words: usize,
-    ) -> Result<Self, ArenaError> {
-        if optimistic_scan_words == 0 {
-            return Err(ArenaError::InvalidScanBudget);
-        }
-        Ok(Self {
-            geometry,
-            optimistic_scan_words,
-            scan_origin: AtomicUsize::new(0),
-            diagnostics: Arc::new(ArenaDiagnostics::default()),
-            registry: BlockRegistry::new(),
-            state: Mutex::new(ArenaState {
-                slots: Vec::new(),
-                next_slot: Some(0),
-            }),
-        })
-    }
-
-    /// Reserves and publishes one inactive stable block slot.
-    ///
-    /// Failure leaves the registry and slot identifier unchanged.
-    #[cfg(test)]
-    fn reserve_slot(&self) -> Result<Arc<BlockSlot>, ArenaError> {
-        let mut state = self.state.lock();
-        self.reserve_slot_locked(&mut state)
-    }
-
-    /// Reserves and publishes one slot while holding arena serialization.
-    ///
-    /// The mutable state reference proves exclusive access without reacquiring
-    /// the mutex. Failure leaves the state and registry generation unchanged.
-    fn reserve_slot_locked(&self, state: &mut ArenaState) -> Result<Arc<BlockSlot>, ArenaError> {
-        let slot_id = state.next_slot.ok_or(ArenaError::SlotIdExhausted)?;
-
-        state.slots.try_reserve(1)?;
-        let slot = Arc::new(BlockSlot::new(slot_id, self.geometry)?);
-        let snapshot = RegistrySnapshot::try_with_slot(&state.slots, &slot)?;
-
-        state.slots.push(Arc::clone(&slot));
-        state.next_slot = slot_id.checked_add(1);
-        self.registry.publish(snapshot);
-        self.diagnostics.record_block_range_reserved();
-        Ok(slot)
-    }
-
-    /// Classifies a complete nonempty range within one stable block slot.
-    ///
-    /// Integer addresses are used only for comparison. This method does not
-    /// construct a pointer or authorize access to the classified range.
-    pub(super) fn classify_range(&self, start: usize, len: usize) -> Option<ClassifiedRange> {
-        self.registry.load().classify_range(start, len)
-    }
-
-    /// Selects one block observed active and free.
-    ///
-    /// Selection is a lock-free hint. A claim may race this scan, so the
-    /// caller must use [`BlockSlot::start_trim`] to recheck the lifecycle,
-    /// bitmap, and prepared-capacity floor under admission serialization.
-    pub(super) fn select_trim_candidate(&self) -> Option<Arc<BlockSlot>> {
-        let snapshot = self.snapshot();
-        let mut scanned = 0;
-        let candidate = snapshot.claim_slots().iter().find_map(|slot| {
-            scanned += 1;
-            slot.appears_free().then(|| Arc::clone(slot))
-        });
-        self.diagnostics.record_trim_slots_scanned(scanned);
-        candidate
-    }
-
-    /// Returns one private arena diagnostic sample.
-    pub(super) fn diagnostics(&self) -> ArenaDiagnosticSnapshot {
-        self.diagnostics.snapshot()
-    }
-
-    /// Claims a complete or partial batch within the optimistic scan budget.
-    ///
-    /// The returned batch retains every gate-passed bit. A complete batch may
-    /// be converted to carrier owners. A partial batch remains suitable for
-    /// serialized fallback and returns its bits if dropped.
-    pub(super) fn claim_optimistic(
-        &self,
-        required: CarrierCount,
-    ) -> Result<ClaimBatch, ArenaError> {
-        if required == CarrierCount::ZERO {
-            return Err(ArenaError::InvalidClaimCount);
-        }
-
-        let snapshot = self.snapshot();
-        let slots = snapshot.claim_slots();
-        let words_per_slot = self.geometry.bitmap_words();
-        let total_positions =
-            slots
-                .len()
-                .checked_mul(words_per_slot)
-                .ok_or(ArenaError::ScanSpaceOverflow {
-                    slots: slots.len(),
-                    words_per_slot,
-                })?;
-        let mut batch = ClaimBatch::new(required, Arc::clone(&self.diagnostics));
-        if total_positions == 0 {
-            self.diagnostics.record_optimistic_scan(0, true);
-            return Ok(batch);
-        }
-
-        let budget = self.optimistic_scan_words.min(total_positions);
-        let origin = self.scan_origin.fetch_add(budget, Ordering::Relaxed) % total_positions;
-        while batch.inspected_words < budget && !batch.is_complete() {
-            let position = wrapped_position(origin, batch.inspected_words, total_positions);
-            let slot_index = position / words_per_slot;
-            let start_word = position % words_per_slot;
-            let word_limit = (words_per_slot - start_word).min(budget - batch.inspected_words);
-            let claim = BlockSlot::try_claim_words(
-                &slots[slot_index],
-                start_word,
-                word_limit,
-                batch.remaining(),
-            )?;
-            let inspected = claim.inspected_words();
-            if inspected == 0 || inspected > word_limit {
-                invariant_violation("bounded block claim reported invalid scan work");
-            }
-            batch.inspected_words += inspected;
-            if let Some(provisional) = claim.into_provisional() {
-                batch.push(provisional)?;
-            }
-        }
-        self.diagnostics
-            .record_optimistic_scan(batch.inspected_words, !batch.is_complete());
-        Ok(batch)
-    }
-
-    /// Completes a partial batch through exhaustive reuse and private growth.
-    ///
-    /// The caller serializes `prepared` with the pool-wide admission floor.
-    /// This method then holds arena serialization through the full registry
-    /// recheck and every preparation. Existing inactive slots are reused
-    /// before another stable range is reserved.
-    pub(super) fn complete_claim_serialized(
-        &self,
-        prepared: &mut CarrierCount,
-        batch: &mut ClaimBatch,
-    ) -> Result<(), ArenaError> {
-        if batch.is_complete() {
-            return Ok(());
-        }
-        self.diagnostics.record_serialized_fallback();
-
-        let mut state = self.state.lock();
-        for slot in &state.slots {
-            if batch.is_complete() {
-                return Ok(());
-            }
-            if let Some(provisional) = BlockSlot::try_claim_exhaustive(slot, batch.remaining())? {
-                batch.push(provisional)?;
-            }
-        }
-
-        for slot in &state.slots {
-            if batch.is_complete() {
-                return Ok(());
-            }
-            let count = std::cmp::min(batch.remaining(), slot.carrier_count());
-            if let Some(provisional) =
-                BlockSlot::prepare_and_claim_if_inactive(slot, prepared, count)?
-            {
-                self.diagnostics.record_block_prepared();
-                batch.push(provisional)?;
-            }
-        }
-
-        while !batch.is_complete() {
-            let slot = self.reserve_slot_locked(&mut state)?;
-            let count = std::cmp::min(batch.remaining(), slot.carrier_count());
-            let provisional = BlockSlot::prepare_and_claim_if_inactive(&slot, prepared, count)?
-                .unwrap_or_else(|| {
-                    invariant_violation("new arena slot was not reusable for private growth")
-                });
-            self.diagnostics.record_block_prepared();
-            batch.push(provisional)?;
-        }
-        Ok(())
-    }
-
-    /// Protects the current immutable registry snapshot.
-    fn snapshot(&self) -> RegistryGuard {
-        self.registry.load()
     }
 }
 
@@ -585,32 +591,32 @@ impl BlockRegistry {
     /// Creates a registry containing no slots.
     fn new() -> Self {
         Self {
-            current: registry_cell::RegistryCell::new(Arc::new(RegistrySnapshot::empty())),
+            current: registry_cell::RegistryCell::new(Arc::new(RegistryGeneration::empty())),
         }
     }
 
     /// Protects the current registry generation.
-    fn load(&self) -> RegistryGuard {
-        RegistryGuard {
+    fn load(&self) -> RegistryGenerationGuard {
+        RegistryGenerationGuard {
             inner: self.current.load(),
         }
     }
 
     /// Publishes a complete registry generation.
-    fn publish(&self, snapshot: RegistrySnapshot) {
-        self.current.store(Arc::new(snapshot));
+    fn publish(&self, generation: RegistryGeneration) {
+        self.current.store(Arc::new(generation));
     }
 }
 
 /// Protected access to one immutable registry generation.
-struct RegistryGuard {
+struct RegistryGenerationGuard {
     inner: registry_cell::RegistryCellGuard,
 }
 
-impl RegistryGuard {
+impl RegistryGenerationGuard {
     /// Returns slots in stable physical-claim order.
-    fn claim_slots(&self) -> &[Arc<BlockSlot>] {
-        &self.inner.as_ref().claim_slots
+    fn slots_in_claim_order(&self) -> &[Arc<BlockSlot>] {
+        &self.inner.as_ref().slots_in_claim_order
     }
 
     /// Classifies a complete nonempty range within one slot.
@@ -620,18 +626,18 @@ impl RegistryGuard {
 }
 
 /// Immutable claim and address indexes published as one generation.
-struct RegistrySnapshot {
+struct RegistryGeneration {
     /// Stable scan order for physical acquisition.
-    claim_slots: Box<[Arc<BlockSlot>]>,
+    slots_in_claim_order: Box<[Arc<BlockSlot>]>,
     /// Non-overlapping virtual ranges sorted by address.
     address_ranges: Box<[AddressRange]>,
 }
 
-impl RegistrySnapshot {
+impl RegistryGeneration {
     /// Creates an empty registry generation.
     fn empty() -> Self {
         Self {
-            claim_slots: Box::default(),
+            slots_in_claim_order: Box::default(),
             address_ranges: Box::default(),
         }
     }
@@ -643,21 +649,21 @@ impl RegistrySnapshot {
             .checked_add(1)
             .ok_or(ArenaError::RegistryCapacityOverflow)?;
 
-        let mut claim_slots = Vec::new();
-        claim_slots.try_reserve_exact(new_len)?;
-        claim_slots.extend(slots.iter().cloned());
-        claim_slots.push(Arc::clone(slot));
+        let mut slots_in_claim_order = Vec::new();
+        slots_in_claim_order.try_reserve_exact(new_len)?;
+        slots_in_claim_order.extend(slots.iter().cloned());
+        slots_in_claim_order.push(Arc::clone(slot));
 
         let mut address_ranges = Vec::new();
         address_ranges.try_reserve_exact(new_len)?;
-        for (slot_index, slot) in claim_slots.iter().enumerate() {
+        for (slot_index, slot) in slots_in_claim_order.iter().enumerate() {
             address_ranges.push(AddressRange::for_slot(slot, slot_index)?);
         }
         address_ranges.sort_unstable_by_key(|range| range.start);
         validate_address_ranges(&address_ranges)?;
 
         Ok(Self {
-            claim_slots: claim_slots.into_boxed_slice(),
+            slots_in_claim_order: slots_in_claim_order.into_boxed_slice(),
             address_ranges: address_ranges.into_boxed_slice(),
         })
     }
@@ -676,10 +682,11 @@ impl RegistrySnapshot {
         if end > range.end {
             return None;
         }
-        let slot =
-            Arc::clone(self.claim_slots.get(range.slot_index).unwrap_or_else(|| {
-                invariant_violation("registry range has an invalid slot index")
-            }));
+        let slot = Arc::clone(
+            self.slots_in_claim_order
+                .get(range.slot_index)
+                .unwrap_or_else(|| invariant_violation("registry range has an invalid slot index")),
+        );
         Some(ClassifiedRange {
             slot,
             offset: start - range.start,
@@ -694,7 +701,7 @@ struct AddressRange {
     start: usize,
     /// Exclusive end of the reservation.
     end: usize,
-    /// Index into [`RegistrySnapshot::claim_slots`].
+    /// Index into [`RegistryGeneration::slots_in_claim_order`].
     slot_index: usize,
 }
 
@@ -774,17 +781,17 @@ mod registry_cell {
 
     use arc_swap::{ArcSwap, Guard};
 
-    use super::RegistrySnapshot;
+    use super::RegistryGeneration;
     use crate::runtime::sync::sync::Arc;
 
     /// Atomic storage for the current registry generation.
     pub(super) struct RegistryCell {
-        inner: ArcSwap<RegistrySnapshot>,
+        inner: ArcSwap<RegistryGeneration>,
     }
 
     impl RegistryCell {
         /// Creates a cell containing `initial`.
-        pub(super) fn new(initial: Arc<RegistrySnapshot>) -> Self {
+        pub(super) fn new(initial: Arc<RegistryGeneration>) -> Self {
             Self {
                 inner: ArcSwap::from(initial),
             }
@@ -798,19 +805,19 @@ mod registry_cell {
         }
 
         /// Replaces the current generation.
-        pub(super) fn store(&self, snapshot: Arc<RegistrySnapshot>) {
-            self.inner.store(snapshot);
+        pub(super) fn store(&self, generation: Arc<RegistryGeneration>) {
+            self.inner.store(generation);
         }
     }
 
     /// Protection for one loaded registry generation.
     pub(super) struct RegistryCellGuard {
-        inner: Guard<Arc<RegistrySnapshot>>,
+        inner: Guard<Arc<RegistryGeneration>>,
     }
 
     impl RegistryCellGuard {
         /// Returns the protected generation.
-        pub(super) fn as_ref(&self) -> &RegistrySnapshot {
+        pub(super) fn as_ref(&self) -> &RegistryGeneration {
             &self.inner
         }
     }
@@ -820,17 +827,17 @@ mod registry_cell {
 mod registry_cell {
     //! Loom-instrumented publication with owned registry generations.
 
-    use super::RegistrySnapshot;
+    use super::RegistryGeneration;
     use crate::runtime::sync::sync::{Arc, Mutex};
 
     /// Loom-instrumented storage for the current registry generation.
     pub(super) struct RegistryCell {
-        inner: Mutex<Arc<RegistrySnapshot>>,
+        inner: Mutex<Arc<RegistryGeneration>>,
     }
 
     impl RegistryCell {
         /// Creates a cell containing `initial`.
-        pub(super) fn new(initial: Arc<RegistrySnapshot>) -> Self {
+        pub(super) fn new(initial: Arc<RegistryGeneration>) -> Self {
             Self {
                 inner: Mutex::new(initial),
             }
@@ -844,19 +851,19 @@ mod registry_cell {
         }
 
         /// Replaces the current generation.
-        pub(super) fn store(&self, snapshot: Arc<RegistrySnapshot>) {
-            *self.inner.lock() = snapshot;
+        pub(super) fn store(&self, generation: Arc<RegistryGeneration>) {
+            *self.inner.lock() = generation;
         }
     }
 
     /// Owned protection for one loaded registry generation.
     pub(super) struct RegistryCellGuard {
-        inner: Arc<RegistrySnapshot>,
+        inner: Arc<RegistryGeneration>,
     }
 
     impl RegistryCellGuard {
         /// Returns the protected generation.
-        pub(super) fn as_ref(&self) -> &RegistrySnapshot {
+        pub(super) fn as_ref(&self) -> &RegistryGeneration {
             &self.inner
         }
     }
@@ -929,7 +936,10 @@ mod tests {
         let arena = Arena::new(geometry(), 4).unwrap();
 
         assert!(arena.classify_range(1, 1).is_none());
-        assert!(arena.snapshot().claim_slots().is_empty());
+        assert!(arena
+            .registry_generation()
+            .slots_in_claim_order()
+            .is_empty());
     }
 
     #[test]
@@ -937,29 +947,56 @@ mod tests {
         let arena = Arena::new(geometry(), 4).unwrap();
         let first = arena.reserve_slot().unwrap();
         let second = arena.reserve_slot().unwrap();
-        let snapshot = arena.snapshot();
+        let generation = arena.registry_generation();
 
         assert_eq!(
-            snapshot
-                .claim_slots()
+            generation
+                .slots_in_claim_order()
                 .iter()
                 .map(|slot| slot.id())
                 .collect::<Vec<_>>(),
             vec![0, 1]
         );
-        assert_eq!(snapshot.inner.as_ref().address_ranges.len(), 2);
-        assert!(snapshot
+        assert_eq!(generation.inner.as_ref().address_ranges.len(), 2);
+        assert!(generation
             .inner
             .as_ref()
             .address_ranges
             .windows(2)
             .all(|pair| pair[0].end <= pair[1].start));
-        assert!(snapshot
-            .claim_slots()
+        assert!(generation
+            .slots_in_claim_order()
             .iter()
             .any(|slot| Arc::ptr_eq(slot, &first)));
-        assert!(snapshot
-            .claim_slots()
+        assert!(generation
+            .slots_in_claim_order()
+            .iter()
+            .any(|slot| Arc::ptr_eq(slot, &second)));
+    }
+
+    #[test]
+    fn production_registry_guard_survives_concurrent_publication() {
+        let arena = Arc::new(Arena::new(geometry(), 4).unwrap());
+        let first = arena.reserve_slot().unwrap();
+        let old_generation = arena.registry_generation();
+
+        let writer_arena = Arc::clone(&arena);
+        let writer = thread::spawn(move || writer_arena.reserve_slot().unwrap());
+        let second = writer.join().unwrap();
+        let new_generation = arena.registry_generation();
+
+        assert_eq!(old_generation.slots_in_claim_order().len(), 1);
+        assert!(Arc::ptr_eq(
+            &old_generation.slots_in_claim_order()[0],
+            &first
+        ));
+        assert_eq!(new_generation.slots_in_claim_order().len(), 2);
+        assert!(new_generation
+            .slots_in_claim_order()
+            .iter()
+            .any(|slot| Arc::ptr_eq(slot, &first)));
+        assert!(new_generation
+            .slots_in_claim_order()
             .iter()
             .any(|slot| Arc::ptr_eq(slot, &second)));
     }
@@ -985,6 +1022,36 @@ mod tests {
         assert!(arena.classify_range(range.start, 0).is_none());
         assert!(arena.classify_range(range.end - 1, 2).is_none());
         assert!(arena.classify_range(usize::MAX, 2).is_none());
+    }
+
+    #[test]
+    fn classification_rejects_gaps_and_cross_slot_ranges() {
+        let geometry = geometry();
+        let slots_in_claim_order = (0..3)
+            .map(|slot_id| Arc::new(BlockSlot::new(slot_id, geometry).unwrap()))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let generation = RegistryGeneration {
+            slots_in_claim_order,
+            address_ranges: vec![
+                AddressRange::new(0x1000, 0x1000, 0).unwrap(),
+                AddressRange::new(0x2000, 0x1000, 1).unwrap(),
+                AddressRange::new(0x4000, 0x1000, 2).unwrap(),
+            ]
+            .into_boxed_slice(),
+        };
+
+        let second = generation
+            .classify_range(0x2000, 1)
+            .expect("the second range begins at its lower boundary");
+        assert!(Arc::ptr_eq(
+            second.slot(),
+            &generation.slots_in_claim_order[1]
+        ));
+        assert_eq!(second.offset(), 0);
+
+        assert!(generation.classify_range(0x3000, 1).is_none());
+        assert!(generation.classify_range(0x1fff, 2).is_none());
     }
 
     #[test]
@@ -1042,7 +1109,10 @@ mod tests {
             arena.reserve_slot(),
             Err(ArenaError::SlotIdExhausted)
         ));
-        assert!(arena.snapshot().claim_slots().is_empty());
+        assert!(arena
+            .registry_generation()
+            .slots_in_claim_order()
+            .is_empty());
     }
 
     #[test]
@@ -1280,7 +1350,7 @@ mod tests {
 
         assert!(batch.is_complete());
         assert_eq!(prepared, CarrierCount::new(65));
-        assert_eq!(arena.snapshot().claim_slots().len(), 1);
+        assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 1);
         let carriers = batch.finish().unwrap();
         assert_eq!(carriers[0].carrier_index(), 64);
         drop(carriers);
@@ -1310,7 +1380,7 @@ mod tests {
 
         assert!(batch.is_complete());
         assert_eq!(prepared, CarrierCount::new(6));
-        assert_eq!(arena.snapshot().claim_slots().len(), 3);
+        assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 3);
         let carriers = batch.finish().unwrap();
         assert!(slots.iter().all(|slot| {
             carriers
@@ -1338,7 +1408,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(prepared, CarrierCount::new(2));
-        assert_eq!(arena.snapshot().claim_slots().len(), 1);
+        assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 1);
         let carriers = batch.finish().unwrap();
         assert_eq!(carriers[0].slot_id(), inactive.id());
         drop(carriers);
@@ -1357,7 +1427,7 @@ mod tests {
 
         assert!(batch.is_complete());
         assert_eq!(prepared, CarrierCount::new(6));
-        assert_eq!(arena.snapshot().claim_slots().len(), 3);
+        assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 3);
         let carriers = batch.finish().unwrap();
         assert_eq!(carriers.len(), 5);
         assert_eq!(
@@ -1391,7 +1461,7 @@ mod tests {
         assert_eq!(prepared, CarrierCount::new(2));
         assert_eq!(batch.claimed(), CarrierCount::new(2));
         assert!(!batch.is_complete());
-        assert_eq!(arena.snapshot().claim_slots().len(), 2);
+        assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 2);
         drop(batch);
         assert_fully_free(&first);
         assert!(BlockSlot::try_claim(&second, CarrierCount::new(1))
@@ -1415,10 +1485,10 @@ mod tests {
         ));
         assert_eq!(prepared, CarrierCount::new(usize::MAX));
         assert_eq!(batch.claimed(), CarrierCount::ZERO);
-        let slots = arena.snapshot();
-        assert_eq!(slots.claim_slots().len(), 1);
+        let generation = arena.registry_generation();
+        assert_eq!(generation.slots_in_claim_order().len(), 1);
         assert!(
-            BlockSlot::try_claim(&slots.claim_slots()[0], CarrierCount::new(1))
+            BlockSlot::try_claim(&generation.slots_in_claim_order()[0], CarrierCount::new(1))
                 .unwrap()
                 .is_none()
         );
@@ -1457,7 +1527,7 @@ mod tests {
         let first = first.join().unwrap();
         let second = second.join().unwrap();
         assert_eq!(*prepared.lock().unwrap(), CarrierCount::new(4));
-        assert_eq!(arena.snapshot().claim_slots().len(), 2);
+        assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 2);
         assert!(first.iter().all(|left| second.iter().all(|right| {
             (left.slot_id(), left.carrier_index()) != (right.slot_id(), right.carrier_index())
         })));
@@ -1583,11 +1653,14 @@ mod loom_tests {
     use super::*;
     use crate::runtime::sync::thread;
 
-    fn assert_coherent(snapshot: &RegistryGuard) {
-        let snapshot = snapshot.inner.as_ref();
-        assert_eq!(snapshot.claim_slots.len(), snapshot.address_ranges.len());
-        for range in &snapshot.address_ranges {
-            let slot = &snapshot.claim_slots[range.slot_index];
+    fn assert_coherent(generation: &RegistryGenerationGuard) {
+        let generation = generation.inner.as_ref();
+        assert_eq!(
+            generation.slots_in_claim_order.len(),
+            generation.address_ranges.len()
+        );
+        for range in &generation.address_ranges {
+            let slot = &generation.slots_in_claim_order[range.slot_index];
             assert_eq!(slot.address_range(), Some(range.start..range.end));
         }
     }
@@ -1607,14 +1680,14 @@ mod loom_tests {
 
             let reader_arena = Arc::clone(&arena);
             let reader = thread::spawn(move || {
-                assert_coherent(&reader_arena.snapshot());
+                assert_coherent(&reader_arena.registry_generation());
             });
 
             writer.join().unwrap();
             reader.join().unwrap();
-            let snapshot = arena.snapshot();
-            assert_coherent(&snapshot);
-            assert_eq!(snapshot.claim_slots().len(), 2);
+            let generation = arena.registry_generation();
+            assert_coherent(&generation);
+            assert_eq!(generation.slots_in_claim_order().len(), 2);
         });
     }
 
@@ -1647,6 +1720,43 @@ mod loom_tests {
             if let (Some(first), Some(second)) = (&first, &second) {
                 assert_ne!(first[0].carrier_index(), second[0].carrier_index());
             }
+        });
+    }
+
+    #[test]
+    fn concurrent_claims_use_distinct_rotated_windows() {
+        loom::model(|| {
+            let page_size = page_size().unwrap().get();
+            let geometry = PoolGeometry::new(page_size, page_size * 65, page_size).unwrap();
+            let arena = Arc::new(Arena::new(geometry, 1).unwrap());
+            let slot = arena.reserve_slot().unwrap();
+            let mut prepared = CarrierCount::ZERO;
+            slot.prepare(&mut prepared).unwrap();
+
+            let claim = |arena: Arc<Arena>| {
+                thread::spawn(move || {
+                    arena
+                        .claim_optimistic(CarrierCount::new(1))
+                        .unwrap()
+                        .finish()
+                        .unwrap()
+                })
+            };
+            let first = claim(Arc::clone(&arena));
+            let second = claim(Arc::clone(&arena));
+
+            let first = first.join().unwrap();
+            let second = second.join().unwrap();
+            let mut indices = [first[0].carrier_index(), second[0].carrier_index()];
+            indices.sort_unstable();
+            assert_eq!(indices, [0, 64]);
+
+            drop(first);
+            drop(second);
+            let returned = BlockSlot::try_claim(&slot, slot.carrier_count())
+                .unwrap()
+                .expect("both rotated-window owners returned");
+            assert_eq!(returned.len(), slot.carrier_count());
         });
     }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -9,6 +9,7 @@ use std::collections::TryReserveError;
 use std::fmt;
 use std::mem::MaybeUninit;
 use std::num::NonZeroUsize;
+#[cfg(test)]
 use std::ops::Range;
 use std::ptr::NonNull;
 
@@ -242,11 +243,7 @@ impl BlockIncarnation {
             if remaining == 0 {
                 break;
             }
-            let valid = if word_index + 1 == geometry.bitmap_words() {
-                geometry.final_word_mask()
-            } else {
-                u64::MAX
-            };
+            let valid = bitmap_word_mask(geometry, word_index);
             let mask = take_lowest(valid, remaining);
             let taken = mask.count_ones() as usize;
             word.store(mask, Ordering::Relaxed);
@@ -429,6 +426,7 @@ impl BlockSlot {
     ///
     /// The integer range grants no access to the backing memory. `None`
     /// reports address arithmetic overflow.
+    #[cfg(test)]
     pub(super) fn address_range(&self) -> Option<Range<usize>> {
         let start = self.base_address();
         start.checked_add(self.reserved_len()).map(|end| start..end)
@@ -598,11 +596,7 @@ impl BlockSlot {
             .iter()
             .enumerate()
             .any(|(word_index, word)| {
-                let valid = if word_index + 1 == slot.geometry.bitmap_words() {
-                    slot.geometry.final_word_mask()
-                } else {
-                    u64::MAX
-                };
+                let valid = bitmap_word_mask(slot.geometry, word_index);
                 word.load(Ordering::SeqCst) & valid != 0
             });
         if busy {
@@ -841,11 +835,7 @@ impl BlockSlot {
             .iter()
             .enumerate()
             .all(|(word_index, word)| {
-                let valid = if word_index + 1 == self.geometry.bitmap_words() {
-                    self.geometry.final_word_mask()
-                } else {
-                    u64::MAX
-                };
+                let valid = bitmap_word_mask(self.geometry, word_index);
                 word.load(Ordering::Acquire) & valid == 0
             })
     }
@@ -862,11 +852,7 @@ impl BlockSlot {
                     .iter()
                     .enumerate()
                     .map(|(word_index, word)| {
-                        let valid = if word_index + 1 == self.geometry.bitmap_words() {
-                            self.geometry.final_word_mask()
-                        } else {
-                            u64::MAX
-                        };
+                        let valid = bitmap_word_mask(self.geometry, word_index);
                         (word.load(Ordering::Acquire) & valid).count_ones() as usize
                     })
                     .sum()
@@ -1055,11 +1041,7 @@ impl BlockClaimAttempt {
             }
             inspected += 1;
             let word = &incarnation.in_use[word_index];
-            let valid = if word_index + 1 == self.slot.geometry.bitmap_words() {
-                self.slot.geometry.final_word_mask()
-            } else {
-                u64::MAX
-            };
+            let valid = bitmap_word_mask(self.slot.geometry, word_index);
             let observed = word.load(Ordering::Relaxed);
             let candidate = take_lowest(!observed & valid, count);
             if candidate == 0 {
@@ -1088,11 +1070,7 @@ impl BlockClaimAttempt {
         for (word_index, word) in incarnation.in_use.iter().enumerate() {
             let mut observed = word.load(Ordering::Relaxed);
             while count != 0 {
-                let valid = if word_index + 1 == self.slot.geometry.bitmap_words() {
-                    self.slot.geometry.final_word_mask()
-                } else {
-                    u64::MAX
-                };
+                let valid = bitmap_word_mask(self.slot.geometry, word_index);
                 let candidate = take_lowest(!observed & valid, count);
                 if candidate == 0 {
                     break;
@@ -1294,6 +1272,13 @@ fn clear_owned_bits(word: &AtomicU64, mask: u64) {
             Err(actual) => observed = actual,
         }
     }
+}
+
+/// Returns valid bits for a checked bitmap word.
+fn bitmap_word_mask(geometry: PoolGeometry, word_index: usize) -> u64 {
+    geometry
+        .bitmap_word_mask(word_index)
+        .unwrap_or_else(|| invariant_violation("incarnation bitmap exceeds block geometry"))
 }
 
 /// Selects at most `count` least-significant bits from `available`.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -9,17 +9,16 @@ use std::collections::TryReserveError;
 use std::fmt;
 use std::mem::MaybeUninit;
 use std::num::NonZeroUsize;
-#[cfg(test)]
-use std::ops::Range;
 use std::ptr::NonNull;
 
 use super::geometry::PoolGeometry;
-#[cfg(test)]
-use super::virtual_memory::VirtualMemoryOperation;
 use super::virtual_memory::{VirtualMemoryError, VirtualRange};
 use super::CarrierCount;
 use crate::runtime::sync::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use crate::runtime::sync::sync::{Arc, Mutex};
+
+#[cfg(test)]
+use {super::virtual_memory::VirtualMemoryOperation, std::ops::Range};
 
 /// Failure to construct, prepare, or claim from one block.
 #[derive(Debug)]
@@ -96,15 +95,15 @@ pub(super) enum TrimBlocked {
     FloorViolation,
     /// A carrier claim won the claim-trim gate.
     Busy,
-    /// A prior trim or failed protection transition still owns the slot.
+    /// A prior trim or failed deactivation still owns the slot.
     CleanupPending,
 }
 
 /// Failed cleanup work that remains safe to retry while the slot is inactive.
 #[derive(Debug)]
 pub(super) enum CleanupRetry {
-    /// Whole-range protection is unknown and must be recovered.
-    ProtectionPending(VirtualMemoryError),
+    /// Whole-range deactivation failed and remains safe to retry.
+    DeactivationPending(VirtualMemoryError),
     /// The range is inaccessible, but backing may remain resident.
     ReclaimPending(VirtualMemoryError),
 }
@@ -119,8 +118,10 @@ enum MappingState {
     },
     /// The complete range is readable and writable.
     Prepared,
-    /// A protection call failed and the complete range must be recovered.
-    ProtectionPending,
+    /// Mapping preparation failed before an incarnation was published.
+    ActivationRecoveryPending,
+    /// Mapping deactivation failed while a draining incarnation remained.
+    DeactivationRecoveryPending,
 }
 
 /// Claim-trim gate state for one block incarnation.
@@ -149,23 +150,49 @@ impl AtomicIncarnationState {
         Self::decode(self.0.load(order))
     }
 
-    /// Stores `value` with `order`.
-    fn store(&self, value: IncarnationState, order: Ordering) {
-        self.0.store(value as u8, order);
+    /// Starts the claim-trim gate transition.
+    fn try_start_trim(&self) -> Result<(), IncarnationState> {
+        self.0
+            .compare_exchange(
+                IncarnationState::Active as u8,
+                IncarnationState::Draining as u8,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .map(|_| ())
+            .map_err(Self::decode)
     }
 
-    /// Compares and exchanges two typed states.
-    fn compare_exchange(
-        &self,
-        current: IncarnationState,
-        new: IncarnationState,
-        success: Ordering,
-        failure: Ordering,
-    ) -> Result<IncarnationState, IncarnationState> {
-        self.0
-            .compare_exchange(current as u8, new as u8, success, failure)
-            .map(Self::decode)
-            .map_err(Self::decode)
+    /// Restores a draining incarnation after trim is abandoned or reversed.
+    fn restore_active(&self) {
+        if self
+            .0
+            .compare_exchange(
+                IncarnationState::Draining as u8,
+                IncarnationState::Active as u8,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_err()
+        {
+            invariant_violation("only a draining incarnation may return to active");
+        }
+    }
+
+    /// Retires a draining incarnation after its mapping becomes inaccessible.
+    fn retire(&self) {
+        if self
+            .0
+            .compare_exchange(
+                IncarnationState::Draining as u8,
+                IncarnationState::Dead as u8,
+                Ordering::Release,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            invariant_violation("only a draining incarnation may retire");
+        }
     }
 
     /// Converts a stored representation into a state.
@@ -368,6 +395,16 @@ mod incarnation_cell {
 use incarnation_cell::{IncarnationCell, IncarnationGuard};
 
 /// Stable block geometry, mapping, and replaceable ownership metadata.
+///
+/// Mapping state and the current incarnation remain separately synchronized
+/// so carrier claims never take `mapping`. Their legal combinations are:
+///
+/// | Mapping state                 | Current incarnation                    |
+/// |-------------------------------|----------------------------------------|
+/// | `Reserved`                    | none                                   |
+/// | `Prepared`                    | `Active` or trim-owned `Draining`      |
+/// | `ActivationRecoveryPending`   | none                                   |
+/// | `DeactivationRecoveryPending` | `Draining`                             |
 pub(super) struct BlockSlot {
     /// Stable slot index.
     id: u32,
@@ -446,14 +483,39 @@ impl BlockSlot {
     pub(super) fn prepare(&self, prepared: &mut CarrierCount) -> Result<(), BlockError> {
         let mut mapping = self.mapping.lock();
         let current = self.current.load();
-        if matches!(*mapping, MappingState::Prepared) {
-            return Err(BlockError::AlreadyPrepared);
-        }
+        let create_fresh = match *mapping {
+            MappingState::Prepared => {
+                let Some(incarnation) = current.as_ref() else {
+                    invariant_violation("prepared mapping has no current incarnation");
+                };
+                if incarnation.state.load(Ordering::Acquire) == IncarnationState::Dead {
+                    invariant_violation("prepared mapping has a dead current incarnation");
+                }
+                return Err(BlockError::AlreadyPrepared);
+            }
+            MappingState::Reserved { .. } | MappingState::ActivationRecoveryPending => {
+                if current.as_ref().is_some() {
+                    invariant_violation("inactive mapping retains a current incarnation");
+                }
+                true
+            }
+            MappingState::DeactivationRecoveryPending => {
+                let Some(incarnation) = current.as_ref() else {
+                    invariant_violation("deactivation recovery lost its current incarnation");
+                };
+                if incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining {
+                    invariant_violation(
+                        "deactivation recovery retained a non-draining incarnation",
+                    );
+                }
+                false
+            }
+        };
 
         let next_prepared = prepared
             .checked_add(self.carrier_count())
             .ok_or(BlockError::PreparedCapacityOverflow)?;
-        let fresh = if current.as_ref().is_none() {
+        let fresh = if create_fresh {
             Some(Arc::new(BlockIncarnation::try_new(
                 self.geometry.bitmap_words(),
             )?))
@@ -461,25 +523,19 @@ impl BlockSlot {
             None
         };
 
-        if let Some(incarnation) = current.as_ref() {
-            if !matches!(*mapping, MappingState::ProtectionPending)
-                || incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining
-            {
-                invariant_violation("only protection recovery may retain a draining incarnation");
-            }
-        }
-
         if let Err(error) = self.range.prepare() {
-            *mapping = MappingState::ProtectionPending;
+            *mapping = if current.as_ref().is_some() {
+                MappingState::DeactivationRecoveryPending
+            } else {
+                MappingState::ActivationRecoveryPending
+            };
             return Err(error.into());
         }
 
         *mapping = MappingState::Prepared;
         *prepared = next_prepared;
         if let Some(incarnation) = current.as_ref() {
-            incarnation
-                .state
-                .store(IncarnationState::Active, Ordering::SeqCst);
+            incarnation.state.restore_active();
         } else if self.current.swap(fresh).is_some() {
             invariant_violation("preparation replaced a current incarnation");
         }
@@ -488,7 +544,8 @@ impl BlockSlot {
 
     /// Prepares a reusable inactive slot with `count` carriers already owned.
     ///
-    /// The caller serializes the pool-wide `prepared` count and admission
+    /// Serialized arena fallback calls this after exhausting active capacity.
+    /// The caller also serializes the pool-wide `prepared` count and admission
     /// floor.
     ///
     /// `None` reports an active slot or cleanup-pending incarnation. Success
@@ -512,8 +569,33 @@ impl BlockSlot {
         }
 
         let mut mapping = slot.mapping.lock();
-        if matches!(*mapping, MappingState::Prepared) || slot.current.load().as_ref().is_some() {
-            return Ok(None);
+        let current = slot.current.load();
+        match *mapping {
+            MappingState::Prepared => {
+                let Some(incarnation) = current.as_ref() else {
+                    invariant_violation("prepared mapping has no current incarnation");
+                };
+                if incarnation.state.load(Ordering::Acquire) == IncarnationState::Dead {
+                    invariant_violation("prepared mapping has a dead current incarnation");
+                }
+                return Ok(None);
+            }
+            MappingState::DeactivationRecoveryPending => {
+                let Some(incarnation) = current.as_ref() else {
+                    invariant_violation("deactivation recovery lost its current incarnation");
+                };
+                if incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining {
+                    invariant_violation(
+                        "deactivation recovery retained a non-draining incarnation",
+                    );
+                }
+                return Ok(None);
+            }
+            MappingState::Reserved { .. } | MappingState::ActivationRecoveryPending => {
+                if current.as_ref().is_some() {
+                    invariant_violation("inactive mapping retains a current incarnation");
+                }
+            }
         }
 
         let next_prepared = prepared
@@ -524,7 +606,7 @@ impl BlockSlot {
         let incarnation = BlockIncarnation::identity(&fresh);
 
         if let Err(error) = slot.range.prepare() {
-            *mapping = MappingState::ProtectionPending;
+            *mapping = MappingState::ActivationRecoveryPending;
             return Err(error.into());
         }
 
@@ -555,7 +637,9 @@ impl BlockSlot {
         match *mapping {
             MappingState::Prepared => {}
             MappingState::Reserved { .. } => return Err(TrimBlocked::NotPrepared),
-            MappingState::ProtectionPending => return Err(TrimBlocked::CleanupPending),
+            MappingState::ActivationRecoveryPending | MappingState::DeactivationRecoveryPending => {
+                return Err(TrimBlocked::CleanupPending)
+            }
         }
 
         let current = slot.current.load();
@@ -577,16 +661,7 @@ impl BlockSlot {
             return Err(TrimBlocked::FloorViolation);
         }
 
-        if incarnation
-            .state
-            .compare_exchange(
-                IncarnationState::Active,
-                IncarnationState::Draining,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            )
-            .is_err()
-        {
+        if incarnation.state.try_start_trim().is_err() {
             return Err(TrimBlocked::CleanupPending);
         }
         loom_seq_cst_fence();
@@ -600,9 +675,7 @@ impl BlockSlot {
                 word.load(Ordering::SeqCst) & valid != 0
             });
         if busy {
-            incarnation
-                .state
-                .store(IncarnationState::Active, Ordering::SeqCst);
+            incarnation.state.restore_active();
             return Err(TrimBlocked::Busy);
         }
 
@@ -629,7 +702,7 @@ impl BlockSlot {
                     invariant_violation("prepared mapping has no current incarnation");
                 };
                 match incarnation.state.load(Ordering::Acquire) {
-                    IncarnationState::Active | IncarnationState::Draining => Ok(()),
+                    IncarnationState::Active | IncarnationState::Draining => return Ok(()),
                     IncarnationState::Dead => {
                         invariant_violation("prepared mapping has a dead current incarnation")
                     }
@@ -641,7 +714,7 @@ impl BlockSlot {
                 if self.current.load().as_ref().is_some() {
                     invariant_violation("inactive mapping has a current incarnation");
                 }
-                Ok(())
+                return Ok(());
             }
             MappingState::Reserved {
                 reclaim_pending: true,
@@ -649,7 +722,7 @@ impl BlockSlot {
                 if self.current.load().as_ref().is_some() {
                     invariant_violation("inactive reclaim has a current incarnation");
                 }
-                match self.range.discard() {
+                return match self.range.discard() {
                     Ok(()) => {
                         *mapping = MappingState::Reserved {
                             reclaim_pending: false,
@@ -657,25 +730,33 @@ impl BlockSlot {
                         Ok(())
                     }
                     Err(error) => Err(CleanupRetry::ReclaimPending(error)),
+                };
+            }
+            MappingState::ActivationRecoveryPending => {
+                if self.current.load().as_ref().is_some() {
+                    invariant_violation("activation recovery retained a current incarnation");
                 }
             }
-            MappingState::ProtectionPending => {
-                if let Some(incarnation) = self.current.load().as_ref() {
-                    if incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining {
-                        invariant_violation(
-                            "protection-pending mapping has a non-draining incarnation",
-                        );
-                    }
-                }
-                if let Err(error) = self.range.deactivate() {
-                    return Err(CleanupRetry::ProtectionPending(error));
-                }
-                *mapping = MappingState::Reserved {
-                    reclaim_pending: false,
+            MappingState::DeactivationRecoveryPending => {
+                let current = self.current.load();
+                let Some(incarnation) = current.as_ref() else {
+                    invariant_violation("deactivation recovery lost its current incarnation");
                 };
-                self.finish_inactive_cleanup(&mut mapping)
+                if incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining {
+                    invariant_violation(
+                        "deactivation recovery retained a non-draining incarnation",
+                    );
+                }
             }
         }
+
+        if let Err(error) = self.range.deactivate() {
+            return Err(CleanupRetry::DeactivationPending(error));
+        }
+        *mapping = MappingState::Reserved {
+            reclaim_pending: false,
+        };
+        self.finish_inactive_cleanup(&mut mapping)
     }
 
     /// Retires a draining incarnation after the range becomes inaccessible.
@@ -688,12 +769,7 @@ impl BlockSlot {
         *mapping = MappingState::Reserved { reclaim_pending };
 
         if let Some(incarnation) = self.current.load().as_ref() {
-            if incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining {
-                invariant_violation("cleanup found a non-draining current incarnation");
-            }
-            incarnation
-                .state
-                .store(IncarnationState::Dead, Ordering::Release);
+            incarnation.state.retire();
             let removed = self
                 .current
                 .swap(None)
@@ -713,6 +789,7 @@ impl BlockSlot {
     ///
     /// Returns `None` when no incarnation is published, no bit is free, or
     /// trim wins the state gate. Zero returns [`BlockError::InvalidClaimCount`].
+    #[cfg(test)]
     pub(super) fn try_claim(
         slot: &Arc<Self>,
         count: CarrierCount,
@@ -942,8 +1019,8 @@ impl TrimCleanup {
         }
 
         if let Err(error) = self.slot.range.deactivate() {
-            *mapping = MappingState::ProtectionPending;
-            return Err(CleanupRetry::ProtectionPending(error));
+            *mapping = MappingState::DeactivationRecoveryPending;
+            return Err(CleanupRetry::DeactivationPending(error));
         }
 
         *mapping = MappingState::Reserved {
@@ -1010,6 +1087,7 @@ impl BlockClaimAttempt {
     /// fetch_or returns       0b0110  // occupancy before this fetch_or
     /// this claim wins        0b0001  // candidate & !previous
     /// ```
+    #[cfg(test)]
     fn take(&mut self, count: usize) -> usize {
         self.take_words(0, self.slot.geometry.bitmap_words(), count)
             .0
@@ -1362,6 +1440,29 @@ mod tests {
     }
 
     #[test]
+    fn incarnation_transitions_enforce_their_predecessors() {
+        let state = AtomicIncarnationState::new(IncarnationState::Active);
+
+        assert_eq!(state.try_start_trim(), Ok(()));
+        assert_eq!(state.load(Ordering::Acquire), IncarnationState::Draining);
+        assert_eq!(state.try_start_trim(), Err(IncarnationState::Draining));
+        state.restore_active();
+        assert_eq!(state.load(Ordering::Acquire), IncarnationState::Active);
+
+        let invalid_retire = catch_unwind(AssertUnwindSafe(|| state.retire()));
+        assert!(invalid_retire.is_err());
+        assert_eq!(state.load(Ordering::Acquire), IncarnationState::Active);
+
+        state.try_start_trim().unwrap();
+        state.retire();
+        assert_eq!(state.load(Ordering::Acquire), IncarnationState::Dead);
+
+        let invalid_restore = catch_unwind(AssertUnwindSafe(|| state.restore_active()));
+        assert!(invalid_restore.is_err());
+        assert_eq!(state.load(Ordering::Acquire), IncarnationState::Dead);
+    }
+
+    #[test]
     fn preparation_publishes_claimable_capacity() {
         let (slot, prepared) = prepared_slot(3);
 
@@ -1417,6 +1518,44 @@ mod tests {
     }
 
     #[test]
+    fn preclaimed_activation_crosses_bitmap_words_without_padding() {
+        let slot = Arc::new(BlockSlot::new(7, geometry(70)).unwrap());
+        let mut prepared = CarrierCount::ZERO;
+
+        let preclaimed =
+            BlockSlot::prepare_and_claim_if_inactive(&slot, &mut prepared, CarrierCount::new(67))
+                .unwrap()
+                .expect("fresh slot should activate")
+                .into_carriers()
+                .unwrap();
+
+        assert_eq!(prepared, CarrierCount::new(70));
+        assert_eq!(preclaimed.len(), 67);
+        assert_eq!(preclaimed.first().unwrap().carrier_index(), 0);
+        assert_eq!(preclaimed.last().unwrap().carrier_index(), 66);
+
+        let remaining = BlockSlot::try_claim(&slot, CarrierCount::new(70))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+        assert_eq!(
+            remaining
+                .iter()
+                .map(CarrierAllocation::carrier_index)
+                .collect::<Vec<_>>(),
+            vec![67, 68, 69]
+        );
+        assert!(BlockSlot::try_claim(&slot, CarrierCount::new(1))
+            .unwrap()
+            .is_none());
+
+        drop(preclaimed);
+        drop(remaining);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
     fn failed_preclaimed_activation_publishes_no_ownership() {
         let slot = Arc::new(BlockSlot::new(7, geometry(2)).unwrap());
         let mut prepared = CarrierCount::ZERO;
@@ -1440,7 +1579,7 @@ mod tests {
         assert_eq!(prepared, CarrierCount::ZERO);
         assert_eq!(slot.live_carriers(), 0);
         assert!(current_identity(&slot).is_none());
-        assert_mapping(&slot, MappingState::ProtectionPending);
+        assert_mapping(&slot, MappingState::ActivationRecoveryPending);
     }
 
     #[test]
@@ -1479,7 +1618,7 @@ mod tests {
         let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
         assert!(matches!(
             cleanup.finish(),
-            Err(CleanupRetry::ProtectionPending(_))
+            Err(CleanupRetry::DeactivationPending(_))
         ));
 
         assert!(BlockSlot::prepare_and_claim_if_inactive(
@@ -1524,7 +1663,7 @@ mod tests {
                 if error.operation() == VirtualMemoryOperation::Prepare
         ));
         assert_eq!(prepared, CarrierCount::ZERO);
-        assert_mapping(&slot, MappingState::ProtectionPending);
+        assert_mapping(&slot, MappingState::ActivationRecoveryPending);
         assert!(current_identity(&slot).is_none());
         assert!(BlockSlot::try_claim(&slot, CarrierCount::new(1))
             .unwrap()
@@ -1543,7 +1682,7 @@ mod tests {
         slot.range
             .inject_failure_once(VirtualMemoryOperation::Prepare);
         assert!(slot.prepare(&mut prepared).is_err());
-        assert_mapping(&slot, MappingState::ProtectionPending);
+        assert_mapping(&slot, MappingState::ActivationRecoveryPending);
         assert!(current_identity(&slot).is_none());
 
         slot.retry_cleanup().unwrap();
@@ -1877,11 +2016,11 @@ mod tests {
 
         assert!(matches!(
             error,
-            CleanupRetry::ProtectionPending(ref error)
+            CleanupRetry::DeactivationPending(ref error)
                 if error.operation() == VirtualMemoryOperation::Deactivate
         ));
         assert_eq!(prepared, CarrierCount::ZERO);
-        assert_mapping(&slot, MappingState::ProtectionPending);
+        assert_mapping(&slot, MappingState::DeactivationRecoveryPending);
         assert_eq!(current_identity(&slot), Some(original_identity));
         assert!(BlockSlot::try_claim(&slot, CarrierCount::new(1))
             .unwrap()
@@ -1909,7 +2048,7 @@ mod tests {
         let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
         assert!(matches!(
             cleanup.finish(),
-            Err(CleanupRetry::ProtectionPending(_))
+            Err(CleanupRetry::DeactivationPending(_))
         ));
 
         slot.retry_cleanup().unwrap();
@@ -2004,7 +2143,7 @@ mod tests {
         drop(cleanup);
 
         assert_eq!(prepared, CarrierCount::ZERO);
-        assert_mapping(&slot, MappingState::ProtectionPending);
+        assert_mapping(&slot, MappingState::DeactivationRecoveryPending);
         assert!(current_identity(&slot).is_some());
         assert!(BlockSlot::try_claim(&slot, CarrierCount::new(1))
             .unwrap()
@@ -2071,6 +2210,21 @@ mod tests {
         assert_eq!(take_lowest(0b1011_0100, 3), 0b0011_0100);
         assert_eq!(take_lowest(0b1011_0100, usize::MAX), 0b1011_0100);
         assert_eq!(take_lowest(u64::MAX, usize::MAX), u64::MAX);
+    }
+
+    #[test]
+    fn repeated_wins_in_one_word_share_one_record() {
+        let mut won = Vec::new();
+
+        record_won(&mut won, 1, 0b0001);
+        record_won(&mut won, 1, 0b0100);
+        record_won(&mut won, 2, 0b0010);
+
+        assert_eq!(won.len(), 2);
+        assert_eq!(won[0].word_index, 1);
+        assert_eq!(won[0].mask, 0b0101);
+        assert_eq!(won[1].word_index, 2);
+        assert_eq!(won[1].mask, 0b0010);
     }
 
     /// Covers every occupancy pattern in the low bytes plus full-width cases.
@@ -2237,7 +2391,7 @@ mod loom_tests {
             let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
             assert!(matches!(
                 cleanup.finish(),
-                Err(CleanupRetry::ProtectionPending(_))
+                Err(CleanupRetry::DeactivationPending(_))
             ));
             assert_eq!(attempt.take(1), 1);
 
@@ -2451,6 +2605,32 @@ mod loom_tests {
             assert_eq!(slot.live_carriers(), 1);
             drop(first);
             drop(second);
+            assert_eq!(slot.live_carriers(), 0);
+        });
+    }
+
+    #[test]
+    fn concurrent_returns_clear_disjoint_bits_in_one_word() {
+        loom::model(|| {
+            let geometry = PoolGeometry::new(4096, 8192, 4096).unwrap();
+            let slot = Arc::new(BlockSlot::new(0, geometry).unwrap());
+            let mut prepared = CarrierCount::ZERO;
+            slot.prepare(&mut prepared).unwrap();
+            let carriers = BlockSlot::try_claim(&slot, CarrierCount::new(2))
+                .unwrap()
+                .unwrap()
+                .into_carriers()
+                .unwrap();
+            let mut carriers = carriers.into_iter();
+            let first = carriers.next().unwrap();
+            let second = carriers.next().unwrap();
+            assert!(carriers.next().is_none());
+
+            let first = thread::spawn(move || drop(first));
+            let second = thread::spawn(move || drop(second));
+            first.join().unwrap();
+            second.join().unwrap();
+
             assert_eq!(slot.live_carriers(), 0);
         });
     }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -9,9 +9,12 @@ use std::collections::TryReserveError;
 use std::fmt;
 use std::mem::MaybeUninit;
 use std::num::NonZeroUsize;
+use std::ops::Range;
 use std::ptr::NonNull;
 
 use super::geometry::PoolGeometry;
+#[cfg(test)]
+use super::virtual_memory::VirtualMemoryOperation;
 use super::virtual_memory::{VirtualMemoryError, VirtualRange};
 use super::CarrierCount;
 use crate::runtime::sync::sync::atomic::{AtomicU64, AtomicU8, Ordering};
@@ -30,6 +33,13 @@ pub(super) enum BlockError {
     PreparedCapacityOverflow,
     /// A claim requested no carriers.
     InvalidClaimCount,
+    /// A claim exceeds one block's carrier capacity.
+    ClaimExceedsBlock {
+        /// Requested carriers.
+        requested: usize,
+        /// Carriers in the block.
+        capacity: usize,
+    },
 }
 
 impl fmt::Display for BlockError {
@@ -40,6 +50,13 @@ impl fmt::Display for BlockError {
             Self::AlreadyPrepared => f.write_str("block already has a prepared incarnation"),
             Self::PreparedCapacityOverflow => f.write_str("prepared carrier count would overflow"),
             Self::InvalidClaimCount => f.write_str("a carrier claim must be nonzero"),
+            Self::ClaimExceedsBlock {
+                requested,
+                capacity,
+            } => write!(
+                f,
+                "carrier claim {requested} exceeds block capacity {capacity}"
+            ),
         }
     }
 }
@@ -49,9 +66,10 @@ impl std::error::Error for BlockError {
         match self {
             Self::VirtualMemory(error) => Some(error),
             Self::Allocation(error) => Some(error),
-            Self::AlreadyPrepared | Self::PreparedCapacityOverflow | Self::InvalidClaimCount => {
-                None
-            }
+            Self::AlreadyPrepared
+            | Self::PreparedCapacityOverflow
+            | Self::InvalidClaimCount
+            | Self::ClaimExceedsBlock { .. } => None,
         }
     }
 }
@@ -210,6 +228,37 @@ impl BlockIncarnation {
         })
     }
 
+    /// Allocates an active incarnation with `count` low carriers owned.
+    fn try_new_preclaimed(
+        geometry: PoolGeometry,
+        count: CarrierCount,
+    ) -> Result<(Self, Vec<WonWord>), TryReserveError> {
+        let incarnation = Self::try_new(geometry.bitmap_words())?;
+        let mut won = Vec::new();
+        won.try_reserve_exact(geometry.bitmap_words())?;
+
+        let mut remaining = count.get();
+        for (word_index, word) in incarnation.in_use.iter().enumerate() {
+            if remaining == 0 {
+                break;
+            }
+            let valid = if word_index + 1 == geometry.bitmap_words() {
+                geometry.final_word_mask()
+            } else {
+                u64::MAX
+            };
+            let mask = take_lowest(valid, remaining);
+            let taken = mask.count_ones() as usize;
+            word.store(mask, Ordering::Relaxed);
+            won.push(WonWord { word_index, mask });
+            remaining -= taken;
+        }
+        if remaining != 0 {
+            invariant_violation("preclaim exceeds valid block geometry");
+        }
+        Ok((incarnation, won))
+    }
+
     /// Returns an opaque identity for diagnostic comparisons.
     fn identity(this: &Arc<Self>) -> IncarnationIdentity {
         let address = Arc::as_ptr(this).addr();
@@ -361,6 +410,35 @@ impl BlockSlot {
         self.geometry.carriers_per_block()
     }
 
+    /// Returns this slot's stable identifier.
+    pub(super) fn id(&self) -> u32 {
+        self.id
+    }
+
+    /// Returns the reservation base for integer comparison.
+    pub(super) fn base_address(&self) -> usize {
+        self.range.base_address()
+    }
+
+    /// Returns the stable virtual reservation length.
+    pub(super) fn reserved_len(&self) -> usize {
+        self.range.len()
+    }
+
+    /// Returns the reserved half-open address range.
+    ///
+    /// The integer range grants no access to the backing memory. `None`
+    /// reports address arithmetic overflow.
+    pub(super) fn address_range(&self) -> Option<Range<usize>> {
+        let start = self.base_address();
+        start.checked_add(self.reserved_len()).map(|end| start..end)
+    }
+
+    /// Returns the number of ownership bitmap words.
+    pub(super) fn bitmap_words(&self) -> usize {
+        self.geometry.bitmap_words()
+    }
+
     /// Prepares the range and makes one incarnation active.
     ///
     /// The caller holds the admission lock that protects the pool-wide
@@ -408,6 +486,60 @@ impl BlockSlot {
             invariant_violation("preparation replaced a current incarnation");
         }
         Ok(())
+    }
+
+    /// Prepares a reusable inactive slot with `count` carriers already owned.
+    ///
+    /// The caller serializes the pool-wide `prepared` count and admission
+    /// floor.
+    ///
+    /// `None` reports an active slot or cleanup-pending incarnation. Success
+    /// increments `prepared` before publishing `Active` and returns ownership
+    /// of exactly `count` carrier bits. Failure publishes no new incarnation
+    /// and leaves `prepared` unchanged. The private incarnation owns its bits
+    /// before publication, so no claim-trim gate is required.
+    pub(super) fn prepare_and_claim_if_inactive(
+        slot: &Arc<Self>,
+        prepared: &mut CarrierCount,
+        count: CarrierCount,
+    ) -> Result<Option<ProvisionalBits>, BlockError> {
+        if count == CarrierCount::ZERO {
+            return Err(BlockError::InvalidClaimCount);
+        }
+        if count > slot.carrier_count() {
+            return Err(BlockError::ClaimExceedsBlock {
+                requested: count.get(),
+                capacity: slot.carrier_count().get(),
+            });
+        }
+
+        let mut mapping = slot.mapping.lock();
+        if matches!(*mapping, MappingState::Prepared) || slot.current.load().as_ref().is_some() {
+            return Ok(None);
+        }
+
+        let next_prepared = prepared
+            .checked_add(slot.carrier_count())
+            .ok_or(BlockError::PreparedCapacityOverflow)?;
+        let (fresh, won) = BlockIncarnation::try_new_preclaimed(slot.geometry, count)?;
+        let fresh = Arc::new(fresh);
+        let incarnation = BlockIncarnation::identity(&fresh);
+
+        if let Err(error) = slot.range.prepare() {
+            *mapping = MappingState::ProtectionPending;
+            return Err(error.into());
+        }
+
+        *mapping = MappingState::Prepared;
+        *prepared = next_prepared;
+        if slot.current.swap(Some(fresh)).is_some() {
+            invariant_violation("preclaimed activation replaced a current incarnation");
+        }
+        Ok(Some(ProvisionalBits {
+            slot: Arc::clone(slot),
+            incarnation,
+            won,
+        }))
     }
 
     /// Confirms that this block may be removed from prepared capacity.
@@ -591,14 +723,65 @@ impl BlockSlot {
         slot: &Arc<Self>,
         count: CarrierCount,
     ) -> Result<Option<ProvisionalBits>, BlockError> {
+        Ok(Self::try_claim_words(slot, 0, slot.bitmap_words(), count)?.into_provisional())
+    }
+
+    /// Exhaustively claims from the current active incarnation.
+    ///
+    /// Unlike the bounded optimistic path, this retries a bitmap word after a
+    /// competing claimant takes selected candidates. It stops only after the
+    /// request is complete or atomic observations find every remaining word
+    /// full.
+    pub(super) fn try_claim_exhaustive(
+        slot: &Arc<Self>,
+        count: CarrierCount,
+    ) -> Result<Option<ProvisionalBits>, BlockError> {
         if count == CarrierCount::ZERO {
             return Err(BlockError::InvalidClaimCount);
         }
+
         let Some(mut attempt) = BlockClaimAttempt::begin(slot)? else {
             return Ok(None);
         };
-        attempt.take(count.get());
+        attempt.take_exhaustive(count.get());
         Ok(attempt.finish())
+    }
+
+    /// Claims from a bounded contiguous bitmap-word window.
+    ///
+    /// `start_word` beyond the bitmap and a zero `word_limit` inspect no
+    /// words. `inspected_words` counts candidate positions even when the slot
+    /// has no active incarnation.
+    pub(super) fn try_claim_words(
+        slot: &Arc<Self>,
+        start_word: usize,
+        word_limit: usize,
+        count: CarrierCount,
+    ) -> Result<BlockClaim, BlockError> {
+        if count == CarrierCount::ZERO {
+            return Err(BlockError::InvalidClaimCount);
+        }
+
+        let inspected_words = slot
+            .bitmap_words()
+            .saturating_sub(start_word)
+            .min(word_limit);
+        if inspected_words == 0 {
+            return Ok(BlockClaim::empty());
+        }
+
+        let Some(mut attempt) = BlockClaimAttempt::begin_with_capacity(slot, inspected_words)?
+        else {
+            return Ok(BlockClaim {
+                provisional: None,
+                inspected_words,
+            });
+        };
+        let (_, inspected_words) = attempt.take_words(start_word, inspected_words, count.get());
+        Ok(BlockClaim {
+            provisional: attempt.finish(),
+            inspected_words,
+        })
     }
 
     /// Returns a set of bits from a gate-passed owner.
@@ -640,6 +823,33 @@ impl BlockSlot {
         );
     }
 
+    /// Returns `true` when the current active incarnation appears all-free.
+    ///
+    /// This is only a trim-selection hint. A concurrent claim may change the
+    /// result immediately; [`BlockSlot::start_trim`] performs the authoritative
+    /// lifecycle, bitmap, and capacity checks.
+    pub(super) fn appears_free(&self) -> bool {
+        let current = self.current.load();
+        let Some(incarnation) = current.as_ref() else {
+            return false;
+        };
+        if incarnation.state.load(Ordering::Acquire) != IncarnationState::Active {
+            return false;
+        }
+        incarnation
+            .in_use
+            .iter()
+            .enumerate()
+            .all(|(word_index, word)| {
+                let valid = if word_index + 1 == self.geometry.bitmap_words() {
+                    self.geometry.final_word_mask()
+                } else {
+                    u64::MAX
+                };
+                word.load(Ordering::Acquire) & valid == 0
+            })
+    }
+
     /// Counts set valid bits in the current incarnation.
     #[cfg(test)]
     fn live_carriers(&self) -> usize {
@@ -662,6 +872,40 @@ impl BlockSlot {
                     .sum()
             })
             .unwrap_or(0)
+    }
+
+    /// Injects one virtual-memory transition failure.
+    #[cfg(test)]
+    pub(super) fn inject_failure_once(&self, operation: VirtualMemoryOperation) {
+        self.range.inject_failure_once(operation);
+    }
+}
+
+/// Result of one bounded block claim.
+pub(super) struct BlockClaim {
+    /// Gate-passed bits won from the inspected window.
+    provisional: Option<ProvisionalBits>,
+    /// Candidate bitmap positions charged to the scan budget.
+    inspected_words: usize,
+}
+
+impl BlockClaim {
+    /// Returns an empty result that inspected no words.
+    fn empty() -> Self {
+        Self {
+            provisional: None,
+            inspected_words: 0,
+        }
+    }
+
+    /// Returns the number of bitmap positions inspected.
+    pub(super) fn inspected_words(&self) -> usize {
+        self.inspected_words
+    }
+
+    /// Consumes the result and returns any won bits.
+    pub(super) fn into_provisional(self) -> Option<ProvisionalBits> {
+        self.provisional
     }
 }
 
@@ -747,13 +991,21 @@ impl BlockClaimAttempt {
     ///
     /// Returns `None` when the slot has no published incarnation.
     fn begin(slot: &Arc<BlockSlot>) -> Result<Option<Self>, TryReserveError> {
+        Self::begin_with_capacity(slot, slot.geometry.bitmap_words())
+    }
+
+    /// Starts a claim with storage for at most `won_capacity` bitmap words.
+    fn begin_with_capacity(
+        slot: &Arc<BlockSlot>,
+        won_capacity: usize,
+    ) -> Result<Option<Self>, TryReserveError> {
         let incarnation = slot.current.load();
         if incarnation.as_ref().is_none() {
             return Ok(None);
         }
 
         let mut won = Vec::new();
-        won.try_reserve_exact(slot.geometry.bitmap_words())?;
+        won.try_reserve_exact(won_capacity)?;
         Ok(Some(Self {
             slot: Arc::clone(slot),
             incarnation,
@@ -772,17 +1024,37 @@ impl BlockClaimAttempt {
     /// fetch_or returns       0b0110  // occupancy before this fetch_or
     /// this claim wins        0b0001  // candidate & !previous
     /// ```
-    fn take(&mut self, mut count: usize) -> usize {
+    fn take(&mut self, count: usize) -> usize {
+        self.take_words(0, self.slot.geometry.bitmap_words(), count)
+            .0
+    }
+
+    /// Claims from `word_count` words beginning at `start_word`.
+    ///
+    /// Returns carriers won and bitmap words inspected.
+    fn take_words(
+        &mut self,
+        start_word: usize,
+        word_count: usize,
+        mut count: usize,
+    ) -> (usize, usize) {
         let incarnation = self
             .incarnation
             .as_ref()
             .expect("a claim attempt protects one incarnation");
         let mut taken = 0;
+        let mut inspected = 0;
+        let end_word = start_word
+            .saturating_add(word_count)
+            .min(incarnation.in_use.len());
 
-        for (word_index, word) in incarnation.in_use.iter().enumerate() {
+        let start_word = start_word.min(end_word);
+        for word_index in start_word..end_word {
             if count == 0 {
                 break;
             }
+            inspected += 1;
+            let word = &incarnation.in_use[word_index];
             let valid = if word_index + 1 == self.slot.geometry.bitmap_words() {
                 self.slot.geometry.final_word_mask()
             } else {
@@ -797,12 +1069,48 @@ impl BlockClaimAttempt {
             let won = candidate & !previous;
             if won != 0 {
                 let won_count = won.count_ones() as usize;
-                self.won.push(WonWord {
-                    word_index,
-                    mask: won,
-                });
+                record_won(&mut self.won, word_index, won);
                 count -= won_count;
                 taken += won_count;
+            }
+        }
+        (taken, inspected)
+    }
+
+    /// Claims until each word is observed full or `count` carriers are won.
+    fn take_exhaustive(&mut self, mut count: usize) -> usize {
+        let incarnation = self
+            .incarnation
+            .as_ref()
+            .expect("a claim attempt protects one incarnation");
+        let mut taken = 0;
+
+        for (word_index, word) in incarnation.in_use.iter().enumerate() {
+            let mut observed = word.load(Ordering::Relaxed);
+            while count != 0 {
+                let valid = if word_index + 1 == self.slot.geometry.bitmap_words() {
+                    self.slot.geometry.final_word_mask()
+                } else {
+                    u64::MAX
+                };
+                let candidate = take_lowest(!observed & valid, count);
+                if candidate == 0 {
+                    break;
+                }
+                let previous = word.fetch_or(candidate, Ordering::SeqCst);
+                // Each collision enters the local occupancy view. The loop
+                // therefore retries at most once per valid carrier bit.
+                observed = previous | candidate;
+                let won = candidate & !previous;
+                if won != 0 {
+                    let won_count = won.count_ones() as usize;
+                    record_won(&mut self.won, word_index, won);
+                    count -= won_count;
+                    taken += won_count;
+                }
+            }
+            if count == 0 {
+                break;
             }
         }
         taken
@@ -923,6 +1231,16 @@ pub(super) struct CarrierAllocation {
 }
 
 impl CarrierAllocation {
+    /// Returns the stable block-slot identifier.
+    pub(super) fn slot_id(&self) -> u32 {
+        self.id.slot
+    }
+
+    /// Returns the carrier index within its block.
+    pub(super) fn carrier_index(&self) -> u32 {
+        self.id.index
+    }
+
     /// Returns the carrier capacity in bytes.
     pub(super) fn capacity(&self) -> usize {
         self.slot.geometry.carrier_size()
@@ -979,17 +1297,27 @@ fn clear_owned_bits(word: &AtomicU64, mask: u64) {
 }
 
 /// Selects at most `count` least-significant bits from `available`.
-fn take_lowest(mut available: u64, count: usize) -> u64 {
-    let mut selected = 0;
+///
+/// The loop executes at most `min(count, available.count_ones())` times and
+/// never more than 64 times.
+fn take_lowest(available: u64, count: usize) -> u64 {
+    let mut remaining = available;
     for _ in 0..count.min(u64::BITS as usize) {
-        if available == 0 {
+        if remaining == 0 {
             break;
         }
-        let bit = 1u64 << available.trailing_zeros();
-        selected |= bit;
-        available &= !bit;
+        remaining &= remaining - 1;
     }
-    selected
+    available ^ remaining
+}
+
+/// Records disjoint bits while retaining at most one entry per word.
+fn record_won(won: &mut Vec<WonWord>, word_index: usize, mask: u64) {
+    if let Some(word) = won.last_mut().filter(|word| word.word_index == word_index) {
+        word.mask |= mask;
+    } else {
+        won.push(WonWord { word_index, mask });
+    }
 }
 
 /// Supplies the store-load edge missing from Loom's atomic model.
@@ -1061,6 +1389,128 @@ mod tests {
 
         drop(claimed);
         assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn preclaimed_activation_publishes_owned_bits() {
+        let slot = Arc::new(BlockSlot::new(7, geometry(4)).unwrap());
+        let mut prepared = CarrierCount::ZERO;
+
+        let preclaimed =
+            BlockSlot::prepare_and_claim_if_inactive(&slot, &mut prepared, CarrierCount::new(2))
+                .unwrap()
+                .expect("fresh slot should activate");
+
+        assert_eq!(prepared, CarrierCount::new(4));
+        assert_eq!(preclaimed.len(), CarrierCount::new(2));
+        assert_eq!(slot.live_carriers(), 2);
+        let preclaimed = preclaimed.into_carriers().unwrap();
+        assert_eq!(
+            preclaimed
+                .iter()
+                .map(|carrier| carrier.id.index)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+
+        let remaining = BlockSlot::try_claim(&slot, CarrierCount::new(4))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+        assert_eq!(
+            remaining
+                .iter()
+                .map(|carrier| carrier.id.index)
+                .collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+
+        drop(preclaimed);
+        drop(remaining);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn failed_preclaimed_activation_publishes_no_ownership() {
+        let slot = Arc::new(BlockSlot::new(7, geometry(2)).unwrap());
+        let mut prepared = CarrierCount::ZERO;
+        slot.range
+            .inject_failure_once(VirtualMemoryOperation::Prepare);
+
+        let error = match BlockSlot::prepare_and_claim_if_inactive(
+            &slot,
+            &mut prepared,
+            CarrierCount::new(1),
+        ) {
+            Ok(_) => panic!("injected preparation failure must reject activation"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            BlockError::VirtualMemory(ref error)
+                if error.operation() == VirtualMemoryOperation::Prepare
+        ));
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert_eq!(slot.live_carriers(), 0);
+        assert!(current_identity(&slot).is_none());
+        assert_mapping(&slot, MappingState::ProtectionPending);
+    }
+
+    #[test]
+    fn preclaimed_activation_rejects_invalid_counts_without_mutation() {
+        let slot = Arc::new(BlockSlot::new(7, geometry(2)).unwrap());
+        let mut prepared = CarrierCount::ZERO;
+
+        assert!(matches!(
+            BlockSlot::prepare_and_claim_if_inactive(&slot, &mut prepared, CarrierCount::ZERO),
+            Err(BlockError::InvalidClaimCount)
+        ));
+        assert!(matches!(
+            BlockSlot::prepare_and_claim_if_inactive(&slot, &mut prepared, CarrierCount::new(3)),
+            Err(BlockError::ClaimExceedsBlock {
+                requested: 3,
+                capacity: 2
+            })
+        ));
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert_eq!(slot.live_carriers(), 0);
+        assert!(current_identity(&slot).is_none());
+        assert_mapping(
+            &slot,
+            MappingState::Reserved {
+                reclaim_pending: false,
+            },
+        );
+    }
+
+    #[test]
+    fn preclaimed_activation_does_not_replace_retained_metadata() {
+        let (slot, mut prepared) = prepared_slot(1);
+        let identity = current_identity(&slot).unwrap();
+        slot.range
+            .inject_failure_once(VirtualMemoryOperation::Deactivate);
+        let cleanup = BlockSlot::start_trim(&slot, &mut prepared, CarrierCount::ZERO).unwrap();
+        assert!(matches!(
+            cleanup.finish(),
+            Err(CleanupRetry::ProtectionPending(_))
+        ));
+
+        assert!(BlockSlot::prepare_and_claim_if_inactive(
+            &slot,
+            &mut prepared,
+            CarrierCount::new(1)
+        )
+        .unwrap()
+        .is_none());
+        assert_eq!(prepared, CarrierCount::ZERO);
+        assert_eq!(current_identity(&slot), Some(identity));
+        assert_eq!(slot.live_carriers(), 0);
+
+        slot.prepare(&mut prepared).unwrap();
+        assert_eq!(prepared, CarrierCount::new(1));
+        assert_eq!(current_identity(&slot), Some(identity));
     }
 
     #[test]
@@ -1164,6 +1614,68 @@ mod tests {
         assert_eq!(unsafe { carrier.ptr().as_ptr().read().assume_init() }, 0x5a);
 
         drop(carrier);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn bounded_claim_inspects_only_its_word_window() {
+        let (slot, _) = prepared_slot(130);
+
+        let claim = BlockSlot::try_claim_words(&slot, 1, 1, CarrierCount::new(2)).unwrap();
+        assert_eq!(claim.inspected_words(), 1);
+        let carriers = claim.into_provisional().unwrap().into_carriers().unwrap();
+        assert_eq!(
+            carriers
+                .iter()
+                .map(|carrier| carrier.id.index)
+                .collect::<Vec<_>>(),
+            vec![64, 65]
+        );
+        drop(carriers);
+
+        let final_word =
+            BlockSlot::try_claim_words(&slot, 2, usize::MAX, CarrierCount::new(8)).unwrap();
+        assert_eq!(final_word.inspected_words(), 1);
+        let carriers = final_word
+            .into_provisional()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+        assert_eq!(
+            carriers
+                .iter()
+                .map(|carrier| carrier.id.index)
+                .collect::<Vec<_>>(),
+            vec![128, 129]
+        );
+        drop(carriers);
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn empty_claim_windows_do_not_mutate_ownership() {
+        let (slot, _) = prepared_slot(65);
+
+        let zero_budget = BlockSlot::try_claim_words(&slot, 0, 0, CarrierCount::new(1)).unwrap();
+        assert_eq!(zero_budget.inspected_words(), 0);
+        assert!(zero_budget.into_provisional().is_none());
+
+        let past_end =
+            BlockSlot::try_claim_words(&slot, slot.bitmap_words(), 1, CarrierCount::new(1))
+                .unwrap();
+        assert_eq!(past_end.inspected_words(), 0);
+        assert!(past_end.into_provisional().is_none());
+        assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[test]
+    fn inactive_window_consumes_scan_positions_without_claiming() {
+        let slot = Arc::new(BlockSlot::new(7, geometry(65)).unwrap());
+
+        let claim = BlockSlot::try_claim_words(&slot, 0, usize::MAX, CarrierCount::new(1)).unwrap();
+
+        assert_eq!(claim.inspected_words(), 2);
+        assert!(claim.into_provisional().is_none());
         assert_eq!(slot.live_carriers(), 0);
     }
 
@@ -1561,6 +2073,11 @@ mod tests {
         assert_eq!(slot.live_carriers(), 0);
     }
 
+    /// Covers selection against a fixed occupancy pattern.
+    ///
+    /// A set bit is a free carrier, so `0b1011_0100` offers four at positions
+    /// 2, 4, 5, and 7. Selection consumes them upward from position 2, and a
+    /// request larger than the free count stops at every free bit.
     #[test]
     fn selects_only_the_requested_low_bits() {
         assert_eq!(take_lowest(0, 8), 0);
@@ -1569,6 +2086,71 @@ mod tests {
         assert_eq!(take_lowest(0b1011_0100, 3), 0b0011_0100);
         assert_eq!(take_lowest(0b1011_0100, usize::MAX), 0b1011_0100);
         assert_eq!(take_lowest(u64::MAX, usize::MAX), u64::MAX);
+    }
+
+    /// Covers every occupancy pattern in the low bytes plus full-width cases.
+    ///
+    /// Selection must satisfy three properties: it selects only free bits, it
+    /// selects the requested count or every free bit when fewer are available,
+    /// and the bits it selects are the lowest free ones. The sweep covers bit
+    /// arrangements; the listed patterns cover positions and counts a 16-bit
+    /// sweep cannot reach.
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "exhaustive pure-integer sweep adds no Miri-specific coverage"
+    )]
+    fn take_lowest_returns_exact_lowest_subset() {
+        fn assert_lowest_subset(available: u64, count: usize) {
+            let selected = take_lowest(available, count);
+            assert_eq!(
+                selected & !available,
+                0,
+                "selected unavailable bits from {available:#018x} with count {count}"
+            );
+            // A request larger than the free count saturates.
+            assert_eq!(
+                selected.count_ones() as usize,
+                count.min(available.count_ones() as usize),
+                "selected the wrong number of bits from {available:#018x} with count {count}"
+            );
+
+            // `leading_zeros` returns 64 for zero, which underflows the
+            // position arithmetic below.
+            let remaining = available & !selected;
+            if selected != 0 && remaining != 0 {
+                // A correctly sized subset is lowest iff no remaining bit is
+                // below a selected bit.
+                let highest_selected = u64::BITS - 1 - selected.leading_zeros();
+                let lowest_remaining = remaining.trailing_zeros();
+                assert!(
+                    highest_selected < lowest_remaining,
+                    "selected {selected:#018x} from {available:#018x} with count {count}"
+                );
+            }
+        }
+
+        for available in 0..=u16::MAX as u64 {
+            for count in 0..=(u16::BITS as usize + 1) {
+                assert_lowest_subset(available, count);
+            }
+        }
+
+        // The top bit alone, the two most distant bits, a high bit above a
+        // sparse low cluster, both alternating phases, and a fully free word.
+        // Counts run past `u64::BITS` to cover the loop bound.
+        for available in [
+            1 << 63,
+            (1 << 63) | 1,
+            0x8000_0000_0000_00a5,
+            0xaaaa_aaaa_aaaa_aaaa,
+            0x5555_5555_5555_5555,
+            u64::MAX,
+        ] {
+            for count in 0..=(u64::BITS as usize + 1) {
+                assert_lowest_subset(available, count);
+            }
+        }
     }
 
     #[test]
@@ -1768,6 +2350,96 @@ mod loom_tests {
                     reclaim_pending: false
                 }
             );
+        });
+    }
+
+    #[test]
+    fn preclaimed_activation_publishes_owned_bits_before_fast_claim() {
+        loom::model(|| {
+            let geometry = PoolGeometry::new(4096, 8192, 4096).unwrap();
+            let slot = Arc::new(BlockSlot::new(0, geometry).unwrap());
+
+            let prepare_slot = Arc::clone(&slot);
+            let prepare = thread::spawn(move || {
+                let mut prepared = CarrierCount::ZERO;
+                let carriers = BlockSlot::prepare_and_claim_if_inactive(
+                    &prepare_slot,
+                    &mut prepared,
+                    CarrierCount::new(1),
+                )
+                .unwrap()
+                .expect("fresh slot should activate")
+                .into_carriers()
+                .unwrap();
+                (prepared, carriers)
+            });
+
+            let claim_slot = Arc::clone(&slot);
+            let claim = thread::spawn(move || {
+                BlockSlot::try_claim(&claim_slot, CarrierCount::new(1))
+                    .unwrap()
+                    .map(ProvisionalBits::into_carriers)
+                    .transpose()
+                    .unwrap()
+            });
+
+            let (prepared, preclaimed) = prepare.join().unwrap();
+            let claimed = claim.join().unwrap();
+
+            assert_eq!(prepared, CarrierCount::new(2));
+            assert_eq!(preclaimed.len(), 1);
+            assert_eq!(preclaimed[0].id.index, 0);
+            if let Some(claimed) = &claimed {
+                assert_eq!(claimed.len(), 1);
+                assert_eq!(claimed[0].id.index, 1);
+            }
+            let expected_live = 1 + claimed.as_ref().map_or(0, Vec::len);
+            assert_eq!(slot.live_carriers(), expected_live);
+
+            drop(preclaimed);
+            drop(claimed);
+            assert_eq!(slot.live_carriers(), 0);
+        });
+    }
+
+    #[test]
+    fn exhaustive_claim_retries_after_an_optimistic_collision() {
+        loom::model(|| {
+            let geometry = PoolGeometry::new(4096, 8192, 4096).unwrap();
+            let slot = Arc::new(BlockSlot::new(0, geometry).unwrap());
+            let mut prepared = CarrierCount::ZERO;
+            slot.prepare(&mut prepared).unwrap();
+
+            let exhaustive_slot = Arc::clone(&slot);
+            let exhaustive = thread::spawn(move || {
+                BlockSlot::try_claim_exhaustive(&exhaustive_slot, CarrierCount::new(1))
+                    .unwrap()
+                    .expect("exhaustive claim must find one of two carriers")
+                    .into_carriers()
+                    .unwrap()
+            });
+            let optimistic_slot = Arc::clone(&slot);
+            let optimistic = thread::spawn(move || {
+                BlockSlot::try_claim(&optimistic_slot, CarrierCount::new(1))
+                    .unwrap()
+                    .map(ProvisionalBits::into_carriers)
+                    .transpose()
+                    .unwrap()
+            });
+
+            let exhaustive = exhaustive.join().unwrap();
+            let optimistic = optimistic.join().unwrap();
+            if let Some(optimistic) = &optimistic {
+                assert_ne!(exhaustive[0].carrier_index(), optimistic[0].carrier_index());
+            }
+            assert_eq!(
+                slot.live_carriers(),
+                1 + optimistic.as_ref().map_or(0, Vec::len)
+            );
+
+            drop(exhaustive);
+            drop(optimistic);
+            assert_eq!(slot.live_carriers(), 0);
         });
     }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/geometry.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/geometry.rs
@@ -182,6 +182,21 @@ impl PoolGeometry {
         self.final_word_mask
     }
 
+    /// Returns valid carrier bits for one bitmap word.
+    ///
+    /// Complete words use every bit. A partial final word excludes padding
+    /// bits. `None` reports a word outside this geometry.
+    pub(super) fn bitmap_word_mask(self, word_index: usize) -> Option<u64> {
+        if word_index >= self.bitmap_words() {
+            return None;
+        }
+        if word_index + 1 == self.bitmap_words() {
+            Some(self.final_word_mask())
+        } else {
+            Some(u64::MAX)
+        }
+    }
+
     /// Rounds a nonzero byte request up to whole carriers.
     pub(super) fn carriers_for_bytes(self, bytes: usize) -> Result<CarrierCount, GeometryError> {
         if bytes == 0 {
@@ -290,15 +305,25 @@ mod tests {
     fn masks_every_partial_bitmap_width() {
         for carriers in 1..=BITS_PER_BITMAP_WORD * 3 {
             let geometry = PoolGeometry::new(1, carriers, 1).unwrap();
-            let complete_words = geometry.bitmap_words() - 1;
-            let valid = complete_words * BITS_PER_BITMAP_WORD
-                + geometry.final_word_mask().count_ones() as usize;
+            let valid = (0..geometry.bitmap_words())
+                .map(|word_index| {
+                    let mask = geometry.bitmap_word_mask(word_index).unwrap();
+                    let expected = if word_index + 1 == geometry.bitmap_words() {
+                        geometry.final_word_mask()
+                    } else {
+                        u64::MAX
+                    };
+                    assert_eq!(mask, expected);
+                    mask.count_ones() as usize
+                })
+                .sum::<usize>();
 
             assert_eq!(
                 geometry.bitmap_words(),
                 carriers.div_ceil(BITS_PER_BITMAP_WORD)
             );
             assert_eq!(valid, carriers);
+            assert_eq!(geometry.bitmap_word_mask(geometry.bitmap_words()), None);
         }
     }
 

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -1467,13 +1467,15 @@ Mapping state records whether the stable virtual range is accessible:
 enum MappingState {
     Reserved { reclaim_pending: bool },
     Prepared,
-    ProtectionPending,
+    ActivationRecoveryPending,
+    DeactivationRecoveryPending,
 }
 ```
 
 Incarnation state controls claims. Mapping state controls access to the stable virtual range.
 `MappingState::Prepared` records a writable, fully prepared mapping; it does not by itself include
-the block in `prepared_capacity`.
+the block in `prepared_capacity`. The recovery variants distinguish a failed preparation with no
+published incarnation from a failed deactivation that retains a `Draining` incarnation.
 
 ```text
 incarnation state
@@ -1505,11 +1507,13 @@ Prepared
   v
 Reserved
 
-Reserved  -- whole-range RW fails ----> ProtectionPending
-Prepared  -- whole-range NONE fails --> ProtectionPending
+Reserved  -- whole-range RW fails ----> ActivationRecoveryPending
+Prepared  -- whole-range NONE fails --> DeactivationRecoveryPending
 
-ProtectionPending -- whole-range NONE succeeds --> Reserved
-ProtectionPending -- whole-range RW succeeds ----> Prepared
+ActivationRecoveryPending   -- whole-range NONE succeeds --> Reserved
+ActivationRecoveryPending   -- whole-range RW succeeds ----> Prepared
+DeactivationRecoveryPending -- whole-range NONE succeeds --> Reserved
+DeactivationRecoveryPending -- whole-range RW succeeds ----> Prepared
 ```
 
 The state machines couple through ordered capacity and publication transitions:
@@ -1521,13 +1525,13 @@ The state machines couple through ordered capacity and publication transitions:
 - All-free confirmation removes the block from `prepared_capacity` while the mapping remains
   `Prepared` and the incarnation remains `Draining`. Cleanup then makes the range inaccessible,
   attempts discard, publishes `Dead`, and clears `current`.
-- A failed protection call enters `ProtectionPending` and leaves the block outside prepared
-  capacity. Initial preparation failure leaves `current` empty; deactivation failure leaves the
-  existing incarnation `Draining`. Neither state is claimable.
+- Failed preparation enters `ActivationRecoveryPending` with `current` empty. Failed deactivation
+  enters `DeactivationRecoveryPending` with the existing incarnation `Draining`. Both states remain
+  outside prepared capacity and are nonclaimable.
 
-A successful whole-range inaccessible transition from `ProtectionPending` continues the inactive
-path. A successful whole-range writable transition restores mapping state first. Admission then
-adds prepared capacity before either publishing a fresh incarnation or restoring a `Draining`
+A successful whole-range inaccessible transition from either recovery state continues the inactive
+path. A successful whole-range writable transition restores mapping state first. Admission then adds
+prepared capacity before either publishing a fresh incarnation or restoring a `Draining`
 incarnation to `Active`. No failed protection call authorizes a mapping, capacity, or incarnation
 transition.
 
@@ -1554,9 +1558,9 @@ Revival preserves the virtual address:
 The default mapping backend keeps each slot's virtual range reserved until pool destruction. The
 [platform contract](#platform-contract) defines its target operations and qualification rules.
 Every result preserves exclusive ownership of the same address. Deactivation success makes access
-fault. Deactivation failure enters `ProtectionPending` without assuming that prior protection
-remains. Discard success makes backing absent or reclaimable; discard failure may retain resident
-pages but cannot make the block claimable.
+fault. Deactivation failure enters `DeactivationRecoveryPending` without assuming that prior
+protection remains. Discard success makes backing absent or reclaimable; discard failure may retain
+resident pages but cannot make the block claimable.
 
 **Alternative: Allocator-owned blocks.** A page-aligned allocation provides the same common-path
 carrier claim, return, and reuse while retained. The standard allocator API does not provide a
@@ -2634,7 +2638,7 @@ Recoverable resource failures remain local:
 | Virtual-range reservation                         | That growth or acquisition attempt fails                                              |
 | Reservation preparation                           | That request fails; reusable capacity prepared before the failure remains available   |
 | Reserved or unreserved acquisition                | The complete debit rolls back; no partial writable buffer escapes                     |
-| Whole-range protection                            | The affected block enters `ProtectionPending` outside prepared capacity               |
+| Whole-range protection                            | The block enters its nonclaimable recovery state outside prepared capacity            |
 | Backing discard                                   | The inactive block records `reclaim_pending`; other blocks remain usable              |
 | Maintenance-thread creation                       | Maintenance is disabled; ordinary paths continue and affected blocks stay unavailable |
 | Ownership, identity, or address-reservation check | The non-returning fail-stop handler aborts without continuing allocator mutation      |
@@ -3082,10 +3086,10 @@ charges as one packed transition.
 | Transition              | Preconditions                                                       | Ordering                                                                                              |
 | ----------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | Prepare or revive block | Stable range retained; target preparation succeeds                  | Establish writable mapping, add block to `prepared_capacity`, then publish fresh `Active` incarnation |
-| Failed preparation      | Any target operation fails                                          | Publish no `Active` incarnation; retain earlier successful preparation                                |
+| Failed preparation      | Any target operation fails                                          | Publish no `Active`; enter `ActivationRecoveryPending`; retain earlier successful preparation         |
 | Abandon trim            | Claim-trim gate observes any valid set bit                          | Restore `Active`; leave `prepared_capacity` unchanged                                                 |
 | Confirm trim            | Gate confirms all valid bits clear and admission floor is preserved | Subtract block from `prepared_capacity`, then perform physical cleanup                                |
-| Failed deactivation     | Whole-range inaccessible transition fails                           | Keep block nonclaimable in `ProtectionPending` outside prepared capacity                              |
+| Failed deactivation     | Whole-range inaccessible transition fails                           | Keep block nonclaimable in `DeactivationRecoveryPending` outside prepared capacity                    |
 | Failed discard          | Range is inaccessible but backing discard fails                     | Keep block inactive with `reclaim_pending`; prepared capacity is unchanged                            |
 
 The admission floor is checked against the post-removal count:
@@ -3226,10 +3230,10 @@ lookup can establish presentation adjacency but cannot recover physical-return a
 | macOS   | Anonymous private `PROT_NONE` mapping      | Whole-range `mprotect(READ \| WRITE)`      | Whole-range `mprotect(NONE)` | `MADV_FREE`             |
 | Windows | `VirtualAlloc(MEM_RESERVE, PAGE_NOACCESS)` | `VirtualAlloc(MEM_COMMIT, PAGE_READWRITE)` | `VirtualFree(MEM_DECOMMIT)`  | Same decommit operation |
 
-All targets must preserve exclusive ownership of the virtual range after every successful or
-failed operation. A failed protection or commit operation enters `ProtectionPending`; no prior
-protection is assumed. Recovery requires a later successful whole-range transition before the block
-can reenter prepared capacity.
+All targets must preserve exclusive ownership of the virtual range after every successful or failed
+operation. Failed initial preparation or commit enters `ActivationRecoveryPending`; failed
+deactivation enters `DeactivationRecoveryPending`. No prior protection is assumed. Recovery
+requires a later successful whole-range transition before the block can reenter prepared capacity.
 
 Windows preparation consumes system commit capacity for each newly required whole block. Starting
 without prepared capacity, a grant commits enough blocks to cover its complete post-grant admission

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -1114,12 +1114,12 @@ struct ArenaState {
 }
 
 struct BlockRegistry {
-    snapshot: ArcSwap<RegistrySnapshot>,
+    generation: ArcSwap<RegistryGeneration>,
 }
 
-struct RegistrySnapshot {
+struct RegistryGeneration {
     // Stable scan order for physical acquisition.
-    claim_slots: Box<[Arc<BlockSlot>]>,
+    slots_in_claim_order: Box<[Arc<BlockSlot>]>,
     // Non-overlapping virtual ranges sorted by start address.
     address_ranges: Box<[AddressRange]>,
 }
@@ -1128,18 +1128,18 @@ struct AddressRange {
     // Exposed addresses used only for comparison; end is exclusive.
     start: usize,
     end: usize,
-    // Index into RegistrySnapshot::claim_slots.
+    // Index into RegistryGeneration::slots_in_claim_order.
     slot_index: usize,
 }
 ```
 
-`BlockRegistry` publishes claim order and address classification as one immutable snapshot.
-Optimistic claim scans load `claim_slots` without taking `ArenaState`. An incoming immutable view
-uses binary search over `address_ranges` and accepts a match only when its complete checked range
-lies within one slot. The integer bounds classify addresses only; carrier pointers are always
-derived from `VirtualRange`.
+`BlockRegistry` publishes claim order and address classification as one immutable generation.
+Optimistic claim scans load `slots_in_claim_order` without taking `ArenaState`. An incoming
+immutable view uses binary search over `address_ranges` and accepts a match only when its complete
+checked range lies within one slot. The integer bounds classify addresses only; carrier pointers
+are always derived from `VirtualRange`.
 
-Snapshot construction rejects address overflow, overlap, or an invalid slot index. Growth rebuilds
+Generation construction rejects address overflow, overlap, or an invalid slot index. Growth rebuilds
 and publishes both arrays while holding `ArenaState`. Return goes directly to the slot recorded by
 the carrier allocation and does not scan the registry.
 
@@ -1193,7 +1193,7 @@ error; no partial batch is exposed.
 
 The common path performs a bounded amount of optimistic bitmap work from a rotating origin:
 
-1. Load one immutable registry snapshot.
+1. Load one immutable registry generation.
 2. Inspect at most the configured number of bitmap words across `Active` blocks.
 3. Keep every bit won from each atomic bitmap operation.
 4. Confirm that each touched block remains `Active` after the bitmap mutation.
@@ -1572,7 +1572,7 @@ instead gives idle trim an explicit page-level operation and failure contract.
 
 **Alternative: Release and replace virtual ranges.** A pool using operating-system mappings could
 release a trimmed range and allocate a new range on later growth. This returns virtual address space
-with the backing but makes trim a topology change. Old claim attempts and registry snapshots must
+with the backing but makes trim a topology change. Old claim attempts and registry generations must
 retire before the address can be reused, or every stale lookup must detect replacement. Revival also
 requires a new slot or registry publication. The selected backend can make a block inaccessible and
 discard its backing or make it reclaimable without waiting for metadata readers to quiesce. Those
@@ -2049,7 +2049,7 @@ impl<'a> SegmentedBytesBuilder<'a> {
 immutable producer view, whether pool-backed or foreign. `push_segmented` consumes the input's
 remaining segments and their existing holds; it does not reconstruct ownership from pointers.
 `PooledBufMut::freeze` constructs pooled segments directly. The private builder resolves the
-complete range of `push_view` with a binary search over the registry snapshot's sorted address
+complete range of `push_view` with a binary search over the registry generation's sorted address
 ranges; the finished value retains no builder borrow. Owner boundaries need not be presentation
 boundaries:
 
@@ -3158,7 +3158,7 @@ as a search hint may use `Relaxed`; ownership is decided by the gated `fetch_or`
 | Packed coverage and uncovered charges | Load or failed CAS retry                      | `Acquire`                                                |
 | Packed coverage and uncovered charges | Successful debit, grant, close, or return CAS | `AcqRel`                                                 |
 | Reservation owner state               | Direct debit, close, rollback, or return      | One packed `AcqRel` read-modify-write                    |
-| Block registry                        | Publish or load immutable registry snapshot   | ArcSwap publication and guard contract                   |
+| Block registry                        | Publish or load immutable registry generation | ArcSwap publication and guard contract                   |
 | Current block incarnation             | Publish, replace, or protect incarnation      | ArcSwap publication and guard contract                   |
 | Wait result                           | Store terminal result and consume it          | `WaitSlot` mutex                                         |
 | Admission ledger and FIFO             | Every read and write                          | `AdmissionState` mutex                                   |


### PR DESCRIPTION
## Summary

This is the second of seven implementation PRs for the [buffer-pool design](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/165). It composes the physical block primitive from [#166](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/166) into a private arena with immutable registry publication, bounded optimistic batch acquisition, serialized fallback and growth, address classification, trim candidate selection, and internal diagnostics.

The design and implementation series are:

1. [Buffer-pool design](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/165)
2. [Physical-storage foundation](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/166)
3. **This PR: Arena acquisition and growth**
4. Admission and pool composition
5. Mutable buffers and segmented delivery
6. Maintenance, configuration, and operations
7. Scheduler and download integration
8. Upload staging and retry integration

The arena remains private and disconnected from transfer-manager operation. This PR is stacked on #166.

## Why

The block primitive provides safe ownership and reclamation within one fixed virtual range. The pool also needs to find carriers across many blocks, return complete multi-block batches, reuse fragmented capacity before growing, and publish new capacity without allowing another claimant to steal the carriers that caused the growth.

The common acquisition path must remain bounded as the pool grows. A bounded scan can miss reusable capacity, so a miss retains its provisional ownership and enters a serialized path that exhaustively rechecks the arena before preparing another block. New incarnations preclaim the missing carriers before publication. This prevents repeated growth under contention while preserving lock-free claims against already published blocks.

This PR establishes that physical allocator contract before admission accounting, reservations, byte containers, maintenance policy, or public APIs are added.

## Overview

### Physical model

The arena coordinates blocks but does not expose byte storage. A `BlockSlot` retains one stable virtual range for its lifetime. Its replaceable incarnation contains the current ownership bitmap, where one set bit represents one owned carrier.

```text
Arena
`-- BlockSlot[]
    |-- stable VirtualRange
    |-- serialized MappingState
    `-- current BlockIncarnation
        `-- in_use[]: one atomic bit per carrier
```

Mapping state remains mutex-protected while the incarnation gate and bitmap remain atomic. This keeps carrier claims off the mapping lock. The legal lifecycle combinations are explicit:

```text
Reserved                     + no current incarnation
Prepared                     + Active or trim-owned Draining incarnation
ActivationRecoveryPending    + no current incarnation
DeactivationRecoveryPending  + Draining incarnation
```

### Registry

`ArenaState` owns the stable slot list and serializes topology changes. Each change rebuilds and atomically publishes one immutable `RegistryGeneration`.

```text
ArenaState
+-- slots: [BlockSlot 0, BlockSlot 1, ...]
|
| rebuild and publish
v
RegistryGeneration
+-- slots_in_claim_order: [slot 0, slot 1, ...]
`-- address_ranges:       [start..end -> slot, ...]  sorted by address
```

The generation contains topology, not a frozen copy of mapping or bitmap state. Those remain live behind each `Arc<BlockSlot>`. Acquisition and address classification load the registry without taking `ArenaState`. Claim order remains stable, while the sorted address index supports binary-search classification of one complete range within one slot. Both indexes publish together because every address entry indexes `slots_in_claim_order`. Classification compares integer addresses only; it does not construct a pointer or authorize memory access.

The corresponding sections in design PR #165 are **Pool structure** and **Block geometry and lifetime**.

### Acquisition

One arena acquisition requests a complete carrier count. `claim_optimistic` scans from a rotating origin and charges an exact bitmap-word budget. It retains every gate-passed bit in `ClaimBatch`.

```text
request N carriers
        |
        | load RegistryGeneration
        | topology is pinned; block state remains live
        v
bounded optimistic scan                         no arena mutex
        |
        v
BlockClaimAttempt
        |
        | fetch_or wins bitmap bits
        | finish() checks Active
        +---------------- gate fails ----------------> clear won bits
        |
        v
ProvisionalBits
        |
        v
ClaimBatch
        |
        +-- complete -------------------------------> CarrierAllocation[N]
        |
        `-- partial
              |
              | complete_claim_serialized()          ArenaState held
              |
              +-- exhaust active blocks
              +-- prepare inactive slots
              `-- reserve new slot
                       |
                       | create private incarnation
                       | preclaim missing carriers
                       | prepare complete mapping
                       | add prepared capacity
                       `-- publish Active
              |
              v
          complete ClaimBatch
              |
              | release ArenaState
              v
          CarrierAllocation[N]
```

| Stage                     | Owner of each set bit     | Protection carried by the owner                                             |
| ------------------------- | ------------------------- | --------------------------------------------------------------------------- |
| Before the state gate     | `BlockClaimAttempt`       | The protected incarnation keeps its bitmap valid for success or rollback    |
| After the state gate      | `ProvisionalBits`         | The gate-passed live bit forces trim to abandon                             |
| Across several blocks     | `ClaimBatch`              | Each provisional owner retains its slot, incarnation, and exact won mask    |
| After complete conversion | `CarrierAllocation`       | The allocation owns one live bit until drop                                 |
| Failed acquisition        | The remaining owner drops | Only bits won by that owner are cleared                                     |

A complete batch converts into one `CarrierAllocation` per won bit. An incomplete batch cannot be converted into `CarrierAllocation`s. Dropping it clears only the bits won by that batch.

> **Serialization boundary:** Optimistic scan and claim do not take `ArenaState`. Exhaustive fallback and growth hold `ArenaState`. This PR passes prepared-capacity state as `&mut CarrierCount`; the next PR replaces that parameter with `&mut AdmissionGuard<'_>`, making pool-wide admission serialization part of the type signature.

The bounded scan may miss free carriers outside its word budget or lose selected bits to a concurrent claimant. Serialized fallback uses an exhaustive block claim that folds each collision into its local occupancy view and continues until the request is complete or every valid bit has been observed occupied.

### Fallback and growth

Serialized fallback holds `ArenaState` while it rechecks every active slot, reuses inactive slots, and reserves new stable ranges. It prepares new capacity with the missing carriers already owned.

The slot may already be visible in a registry generation, but it is not claimable until the preclaimed incarnation is published. Optimistic claimants therefore cannot consume the new capacity before the fallback claimant receives its complete batch. Preparation failure records `ActivationRecoveryPending` without publishing an incarnation. A failed trim deactivation records `DeactivationRecoveryPending` while retaining the draining incarnation, so the recovery cause is explicit rather than inferred solely from incarnation presence.

Preparation failure preserves blocks prepared earlier in the same fallback. The caller retains the partial `ClaimBatch`, so rollback remains exact.

The corresponding section in design PR #165 is **Carrier claiming and fallback**.

### Trim selection and diagnostics

For reclamation, the arena scans for a prepared block whose carrier bitmap is currently empty. That lock-free observation identifies only a candidate. `BlockSlot::start_trim` remains the authority that rechecks lifecycle state, ownership bits, and the prepared-capacity floor under admission serialization.

Private saturating counters record optimistic scan work and misses, serialized fallback, block preparation, virtual-range growth, unpublished claim rollback, and trim-selection work. They do not participate in allocator decisions and are not a public metrics surface.

## How to review

Follow the acquisition diagram once through optimistic success using `one_batch_accumulates_carriers_across_blocks`, then through the partial branch using `serialized_fallback_exhausts_fragmented_capacity_before_growth`. Stop growth after one successful preparation with `later_preparation_failure_preserves_earlier_capacity` to see rollback preserve prepared capacity and return provisional ownership.

Finish with the concurrency models beside the transitions they exercise: `registry_generation_is_published_coherently` for publication, `concurrent_claims_use_distinct_rotated_windows` for scan distribution, `exhaustive_claim_retries_after_an_optimistic_collision` for collision recovery, `private_growth_cannot_be_stolen_by_an_optimistic_claim` for preclaim publication, and `claim_and_trim_cannot_both_pass_the_gate` for reclamation exclusion. `production_registry_guard_survives_concurrent_publication` separately exercises the production ArcSwap adapter because Loom substitutes its own registry cell.

## Future

The next PR joins the arena to admission accounting, reservations, FIFO waiters, and the private `BufferPool` core. It will replace caller-supplied prepared state with the admission guard and prove complete acquisition, rollback, close, return, and shutdown through the composed pool boundary.
