### PR TITLE
buffer pool: admission and pool composition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "same-file",
  "serde",
  "serde_json",
+ "smallvec",
  "tempfile",
  "test-common",
  "tokio",

--- a/aws-sdk-s3-transfer-manager/Cargo.toml
+++ b/aws-sdk-s3-transfer-manager/Cargo.toml
@@ -41,6 +41,7 @@ http-body-1x = { package = "http-body", version = "1" }
 same-file = "1.0.6"
 dial9-tokio-telemetry = { version = "0.3", optional = true, features = ["cpu-profiling"] }
 arc-swap = "1.9.2"
+smallvec = "1"
 
 [features]
 dial9 = ["dep:dial9-tokio-telemetry"]

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -3,12 +3,119 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Fixed-size carrier geometry, virtual memory, and physical ownership.
+//! Elastic admission and fixed-size pooled storage.
 
+use crate::runtime::sync::sync::{Arc, Mutex};
+
+mod acquisition;
+mod admission;
 mod arena;
 mod block;
 mod geometry;
+mod metrics;
 mod virtual_memory;
+
+#[cfg(test)]
+use acquisition::AcquisitionAllocationFailures;
+use admission::{AdmissionState, CoverageState, MAX_PACKED_CARRIERS};
+pub(crate) use admission::{Reservation, ReserveError, ReserveFuture};
+use arena::{Arena, ArenaError};
+use geometry::{GeometryError, PoolGeometry};
+use metrics::MemoryMetrics;
+
+/// A cloneable handle to one admission, accounting, and storage domain.
+#[derive(Clone)]
+pub(crate) struct BufferPool {
+    inner: Arc<PoolInner>,
+}
+
+/// Shared state retained by pool handles, reservations, and carrier owners.
+struct PoolInner {
+    /// Planned-demand policy and prepared-capacity serialization.
+    admission: Mutex<AdmissionState>,
+    /// Aggregate acquisition charges changed at carrier frequency.
+    coverage: CoverageState,
+    /// Stable virtual ranges and physical carrier ownership.
+    arena: Arena,
+    /// One-shot acquisition metadata failure injection.
+    #[cfg(test)]
+    acquisition_allocation_failures: AcquisitionAllocationFailures,
+}
+
+impl BufferPool {
+    /// Constructs a pool from geometry and a validated configured capacity.
+    ///
+    /// Callers validate capacity policy before this internal boundary.
+    /// Construction reserves no blocks and prepares no physical capacity.
+    fn from_validated_parts(
+        geometry: PoolGeometry,
+        configured_capacity: CarrierCount,
+        optimistic_scan_words: usize,
+    ) -> Result<Self, ArenaError> {
+        assert!(
+            configured_capacity != CarrierCount::ZERO,
+            "configured capacity must be nonzero"
+        );
+        assert!(
+            configured_capacity <= MAX_PACKED_CARRIERS,
+            "configured capacity must fit packed accounting"
+        );
+
+        Ok(Self {
+            inner: Arc::new(PoolInner {
+                admission: Mutex::new(AdmissionState::new(configured_capacity)),
+                coverage: CoverageState::new(),
+                arena: Arena::new(geometry, optimistic_scan_words)?,
+                #[cfg(test)]
+                acquisition_allocation_failures: AcquisitionAllocationFailures::new(),
+            }),
+        })
+    }
+
+    /// Attempts one immediate reservation grant.
+    ///
+    /// `Ok(None)` reports an older FIFO request or current admission pressure.
+    /// A successful grant has already prepared storage through its complete
+    /// admission floor.
+    pub(crate) fn try_reserve(&self, bytes: usize) -> Result<Option<Reservation>, ReserveError> {
+        let envelope = self.reservation_envelope(bytes)?;
+        PoolInner::try_reserve_count(&self.inner, envelope)
+    }
+
+    /// Creates a lazy, cancellation-safe reservation request.
+    ///
+    /// The first poll either returns an immediate result or enters the
+    /// pool-wide FIFO. Invalid requests and physical preparation failures
+    /// resolve through the future's `ReserveError`.
+    pub(crate) fn reserve(&self, bytes: usize) -> ReserveFuture {
+        ReserveFuture::new(self.clone(), bytes)
+    }
+
+    /// Returns one coherent sample of this pool's memory state.
+    pub(crate) fn metrics(&self) -> MemoryMetrics {
+        self.inner.memory_metrics()
+    }
+
+    /// Converts one public byte request to its checked carrier envelope.
+    fn reservation_envelope(&self, bytes: usize) -> Result<CarrierCount, ReserveError> {
+        let envelope = self
+            .inner
+            .arena
+            .carriers_for_bytes(bytes)
+            .map_err(map_reservation_geometry_error)?;
+        if envelope > MAX_PACKED_CARRIERS {
+            return Err(ReserveError::CapacityOverflow);
+        }
+        Ok(envelope)
+    }
+}
+
+fn map_reservation_geometry_error(error: GeometryError) -> ReserveError {
+    match error {
+        GeometryError::ZeroByteRequest => ReserveError::InvalidSize,
+        error => panic!("validated geometry returned an impossible byte-conversion error: {error}"),
+    }
+}
 
 /// A count of fixed-size carriers.
 #[repr(transparent)]
@@ -20,7 +127,7 @@ impl CarrierCount {
     const ZERO: Self = Self(0);
 
     /// Wraps a carrier count.
-    fn new(value: usize) -> Self {
+    const fn new(value: usize) -> Self {
         Self(value)
     }
 
@@ -37,5 +144,10 @@ impl CarrierCount {
     /// Subtracts two counts, returning `None` on underflow.
     fn checked_sub(self, other: Self) -> Option<Self> {
         self.0.checked_sub(other.0).map(Self)
+    }
+
+    /// Converts this count to the packed accounting lane width.
+    fn try_as_u32(self) -> Option<u32> {
+        u32::try_from(self.0).ok()
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -5,6 +5,8 @@
 
 //! Elastic admission and fixed-size pooled storage.
 
+use std::task::Waker;
+
 use crate::runtime::sync::sync::{Arc, Mutex};
 
 mod acquisition;
@@ -13,15 +15,23 @@ mod arena;
 mod block;
 mod geometry;
 mod metrics;
+#[cfg(test)]
+mod test_util;
 mod virtual_memory;
 
-#[cfg(test)]
-use acquisition::AcquisitionAllocationFailures;
-use admission::{AdmissionState, CoverageState, MAX_PACKED_CARRIERS};
+use acquisition::{acquire_count, AcquireError, AcquiredRuns};
+use admission::{
+    wake_all, AdmissionGuard, AdmissionState, CoverageState, ReservationPoll, WaitSlot, WaitState,
+    Waiter, MAX_PACKED_CARRIERS,
+};
 pub(crate) use admission::{Reservation, ReserveError, ReserveFuture};
 use arena::{Arena, ArenaError};
+use block::BlockError;
 use geometry::{GeometryError, PoolGeometry};
-use metrics::MemoryMetrics;
+use metrics::{MemoryMetricState, MemoryMetrics};
+
+#[cfg(test)]
+use test_util::TestHooks;
 
 /// A cloneable handle to one admission, accounting, and storage domain.
 #[derive(Clone)]
@@ -29,46 +39,30 @@ pub(crate) struct BufferPool {
     inner: Arc<PoolInner>,
 }
 
-/// Shared state retained by pool handles, reservations, and carrier owners.
-struct PoolInner {
-    /// Planned-demand policy and prepared-capacity serialization.
-    admission: Mutex<AdmissionState>,
-    /// Aggregate acquisition charges changed at carrier frequency.
-    coverage: CoverageState,
-    /// Stable virtual ranges and physical carrier ownership.
-    arena: Arena,
-    /// One-shot acquisition metadata failure injection.
-    #[cfg(test)]
-    acquisition_allocation_failures: AcquisitionAllocationFailures,
-}
-
 impl BufferPool {
-    /// Constructs a pool from geometry and a validated configured capacity.
+    /// Constructs a pool from checked geometry and internal configuration.
     ///
-    /// Callers validate capacity policy before this internal boundary.
+    /// Invalid capacity indicates an internal configuration defect. Public
+    /// configuration validates these values before reaching this boundary.
     /// Construction reserves no blocks and prepares no physical capacity.
-    fn from_validated_parts(
+    fn from_parts(
         geometry: PoolGeometry,
         configured_capacity: CarrierCount,
         optimistic_scan_words: usize,
     ) -> Result<Self, ArenaError> {
-        assert!(
-            configured_capacity != CarrierCount::ZERO,
-            "configured capacity must be nonzero"
-        );
-        assert!(
-            configured_capacity <= MAX_PACKED_CARRIERS,
-            "configured capacity must fit packed accounting"
-        );
+        if configured_capacity == CarrierCount::ZERO {
+            invariant_violation("configured capacity must be nonzero");
+        }
+        if configured_capacity > MAX_PACKED_CARRIERS {
+            invariant_violation("configured capacity must fit packed accounting");
+        }
 
         Ok(Self {
-            inner: Arc::new(PoolInner {
-                admission: Mutex::new(AdmissionState::new(configured_capacity)),
-                coverage: CoverageState::new(),
-                arena: Arena::new(geometry, optimistic_scan_words)?,
-                #[cfg(test)]
-                acquisition_allocation_failures: AcquisitionAllocationFailures::new(),
-            }),
+            inner: Arc::new(PoolInner::new(
+                geometry,
+                configured_capacity,
+                optimistic_scan_words,
+            )?),
         })
     }
 
@@ -96,11 +90,46 @@ impl BufferPool {
         self.inner.memory_metrics()
     }
 
+    /// Acquires at least `min_bytes` under one reservation.
+    ///
+    /// Capacity is rounded up to complete carriers. The reservation must
+    /// belong to this pool, remain open, and retain enough direct-acquisition
+    /// authority for the rounded request. Failure exposes no partial carrier
+    /// ownership.
+    pub(crate) fn acquire(
+        &self,
+        reservation: &Reservation,
+        min_bytes: usize,
+    ) -> Result<AcquiredRuns, AcquireError> {
+        let count = self.acquisition_count(min_bytes)?;
+        let direct = reservation
+            .acquisition_state()
+            .ok_or(AcquireError::ReservationClosed)?;
+        if !direct.belongs_to(&self.inner) {
+            return Err(AcquireError::ForeignReservation);
+        }
+        acquire_count(&self.inner, Some(Arc::clone(direct)), count)
+    }
+
+    /// Acquires at least `min_bytes` without reservation-local authority.
+    ///
+    /// Capacity is rounded up to complete carriers. The request still
+    /// participates in aggregate accounting and may prepare physical capacity
+    /// or raise admission above its normal configured ceiling. Failure exposes
+    /// no partial carrier ownership.
+    pub(crate) fn acquire_unreserved(
+        &self,
+        min_bytes: usize,
+    ) -> Result<AcquiredRuns, AcquireError> {
+        let count = self.acquisition_count(min_bytes)?;
+        acquire_count(&self.inner, None, count)
+    }
+
     /// Converts one public byte request to its checked carrier envelope.
     fn reservation_envelope(&self, bytes: usize) -> Result<CarrierCount, ReserveError> {
         let envelope = self
             .inner
-            .arena
+            .geometry
             .carriers_for_bytes(bytes)
             .map_err(map_reservation_geometry_error)?;
         if envelope > MAX_PACKED_CARRIERS {
@@ -108,12 +137,300 @@ impl BufferPool {
         }
         Ok(envelope)
     }
+
+    /// Converts one acquisition request to its complete carrier count.
+    fn acquisition_count(&self, min_bytes: usize) -> Result<CarrierCount, AcquireError> {
+        self.inner
+            .geometry
+            .carriers_for_bytes(min_bytes)
+            .map_err(|error| match error {
+                GeometryError::ZeroByteRequest => AcquireError::InvalidSize,
+                _ => AcquireError::CapacityOverflow,
+            })
+    }
+}
+
+/// Shared state retained by pool handles, reservations, and carrier owners.
+struct PoolInner {
+    /// Immutable page, block, carrier, and bitmap dimensions.
+    geometry: PoolGeometry,
+    /// Planned-demand policy and prepared-capacity serialization.
+    admission: Mutex<AdmissionState>,
+    /// Aggregate charges updated by carrier acquisition and final return.
+    coverage: CoverageState,
+    /// Stable virtual ranges and physical carrier ownership.
+    arena: Arena,
+    /// Per-pool failure injection and test-only observations.
+    #[cfg(test)]
+    test_hooks: TestHooks,
+}
+
+impl PoolInner {
+    /// Constructs an empty pool domain without reserving virtual ranges.
+    fn new(
+        geometry: PoolGeometry,
+        configured_capacity: CarrierCount,
+        optimistic_scan_words: usize,
+    ) -> Result<Self, ArenaError> {
+        Ok(Self {
+            geometry,
+            admission: Mutex::new(AdmissionState::new(configured_capacity)),
+            coverage: CoverageState::new(),
+            arena: Arena::new(geometry, optimistic_scan_words)?,
+            #[cfg(test)]
+            test_hooks: TestHooks::new(),
+        })
+    }
+
+    /// Returns one coherent admission and aggregate memory sample.
+    fn memory_metrics(&self) -> MemoryMetrics {
+        let admission = self.admission.lock();
+        let coverage = self.coverage.snapshot();
+        admission.ledger.assert_invariants(coverage);
+
+        let admission_used = admission
+            .ledger
+            .admission_used(coverage)
+            .unwrap_or_else(|_| invariant_violation("completed admission exceeds packed capacity"));
+        let covered_charges = admission
+            .ledger
+            .active_planned_demand
+            .checked_sub(coverage.available)
+            .unwrap_or_else(|| {
+                invariant_violation("available coverage exceeds active planned demand")
+            });
+        let charged_capacity = covered_charges
+            .checked_add(coverage.uncovered)
+            .unwrap_or_else(|| invariant_violation("completed charges exceed packed capacity"));
+
+        MemoryMetrics::from_carriers(
+            self.geometry.carrier_size(),
+            MemoryMetricState {
+                configured_capacity: admission.ledger.configured_capacity,
+                admission_used,
+                active_planned_demand: admission.ledger.active_planned_demand,
+                charged_capacity,
+                prepared_capacity: admission.ledger.prepared_capacity,
+                queued_reservations: admission.waiters.len(),
+                parked_reservations_total: admission.parked_reservations_total,
+            },
+        )
+    }
+
+    /// Attempts an aggregate debit without admission serialization.
+    ///
+    /// `Ok(false)` leaves accounting unchanged and requires the caller to use
+    /// the serialized shortfall path.
+    fn try_debit_covered(&self, count: CarrierCount) -> Result<bool, ReserveError> {
+        self.coverage
+            .try_debit_covered(count)
+            .map_err(|_| ReserveError::CapacityOverflow)
+    }
+
+    /// Publishes a shortfall debit and prepares through its admission floor.
+    ///
+    /// Failure reverses the aggregate debit before returning. The caller
+    /// remains responsible for rolling back reservation-local authority.
+    fn debit_and_prepare_locked(
+        pool: &Arc<Self>,
+        admission: &mut AdmissionGuard<'_>,
+        count: CarrierCount,
+    ) -> Result<(), ReserveError> {
+        pool.coverage
+            .debit(count, admission.maximum_uncovered())
+            .map_err(|_| ReserveError::CapacityOverflow)?;
+
+        let floor = match admission.acquisition_floor(&pool.coverage) {
+            Ok(floor) => floor,
+            Err(error) => {
+                admission.rollback_acquisition(&pool.coverage, count);
+                return Err(error);
+            }
+        };
+        if let Err(error) = pool.arena.prepare_to(admission, floor) {
+            admission.rollback_acquisition(&pool.coverage, count);
+            return Err(map_preparation_error(error));
+        }
+        Ok(())
+    }
+
+    /// Attempts one immediate grant without bypassing the FIFO.
+    fn try_reserve_count(
+        pool: &Arc<Self>,
+        envelope: CarrierCount,
+    ) -> Result<Option<Reservation>, ReserveError> {
+        if envelope == CarrierCount::ZERO {
+            return Err(ReserveError::InvalidSize);
+        }
+        if envelope > MAX_PACKED_CARRIERS {
+            return Err(ReserveError::CapacityOverflow);
+        }
+
+        let mut admission = AdmissionGuard::new(pool.admission.lock());
+        if !admission.inner.waiters.is_empty() {
+            return Ok(None);
+        }
+        let coverage = pool.coverage.snapshot();
+        if !admission.can_grant(coverage, envelope) {
+            return Ok(None);
+        }
+
+        Self::prepare_and_grant_locked(pool, &mut admission, envelope).map(Some)
+    }
+
+    /// Grants one first-poll request or links it behind existing work.
+    fn reserve_or_enqueue(
+        pool: &Arc<Self>,
+        envelope: CarrierCount,
+        waker: Waker,
+    ) -> Result<ReservationPoll, ReserveError> {
+        if envelope == CarrierCount::ZERO {
+            return Err(ReserveError::InvalidSize);
+        }
+        if envelope > MAX_PACKED_CARRIERS {
+            return Err(ReserveError::CapacityOverflow);
+        }
+
+        let mut admission = AdmissionGuard::new(pool.admission.lock());
+        let coverage = pool.coverage.snapshot();
+        if admission.inner.waiters.is_empty() && admission.can_grant(coverage, envelope) {
+            return Self::prepare_and_grant_locked(pool, &mut admission, envelope)
+                .map(ReservationPoll::Ready);
+        }
+
+        admission
+            .inner
+            .waiters
+            .try_reserve(1)
+            .map_err(|_| ReserveError::PhysicalPreparationFailed)?;
+        let slot = Arc::new(WaitSlot::new(waker));
+        admission.inner.waiters.push_back(Waiter {
+            envelope,
+            slot: Arc::clone(&slot),
+        });
+        admission.inner.parked_reservations_total =
+            admission.inner.parked_reservations_total.saturating_add(1);
+        Ok(ReservationPoll::Queued(slot))
+    }
+
+    /// Removes one cancelled queue link and reconsiders the exposed head.
+    fn cancel_waiter(pool: &Arc<Self>, slot: &Arc<WaitSlot>) -> Vec<Waker> {
+        let mut admission = AdmissionGuard::new(pool.admission.lock());
+        if let Some(index) = admission
+            .inner
+            .waiters
+            .iter()
+            .position(|waiter| Arc::ptr_eq(&waiter.slot, slot))
+        {
+            admission.inner.waiters.remove(index);
+        }
+        Self::drain_fifo_locked(pool, &mut admission)
+    }
+
+    /// Prepares and publishes one grant while admission is serialized.
+    fn prepare_and_grant_locked(
+        pool: &Arc<Self>,
+        admission: &mut AdmissionGuard<'_>,
+        envelope: CarrierCount,
+    ) -> Result<Reservation, ReserveError> {
+        let coverage = pool.coverage.snapshot();
+        let target = admission.grant_target(coverage, envelope)?;
+        pool.arena
+            .prepare_to(admission, target)
+            .map_err(map_preparation_error)?;
+        admission.commit_grant(&pool.coverage, envelope)?;
+        Ok(Reservation::new(Arc::clone(pool), envelope))
+    }
+
+    /// Transfers every eligible FIFO head and returns wakers for post-unlock use.
+    fn drain_fifo_locked(pool: &Arc<Self>, admission: &mut AdmissionGuard<'_>) -> Vec<Waker> {
+        let mut wakers = Vec::new();
+        while let Some(front) = admission.inner.waiters.front() {
+            let envelope = front.envelope;
+            let slot = Arc::clone(&front.slot);
+            let mut slot_state = slot.state.lock();
+
+            match &*slot_state {
+                WaitState::Taken => {
+                    admission.inner.waiters.pop_front();
+                    continue;
+                }
+                WaitState::Queued { .. } => {}
+                WaitState::Granted(_) | WaitState::Failed(_) => {
+                    invariant_violation("terminal reservation result remained linked in the FIFO");
+                }
+            }
+
+            let coverage = pool.coverage.snapshot();
+            if !admission.can_grant(coverage, envelope) {
+                break;
+            }
+
+            let result = Self::prepare_and_grant_locked(pool, admission, envelope);
+            let previous = std::mem::replace(&mut *slot_state, WaitState::Taken);
+            let WaitState::Queued { waker } = previous else {
+                invariant_violation("reservation head changed while its slot lock was held");
+            };
+            *slot_state = match result {
+                Ok(reservation) => WaitState::Granted(reservation),
+                Err(error) => WaitState::Failed(error),
+            };
+
+            let Some(removed) = admission.inner.waiters.pop_front() else {
+                invariant_violation("reservation head disappeared while admission was held");
+            };
+            if !Arc::ptr_eq(&removed.slot, &slot) {
+                invariant_violation("FIFO head changed while admission was held");
+            }
+            wakers.push(waker);
+        }
+        wakers
+    }
+
+    /// Retires aggregate charges and reconsiders work exposed by repayment.
+    ///
+    /// Physical ownership and direct provenance are returned before this
+    /// boundary. Coverage-only returns stay lock-free. Repayment of uncovered
+    /// charges enters admission and invokes wakers only after unlocking.
+    fn release_acquisition_charges(pool: &Arc<Self>, count: CarrierCount) {
+        let returned = pool.coverage.release(count);
+        if returned.uncovered_removed == CarrierCount::ZERO {
+            return;
+        }
+
+        let wakers = {
+            let mut admission = AdmissionGuard::new(pool.admission.lock());
+            let wakers = Self::drain_fifo_locked(pool, &mut admission);
+            admission
+                .inner
+                .ledger
+                .assert_invariants(pool.coverage.snapshot());
+            wakers
+        };
+        wake_all(wakers);
+    }
 }
 
 fn map_reservation_geometry_error(error: GeometryError) -> ReserveError {
     match error {
         GeometryError::ZeroByteRequest => ReserveError::InvalidSize,
-        error => panic!("validated geometry returned an impossible byte-conversion error: {error}"),
+        _ => invariant_violation("checked geometry rejected byte-to-carrier conversion"),
+    }
+}
+
+fn map_preparation_error(error: ArenaError) -> ReserveError {
+    match error {
+        ArenaError::Block(BlockError::PreparedCapacityOverflow)
+        | ArenaError::SlotIdExhausted
+        | ArenaError::RegistryCapacityOverflow
+        | ArenaError::AddressOverflow { .. }
+        | ArenaError::ScanSpaceOverflow { .. } => ReserveError::CapacityOverflow,
+        ArenaError::Block(_)
+        | ArenaError::Allocation(_)
+        | ArenaError::InvalidScanBudget
+        | ArenaError::InvalidClaimCount
+        | ArenaError::IncompleteClaim { .. }
+        | ArenaError::AddressOverlap { .. } => ReserveError::PhysicalPreparationFailed,
     }
 }
 
@@ -149,5 +466,25 @@ impl CarrierCount {
     /// Converts this count to the packed accounting lane width.
     fn try_as_u32(self) -> Option<u32> {
         u32::try_from(self.0).ok()
+    }
+}
+
+/// Stops execution after an internal buffer-pool invariant fails.
+#[cold]
+#[track_caller]
+fn invariant_violation(message: &'static str) -> ! {
+    tracing::error!(
+        target: crate::telemetry::TARGET_MEMORY,
+        reason = message,
+        "buffer-pool invariant violated; aborting"
+    );
+
+    #[cfg(test)]
+    panic!("buffer-pool invariant violated: {message}");
+
+    #[cfg(not(test))]
+    {
+        let _ = message;
+        std::process::abort()
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/acquisition.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/acquisition.rs
@@ -1,0 +1,1393 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Complete carrier acquisition and physical-first final return.
+//!
+//! Accounting is installed before bitmap ownership. A pending transaction
+//! retains both until every carrier has become a guard or rollback has
+//! returned all physical ownership before releasing its charges.
+
+use std::fmt;
+
+use smallvec::SmallVec;
+
+use super::admission::{
+    AdmissionGuard, DirectDebitError, Reservation, ReservationState, ReserveError,
+};
+use super::arena::{ArenaError, ClaimBatch};
+use super::block::{BlockError, CarrierAllocation};
+use super::{BufferPool, CarrierCount, PoolInner};
+#[cfg(test)]
+use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
+use crate::runtime::sync::sync::Arc;
+
+/// Failure to acquire a complete mutable carrier batch.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AcquireError {
+    /// The byte request was zero.
+    InvalidSize,
+    /// The reservation belongs to another pool.
+    ForeignReservation,
+    /// The reservation no longer permits carrier acquisition.
+    ReservationClosed,
+    /// The request exceeds the reservation's direct-acquisition authority.
+    ReservationCapacityExceeded,
+    /// Geometry or accounting cannot represent the request.
+    CapacityOverflow,
+    /// Physical storage or ownership metadata could not be allocated.
+    PhysicalAllocationFailed,
+}
+
+impl fmt::Display for AcquireError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSize => f.write_str("acquisition size must be nonzero"),
+            Self::ForeignReservation => f.write_str("reservation belongs to another buffer pool"),
+            Self::ReservationClosed => f.write_str("reservation acquisition is closed"),
+            Self::ReservationCapacityExceeded => {
+                f.write_str("acquisition exceeds reservation capacity")
+            }
+            Self::CapacityOverflow => {
+                f.write_str("acquisition exceeds buffer-pool accounting capacity")
+            }
+            Self::PhysicalAllocationFailed => f.write_str("physical buffer-pool allocation failed"),
+        }
+    }
+}
+
+impl std::error::Error for AcquireError {}
+
+/// One-shot failure injection for fallible acquisition metadata boundaries.
+#[cfg(test)]
+pub(super) struct AcquisitionAllocationFailures {
+    /// Remaining boundaries before the injected failure.
+    remaining: AtomicUsize,
+}
+
+#[cfg(test)]
+impl AcquisitionAllocationFailures {
+    /// Creates a disabled injector.
+    pub(super) fn new() -> Self {
+        Self {
+            remaining: AtomicUsize::new(0),
+        }
+    }
+
+    /// Fails the `boundary`th subsequent metadata reservation.
+    fn inject_on_nth(&self, boundary: usize) {
+        assert!(boundary != 0, "failure boundary must be nonzero");
+        self.remaining
+            .compare_exchange(0, boundary, Ordering::AcqRel, Ordering::Acquire)
+            .expect("an acquisition allocation failure is already pending");
+    }
+
+    /// Returns whether this boundary consumes the injected failure.
+    fn take(&self) -> bool {
+        self.remaining
+            .fetch_update(
+                Ordering::AcqRel,
+                Ordering::Acquire,
+                |remaining| match remaining {
+                    0 => None,
+                    1 => Some(0),
+                    remaining => Some(remaining - 1),
+                },
+            )
+            .is_ok_and(|previous| previous == 1)
+    }
+}
+
+impl BufferPool {
+    /// Acquires a complete carrier-rounded batch under one reservation.
+    pub(crate) fn acquire(
+        &self,
+        reservation: &Reservation,
+        min_bytes: usize,
+    ) -> Result<AcquiredRuns, AcquireError> {
+        let count = self.acquisition_count(min_bytes)?;
+        let direct = reservation
+            .acquisition_state()
+            .ok_or(AcquireError::ReservationClosed)?;
+        if !direct.belongs_to(&self.inner) {
+            return Err(AcquireError::ForeignReservation);
+        }
+        acquire_count(&self.inner, Some(Arc::clone(direct)), count)
+    }
+
+    /// Acquires a complete carrier-rounded batch without a reservation.
+    pub(crate) fn acquire_unreserved(
+        &self,
+        min_bytes: usize,
+    ) -> Result<AcquiredRuns, AcquireError> {
+        let count = self.acquisition_count(min_bytes)?;
+        acquire_count(&self.inner, None, count)
+    }
+
+    /// Converts one acquisition request to its complete carrier count.
+    fn acquisition_count(&self, min_bytes: usize) -> Result<CarrierCount, AcquireError> {
+        self.inner
+            .arena
+            .carriers_for_bytes(min_bytes)
+            .map_err(|error| match error {
+                super::geometry::GeometryError::ZeroByteRequest => AcquireError::InvalidSize,
+                _ => AcquireError::CapacityOverflow,
+            })
+    }
+
+    /// Injects one acquisition metadata allocation failure for tests.
+    #[cfg(test)]
+    fn inject_acquisition_allocation_failure(&self, boundary: usize) {
+        self.inner
+            .acquisition_allocation_failures
+            .inject_on_nth(boundary);
+    }
+}
+
+/// Aggregate and optional direct charges not yet owned by carrier guards.
+struct AcquisitionDebit {
+    /// Pool whose aggregate accounting owns every remaining charge.
+    pool: Arc<PoolInner>,
+    /// Reservation whose direct authority owns every remaining charge.
+    direct: Option<Arc<ReservationState>>,
+    /// Charges not yet transferred to carrier guards.
+    untransferred: CarrierCount,
+}
+
+impl AcquisitionDebit {
+    /// Installs a complete accounting debit before physical acquisition.
+    fn install(
+        pool: &Arc<PoolInner>,
+        direct: Option<Arc<ReservationState>>,
+        count: CarrierCount,
+    ) -> Result<Self, AcquireError> {
+        if let Some(direct) = direct.as_ref() {
+            direct
+                .precheck_debit(count)
+                .map_err(map_direct_debit_error)?;
+        }
+
+        let aggregate = match pool.try_debit_covered(count) {
+            Ok(true) => Ok(()),
+            Ok(false) => {
+                let mut admission = AdmissionGuard::new(pool.admission.lock());
+                PoolInner::debit_and_prepare_locked(pool, &mut admission, count)
+            }
+            Err(error) => Err(error),
+        };
+        if let Err(error) = aggregate {
+            return Err(map_reserve_error(error));
+        }
+        if let Some(direct) = direct.as_ref() {
+            if let Err(error) = direct.try_debit(count) {
+                PoolInner::release_acquisition_charges(pool, count);
+                return Err(map_direct_debit_error(error));
+            }
+        }
+
+        Ok(Self {
+            pool: Arc::clone(pool),
+            direct,
+            untransferred: count,
+        })
+    }
+
+    /// Transfers one physical allocation and its accounting provenance.
+    fn transfer(&mut self, allocation: CarrierAllocation) -> Arc<CarrierGuard> {
+        assert!(
+            self.untransferred != CarrierCount::ZERO,
+            "acquisition debit transferred too many charges"
+        );
+        let guard = Arc::new(CarrierGuard {
+            pool: Arc::clone(&self.pool),
+            allocation: Some(allocation),
+            direct: self.direct.as_ref().map(Arc::clone),
+        });
+        self.untransferred = self
+            .untransferred
+            .checked_sub(CarrierCount::new(1))
+            .expect("acquisition debit must retain a transferred charge");
+        guard
+    }
+}
+
+impl Drop for AcquisitionDebit {
+    fn drop(&mut self) {
+        if self.untransferred == CarrierCount::ZERO {
+            return;
+        }
+        if let Some(direct) = self.direct.as_ref() {
+            direct.release(self.untransferred);
+        }
+        PoolInner::release_acquisition_charges(&self.pool, self.untransferred);
+    }
+}
+
+/// Physical and accounting ownership retained until acquisition commits.
+struct PendingAcquisition {
+    /// Completed carrier owners returned before the remaining transaction.
+    guards: Vec<Arc<CarrierGuard>>,
+    /// Provisional physical bits returned before accounting rollback.
+    claim: Option<ClaimBatch>,
+    /// Aggregate and direct charges released last.
+    debit: Option<AcquisitionDebit>,
+}
+
+impl PendingAcquisition {
+    /// Creates a pending transaction after its complete debit is installed.
+    fn new(debit: AcquisitionDebit) -> Self {
+        Self {
+            guards: Vec::new(),
+            claim: None,
+            debit: Some(debit),
+        }
+    }
+
+    /// Converts one complete physical batch into grouped carrier ownership.
+    fn finish(mut self) -> Result<AcquiredRuns, AcquireError> {
+        let claim = self
+            .claim
+            .take()
+            .expect("pending acquisition must retain its physical claim");
+        let allocations = claim.finish().map_err(map_arena_error)?;
+        let pool = &self
+            .debit
+            .as_ref()
+            .expect("pending acquisition must retain its accounting debit")
+            .pool;
+        if allocation_failure_injected(pool) {
+            return Err(AcquireError::PhysicalAllocationFailed);
+        }
+        self.guards
+            .try_reserve_exact(allocations.len())
+            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+
+        let debit = self
+            .debit
+            .as_mut()
+            .expect("pending acquisition must retain its accounting debit");
+        for allocation in allocations {
+            self.guards.push(debit.transfer(allocation));
+        }
+        assert_eq!(
+            debit.untransferred,
+            CarrierCount::ZERO,
+            "complete acquisition left untransferred charges"
+        );
+
+        AcquiredRuns::try_from_guards(std::mem::take(&mut self.guards))
+    }
+}
+
+impl Drop for PendingAcquisition {
+    fn drop(&mut self) {
+        self.guards.clear();
+        drop(self.claim.take());
+        drop(self.debit.take());
+    }
+}
+
+/// Complete carrier runs returned by one acquisition transaction.
+pub(crate) struct AcquiredRuns {
+    /// Contiguous physical runs in ascending slot and carrier order.
+    runs: SmallVec<[CarrierRun; 4]>,
+    /// Complete carrier-rounded capacity.
+    capacity: usize,
+}
+
+impl AcquiredRuns {
+    /// Groups physical owners into ascending adjacent carrier runs.
+    fn try_from_guards(mut guards: Vec<Arc<CarrierGuard>>) -> Result<AcquiredRuns, AcquireError> {
+        guards.sort_unstable_by_key(|guard| guard.identity());
+        let pool = Arc::clone(
+            &guards
+                .first()
+                .expect("complete acquisition must contain a carrier")
+                .pool,
+        );
+
+        let mut runs = SmallVec::<[CarrierRun; 4]>::new();
+        if allocation_failure_injected(&pool) {
+            return Err(AcquireError::PhysicalAllocationFailed);
+        }
+        runs.try_reserve(guards.len())
+            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+        let mut capacity = 0usize;
+        for guard in guards {
+            capacity = capacity
+                .checked_add(guard.capacity())
+                .ok_or(AcquireError::CapacityOverflow)?;
+            if let Some(run) = runs.last_mut() {
+                if run.can_append(&guard) {
+                    run.try_append(guard)?;
+                    continue;
+                }
+            }
+            runs.push(CarrierRun::try_new(guard)?);
+        }
+
+        Ok(Self { runs, capacity })
+    }
+
+    /// Returns the complete carrier-rounded byte capacity.
+    pub(crate) fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns the number of contiguous carrier runs.
+    pub(crate) fn run_count(&self) -> usize {
+        self.runs.len()
+    }
+
+    /// Transfers the grouped carrier owners to the mutable-buffer layer.
+    pub(super) fn into_runs(self) -> SmallVec<[CarrierRun; 4]> {
+        self.runs
+    }
+}
+
+/// Adjacent carriers within one stable block slot.
+pub(super) struct CarrierRun {
+    /// Stable block slot containing the run.
+    slot_id: u32,
+    /// First carrier index within the slot.
+    first_carrier: u32,
+    /// Total run capacity in bytes.
+    capacity: usize,
+    /// Per-carrier owners in ascending address order.
+    carriers: Vec<Arc<CarrierGuard>>,
+}
+
+impl CarrierRun {
+    /// Creates a run containing one carrier.
+    fn try_new(guard: Arc<CarrierGuard>) -> Result<Self, AcquireError> {
+        let (slot_id, first_carrier) = guard.identity();
+        let capacity = guard.capacity();
+        let mut carriers = Vec::new();
+        if allocation_failure_injected(&guard.pool) {
+            return Err(AcquireError::PhysicalAllocationFailed);
+        }
+        carriers
+            .try_reserve_exact(1)
+            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+        carriers.push(guard);
+        Ok(Self {
+            slot_id,
+            first_carrier,
+            capacity,
+            carriers,
+        })
+    }
+
+    /// Returns whether `guard` immediately follows this run.
+    fn can_append(&self, guard: &CarrierGuard) -> bool {
+        let run_len =
+            u32::try_from(self.carriers.len()).expect("carrier run length must fit block geometry");
+        let next = self
+            .first_carrier
+            .checked_add(run_len)
+            .expect("carrier run end must fit block geometry");
+        guard.identity() == (self.slot_id, next)
+    }
+
+    /// Appends one adjacent carrier without exposing a partial run on failure.
+    fn try_append(&mut self, guard: Arc<CarrierGuard>) -> Result<(), AcquireError> {
+        if allocation_failure_injected(&guard.pool) {
+            return Err(AcquireError::PhysicalAllocationFailed);
+        }
+        self.carriers
+            .try_reserve(1)
+            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+        self.capacity = self
+            .capacity
+            .checked_add(guard.capacity())
+            .ok_or(AcquireError::CapacityOverflow)?;
+        self.carriers.push(guard);
+        Ok(())
+    }
+
+    /// Returns the run's total byte capacity.
+    pub(super) fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// Returns the first carrier's checked writable pointer.
+    pub(super) fn ptr(&self) -> std::ptr::NonNull<std::mem::MaybeUninit<u8>> {
+        self.carriers
+            .first()
+            .expect("carrier run must be nonempty")
+            .ptr()
+    }
+
+    /// Transfers per-carrier ownership in ascending address order.
+    pub(super) fn into_carriers(self) -> Vec<Arc<CarrierGuard>> {
+        self.carriers
+    }
+}
+
+/// One physical carrier and its aggregate accounting charge.
+pub(super) struct CarrierGuard {
+    /// Pool retained through final physical and accounting return.
+    pool: Arc<PoolInner>,
+    /// Single-owner physical return capability.
+    allocation: Option<CarrierAllocation>,
+    /// Optional reservation-local return provenance.
+    direct: Option<Arc<ReservationState>>,
+}
+
+impl CarrierGuard {
+    /// Returns stable identity used only to group adjacent carriers.
+    fn identity(&self) -> (u32, u32) {
+        let allocation = self
+            .allocation
+            .as_ref()
+            .expect("live carrier guard must retain its allocation");
+        (allocation.slot_id(), allocation.carrier_index())
+    }
+
+    /// Returns this carrier's byte capacity.
+    pub(super) fn capacity(&self) -> usize {
+        self.allocation
+            .as_ref()
+            .expect("live carrier guard must retain its allocation")
+            .capacity()
+    }
+
+    /// Returns the first byte of this exclusively owned carrier.
+    pub(super) fn ptr(&self) -> std::ptr::NonNull<std::mem::MaybeUninit<u8>> {
+        self.allocation
+            .as_ref()
+            .expect("live carrier guard must retain its allocation")
+            .ptr()
+    }
+}
+
+impl Drop for CarrierGuard {
+    fn drop(&mut self) {
+        let allocation = self
+            .allocation
+            .take()
+            .expect("carrier guard returned its allocation more than once");
+        drop(allocation);
+        if let Some(direct) = self.direct.as_ref() {
+            direct.release(CarrierCount::new(1));
+        }
+        PoolInner::release_acquisition_charges(&self.pool, CarrierCount::new(1));
+    }
+}
+
+/// Installs accounting, acquires a complete physical batch, and groups it.
+fn acquire_count(
+    pool: &Arc<PoolInner>,
+    direct: Option<Arc<ReservationState>>,
+    count: CarrierCount,
+) -> Result<AcquiredRuns, AcquireError> {
+    let debit = AcquisitionDebit::install(pool, direct, count)?;
+    let mut pending = PendingAcquisition::new(debit);
+    pending.claim = Some(
+        pool.arena
+            .claim_optimistic(count)
+            .map_err(map_arena_error)?,
+    );
+
+    if !pending
+        .claim
+        .as_ref()
+        .expect("pending acquisition must retain its claim")
+        .is_complete()
+    {
+        let fallback = {
+            let mut admission = AdmissionGuard::new(pool.admission.lock());
+            pool.arena.complete_claim_serialized(
+                &mut admission,
+                pending
+                    .claim
+                    .as_mut()
+                    .expect("pending acquisition must retain its claim"),
+            )
+        };
+        fallback.map_err(map_arena_error)?;
+    }
+
+    pending.finish()
+}
+
+/// Returns whether test injection fails this fallible allocation boundary.
+fn allocation_failure_injected(pool: &PoolInner) -> bool {
+    #[cfg(test)]
+    {
+        pool.acquisition_allocation_failures.take()
+    }
+    #[cfg(not(test))]
+    {
+        let _ = pool;
+        false
+    }
+}
+
+fn map_direct_debit_error(error: DirectDebitError) -> AcquireError {
+    match error {
+        DirectDebitError::Closed => AcquireError::ReservationClosed,
+        DirectDebitError::CapacityExceeded => AcquireError::ReservationCapacityExceeded,
+        DirectDebitError::CapacityOverflow => AcquireError::CapacityOverflow,
+    }
+}
+
+fn map_reserve_error(error: ReserveError) -> AcquireError {
+    match error {
+        ReserveError::InvalidSize => AcquireError::InvalidSize,
+        ReserveError::PhysicalPreparationFailed => AcquireError::PhysicalAllocationFailed,
+        ReserveError::CapacityOverflow => AcquireError::CapacityOverflow,
+    }
+}
+
+fn map_arena_error(error: ArenaError) -> AcquireError {
+    match error {
+        ArenaError::Block(BlockError::PreparedCapacityOverflow)
+        | ArenaError::SlotIdExhausted
+        | ArenaError::RegistryCapacityOverflow
+        | ArenaError::AddressOverflow { .. }
+        | ArenaError::ScanSpaceOverflow { .. } => AcquireError::CapacityOverflow,
+        ArenaError::Block(_)
+        | ArenaError::Allocation(_)
+        | ArenaError::InvalidScanBudget
+        | ArenaError::InvalidClaimCount
+        | ArenaError::IncompleteClaim { .. }
+        | ArenaError::AddressOverlap { .. } => AcquireError::PhysicalAllocationFailed,
+    }
+}
+
+#[cfg(all(test, not(s3_tm_loom)))]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::mpsc;
+    use std::sync::Arc as StdArc;
+    use std::task::{Context, Poll, Wake, Waker};
+    use std::time::Duration;
+
+    use super::super::block::{BlockSlot, TrimBlocked};
+    use super::super::geometry::PoolGeometry;
+    use super::super::virtual_memory::{page_size, VirtualMemoryOperation};
+    use super::super::ReserveFuture;
+    use super::*;
+
+    struct ClaimingWake {
+        pool: BufferPool,
+        wakes: AtomicUsize,
+        claimed: AtomicBool,
+    }
+
+    impl Wake for ClaimingWake {
+        fn wake(self: StdArc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &StdArc<Self>) {
+            let claim = self
+                .pool
+                .inner
+                .arena
+                .claim_optimistic(CarrierCount::new(1))
+                .expect("wake-time claim");
+            self.claimed.store(claim.is_complete(), Ordering::Release);
+            self.wakes.fetch_add(1, Ordering::Release);
+        }
+    }
+
+    fn test_pool(
+        block_carriers: usize,
+        configured: usize,
+        optimistic_scan_words: usize,
+    ) -> (BufferPool, usize) {
+        let page_size = page_size().unwrap().get();
+        let geometry = PoolGeometry::new(
+            page_size,
+            page_size.checked_mul(block_carriers).unwrap(),
+            page_size,
+        )
+        .unwrap();
+        let pool = BufferPool::from_validated_parts(
+            geometry,
+            CarrierCount::new(configured),
+            optimistic_scan_words,
+        )
+        .unwrap();
+        (pool, page_size)
+    }
+
+    fn poll_reserve(
+        future: &mut ReserveFuture,
+        waker: &Waker,
+    ) -> Poll<Result<Reservation, ReserveError>> {
+        let mut context = Context::from_waker(waker);
+        Pin::new(future).poll(&mut context)
+    }
+
+    #[test]
+    fn test_acquisition_rejects_zero_foreign_and_excess_requests() {
+        let (first, carrier_size) = test_pool(1, 1, 1);
+        let (second, _) = test_pool(1, 1, 1);
+        let reservation = first
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("initial reservation");
+
+        assert!(matches!(
+            first.acquire_unreserved(0),
+            Err(AcquireError::InvalidSize)
+        ));
+        assert!(matches!(
+            second.acquire(&reservation, carrier_size),
+            Err(AcquireError::ForeignReservation)
+        ));
+        assert!(matches!(
+            first.acquire(&reservation, carrier_size * 2),
+            Err(AcquireError::ReservationCapacityExceeded)
+        ));
+        assert_eq!(
+            first.inner.test_accounting_state(),
+            (
+                CarrierCount::new(1),
+                CarrierCount::new(1),
+                CarrierCount::new(1),
+                CarrierCount::ZERO,
+                0,
+            )
+        );
+
+        let direct = Arc::clone(reservation.acquisition_state().unwrap());
+        reservation.close_acquisition();
+        assert!(matches!(
+            acquire_count(&first.inner, Some(direct), CarrierCount::new(1)),
+            Err(AcquireError::ReservationClosed)
+        ));
+    }
+
+    #[test]
+    fn test_reserved_acquisition_returns_direct_and_aggregate_authority() {
+        let (pool, carrier_size) = test_pool(2, 2, 1);
+        let reservation = pool
+            .try_reserve(carrier_size * 2)
+            .unwrap()
+            .expect("reservation");
+        let direct = Arc::clone(reservation.acquisition_state().unwrap());
+
+        let acquired = pool.acquire(&reservation, carrier_size + 1).unwrap();
+
+        assert_eq!(acquired.capacity(), carrier_size * 2);
+        assert_eq!(acquired.run_count(), 1);
+        assert_eq!(direct.test_owner_state(), (false, CarrierCount::new(2)));
+        assert_eq!(
+            pool.inner.test_accounting_state(),
+            (
+                CarrierCount::new(2),
+                CarrierCount::new(2),
+                CarrierCount::ZERO,
+                CarrierCount::ZERO,
+                0,
+            )
+        );
+
+        drop(acquired);
+        assert_eq!(direct.test_owner_state(), (false, CarrierCount::ZERO));
+        assert_eq!(pool.inner.test_accounting_state().2, CarrierCount::new(2));
+        reservation.close_acquisition();
+        assert_eq!(
+            pool.inner.test_accounting_state(),
+            (
+                CarrierCount::new(2),
+                CarrierCount::ZERO,
+                CarrierCount::ZERO,
+                CarrierCount::ZERO,
+                0,
+            )
+        );
+    }
+
+    #[test]
+    fn test_unreserved_shortfall_prepares_and_groups_complete_runs() {
+        let (pool, carrier_size) = test_pool(2, 1, 1);
+
+        let acquired = pool.acquire_unreserved(carrier_size * 3).unwrap();
+
+        assert_eq!(acquired.capacity(), carrier_size * 3);
+        assert_eq!(acquired.run_count(), 2);
+        assert_eq!(acquired.runs[0].capacity(), carrier_size * 2);
+        assert_eq!(acquired.runs[1].capacity(), carrier_size);
+        assert_eq!(
+            pool.inner.test_accounting_state(),
+            (
+                CarrierCount::new(4),
+                CarrierCount::ZERO,
+                CarrierCount::ZERO,
+                CarrierCount::new(3),
+                0,
+            )
+        );
+
+        drop(acquired);
+        assert_eq!(
+            pool.inner.test_accounting_state(),
+            (
+                CarrierCount::new(4),
+                CarrierCount::ZERO,
+                CarrierCount::ZERO,
+                CarrierCount::ZERO,
+                0,
+            )
+        );
+    }
+
+    #[test]
+    fn test_partial_optimistic_claim_completes_through_fallback() {
+        let (pool, carrier_size) = test_pool(65, 65, 1);
+        let reservation = pool
+            .try_reserve(carrier_size * 65)
+            .unwrap()
+            .expect("reservation");
+
+        let acquired = pool.acquire(&reservation, carrier_size * 65).unwrap();
+
+        assert_eq!(acquired.capacity(), carrier_size * 65);
+        assert_eq!(acquired.run_count(), 1);
+        assert_eq!(pool.inner.arena.diagnostics().serialized_fallbacks, 1);
+    }
+
+    #[test]
+    fn test_preparation_failure_restores_direct_and_aggregate_debits() {
+        let (pool, carrier_size) = test_pool(1, 1, 1);
+        let reservation = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("reservation");
+        let direct = Arc::clone(reservation.acquisition_state().unwrap());
+        let occupying = pool.acquire_unreserved(carrier_size).unwrap();
+        let failed_slot = pool.inner.arena.reserve_slot().unwrap();
+        failed_slot.inject_failure_once(VirtualMemoryOperation::Prepare);
+
+        assert!(matches!(
+            pool.acquire(&reservation, carrier_size),
+            Err(AcquireError::PhysicalAllocationFailed)
+        ));
+        assert_eq!(direct.test_owner_state(), (false, CarrierCount::ZERO));
+        assert_eq!(
+            pool.inner.test_accounting_state(),
+            (
+                CarrierCount::new(1),
+                CarrierCount::new(1),
+                CarrierCount::ZERO,
+                CarrierCount::ZERO,
+                0,
+            )
+        );
+
+        let retry = pool.acquire(&reservation, carrier_size).unwrap();
+        assert_eq!(retry.capacity(), carrier_size);
+        drop(retry);
+        drop(occupying);
+    }
+
+    #[test]
+    fn test_covered_acquisition_does_not_enter_admission() {
+        let (pool, carrier_size) = test_pool(1, 1, 1);
+        let reservation = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("reservation");
+        let admission = pool.inner.admission.lock();
+        let worker_pool = pool.clone();
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        let worker = std::thread::spawn(move || {
+            let acquired = worker_pool.acquire(&reservation, carrier_size);
+            let result = match &acquired {
+                Ok(runs) => Ok(runs.capacity()),
+                Err(error) => Err(*error),
+            };
+            acquired_tx.send(result).unwrap();
+            release_rx.recv().unwrap();
+            drop(acquired);
+            drop(reservation);
+        });
+
+        assert_eq!(
+            acquired_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("covered acquisition blocked on admission")
+                .unwrap(),
+            carrier_size
+        );
+        drop(admission);
+        release_tx.send(()).unwrap();
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn test_pending_rollback_returns_bits_before_releasing_charges() {
+        let (pool, _) = test_pool(2, 1, 1);
+        let count = CarrierCount::new(2);
+        let debit = AcquisitionDebit::install(&pool.inner, None, count).unwrap();
+        let claim = pool.inner.arena.claim_optimistic(count).unwrap();
+        assert!(claim.is_complete());
+        let mut pending = PendingAcquisition::new(debit);
+        pending.claim = Some(claim);
+
+        drop(pending);
+
+        assert_eq!(pool.inner.test_accounting_state().3, CarrierCount::ZERO);
+        let reclaimed = pool.inner.arena.claim_optimistic(count).unwrap();
+        assert!(reclaimed.is_complete());
+        drop(reclaimed);
+    }
+
+    #[test]
+    fn test_uncovered_return_drains_fifo_after_physical_return() {
+        let (pool, carrier_size) = test_pool(1, 2, 1);
+        let first = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("first reservation");
+        let first_acquired = pool.acquire(&first, carrier_size).unwrap();
+        first.close_acquisition();
+
+        let second = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("idle-only reservation");
+        let second_acquired = pool.acquire(&second, carrier_size).unwrap();
+        let wake_state = StdArc::new(ClaimingWake {
+            pool: pool.clone(),
+            wakes: AtomicUsize::new(0),
+            claimed: AtomicBool::new(false),
+        });
+        let waker = Waker::from(StdArc::clone(&wake_state));
+        let mut queued = pool.reserve(carrier_size);
+        assert!(poll_reserve(&mut queued, &waker).is_pending());
+
+        drop(first_acquired);
+
+        assert_eq!(wake_state.wakes.load(Ordering::Acquire), 1);
+        assert!(
+            wake_state.claimed.load(Ordering::Acquire),
+            "waiter reentry ran before the returned physical bit was reusable"
+        );
+        let third = match poll_reserve(&mut queued, &waker) {
+            Poll::Ready(Ok(reservation)) => reservation,
+            Poll::Ready(Err(error)) => panic!("queued reservation failed: {error}"),
+            Poll::Pending => panic!("uncovered repayment stranded an eligible waiter"),
+        };
+        drop(second_acquired);
+        drop(second);
+        drop(third);
+    }
+
+    #[test]
+    fn test_return_and_close_orders_converge() {
+        fn run(close_first: bool) -> (CarrierCount, CarrierCount, CarrierCount) {
+            let (pool, carrier_size) = test_pool(1, 1, 1);
+            let reservation = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("reservation");
+            let acquired = pool.acquire(&reservation, carrier_size).unwrap();
+            if close_first {
+                reservation.close_acquisition();
+                drop(acquired);
+            } else {
+                drop(acquired);
+                reservation.close_acquisition();
+            }
+            let (_, active, available, uncovered, _) = pool.inner.test_accounting_state();
+            (active, available, uncovered)
+        }
+
+        assert_eq!(
+            run(false),
+            (CarrierCount::ZERO, CarrierCount::ZERO, CarrierCount::ZERO)
+        );
+        assert_eq!(run(true), run(false));
+    }
+
+    #[test]
+    fn test_close_preserves_other_reservation_coverage_under_normal_ceiling() {
+        let (pool, carrier_size) = test_pool(4, 8, 1);
+        let first = pool
+            .try_reserve(carrier_size * 3)
+            .unwrap()
+            .expect("first reservation");
+        let first_acquired = pool.acquire(&first, carrier_size * 3).unwrap();
+        let second = pool
+            .try_reserve(carrier_size * 3)
+            .unwrap()
+            .expect("second reservation");
+
+        first.close_acquisition();
+
+        let closed = pool.metrics();
+        assert_eq!(
+            closed.active_planned_demand_bytes(),
+            (carrier_size * 3) as u64
+        );
+        assert_eq!(closed.charged_capacity_bytes(), (carrier_size * 3) as u64);
+        assert_eq!(closed.admission_used_bytes(), (carrier_size * 6) as u64);
+        assert!(
+            pool.try_reserve(carrier_size * 4).unwrap().is_none(),
+            "close made another reservation's coverage available for a new grant"
+        );
+
+        let second_acquired = pool.acquire(&second, carrier_size * 3).unwrap();
+        assert!(first_acquired.capacity() + second_acquired.capacity() <= carrier_size * 8);
+
+        drop(first_acquired);
+        let third = pool
+            .try_reserve(carrier_size * 4)
+            .unwrap()
+            .expect("returned ownership restores normal headroom");
+        let third_acquired = pool.acquire(&third, carrier_size * 4).unwrap();
+        assert!(second_acquired.capacity() + third_acquired.capacity() <= carrier_size * 8);
+
+        drop(second_acquired);
+        drop(second);
+        drop(third_acquired);
+        drop(third);
+    }
+
+    #[test]
+    fn test_carrier_owner_retains_pool_until_final_return() {
+        let (pool, carrier_size) = test_pool(1, 1, 1);
+        let weak = Arc::downgrade(&pool.inner);
+        let acquired = pool.acquire_unreserved(carrier_size).unwrap();
+
+        drop(pool);
+        assert!(weak.upgrade().is_some());
+        drop(acquired);
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn test_acquisition_ownership_is_send_and_sync() {
+        fn assert_send<T: Send>() {}
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send::<AcquiredRuns>();
+        assert_send_sync::<CarrierGuard>();
+    }
+
+    #[test]
+    fn test_metadata_allocation_failure_rolls_back_every_commit_boundary() {
+        for boundary in 1..=4 {
+            let (pool, carrier_size) = test_pool(2, 2, 1);
+            let reservation = pool
+                .try_reserve(carrier_size * 2)
+                .unwrap()
+                .expect("reservation");
+            let direct = Arc::clone(reservation.acquisition_state().unwrap());
+            pool.inject_acquisition_allocation_failure(boundary);
+
+            assert!(
+                matches!(
+                    pool.acquire(&reservation, carrier_size * 2),
+                    Err(AcquireError::PhysicalAllocationFailed)
+                ),
+                "metadata boundary {boundary} did not fail"
+            );
+            assert_eq!(
+                direct.test_owner_state(),
+                (false, CarrierCount::ZERO),
+                "metadata boundary {boundary} leaked direct authority"
+            );
+            let metrics = pool.metrics();
+            assert_eq!(
+                metrics.charged_capacity_bytes(),
+                0,
+                "metadata boundary {boundary} leaked aggregate charges"
+            );
+            assert_eq!(
+                metrics.active_planned_demand_bytes(),
+                (carrier_size * 2) as u64
+            );
+
+            let retry = pool
+                .acquire(&reservation, carrier_size * 2)
+                .expect("pool remains usable after metadata failure");
+            drop(retry);
+            drop(reservation);
+        }
+    }
+
+    #[test]
+    fn test_in_flight_shortfall_charge_preserves_trim_floor() {
+        let (pool, _) = test_pool(2, 1, 1);
+        let debit = AcquisitionDebit::install(&pool.inner, None, CarrierCount::new(1)).unwrap();
+        let candidate = pool
+            .inner
+            .arena
+            .select_trim_candidate()
+            .expect("prepared free block");
+
+        {
+            let mut admission = AdmissionGuard::new(pool.inner.admission.lock());
+            let floor = admission.acquisition_floor(&pool.inner.coverage).unwrap();
+            assert!(matches!(
+                BlockSlot::start_trim(&candidate, admission.prepared_capacity_mut(), floor,),
+                Err(TrimBlocked::FloorViolation)
+            ));
+        }
+
+        drop(debit);
+        let cleanup = {
+            let mut admission = AdmissionGuard::new(pool.inner.admission.lock());
+            let floor = admission.acquisition_floor(&pool.inner.coverage).unwrap();
+            BlockSlot::start_trim(&candidate, admission.prepared_capacity_mut(), floor)
+                .expect("returned charge permits trim")
+        };
+        cleanup.finish().unwrap();
+        assert_eq!(pool.metrics().prepared_capacity_bytes(), 0);
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc as StdArc;
+    use std::task::{Context, Poll, Wake, Waker};
+
+    use super::super::block::{BlockSlot, TrimBlocked};
+    use super::super::geometry::PoolGeometry;
+    use super::super::virtual_memory::page_size;
+    use super::super::ReserveFuture;
+    use super::*;
+    use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
+    use crate::runtime::sync::sync::Arc;
+    use crate::runtime::sync::thread;
+
+    struct CountingWake {
+        count: Arc<AtomicUsize>,
+    }
+
+    impl Wake for CountingWake {
+        fn wake(self: StdArc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &StdArc<Self>) {
+            self.count.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    fn test_pool(configured: usize) -> (BufferPool, usize) {
+        let page_size = page_size().unwrap().get();
+        let geometry = PoolGeometry::new(page_size, page_size, page_size).unwrap();
+        let pool =
+            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
+        (pool, page_size)
+    }
+
+    fn counting_waker() -> (Waker, Arc<AtomicUsize>) {
+        let count = Arc::new(AtomicUsize::new(0));
+        let state = CountingWake {
+            count: Arc::clone(&count),
+        };
+        (Waker::from(StdArc::new(state)), count)
+    }
+
+    fn poll_reserve(
+        future: &mut ReserveFuture,
+        waker: &Waker,
+    ) -> Poll<Result<Reservation, ReserveError>> {
+        let mut context = Context::from_waker(waker);
+        Pin::new(future).poll(&mut context)
+    }
+
+    #[test]
+    fn test_final_return_racing_close_converges() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(1);
+            let reservation = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("reservation");
+            let acquired = pool.acquire(&reservation, carrier_size).unwrap();
+
+            let closing = thread::spawn(move || reservation.close_acquisition());
+            let returning = thread::spawn(move || drop(acquired));
+            closing.join().unwrap();
+            returning.join().unwrap();
+
+            let (_, active, available, uncovered, _) = pool.inner.test_accounting_state();
+            assert_eq!(active, CarrierCount::ZERO);
+            assert_eq!(available, CarrierCount::ZERO);
+            assert_eq!(uncovered, CarrierCount::ZERO);
+        });
+    }
+
+    #[test]
+    fn test_close_cannot_free_another_reservations_coverage_for_grant() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(2);
+            let first = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("first reservation");
+            let first_acquired = pool.acquire(&first, carrier_size).unwrap();
+            let second = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("second reservation");
+
+            let closing = thread::spawn(move || first.close_acquisition());
+            let granting_pool = pool.clone();
+            let granting = thread::spawn(move || granting_pool.try_reserve(carrier_size).unwrap());
+
+            closing.join().unwrap();
+            assert!(
+                granting.join().unwrap().is_none(),
+                "close admitted work against another reservation's coverage"
+            );
+            let (_, active, available, uncovered, _) = pool.inner.test_accounting_state();
+            assert_eq!(active, CarrierCount::new(1));
+            assert_eq!(available, CarrierCount::new(1));
+            assert_eq!(uncovered, CarrierCount::new(1));
+
+            drop(first_acquired);
+            drop(second);
+        });
+    }
+
+    #[test]
+    fn test_concurrent_acquisitions_consume_direct_authority_once() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(1);
+            let reservation = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("reservation");
+            let direct = Arc::clone(reservation.acquisition_state().unwrap());
+
+            let first_pool = Arc::clone(&pool.inner);
+            let first_direct = Arc::clone(&direct);
+            let first = thread::spawn(move || {
+                acquire_count(&first_pool, Some(first_direct), CarrierCount::new(1))
+            });
+            let second_pool = Arc::clone(&pool.inner);
+            let second = thread::spawn(move || {
+                acquire_count(&second_pool, Some(direct), CarrierCount::new(1))
+            });
+
+            let first = first.join().unwrap();
+            let second = second.join().unwrap();
+            assert_eq!(usize::from(first.is_ok()) + usize::from(second.is_ok()), 1);
+            assert!(
+                matches!(first, Err(AcquireError::ReservationCapacityExceeded))
+                    || matches!(second, Err(AcquireError::ReservationCapacityExceeded))
+            );
+            drop(first);
+            drop(second);
+            drop(reservation);
+            let (_, active, available, uncovered, _) = pool.inner.test_accounting_state();
+            assert_eq!(active, CarrierCount::ZERO);
+            assert_eq!(available, CarrierCount::ZERO);
+            assert_eq!(uncovered, CarrierCount::ZERO);
+        });
+    }
+
+    #[test]
+    fn test_final_return_racing_waiter_enqueue_cannot_strand_grant() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(2);
+            let returned = pool.acquire_unreserved(carrier_size).unwrap();
+            let holder = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("idle-only reservation");
+            let (waker, wake_count) = counting_waker();
+            let mut future = pool.reserve(carrier_size);
+
+            let returning = thread::spawn(move || drop(returned));
+            let first_poll = poll_reserve(&mut future, &waker);
+            returning.join().unwrap();
+            let granted = match first_poll {
+                Poll::Ready(Ok(reservation)) => reservation,
+                Poll::Ready(Err(error)) => panic!("reservation failed: {error}"),
+                Poll::Pending => match poll_reserve(&mut future, &waker) {
+                    Poll::Ready(Ok(reservation)) => reservation,
+                    Poll::Ready(Err(error)) => panic!("reservation failed: {error}"),
+                    Poll::Pending => panic!("return stranded an eligible waiter"),
+                },
+            };
+
+            assert!(wake_count.load(Ordering::Acquire) <= 1);
+            drop(holder);
+            drop(granted);
+            let (_, active, available, uncovered, waiters) = pool.inner.test_accounting_state();
+            assert_eq!(active, CarrierCount::ZERO);
+            assert_eq!(available, CarrierCount::ZERO);
+            assert_eq!(uncovered, CarrierCount::ZERO);
+            assert_eq!(waiters, 0);
+        });
+    }
+
+    #[test]
+    fn test_close_racing_direct_debit_rollback_cannot_reopen_authority() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(1);
+            let reservation = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("reservation");
+            let direct = Arc::clone(reservation.acquisition_state().unwrap());
+
+            let debiting_pool = Arc::clone(&pool.inner);
+            let debiting_direct = Arc::clone(&direct);
+            let debiting = thread::spawn(move || {
+                AcquisitionDebit::install(
+                    &debiting_pool,
+                    Some(debiting_direct),
+                    CarrierCount::new(1),
+                )
+            });
+            let closing = thread::spawn(move || reservation.close_acquisition());
+            let debit = debiting.join().unwrap();
+            closing.join().unwrap();
+
+            match debit {
+                Ok(debit) => {
+                    assert_eq!(direct.test_owner_state(), (true, CarrierCount::new(1)));
+                    let (_, active, available, uncovered, _) = pool.inner.test_accounting_state();
+                    assert_eq!(active, CarrierCount::ZERO);
+                    assert_eq!(available, CarrierCount::ZERO);
+                    assert_eq!(uncovered, CarrierCount::new(1));
+                    drop(debit);
+                }
+                Err(AcquireError::ReservationClosed) => {
+                    assert_eq!(direct.test_owner_state(), (true, CarrierCount::ZERO));
+                }
+                Err(error) => panic!("unexpected acquisition debit error: {error}"),
+            }
+
+            assert_eq!(direct.test_owner_state(), (true, CarrierCount::ZERO));
+            let (_, active, available, uncovered, _) = pool.inner.test_accounting_state();
+            assert_eq!(active, CarrierCount::ZERO);
+            assert_eq!(available, CarrierCount::ZERO);
+            assert_eq!(uncovered, CarrierCount::ZERO);
+        });
+    }
+
+    #[test]
+    fn test_shortfall_rollback_racing_waiter_enqueue_cannot_strand_grant() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(2);
+            let debit = AcquisitionDebit::install(&pool.inner, None, CarrierCount::new(1)).unwrap();
+            let holder = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("idle-only reservation");
+            let (waker, wake_count) = counting_waker();
+            let mut future = pool.reserve(carrier_size);
+
+            let rolling_back = thread::spawn(move || drop(debit));
+            let first_poll = poll_reserve(&mut future, &waker);
+            rolling_back.join().unwrap();
+            let granted = match first_poll {
+                Poll::Ready(Ok(reservation)) => reservation,
+                Poll::Ready(Err(error)) => panic!("reservation failed: {error}"),
+                Poll::Pending => match poll_reserve(&mut future, &waker) {
+                    Poll::Ready(Ok(reservation)) => reservation,
+                    Poll::Ready(Err(error)) => panic!("reservation failed: {error}"),
+                    Poll::Pending => panic!("rollback stranded an eligible waiter"),
+                },
+            };
+
+            assert!(wake_count.load(Ordering::Acquire) <= 1);
+            drop(holder);
+            drop(granted);
+            let (_, active, available, uncovered, waiters) = pool.inner.test_accounting_state();
+            assert_eq!(active, CarrierCount::ZERO);
+            assert_eq!(available, CarrierCount::ZERO);
+            assert_eq!(uncovered, CarrierCount::ZERO);
+            assert_eq!(waiters, 0);
+        });
+    }
+
+    #[test]
+    fn test_manager_local_teardown_preserves_escaped_owner_and_shared_pool() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(2);
+            let manager_pool = pool.clone();
+            let reservation = manager_pool
+                .try_reserve(carrier_size * 2)
+                .unwrap()
+                .expect("manager reservation");
+            let escaped = manager_pool.acquire(&reservation, carrier_size).unwrap();
+            let (waker, _) = counting_waker();
+            let mut queued = manager_pool.reserve(carrier_size);
+            assert!(poll_reserve(&mut queued, &waker).is_pending());
+            drop(manager_pool);
+
+            let cancelling = thread::spawn(move || drop(queued));
+            let closing = thread::spawn(move || reservation.close_acquisition());
+            cancelling.join().unwrap();
+            closing.join().unwrap();
+
+            let retained = pool.metrics();
+            assert_eq!(retained.active_planned_demand_bytes(), 0);
+            assert_eq!(retained.charged_capacity_bytes(), carrier_size as u64);
+            assert_eq!(retained.queued_reservations(), 0);
+
+            let shared = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("shared pool remains operational");
+            drop(shared);
+            drop(escaped);
+            let released = pool.metrics();
+            assert_eq!(released.admission_used_bytes(), 0);
+            assert_eq!(released.charged_capacity_bytes(), 0);
+        });
+    }
+
+    #[test]
+    fn test_published_shortfall_floor_blocks_trim_during_unlocked_claim() {
+        loom::model(|| {
+            let (pool, _) = test_pool(1);
+            let debit = AcquisitionDebit::install(&pool.inner, None, CarrierCount::new(1)).unwrap();
+            let candidate = pool
+                .inner
+                .arena
+                .select_trim_candidate()
+                .expect("prepared free block");
+
+            let claiming_pool = pool.clone();
+            let claiming = thread::spawn(move || {
+                claiming_pool
+                    .inner
+                    .arena
+                    .claim_optimistic(CarrierCount::new(1))
+                    .unwrap()
+            });
+            let trimming_pool = pool.clone();
+            let trimming = thread::spawn(move || {
+                let mut admission = AdmissionGuard::new(trimming_pool.inner.admission.lock());
+                let floor = admission
+                    .acquisition_floor(&trimming_pool.inner.coverage)
+                    .unwrap();
+                assert!(matches!(
+                    BlockSlot::start_trim(&candidate, admission.prepared_capacity_mut(), floor,),
+                    Err(TrimBlocked::FloorViolation)
+                ));
+            });
+
+            let claim = claiming.join().unwrap();
+            trimming.join().unwrap();
+            assert!(claim.is_complete());
+            drop(claim);
+            drop(debit);
+            assert_eq!(pool.metrics().admission_used_bytes(), 0);
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/acquisition.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/acquisition.rs
@@ -13,15 +13,17 @@ use std::fmt;
 
 use smallvec::SmallVec;
 
-use super::admission::{
-    AdmissionGuard, DirectDebitError, Reservation, ReservationState, ReserveError,
-};
+use super::admission::{AdmissionGuard, DirectDebitError, ReservationState, ReserveError};
 use super::arena::{ArenaError, ClaimBatch};
 use super::block::{BlockError, CarrierAllocation};
-use super::{BufferPool, CarrierCount, PoolInner};
-#[cfg(test)]
-use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
+use super::{invariant_violation, CarrierCount, PoolInner};
 use crate::runtime::sync::sync::Arc;
+
+/// Carrier runs stored inline before metadata spills to the heap.
+const INLINE_CARRIER_RUNS: usize = 4;
+
+/// Fallible carrier-run storage shared with the mutable-buffer layer.
+type CarrierRuns = SmallVec<[CarrierRun; INLINE_CARRIER_RUNS]>;
 
 /// Failure to acquire a complete mutable carrier batch.
 #[non_exhaustive]
@@ -59,92 +61,6 @@ impl fmt::Display for AcquireError {
 }
 
 impl std::error::Error for AcquireError {}
-
-/// One-shot failure injection for fallible acquisition metadata boundaries.
-#[cfg(test)]
-pub(super) struct AcquisitionAllocationFailures {
-    /// Remaining boundaries before the injected failure.
-    remaining: AtomicUsize,
-}
-
-#[cfg(test)]
-impl AcquisitionAllocationFailures {
-    /// Creates a disabled injector.
-    pub(super) fn new() -> Self {
-        Self {
-            remaining: AtomicUsize::new(0),
-        }
-    }
-
-    /// Fails the `boundary`th subsequent metadata reservation.
-    fn inject_on_nth(&self, boundary: usize) {
-        assert!(boundary != 0, "failure boundary must be nonzero");
-        self.remaining
-            .compare_exchange(0, boundary, Ordering::AcqRel, Ordering::Acquire)
-            .expect("an acquisition allocation failure is already pending");
-    }
-
-    /// Returns whether this boundary consumes the injected failure.
-    fn take(&self) -> bool {
-        self.remaining
-            .fetch_update(
-                Ordering::AcqRel,
-                Ordering::Acquire,
-                |remaining| match remaining {
-                    0 => None,
-                    1 => Some(0),
-                    remaining => Some(remaining - 1),
-                },
-            )
-            .is_ok_and(|previous| previous == 1)
-    }
-}
-
-impl BufferPool {
-    /// Acquires a complete carrier-rounded batch under one reservation.
-    pub(crate) fn acquire(
-        &self,
-        reservation: &Reservation,
-        min_bytes: usize,
-    ) -> Result<AcquiredRuns, AcquireError> {
-        let count = self.acquisition_count(min_bytes)?;
-        let direct = reservation
-            .acquisition_state()
-            .ok_or(AcquireError::ReservationClosed)?;
-        if !direct.belongs_to(&self.inner) {
-            return Err(AcquireError::ForeignReservation);
-        }
-        acquire_count(&self.inner, Some(Arc::clone(direct)), count)
-    }
-
-    /// Acquires a complete carrier-rounded batch without a reservation.
-    pub(crate) fn acquire_unreserved(
-        &self,
-        min_bytes: usize,
-    ) -> Result<AcquiredRuns, AcquireError> {
-        let count = self.acquisition_count(min_bytes)?;
-        acquire_count(&self.inner, None, count)
-    }
-
-    /// Converts one acquisition request to its complete carrier count.
-    fn acquisition_count(&self, min_bytes: usize) -> Result<CarrierCount, AcquireError> {
-        self.inner
-            .arena
-            .carriers_for_bytes(min_bytes)
-            .map_err(|error| match error {
-                super::geometry::GeometryError::ZeroByteRequest => AcquireError::InvalidSize,
-                _ => AcquireError::CapacityOverflow,
-            })
-    }
-
-    /// Injects one acquisition metadata allocation failure for tests.
-    #[cfg(test)]
-    fn inject_acquisition_allocation_failure(&self, boundary: usize) {
-        self.inner
-            .acquisition_allocation_failures
-            .inject_on_nth(boundary);
-    }
-}
 
 /// Aggregate and optional direct charges not yet owned by carrier guards.
 struct AcquisitionDebit {
@@ -196,19 +112,15 @@ impl AcquisitionDebit {
 
     /// Transfers one physical allocation and its accounting provenance.
     fn transfer(&mut self, allocation: CarrierAllocation) -> Arc<CarrierGuard> {
-        assert!(
-            self.untransferred != CarrierCount::ZERO,
-            "acquisition debit transferred too many charges"
-        );
+        let Some(untransferred) = self.untransferred.checked_sub(CarrierCount::new(1)) else {
+            invariant_violation("acquisition debit transferred too many charges");
+        };
         let guard = Arc::new(CarrierGuard {
             pool: Arc::clone(&self.pool),
             allocation: Some(allocation),
             direct: self.direct.as_ref().map(Arc::clone),
         });
-        self.untransferred = self
-            .untransferred
-            .checked_sub(CarrierCount::new(1))
-            .expect("acquisition debit must retain a transferred charge");
+        self.untransferred = untransferred;
         guard
     }
 }
@@ -250,12 +162,12 @@ impl PendingAcquisition {
         let claim = self
             .claim
             .take()
-            .expect("pending acquisition must retain its physical claim");
+            .unwrap_or_else(|| invariant_violation("pending acquisition lost its physical claim"));
         let allocations = claim.finish().map_err(map_arena_error)?;
         let pool = &self
             .debit
             .as_ref()
-            .expect("pending acquisition must retain its accounting debit")
+            .unwrap_or_else(|| invariant_violation("pending acquisition lost its accounting debit"))
             .pool;
         if allocation_failure_injected(pool) {
             return Err(AcquireError::PhysicalAllocationFailed);
@@ -264,18 +176,15 @@ impl PendingAcquisition {
             .try_reserve_exact(allocations.len())
             .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
 
-        let debit = self
-            .debit
-            .as_mut()
-            .expect("pending acquisition must retain its accounting debit");
+        let debit = self.debit.as_mut().unwrap_or_else(|| {
+            invariant_violation("pending acquisition lost its accounting debit")
+        });
         for allocation in allocations {
             self.guards.push(debit.transfer(allocation));
         }
-        assert_eq!(
-            debit.untransferred,
-            CarrierCount::ZERO,
-            "complete acquisition left untransferred charges"
-        );
+        if debit.untransferred != CarrierCount::ZERO {
+            invariant_violation("complete acquisition left untransferred charges");
+        }
 
         AcquiredRuns::try_from_guards(std::mem::take(&mut self.guards))
     }
@@ -292,7 +201,7 @@ impl Drop for PendingAcquisition {
 /// Complete carrier runs returned by one acquisition transaction.
 pub(crate) struct AcquiredRuns {
     /// Contiguous physical runs in ascending slot and carrier order.
-    runs: SmallVec<[CarrierRun; 4]>,
+    runs: CarrierRuns,
     /// Complete carrier-rounded capacity.
     capacity: usize,
 }
@@ -304,16 +213,11 @@ impl AcquiredRuns {
         let pool = Arc::clone(
             &guards
                 .first()
-                .expect("complete acquisition must contain a carrier")
+                .unwrap_or_else(|| invariant_violation("complete acquisition contains no carrier"))
                 .pool,
         );
 
-        let mut runs = SmallVec::<[CarrierRun; 4]>::new();
-        if allocation_failure_injected(&pool) {
-            return Err(AcquireError::PhysicalAllocationFailed);
-        }
-        runs.try_reserve(guards.len())
-            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+        let mut runs = CarrierRuns::new();
         let mut capacity = 0usize;
         for guard in guards {
             capacity = capacity
@@ -325,6 +229,11 @@ impl AcquiredRuns {
                     continue;
                 }
             }
+            if allocation_failure_injected(&pool) {
+                return Err(AcquireError::PhysicalAllocationFailed);
+            }
+            runs.try_reserve(1)
+                .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
             runs.push(CarrierRun::try_new(guard)?);
         }
 
@@ -342,7 +251,7 @@ impl AcquiredRuns {
     }
 
     /// Transfers the grouped carrier owners to the mutable-buffer layer.
-    pub(super) fn into_runs(self) -> SmallVec<[CarrierRun; 4]> {
+    pub(super) fn into_runs(self) -> CarrierRuns {
         self.runs
     }
 }
@@ -382,12 +291,12 @@ impl CarrierRun {
 
     /// Returns whether `guard` immediately follows this run.
     fn can_append(&self, guard: &CarrierGuard) -> bool {
-        let run_len =
-            u32::try_from(self.carriers.len()).expect("carrier run length must fit block geometry");
+        let run_len = u32::try_from(self.carriers.len())
+            .unwrap_or_else(|_| invariant_violation("carrier run length exceeds block geometry"));
         let next = self
             .first_carrier
             .checked_add(run_len)
-            .expect("carrier run end must fit block geometry");
+            .unwrap_or_else(|| invariant_violation("carrier run end exceeds block geometry"));
         guard.identity() == (self.slot_id, next)
     }
 
@@ -416,7 +325,7 @@ impl CarrierRun {
     pub(super) fn ptr(&self) -> std::ptr::NonNull<std::mem::MaybeUninit<u8>> {
         self.carriers
             .first()
-            .expect("carrier run must be nonempty")
+            .unwrap_or_else(|| invariant_violation("carrier run contains no carriers"))
             .ptr()
     }
 
@@ -442,7 +351,7 @@ impl CarrierGuard {
         let allocation = self
             .allocation
             .as_ref()
-            .expect("live carrier guard must retain its allocation");
+            .unwrap_or_else(|| invariant_violation("live carrier guard lost its allocation"));
         (allocation.slot_id(), allocation.carrier_index())
     }
 
@@ -450,7 +359,7 @@ impl CarrierGuard {
     pub(super) fn capacity(&self) -> usize {
         self.allocation
             .as_ref()
-            .expect("live carrier guard must retain its allocation")
+            .unwrap_or_else(|| invariant_violation("live carrier guard lost its allocation"))
             .capacity()
     }
 
@@ -458,7 +367,7 @@ impl CarrierGuard {
     pub(super) fn ptr(&self) -> std::ptr::NonNull<std::mem::MaybeUninit<u8>> {
         self.allocation
             .as_ref()
-            .expect("live carrier guard must retain its allocation")
+            .unwrap_or_else(|| invariant_violation("live carrier guard lost its allocation"))
             .ptr()
     }
 }
@@ -468,7 +377,7 @@ impl Drop for CarrierGuard {
         let allocation = self
             .allocation
             .take()
-            .expect("carrier guard returned its allocation more than once");
+            .unwrap_or_else(|| invariant_violation("carrier guard returned its allocation twice"));
         drop(allocation);
         if let Some(direct) = self.direct.as_ref() {
             direct.release(CarrierCount::new(1));
@@ -478,7 +387,7 @@ impl Drop for CarrierGuard {
 }
 
 /// Installs accounting, acquires a complete physical batch, and groups it.
-fn acquire_count(
+pub(super) fn acquire_count(
     pool: &Arc<PoolInner>,
     direct: Option<Arc<ReservationState>>,
     count: CarrierCount,
@@ -494,7 +403,7 @@ fn acquire_count(
     if !pending
         .claim
         .as_ref()
-        .expect("pending acquisition must retain its claim")
+        .unwrap_or_else(|| invariant_violation("pending acquisition lost its claim"))
         .is_complete()
     {
         let fallback = {
@@ -504,7 +413,7 @@ fn acquire_count(
                 pending
                     .claim
                     .as_mut()
-                    .expect("pending acquisition must retain its claim"),
+                    .unwrap_or_else(|| invariant_violation("pending acquisition lost its claim")),
             )
         };
         fallback.map_err(map_arena_error)?;
@@ -517,7 +426,7 @@ fn acquire_count(
 fn allocation_failure_injected(pool: &PoolInner) -> bool {
     #[cfg(test)]
     {
-        pool.acquisition_allocation_failures.take()
+        pool.test_hooks.take_acquisition_allocation_failure()
     }
     #[cfg(not(test))]
     {
@@ -560,18 +469,16 @@ fn map_arena_error(error: ArenaError) -> AcquireError {
 
 #[cfg(all(test, not(s3_tm_loom)))]
 mod tests {
-    use std::future::Future;
-    use std::pin::Pin;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::mpsc;
     use std::sync::Arc as StdArc;
-    use std::task::{Context, Poll, Wake, Waker};
+    use std::task::{Poll, Wake, Waker};
     use std::time::Duration;
 
     use super::super::block::{BlockSlot, TrimBlocked};
-    use super::super::geometry::PoolGeometry;
-    use super::super::virtual_memory::{page_size, VirtualMemoryOperation};
-    use super::super::ReserveFuture;
+    use super::super::test_util::{poll_reserve, test_pool_with_scan as test_pool};
+    use super::super::virtual_memory::VirtualMemoryOperation;
+    use super::super::{BufferPool, Reservation};
     use super::*;
 
     struct ClaimingWake {
@@ -595,35 +502,6 @@ mod tests {
             self.claimed.store(claim.is_complete(), Ordering::Release);
             self.wakes.fetch_add(1, Ordering::Release);
         }
-    }
-
-    fn test_pool(
-        block_carriers: usize,
-        configured: usize,
-        optimistic_scan_words: usize,
-    ) -> (BufferPool, usize) {
-        let page_size = page_size().unwrap().get();
-        let geometry = PoolGeometry::new(
-            page_size,
-            page_size.checked_mul(block_carriers).unwrap(),
-            page_size,
-        )
-        .unwrap();
-        let pool = BufferPool::from_validated_parts(
-            geometry,
-            CarrierCount::new(configured),
-            optimistic_scan_words,
-        )
-        .unwrap();
-        (pool, page_size)
-    }
-
-    fn poll_reserve(
-        future: &mut ReserveFuture,
-        waker: &Waker,
-    ) -> Poll<Result<Reservation, ReserveError>> {
-        let mut context = Context::from_waker(waker);
-        Pin::new(future).poll(&mut context)
     }
 
     #[test]
@@ -957,6 +835,157 @@ mod tests {
     }
 
     #[test]
+    fn test_reserved_composition_preserves_normal_capacity() {
+        const CONFIGURED_CARRIERS: usize = 4;
+        const RESERVATION_SLOTS: usize = 4;
+        const SEQUENCES: u64 = 32;
+        const STEPS: usize = 48;
+
+        struct Actor {
+            reservation: Option<Reservation>,
+            envelope: usize,
+            outstanding: usize,
+            used: bool,
+        }
+
+        struct Owner {
+            actor: usize,
+            carriers: usize,
+            runs: AcquiredRuns,
+        }
+
+        fn next(state: &mut u64) -> usize {
+            *state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            (*state >> 32) as usize
+        }
+
+        for sequence in 0..SEQUENCES {
+            let (pool, carrier_size) = test_pool(CONFIGURED_CARRIERS, CONFIGURED_CARRIERS, 1);
+            let mut state = sequence + 1;
+            let mut actors: Vec<Actor> = (0..RESERVATION_SLOTS)
+                .map(|_| Actor {
+                    reservation: None,
+                    envelope: 0,
+                    outstanding: 0,
+                    used: false,
+                })
+                .collect();
+            let mut owners = Vec::<Owner>::new();
+
+            for _ in 0..STEPS {
+                match next(&mut state) % 4 {
+                    0 => {
+                        let active: usize = actors
+                            .iter()
+                            .filter_map(|actor| actor.reservation.as_ref().map(|_| actor.envelope))
+                            .sum();
+                        let live: usize = owners.iter().map(|owner| owner.carriers).sum();
+
+                        // When no reservation is active, one request may exceed
+                        // the normal ceiling so retained owners cannot stop
+                        // progress. This model covers normal-ceiling admission.
+                        if active == 0 && live != 0 {
+                            continue;
+                        }
+                        let Some(actor) = actors.iter_mut().find(|actor| !actor.used) else {
+                            continue;
+                        };
+                        let envelope = 1 + next(&mut state) % (CONFIGURED_CARRIERS - 1);
+                        if let Some(reservation) =
+                            pool.try_reserve(envelope * carrier_size).unwrap()
+                        {
+                            actor.reservation = Some(reservation);
+                            actor.envelope = envelope;
+                            actor.used = true;
+                        }
+                    }
+                    1 => {
+                        let candidates: Vec<usize> = actors
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(index, actor)| {
+                                (actor.reservation.is_some() && actor.outstanding < actor.envelope)
+                                    .then_some(index)
+                            })
+                            .collect();
+                        if candidates.is_empty() {
+                            continue;
+                        }
+                        let actor_index = candidates[next(&mut state) % candidates.len()];
+                        let actor = &mut actors[actor_index];
+                        let remaining = actor.envelope - actor.outstanding;
+                        let carriers = 1 + next(&mut state) % remaining;
+                        let runs = pool
+                            .acquire(actor.reservation.as_ref().unwrap(), carriers * carrier_size)
+                            .unwrap();
+                        actor.outstanding += carriers;
+                        owners.push(Owner {
+                            actor: actor_index,
+                            carriers,
+                            runs,
+                        });
+                    }
+                    2 => {
+                        let open: Vec<usize> = actors
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(index, actor)| actor.reservation.as_ref().map(|_| index))
+                            .collect();
+                        if let Some(index) = open.get(next(&mut state) % open.len().max(1)) {
+                            actors[*index]
+                                .reservation
+                                .take()
+                                .unwrap()
+                                .close_acquisition();
+                        }
+                    }
+                    _ => {
+                        if owners.is_empty() {
+                            continue;
+                        }
+                        let index = next(&mut state) % owners.len();
+                        let owner = owners.swap_remove(index);
+                        actors[owner.actor].outstanding -= owner.carriers;
+                        drop(owner.runs);
+                    }
+                }
+
+                let live: usize = owners.iter().map(|owner| owner.carriers).sum();
+                let active: usize = actors
+                    .iter()
+                    .filter_map(|actor| actor.reservation.as_ref().map(|_| actor.envelope))
+                    .sum();
+                let metrics = pool.metrics();
+                assert!(
+                    live <= CONFIGURED_CARRIERS,
+                    "sequence {sequence} retained {live} carriers above the normal ceiling"
+                );
+                assert_eq!(
+                    metrics.charged_capacity_bytes(),
+                    (live * carrier_size) as u64,
+                    "sequence {sequence} lost or duplicated a carrier charge"
+                );
+                assert_eq!(
+                    metrics.active_planned_demand_bytes(),
+                    (active * carrier_size) as u64,
+                    "sequence {sequence} diverged from its open envelopes"
+                );
+            }
+
+            for actor in &mut actors {
+                drop(actor.reservation.take());
+            }
+            drop(owners);
+            let metrics = pool.metrics();
+            assert_eq!(metrics.active_planned_demand_bytes(), 0);
+            assert_eq!(metrics.charged_capacity_bytes(), 0);
+            assert_eq!(metrics.admission_used_bytes(), 0);
+        }
+    }
+
+    #[test]
     fn test_carrier_owner_retains_pool_until_final_return() {
         let (pool, carrier_size) = test_pool(1, 1, 1);
         let weak = Arc::downgrade(&pool.inner);
@@ -1052,57 +1081,16 @@ mod tests {
 
 #[cfg(all(test, s3_tm_loom))]
 mod loom_tests {
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::sync::Arc as StdArc;
-    use std::task::{Context, Poll, Wake, Waker};
+    use std::task::Poll;
 
     use super::super::block::{BlockSlot, TrimBlocked};
-    use super::super::geometry::PoolGeometry;
-    use super::super::virtual_memory::page_size;
-    use super::super::ReserveFuture;
+    use super::super::test_util::{
+        counting_waker, poll_reserve, test_single_carrier_pool as test_pool,
+    };
     use super::*;
-    use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
+    use crate::runtime::sync::sync::atomic::Ordering;
     use crate::runtime::sync::sync::Arc;
     use crate::runtime::sync::thread;
-
-    struct CountingWake {
-        count: Arc<AtomicUsize>,
-    }
-
-    impl Wake for CountingWake {
-        fn wake(self: StdArc<Self>) {
-            self.wake_by_ref();
-        }
-
-        fn wake_by_ref(self: &StdArc<Self>) {
-            self.count.fetch_add(1, Ordering::AcqRel);
-        }
-    }
-
-    fn test_pool(configured: usize) -> (BufferPool, usize) {
-        let page_size = page_size().unwrap().get();
-        let geometry = PoolGeometry::new(page_size, page_size, page_size).unwrap();
-        let pool =
-            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
-        (pool, page_size)
-    }
-
-    fn counting_waker() -> (Waker, Arc<AtomicUsize>) {
-        let count = Arc::new(AtomicUsize::new(0));
-        let state = CountingWake {
-            count: Arc::clone(&count),
-        };
-        (Waker::from(StdArc::new(state)), count)
-    }
-
-    fn poll_reserve(
-        future: &mut ReserveFuture,
-        waker: &Waker,
-    ) -> Poll<Result<Reservation, ReserveError>> {
-        let mut context = Context::from_waker(waker);
-        Pin::new(future).poll(&mut context)
-    }
 
     #[test]
     fn test_final_return_racing_close_converges() {

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission.rs
@@ -17,10 +17,13 @@ use std::task::Waker;
 use crate::runtime::sync::sync::atomic::{AtomicU64, Ordering};
 use crate::runtime::sync::sync::{Arc, MutexGuard};
 
-use super::arena::ArenaError;
-use super::block::BlockError;
-use super::metrics::{MemoryMetricState, MemoryMetrics};
-use super::{CarrierCount, PoolInner};
+use super::{invariant_violation, CarrierCount, PoolInner};
+
+/// Closed bit in [`ReservationOwnerState::packed`].
+const RESERVATION_CLOSED: u64 = 1 << 63;
+
+/// Direct owners and in-flight debits in [`ReservationOwnerState::packed`].
+const DIRECT_OUTSTANDING_MASK: u64 = !RESERVATION_CLOSED;
 
 mod coverage;
 use coverage::CoverageSnapshot;
@@ -28,31 +31,16 @@ pub(super) use coverage::{CoverageState, MAX_PACKED_CARRIERS};
 
 mod waiter;
 pub(crate) use waiter::ReserveFuture;
-use waiter::{ReservationPoll, WaitSlot, WaitState, Waiter};
+pub(super) use waiter::{ReservationPoll, WaitSlot, WaitState, Waiter};
 
 /// Planned-demand state protected by the pool admission mutex.
 pub(super) struct AdmissionState {
     /// Counters participating in grant and preparation decisions.
-    ledger: AdmissionLedger,
+    pub(super) ledger: AdmissionLedger,
     /// Reservation requests retained in strict arrival order.
-    waiters: VecDeque<Waiter>,
+    pub(super) waiters: VecDeque<Waiter>,
     /// Cumulative requests that entered the FIFO.
-    parked_reservations_total: u64,
-}
-
-/// Proof that one operation owns admission serialization.
-pub(super) struct AdmissionGuard<'a> {
-    inner: MutexGuard<'a, AdmissionState>,
-}
-
-/// Carrier-granular values used to decide and back new admission.
-struct AdmissionLedger {
-    /// Normal admission ceiling.
-    configured_capacity: CarrierCount,
-    /// Capacity whose complete preparation steps have succeeded.
-    prepared_capacity: CarrierCount,
-    /// Complete envelopes whose acquisition authority remains open.
-    active_planned_demand: CarrierCount,
+    pub(super) parked_reservations_total: u64,
 }
 
 impl AdmissionState {
@@ -68,6 +56,11 @@ impl AdmissionState {
             parked_reservations_total: 0,
         }
     }
+}
+
+/// Proof that one operation owns admission serialization.
+pub(super) struct AdmissionGuard<'a> {
+    pub(super) inner: MutexGuard<'a, AdmissionState>,
 }
 
 impl<'a> AdmissionGuard<'a> {
@@ -87,12 +80,12 @@ impl<'a> AdmissionGuard<'a> {
     }
 
     /// Returns whether one fresh request is immediately eligible.
-    fn can_grant(&self, coverage: CoverageSnapshot, envelope: CarrierCount) -> bool {
+    pub(super) fn can_grant(&self, coverage: CoverageSnapshot, envelope: CarrierCount) -> bool {
         self.inner.ledger.can_grant(coverage, envelope)
     }
 
     /// Computes and validates the post-grant admission floor.
-    fn grant_target(
+    pub(super) fn grant_target(
         &self,
         coverage: CoverageSnapshot,
         envelope: CarrierCount,
@@ -101,7 +94,7 @@ impl<'a> AdmissionGuard<'a> {
     }
 
     /// Publishes one prepared grant.
-    fn commit_grant(
+    pub(super) fn commit_grant(
         &mut self,
         coverage: &CoverageState,
         envelope: CarrierCount,
@@ -110,7 +103,7 @@ impl<'a> AdmissionGuard<'a> {
     }
 
     /// Retires one open envelope without releasing its carrier owners.
-    fn close_envelope(
+    pub(super) fn close_envelope(
         &mut self,
         coverage: &CoverageState,
         envelope: CarrierCount,
@@ -125,7 +118,9 @@ impl<'a> AdmissionGuard<'a> {
     pub(super) fn maximum_uncovered(&self) -> CarrierCount {
         MAX_PACKED_CARRIERS
             .checked_sub(self.inner.ledger.active_planned_demand)
-            .expect("active planned demand must fit packed admission")
+            .unwrap_or_else(|| {
+                invariant_violation("active planned demand exceeds packed admission")
+            })
     }
 
     /// Returns the floor required by the current admission state.
@@ -143,16 +138,33 @@ impl<'a> AdmissionGuard<'a> {
     }
 }
 
+/// Carrier-granular values used to decide and back new admission.
+pub(super) struct AdmissionLedger {
+    /// Normal admission ceiling.
+    pub(super) configured_capacity: CarrierCount,
+    /// Capacity whose complete preparation steps have succeeded.
+    pub(super) prepared_capacity: CarrierCount,
+    /// Complete envelopes whose acquisition authority remains open.
+    pub(super) active_planned_demand: CarrierCount,
+}
+
 impl AdmissionLedger {
     /// Returns active envelopes plus ownership outside their coverage.
-    fn admission_used(&self, coverage: CoverageSnapshot) -> Result<CarrierCount, ReserveError> {
+    pub(super) fn admission_used(
+        &self,
+        coverage: CoverageSnapshot,
+    ) -> Result<CarrierCount, ReserveError> {
         self.active_planned_demand
             .checked_add(coverage.uncovered)
             .filter(|count| *count <= MAX_PACKED_CARRIERS)
             .ok_or(ReserveError::CapacityOverflow)
     }
 
-    /// Checks the normal ceiling or the idle-only progress rule.
+    /// Returns whether one envelope may be granted now.
+    ///
+    /// A request normally fits below the configured ceiling. If no reservation
+    /// remains active, one request may exceed that ceiling so retained
+    /// uncovered ownership cannot prevent all future progress.
     fn can_grant(&self, coverage: CoverageSnapshot, envelope: CarrierCount) -> bool {
         let normal = self
             .admission_used(coverage)
@@ -210,19 +222,19 @@ impl AdmissionLedger {
         envelope: CarrierCount,
         direct_outstanding: CarrierCount,
     ) {
-        self.active_planned_demand = self
-            .active_planned_demand
-            .checked_sub(envelope)
-            .expect("reservation close exceeds active planned demand");
+        let Some(remaining_active) = self.active_planned_demand.checked_sub(envelope) else {
+            invariant_violation("reservation close exceeds active planned demand");
+        };
+        self.active_planned_demand = remaining_active;
         coverage.remove_coverage(envelope, direct_outstanding, self.active_planned_demand);
         self.assert_invariants(coverage.snapshot());
     }
 
     /// Checks identities required after each serialized transition.
-    fn assert_invariants(&self, coverage: CoverageSnapshot) {
+    pub(super) fn assert_invariants(&self, coverage: CoverageSnapshot) {
         let admission_used = self
             .admission_used(coverage)
-            .expect("completed admission state must fit packed accounting");
+            .unwrap_or_else(|_| invariant_violation("completed admission exceeds packed capacity"));
         if self.prepared_capacity < admission_used {
             invariant_violation("prepared capacity does not cover admission used");
         }
@@ -277,7 +289,7 @@ pub(super) struct ReservationState {
 
 impl Reservation {
     /// Creates one open reservation for an already published grant.
-    fn new(pool: Arc<PoolInner>, envelope: CarrierCount) -> Self {
+    pub(super) fn new(pool: Arc<PoolInner>, envelope: CarrierCount) -> Self {
         Self {
             state: Some(Arc::new(ReservationState {
                 pool,
@@ -355,313 +367,11 @@ impl ReservationState {
     }
 }
 
-impl PoolInner {
-    /// Returns one coherent admission and aggregate memory sample.
-    pub(super) fn memory_metrics(&self) -> MemoryMetrics {
-        let admission = self.admission.lock();
-        let coverage = self.coverage.snapshot();
-        admission.ledger.assert_invariants(coverage);
-
-        let admission_used = admission
-            .ledger
-            .admission_used(coverage)
-            .expect("completed admission state must fit packed accounting");
-        let covered_charges = admission
-            .ledger
-            .active_planned_demand
-            .checked_sub(coverage.available)
-            .expect("available coverage cannot exceed active planned demand");
-        let charged_capacity = covered_charges
-            .checked_add(coverage.uncovered)
-            .expect("completed charge state must fit packed accounting");
-
-        MemoryMetrics::from_carriers(
-            self.arena.carrier_size(),
-            MemoryMetricState {
-                configured_capacity: admission.ledger.configured_capacity,
-                admission_used,
-                active_planned_demand: admission.ledger.active_planned_demand,
-                charged_capacity,
-                prepared_capacity: admission.ledger.prepared_capacity,
-                queued_reservations: admission.waiters.len(),
-                parked_reservations_total: admission.parked_reservations_total,
-            },
-        )
-    }
-
-    /// Returns one coherent admission and aggregate sample for composed tests.
-    #[cfg(test)]
-    pub(super) fn test_accounting_state(
-        &self,
-    ) -> (
-        CarrierCount,
-        CarrierCount,
-        CarrierCount,
-        CarrierCount,
-        usize,
-    ) {
-        let admission = self.admission.lock();
-        let coverage = self.coverage.snapshot();
-        (
-            admission.ledger.prepared_capacity,
-            admission.ledger.active_planned_demand,
-            coverage.available,
-            coverage.uncovered,
-            admission.waiters.len(),
-        )
-    }
-
-    /// Attempts an aggregate debit without admission serialization.
-    ///
-    /// `Ok(false)` leaves accounting unchanged and requires the caller to use
-    /// the serialized shortfall path.
-    pub(super) fn try_debit_covered(&self, count: CarrierCount) -> Result<bool, ReserveError> {
-        self.coverage
-            .try_debit_covered(count)
-            .map_err(|_| ReserveError::CapacityOverflow)
-    }
-
-    /// Publishes a shortfall debit and prepares through its admission floor.
-    ///
-    /// Failure reverses the aggregate debit before returning. The caller
-    /// remains responsible for rolling back reservation-local authority.
-    pub(super) fn debit_and_prepare_locked(
-        pool: &Arc<Self>,
-        admission: &mut AdmissionGuard<'_>,
-        count: CarrierCount,
-    ) -> Result<(), ReserveError> {
-        pool.coverage
-            .debit(count, admission.maximum_uncovered())
-            .map_err(|_| ReserveError::CapacityOverflow)?;
-
-        let floor = match admission.acquisition_floor(&pool.coverage) {
-            Ok(floor) => floor,
-            Err(error) => {
-                admission.rollback_acquisition(&pool.coverage, count);
-                return Err(error);
-            }
-        };
-        if let Err(error) = pool.arena.prepare_to(admission, floor) {
-            admission.rollback_acquisition(&pool.coverage, count);
-            return Err(map_preparation_error(error));
-        }
-        Ok(())
-    }
-
-    /// Attempts one immediate grant without bypassing the FIFO.
-    pub(super) fn try_reserve_count(
-        pool: &Arc<Self>,
-        envelope: CarrierCount,
-    ) -> Result<Option<Reservation>, ReserveError> {
-        if envelope == CarrierCount::ZERO {
-            return Err(ReserveError::InvalidSize);
-        }
-        if envelope > MAX_PACKED_CARRIERS {
-            return Err(ReserveError::CapacityOverflow);
-        }
-
-        let mut admission = AdmissionGuard::new(pool.admission.lock());
-        if !admission.inner.waiters.is_empty() {
-            return Ok(None);
-        }
-        let coverage = pool.coverage.snapshot();
-        if !admission.can_grant(coverage, envelope) {
-            return Ok(None);
-        }
-
-        Self::prepare_and_grant_locked(pool, &mut admission, envelope).map(Some)
-    }
-
-    /// Grants one first-poll request or links it behind existing work.
-    fn reserve_or_enqueue(
-        pool: &Arc<Self>,
-        envelope: CarrierCount,
-        waker: Waker,
-    ) -> Result<ReservationPoll, ReserveError> {
-        if envelope == CarrierCount::ZERO {
-            return Err(ReserveError::InvalidSize);
-        }
-        if envelope > MAX_PACKED_CARRIERS {
-            return Err(ReserveError::CapacityOverflow);
-        }
-
-        let mut admission = AdmissionGuard::new(pool.admission.lock());
-        let coverage = pool.coverage.snapshot();
-        if admission.inner.waiters.is_empty() && admission.can_grant(coverage, envelope) {
-            return Self::prepare_and_grant_locked(pool, &mut admission, envelope)
-                .map(ReservationPoll::Ready);
-        }
-
-        admission
-            .inner
-            .waiters
-            .try_reserve(1)
-            .map_err(|_| ReserveError::PhysicalPreparationFailed)?;
-        let slot = Arc::new(WaitSlot::new(waker));
-        admission.inner.waiters.push_back(Waiter {
-            envelope,
-            slot: Arc::clone(&slot),
-        });
-        admission.inner.parked_reservations_total =
-            admission.inner.parked_reservations_total.saturating_add(1);
-        Ok(ReservationPoll::Queued(slot))
-    }
-
-    /// Removes one cancelled queue link and reconsiders the exposed head.
-    fn cancel_waiter(pool: &Arc<Self>, slot: &Arc<WaitSlot>) -> Vec<Waker> {
-        let mut admission = AdmissionGuard::new(pool.admission.lock());
-        if let Some(index) = admission
-            .inner
-            .waiters
-            .iter()
-            .position(|waiter| Arc::ptr_eq(&waiter.slot, slot))
-        {
-            admission.inner.waiters.remove(index);
-        }
-        Self::drain_fifo_locked(pool, &mut admission)
-    }
-
-    /// Prepares and publishes one grant while admission is serialized.
-    fn prepare_and_grant_locked(
-        pool: &Arc<Self>,
-        admission: &mut AdmissionGuard<'_>,
-        envelope: CarrierCount,
-    ) -> Result<Reservation, ReserveError> {
-        let coverage = pool.coverage.snapshot();
-        let target = admission.grant_target(coverage, envelope)?;
-        pool.arena
-            .prepare_to(admission, target)
-            .map_err(map_preparation_error)?;
-        admission.commit_grant(&pool.coverage, envelope)?;
-        Ok(Reservation::new(Arc::clone(pool), envelope))
-    }
-
-    /// Transfers every eligible FIFO head and returns wakers for post-unlock use.
-    fn drain_fifo_locked(pool: &Arc<Self>, admission: &mut AdmissionGuard<'_>) -> Vec<Waker> {
-        let mut wakers = Vec::new();
-        while let Some(front) = admission.inner.waiters.front() {
-            let envelope = front.envelope;
-            let slot = Arc::clone(&front.slot);
-            let mut slot_state = slot.state.lock();
-
-            match &*slot_state {
-                WaitState::Taken => {
-                    admission.inner.waiters.pop_front();
-                    continue;
-                }
-                WaitState::Queued { .. } => {}
-                WaitState::Granted(_) | WaitState::Failed(_) => {
-                    panic!("terminal reservation result remained linked in the FIFO");
-                }
-            }
-
-            let coverage = pool.coverage.snapshot();
-            if !admission.can_grant(coverage, envelope) {
-                break;
-            }
-
-            let result = Self::prepare_and_grant_locked(pool, admission, envelope);
-            let previous = std::mem::replace(&mut *slot_state, WaitState::Taken);
-            let WaitState::Queued { waker } = previous else {
-                panic!("reservation head changed while its slot lock was held");
-            };
-            *slot_state = match result {
-                Ok(reservation) => WaitState::Granted(reservation),
-                Err(error) => WaitState::Failed(error),
-            };
-
-            let removed = admission
-                .inner
-                .waiters
-                .pop_front()
-                .expect("reservation head disappeared while admission was held");
-            assert!(
-                Arc::ptr_eq(&removed.slot, &slot),
-                "FIFO head changed while admission was held"
-            );
-            wakers.push(waker);
-        }
-        wakers
-    }
-
-    /// Retires aggregate charges and reconsiders work exposed by repayment.
-    ///
-    /// Physical ownership and direct provenance are returned before this
-    /// boundary. Coverage-only returns stay lock-free. Repayment of uncovered
-    /// charges enters admission and invokes wakers only after unlocking.
-    pub(super) fn release_acquisition_charges(pool: &Arc<Self>, count: CarrierCount) {
-        let returned = pool.coverage.release(count);
-        if returned.uncovered_removed == CarrierCount::ZERO {
-            return;
-        }
-
-        let wakers = {
-            let mut admission = AdmissionGuard::new(pool.admission.lock());
-            let wakers = Self::drain_fifo_locked(pool, &mut admission);
-            admission
-                .inner
-                .ledger
-                .assert_invariants(pool.coverage.snapshot());
-            wakers
-        };
-        wake_all(wakers);
-    }
-}
-
 /// Wakes terminal reservation futures after every pool lock is released.
-fn wake_all(wakers: Vec<Waker>) {
+pub(super) fn wake_all(wakers: Vec<Waker>) {
     for waker in wakers {
         waker.wake();
     }
-}
-
-fn map_preparation_error(error: ArenaError) -> ReserveError {
-    match error {
-        ArenaError::Block(BlockError::PreparedCapacityOverflow)
-        | ArenaError::SlotIdExhausted
-        | ArenaError::RegistryCapacityOverflow
-        | ArenaError::AddressOverflow { .. }
-        | ArenaError::ScanSpaceOverflow { .. } => ReserveError::CapacityOverflow,
-        ArenaError::Block(_)
-        | ArenaError::Allocation(_)
-        | ArenaError::InvalidScanBudget
-        | ArenaError::InvalidClaimCount
-        | ArenaError::IncompleteClaim { .. }
-        | ArenaError::AddressOverlap { .. } => ReserveError::PhysicalPreparationFailed,
-    }
-}
-
-/// Stops execution after an admission or accounting invariant fails.
-#[cold]
-fn invariant_violation(message: &'static str) -> ! {
-    tracing::error!(
-        target: crate::telemetry::TARGET_MEMORY,
-        reason = message,
-        "buffer-pool admission invariant violated; aborting"
-    );
-
-    #[cfg(test)]
-    panic!("buffer-pool admission invariant violated: {message}");
-
-    #[cfg(not(test))]
-    {
-        let _ = message;
-        std::process::abort()
-    }
-}
-
-/// Closed bit in [`ReservationOwnerState::packed`].
-const RESERVATION_CLOSED: u64 = 1 << 63;
-
-/// Direct owners and in-flight debits in [`ReservationOwnerState::packed`].
-const DIRECT_OUTSTANDING_MASK: u64 = !RESERVATION_CLOSED;
-
-/// Reservation-local acquisition state.
-///
-/// The high bit records close. The remaining bits count direct carrier owners
-/// and acquisition debits that have not yet become owners.
-struct ReservationOwnerState {
-    packed: AtomicU64,
 }
 
 /// Why a reservation-local debit could not be installed.
@@ -684,6 +394,14 @@ struct ReservationOwnerSnapshot {
     direct_outstanding: CarrierCount,
 }
 
+/// Reservation-local acquisition state.
+///
+/// The high bit records close. The remaining bits count direct carrier owners
+/// and acquisition debits that have not yet become owners.
+struct ReservationOwnerState {
+    packed: AtomicU64,
+}
+
 impl ReservationOwnerState {
     /// Creates open authority with no direct owners.
     fn new() -> Self {
@@ -692,7 +410,10 @@ impl ReservationOwnerState {
         }
     }
 
-    /// Checks one debit without reserving direct-acquisition authority.
+    /// Rejects a debit that the current state already makes impossible.
+    ///
+    /// This load does not reserve authority and may race close or another
+    /// debit. [`Self::try_debit`] performs the authoritative atomic update.
     fn precheck_debit(
         &self,
         envelope: CarrierCount,
@@ -758,7 +479,7 @@ impl ReservationOwnerState {
         }
         Some(CarrierCount::new(
             usize::try_from(previous & DIRECT_OUTSTANDING_MASK)
-                .expect("direct owner count must fit usize"),
+                .unwrap_or_else(|_| invariant_violation("direct owner count does not fit usize")),
         ))
     }
 
@@ -767,7 +488,9 @@ impl ReservationOwnerState {
     /// Returns `true` when the reservation remains open. Release preserves the
     /// closed bit and cannot restore acquisition authority after close.
     fn release(&self, count: CarrierCount) -> bool {
-        let count = u64::try_from(count.get()).expect("direct release count must fit owner state");
+        let count = u64::try_from(count.get()).unwrap_or_else(|_| {
+            invariant_violation("direct release count does not fit owner state")
+        });
         let previous = self
             .packed
             .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
@@ -776,7 +499,9 @@ impl ReservationOwnerState {
                     .checked_sub(count)
                     .map(|next| (current & RESERVATION_CLOSED) | next)
             })
-            .expect("direct release exceeds outstanding ownership");
+            .unwrap_or_else(|_| {
+                invariant_violation("direct release exceeds outstanding ownership")
+            });
         previous & RESERVATION_CLOSED == 0
     }
 
@@ -786,8 +511,9 @@ impl ReservationOwnerState {
         ReservationOwnerSnapshot {
             closed: packed & RESERVATION_CLOSED != 0,
             direct_outstanding: CarrierCount::new(
-                usize::try_from(packed & DIRECT_OUTSTANDING_MASK)
-                    .expect("direct owner count must fit usize"),
+                usize::try_from(packed & DIRECT_OUTSTANDING_MASK).unwrap_or_else(|_| {
+                    invariant_violation("direct owner count does not fit usize")
+                }),
             ),
         }
     }
@@ -795,23 +521,10 @@ impl ReservationOwnerState {
 
 #[cfg(all(test, not(s3_tm_loom)))]
 mod tests {
-    use super::super::geometry::PoolGeometry;
-    use super::super::virtual_memory::{page_size, VirtualMemoryOperation};
+    use super::super::test_util::test_pool;
+    use super::super::virtual_memory::VirtualMemoryOperation;
     use super::super::BufferPool;
     use super::*;
-
-    fn test_pool(block_carriers: usize, configured: usize) -> (BufferPool, usize) {
-        let page_size = page_size().unwrap().get();
-        let geometry = PoolGeometry::new(
-            page_size,
-            page_size.checked_mul(block_carriers).unwrap(),
-            page_size,
-        )
-        .unwrap();
-        let pool =
-            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
-        (pool, page_size)
-    }
 
     #[test]
     fn test_immediate_grant_prepares_before_publication() {
@@ -1076,21 +789,11 @@ mod tests {
 
 #[cfg(all(test, s3_tm_loom))]
 mod loom_tests {
-    use super::super::geometry::PoolGeometry;
-    use super::super::virtual_memory::page_size;
-    use super::super::BufferPool;
+    use super::super::test_util::test_single_carrier_pool as test_pool;
     use crate::runtime::sync::sync::Arc;
     use crate::runtime::sync::thread;
 
     use super::*;
-
-    fn test_pool(configured: usize) -> (BufferPool, usize) {
-        let page_size = page_size().unwrap().get();
-        let geometry = PoolGeometry::new(page_size, page_size, page_size).unwrap();
-        let pool =
-            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
-        (pool, page_size)
-    }
 
     #[test]
     fn test_concurrent_immediate_grants_respect_normal_capacity() {

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission.rs
@@ -1,0 +1,1220 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Planned-demand admission, FIFO waiters, and acquisition accounting.
+//!
+//! Aggregate coverage and reservation-local authority are independent state
+//! machines. Aggregate coverage determines how an acquisition is charged to
+//! the pool. Reservation-local authority determines whether one admitted work
+//! item may make that acquisition.
+
+use std::collections::VecDeque;
+use std::fmt;
+use std::task::Waker;
+
+use crate::runtime::sync::sync::atomic::{AtomicU64, Ordering};
+use crate::runtime::sync::sync::{Arc, MutexGuard};
+
+use super::arena::ArenaError;
+use super::block::BlockError;
+use super::metrics::{MemoryMetricState, MemoryMetrics};
+use super::{CarrierCount, PoolInner};
+
+mod coverage;
+use coverage::CoverageSnapshot;
+pub(super) use coverage::{CoverageState, MAX_PACKED_CARRIERS};
+
+mod waiter;
+pub(crate) use waiter::ReserveFuture;
+use waiter::{ReservationPoll, WaitSlot, WaitState, Waiter};
+
+/// Planned-demand state protected by the pool admission mutex.
+pub(super) struct AdmissionState {
+    /// Counters participating in grant and preparation decisions.
+    ledger: AdmissionLedger,
+    /// Reservation requests retained in strict arrival order.
+    waiters: VecDeque<Waiter>,
+    /// Cumulative requests that entered the FIFO.
+    parked_reservations_total: u64,
+}
+
+/// Proof that one operation owns admission serialization.
+pub(super) struct AdmissionGuard<'a> {
+    inner: MutexGuard<'a, AdmissionState>,
+}
+
+/// Carrier-granular values used to decide and back new admission.
+struct AdmissionLedger {
+    /// Normal admission ceiling.
+    configured_capacity: CarrierCount,
+    /// Capacity whose complete preparation steps have succeeded.
+    prepared_capacity: CarrierCount,
+    /// Complete envelopes whose acquisition authority remains open.
+    active_planned_demand: CarrierCount,
+}
+
+impl AdmissionState {
+    /// Creates empty admission state with one immutable normal ceiling.
+    pub(super) fn new(configured_capacity: CarrierCount) -> Self {
+        Self {
+            ledger: AdmissionLedger {
+                configured_capacity,
+                prepared_capacity: CarrierCount::ZERO,
+                active_planned_demand: CarrierCount::ZERO,
+            },
+            waiters: VecDeque::new(),
+            parked_reservations_total: 0,
+        }
+    }
+}
+
+impl<'a> AdmissionGuard<'a> {
+    /// Wraps the mutex guard that establishes admission serialization.
+    pub(super) fn new(inner: MutexGuard<'a, AdmissionState>) -> Self {
+        Self { inner }
+    }
+
+    /// Returns prepared capacity.
+    pub(super) fn prepared_capacity(&self) -> CarrierCount {
+        self.inner.ledger.prepared_capacity
+    }
+
+    /// Returns exclusive prepared-capacity access under admission.
+    pub(super) fn prepared_capacity_mut(&mut self) -> &mut CarrierCount {
+        &mut self.inner.ledger.prepared_capacity
+    }
+
+    /// Returns whether one fresh request is immediately eligible.
+    fn can_grant(&self, coverage: CoverageSnapshot, envelope: CarrierCount) -> bool {
+        self.inner.ledger.can_grant(coverage, envelope)
+    }
+
+    /// Computes and validates the post-grant admission floor.
+    fn grant_target(
+        &self,
+        coverage: CoverageSnapshot,
+        envelope: CarrierCount,
+    ) -> Result<CarrierCount, ReserveError> {
+        self.inner.ledger.grant_target(coverage, envelope)
+    }
+
+    /// Publishes one prepared grant.
+    fn commit_grant(
+        &mut self,
+        coverage: &CoverageState,
+        envelope: CarrierCount,
+    ) -> Result<(), ReserveError> {
+        self.inner.ledger.commit_grant(coverage, envelope)
+    }
+
+    /// Retires one open envelope without releasing its carrier owners.
+    fn close_envelope(
+        &mut self,
+        coverage: &CoverageState,
+        envelope: CarrierCount,
+        direct_outstanding: CarrierCount,
+    ) {
+        self.inner
+            .ledger
+            .close_envelope(coverage, envelope, direct_outstanding);
+    }
+
+    /// Returns the largest uncovered count compatible with packed admission.
+    pub(super) fn maximum_uncovered(&self) -> CarrierCount {
+        MAX_PACKED_CARRIERS
+            .checked_sub(self.inner.ledger.active_planned_demand)
+            .expect("active planned demand must fit packed admission")
+    }
+
+    /// Returns the floor required by the current admission state.
+    pub(super) fn acquisition_floor(
+        &self,
+        coverage: &CoverageState,
+    ) -> Result<CarrierCount, ReserveError> {
+        self.inner.ledger.admission_used(coverage.snapshot())
+    }
+
+    /// Reverses an unexposed acquisition while admission remains held.
+    pub(super) fn rollback_acquisition(&mut self, coverage: &CoverageState, count: CarrierCount) {
+        coverage.release(count);
+        self.inner.ledger.assert_invariants(coverage.snapshot());
+    }
+}
+
+impl AdmissionLedger {
+    /// Returns active envelopes plus ownership outside their coverage.
+    fn admission_used(&self, coverage: CoverageSnapshot) -> Result<CarrierCount, ReserveError> {
+        self.active_planned_demand
+            .checked_add(coverage.uncovered)
+            .filter(|count| *count <= MAX_PACKED_CARRIERS)
+            .ok_or(ReserveError::CapacityOverflow)
+    }
+
+    /// Checks the normal ceiling or the idle-only progress rule.
+    fn can_grant(&self, coverage: CoverageSnapshot, envelope: CarrierCount) -> bool {
+        let normal = self
+            .admission_used(coverage)
+            .ok()
+            .and_then(|used| used.checked_add(envelope))
+            .is_some_and(|next| next <= self.configured_capacity);
+        normal || self.active_planned_demand == CarrierCount::ZERO
+    }
+
+    /// Returns the prepared-capacity floor required after one grant.
+    fn grant_target(
+        &self,
+        coverage: CoverageSnapshot,
+        envelope: CarrierCount,
+    ) -> Result<CarrierCount, ReserveError> {
+        self.admission_used(coverage)?
+            .checked_add(envelope)
+            .filter(|target| *target <= MAX_PACKED_CARRIERS)
+            .ok_or(ReserveError::CapacityOverflow)
+    }
+
+    /// Adds one complete envelope after its floor has been prepared.
+    fn commit_grant(
+        &mut self,
+        coverage: &CoverageState,
+        envelope: CarrierCount,
+    ) -> Result<(), ReserveError> {
+        let snapshot = coverage.snapshot();
+        let next_active = self
+            .active_planned_demand
+            .checked_add(envelope)
+            .ok_or(ReserveError::CapacityOverflow)?;
+        let next_admission_used = next_active
+            .checked_add(snapshot.uncovered)
+            .filter(|total| *total <= MAX_PACKED_CARRIERS)
+            .ok_or(ReserveError::CapacityOverflow)?;
+        if self.prepared_capacity < next_admission_used {
+            invariant_violation(
+                "reservation grant did not prepare its admission floor before publication",
+            );
+        }
+
+        coverage
+            .add_coverage(envelope)
+            .map_err(|_| ReserveError::CapacityOverflow)?;
+        self.active_planned_demand = next_active;
+        self.assert_invariants(coverage.snapshot());
+        Ok(())
+    }
+
+    /// Withdraws one envelope and reclassifies occupied coverage.
+    fn close_envelope(
+        &mut self,
+        coverage: &CoverageState,
+        envelope: CarrierCount,
+        direct_outstanding: CarrierCount,
+    ) {
+        self.active_planned_demand = self
+            .active_planned_demand
+            .checked_sub(envelope)
+            .expect("reservation close exceeds active planned demand");
+        coverage.remove_coverage(envelope, direct_outstanding, self.active_planned_demand);
+        self.assert_invariants(coverage.snapshot());
+    }
+
+    /// Checks identities required after each serialized transition.
+    fn assert_invariants(&self, coverage: CoverageSnapshot) {
+        let admission_used = self
+            .admission_used(coverage)
+            .expect("completed admission state must fit packed accounting");
+        if self.prepared_capacity < admission_used {
+            invariant_violation("prepared capacity does not cover admission used");
+        }
+        if coverage.available > self.active_planned_demand {
+            invariant_violation("available coverage exceeds active planned demand");
+        }
+    }
+}
+
+/// Failure to create a new reservation.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ReserveError {
+    /// The byte request was zero.
+    InvalidSize,
+    /// Physical storage could not be prepared.
+    PhysicalPreparationFailed,
+    /// The request or resulting accounting state is not representable.
+    CapacityOverflow,
+}
+
+impl fmt::Display for ReserveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSize => f.write_str("reservation size must be nonzero"),
+            Self::PhysicalPreparationFailed => {
+                f.write_str("physical buffer-pool preparation failed")
+            }
+            Self::CapacityOverflow => {
+                f.write_str("reservation exceeds buffer-pool accounting capacity")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ReserveError {}
+
+/// Non-cloneable acquisition authority for one admitted envelope.
+pub(crate) struct Reservation {
+    state: Option<Arc<ReservationState>>,
+}
+
+/// Private reservation state retained by future direct carrier owners.
+pub(super) struct ReservationState {
+    /// Pool that granted the reservation.
+    pool: Arc<PoolInner>,
+    /// Complete admitted envelope.
+    envelope: CarrierCount,
+    /// Close state and direct owners or in-flight debits.
+    owner_state: ReservationOwnerState,
+}
+
+impl Reservation {
+    /// Creates one open reservation for an already published grant.
+    fn new(pool: Arc<PoolInner>, envelope: CarrierCount) -> Self {
+        Self {
+            state: Some(Arc::new(ReservationState {
+                pool,
+                envelope,
+                owner_state: ReservationOwnerState::new(),
+            })),
+        }
+    }
+
+    /// Revokes acquisition of new carriers and retires planned demand.
+    pub(crate) fn close_acquisition(mut self) {
+        self.close();
+    }
+
+    fn close(&mut self) {
+        if let Some(state) = self.state.take() {
+            state.close_acquisition();
+        }
+    }
+
+    /// Returns the private state retained by a direct acquisition.
+    pub(super) fn acquisition_state(&self) -> Option<&Arc<ReservationState>> {
+        self.state.as_ref()
+    }
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+impl ReservationState {
+    /// Returns whether this reservation belongs to `pool`.
+    pub(super) fn belongs_to(&self, pool: &Arc<PoolInner>) -> bool {
+        Arc::ptr_eq(&self.pool, pool)
+    }
+
+    /// Installs one complete direct-acquisition debit.
+    pub(super) fn try_debit(&self, count: CarrierCount) -> Result<(), DirectDebitError> {
+        self.owner_state.try_debit(self.envelope, count)
+    }
+
+    /// Rejects an already impossible debit before aggregate preparation.
+    ///
+    /// This load does not reserve authority. The caller must still use
+    /// [`Self::try_debit`] after publishing its aggregate charge.
+    pub(super) fn precheck_debit(&self, count: CarrierCount) -> Result<(), DirectDebitError> {
+        self.owner_state.precheck_debit(self.envelope, count)
+    }
+
+    /// Retires direct owners or an in-flight debit.
+    pub(super) fn release(&self, count: CarrierCount) {
+        self.owner_state.release(count);
+    }
+
+    /// Returns direct-owner state for composed acquisition tests.
+    #[cfg(test)]
+    pub(super) fn test_owner_state(&self) -> (bool, CarrierCount) {
+        let snapshot = self.owner_state.snapshot();
+        (snapshot.closed, snapshot.direct_outstanding)
+    }
+
+    /// Closes direct authority and withdraws this reservation's envelope.
+    fn close_acquisition(&self) {
+        let wakers = {
+            let mut admission = AdmissionGuard::new(self.pool.admission.lock());
+            let Some(direct_outstanding) = self.owner_state.close() else {
+                return;
+            };
+            admission.close_envelope(&self.pool.coverage, self.envelope, direct_outstanding);
+            PoolInner::drain_fifo_locked(&self.pool, &mut admission)
+        };
+        wake_all(wakers);
+    }
+}
+
+impl PoolInner {
+    /// Returns one coherent admission and aggregate memory sample.
+    pub(super) fn memory_metrics(&self) -> MemoryMetrics {
+        let admission = self.admission.lock();
+        let coverage = self.coverage.snapshot();
+        admission.ledger.assert_invariants(coverage);
+
+        let admission_used = admission
+            .ledger
+            .admission_used(coverage)
+            .expect("completed admission state must fit packed accounting");
+        let covered_charges = admission
+            .ledger
+            .active_planned_demand
+            .checked_sub(coverage.available)
+            .expect("available coverage cannot exceed active planned demand");
+        let charged_capacity = covered_charges
+            .checked_add(coverage.uncovered)
+            .expect("completed charge state must fit packed accounting");
+
+        MemoryMetrics::from_carriers(
+            self.arena.carrier_size(),
+            MemoryMetricState {
+                configured_capacity: admission.ledger.configured_capacity,
+                admission_used,
+                active_planned_demand: admission.ledger.active_planned_demand,
+                charged_capacity,
+                prepared_capacity: admission.ledger.prepared_capacity,
+                queued_reservations: admission.waiters.len(),
+                parked_reservations_total: admission.parked_reservations_total,
+            },
+        )
+    }
+
+    /// Returns one coherent admission and aggregate sample for composed tests.
+    #[cfg(test)]
+    pub(super) fn test_accounting_state(
+        &self,
+    ) -> (
+        CarrierCount,
+        CarrierCount,
+        CarrierCount,
+        CarrierCount,
+        usize,
+    ) {
+        let admission = self.admission.lock();
+        let coverage = self.coverage.snapshot();
+        (
+            admission.ledger.prepared_capacity,
+            admission.ledger.active_planned_demand,
+            coverage.available,
+            coverage.uncovered,
+            admission.waiters.len(),
+        )
+    }
+
+    /// Attempts an aggregate debit without admission serialization.
+    ///
+    /// `Ok(false)` leaves accounting unchanged and requires the caller to use
+    /// the serialized shortfall path.
+    pub(super) fn try_debit_covered(&self, count: CarrierCount) -> Result<bool, ReserveError> {
+        self.coverage
+            .try_debit_covered(count)
+            .map_err(|_| ReserveError::CapacityOverflow)
+    }
+
+    /// Publishes a shortfall debit and prepares through its admission floor.
+    ///
+    /// Failure reverses the aggregate debit before returning. The caller
+    /// remains responsible for rolling back reservation-local authority.
+    pub(super) fn debit_and_prepare_locked(
+        pool: &Arc<Self>,
+        admission: &mut AdmissionGuard<'_>,
+        count: CarrierCount,
+    ) -> Result<(), ReserveError> {
+        pool.coverage
+            .debit(count, admission.maximum_uncovered())
+            .map_err(|_| ReserveError::CapacityOverflow)?;
+
+        let floor = match admission.acquisition_floor(&pool.coverage) {
+            Ok(floor) => floor,
+            Err(error) => {
+                admission.rollback_acquisition(&pool.coverage, count);
+                return Err(error);
+            }
+        };
+        if let Err(error) = pool.arena.prepare_to(admission, floor) {
+            admission.rollback_acquisition(&pool.coverage, count);
+            return Err(map_preparation_error(error));
+        }
+        Ok(())
+    }
+
+    /// Attempts one immediate grant without bypassing the FIFO.
+    pub(super) fn try_reserve_count(
+        pool: &Arc<Self>,
+        envelope: CarrierCount,
+    ) -> Result<Option<Reservation>, ReserveError> {
+        if envelope == CarrierCount::ZERO {
+            return Err(ReserveError::InvalidSize);
+        }
+        if envelope > MAX_PACKED_CARRIERS {
+            return Err(ReserveError::CapacityOverflow);
+        }
+
+        let mut admission = AdmissionGuard::new(pool.admission.lock());
+        if !admission.inner.waiters.is_empty() {
+            return Ok(None);
+        }
+        let coverage = pool.coverage.snapshot();
+        if !admission.can_grant(coverage, envelope) {
+            return Ok(None);
+        }
+
+        Self::prepare_and_grant_locked(pool, &mut admission, envelope).map(Some)
+    }
+
+    /// Grants one first-poll request or links it behind existing work.
+    fn reserve_or_enqueue(
+        pool: &Arc<Self>,
+        envelope: CarrierCount,
+        waker: Waker,
+    ) -> Result<ReservationPoll, ReserveError> {
+        if envelope == CarrierCount::ZERO {
+            return Err(ReserveError::InvalidSize);
+        }
+        if envelope > MAX_PACKED_CARRIERS {
+            return Err(ReserveError::CapacityOverflow);
+        }
+
+        let mut admission = AdmissionGuard::new(pool.admission.lock());
+        let coverage = pool.coverage.snapshot();
+        if admission.inner.waiters.is_empty() && admission.can_grant(coverage, envelope) {
+            return Self::prepare_and_grant_locked(pool, &mut admission, envelope)
+                .map(ReservationPoll::Ready);
+        }
+
+        admission
+            .inner
+            .waiters
+            .try_reserve(1)
+            .map_err(|_| ReserveError::PhysicalPreparationFailed)?;
+        let slot = Arc::new(WaitSlot::new(waker));
+        admission.inner.waiters.push_back(Waiter {
+            envelope,
+            slot: Arc::clone(&slot),
+        });
+        admission.inner.parked_reservations_total =
+            admission.inner.parked_reservations_total.saturating_add(1);
+        Ok(ReservationPoll::Queued(slot))
+    }
+
+    /// Removes one cancelled queue link and reconsiders the exposed head.
+    fn cancel_waiter(pool: &Arc<Self>, slot: &Arc<WaitSlot>) -> Vec<Waker> {
+        let mut admission = AdmissionGuard::new(pool.admission.lock());
+        if let Some(index) = admission
+            .inner
+            .waiters
+            .iter()
+            .position(|waiter| Arc::ptr_eq(&waiter.slot, slot))
+        {
+            admission.inner.waiters.remove(index);
+        }
+        Self::drain_fifo_locked(pool, &mut admission)
+    }
+
+    /// Prepares and publishes one grant while admission is serialized.
+    fn prepare_and_grant_locked(
+        pool: &Arc<Self>,
+        admission: &mut AdmissionGuard<'_>,
+        envelope: CarrierCount,
+    ) -> Result<Reservation, ReserveError> {
+        let coverage = pool.coverage.snapshot();
+        let target = admission.grant_target(coverage, envelope)?;
+        pool.arena
+            .prepare_to(admission, target)
+            .map_err(map_preparation_error)?;
+        admission.commit_grant(&pool.coverage, envelope)?;
+        Ok(Reservation::new(Arc::clone(pool), envelope))
+    }
+
+    /// Transfers every eligible FIFO head and returns wakers for post-unlock use.
+    fn drain_fifo_locked(pool: &Arc<Self>, admission: &mut AdmissionGuard<'_>) -> Vec<Waker> {
+        let mut wakers = Vec::new();
+        while let Some(front) = admission.inner.waiters.front() {
+            let envelope = front.envelope;
+            let slot = Arc::clone(&front.slot);
+            let mut slot_state = slot.state.lock();
+
+            match &*slot_state {
+                WaitState::Taken => {
+                    admission.inner.waiters.pop_front();
+                    continue;
+                }
+                WaitState::Queued { .. } => {}
+                WaitState::Granted(_) | WaitState::Failed(_) => {
+                    panic!("terminal reservation result remained linked in the FIFO");
+                }
+            }
+
+            let coverage = pool.coverage.snapshot();
+            if !admission.can_grant(coverage, envelope) {
+                break;
+            }
+
+            let result = Self::prepare_and_grant_locked(pool, admission, envelope);
+            let previous = std::mem::replace(&mut *slot_state, WaitState::Taken);
+            let WaitState::Queued { waker } = previous else {
+                panic!("reservation head changed while its slot lock was held");
+            };
+            *slot_state = match result {
+                Ok(reservation) => WaitState::Granted(reservation),
+                Err(error) => WaitState::Failed(error),
+            };
+
+            let removed = admission
+                .inner
+                .waiters
+                .pop_front()
+                .expect("reservation head disappeared while admission was held");
+            assert!(
+                Arc::ptr_eq(&removed.slot, &slot),
+                "FIFO head changed while admission was held"
+            );
+            wakers.push(waker);
+        }
+        wakers
+    }
+
+    /// Retires aggregate charges and reconsiders work exposed by repayment.
+    ///
+    /// Physical ownership and direct provenance are returned before this
+    /// boundary. Coverage-only returns stay lock-free. Repayment of uncovered
+    /// charges enters admission and invokes wakers only after unlocking.
+    pub(super) fn release_acquisition_charges(pool: &Arc<Self>, count: CarrierCount) {
+        let returned = pool.coverage.release(count);
+        if returned.uncovered_removed == CarrierCount::ZERO {
+            return;
+        }
+
+        let wakers = {
+            let mut admission = AdmissionGuard::new(pool.admission.lock());
+            let wakers = Self::drain_fifo_locked(pool, &mut admission);
+            admission
+                .inner
+                .ledger
+                .assert_invariants(pool.coverage.snapshot());
+            wakers
+        };
+        wake_all(wakers);
+    }
+}
+
+/// Wakes terminal reservation futures after every pool lock is released.
+fn wake_all(wakers: Vec<Waker>) {
+    for waker in wakers {
+        waker.wake();
+    }
+}
+
+fn map_preparation_error(error: ArenaError) -> ReserveError {
+    match error {
+        ArenaError::Block(BlockError::PreparedCapacityOverflow)
+        | ArenaError::SlotIdExhausted
+        | ArenaError::RegistryCapacityOverflow
+        | ArenaError::AddressOverflow { .. }
+        | ArenaError::ScanSpaceOverflow { .. } => ReserveError::CapacityOverflow,
+        ArenaError::Block(_)
+        | ArenaError::Allocation(_)
+        | ArenaError::InvalidScanBudget
+        | ArenaError::InvalidClaimCount
+        | ArenaError::IncompleteClaim { .. }
+        | ArenaError::AddressOverlap { .. } => ReserveError::PhysicalPreparationFailed,
+    }
+}
+
+/// Stops execution after an admission or accounting invariant fails.
+#[cold]
+fn invariant_violation(message: &'static str) -> ! {
+    tracing::error!(
+        target: crate::telemetry::TARGET_MEMORY,
+        reason = message,
+        "buffer-pool admission invariant violated; aborting"
+    );
+
+    #[cfg(test)]
+    panic!("buffer-pool admission invariant violated: {message}");
+
+    #[cfg(not(test))]
+    {
+        let _ = message;
+        std::process::abort()
+    }
+}
+
+/// Closed bit in [`ReservationOwnerState::packed`].
+const RESERVATION_CLOSED: u64 = 1 << 63;
+
+/// Direct owners and in-flight debits in [`ReservationOwnerState::packed`].
+const DIRECT_OUTSTANDING_MASK: u64 = !RESERVATION_CLOSED;
+
+/// Reservation-local acquisition state.
+///
+/// The high bit records close. The remaining bits count direct carrier owners
+/// and acquisition debits that have not yet become owners.
+struct ReservationOwnerState {
+    packed: AtomicU64,
+}
+
+/// Why a reservation-local debit could not be installed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum DirectDebitError {
+    /// The reservation no longer permits new carrier acquisition.
+    Closed,
+    /// The debit would exceed the admitted envelope.
+    CapacityExceeded,
+    /// The count cannot be represented in the packed owner state.
+    CapacityOverflow,
+}
+
+/// One coherent reservation-owner sample.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ReservationOwnerSnapshot {
+    /// Whether acquisition of new carriers is closed.
+    closed: bool,
+    /// Direct owners and in-flight debits.
+    direct_outstanding: CarrierCount,
+}
+
+impl ReservationOwnerState {
+    /// Creates open authority with no direct owners.
+    fn new() -> Self {
+        Self {
+            packed: AtomicU64::new(0),
+        }
+    }
+
+    /// Checks one debit without reserving direct-acquisition authority.
+    fn precheck_debit(
+        &self,
+        envelope: CarrierCount,
+        count: CarrierCount,
+    ) -> Result<(), DirectDebitError> {
+        let envelope =
+            u64::try_from(envelope.get()).map_err(|_| DirectDebitError::CapacityOverflow)?;
+        let count = u64::try_from(count.get()).map_err(|_| DirectDebitError::CapacityOverflow)?;
+        if envelope > DIRECT_OUTSTANDING_MASK || count > DIRECT_OUTSTANDING_MASK {
+            return Err(DirectDebitError::CapacityOverflow);
+        }
+
+        let current = self.packed.load(Ordering::Acquire);
+        if current & RESERVATION_CLOSED != 0 {
+            return Err(DirectDebitError::Closed);
+        }
+        (current & DIRECT_OUTSTANDING_MASK)
+            .checked_add(count)
+            .filter(|next| *next <= envelope)
+            .map(|_| ())
+            .ok_or(DirectDebitError::CapacityExceeded)
+    }
+
+    /// Installs one complete direct-acquisition debit.
+    ///
+    /// Close and debit linearize on the same atomic word. A successful debit
+    /// remains valid if close follows it. A debit that observes close fails.
+    fn try_debit(
+        &self,
+        envelope: CarrierCount,
+        count: CarrierCount,
+    ) -> Result<(), DirectDebitError> {
+        let envelope =
+            u64::try_from(envelope.get()).map_err(|_| DirectDebitError::CapacityOverflow)?;
+        let count = u64::try_from(count.get()).map_err(|_| DirectDebitError::CapacityOverflow)?;
+        if envelope > DIRECT_OUTSTANDING_MASK || count > DIRECT_OUTSTANDING_MASK {
+            return Err(DirectDebitError::CapacityOverflow);
+        }
+
+        let result = self
+            .packed
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                if current & RESERVATION_CLOSED != 0 {
+                    return None;
+                }
+                (current & DIRECT_OUTSTANDING_MASK)
+                    .checked_add(count)
+                    .filter(|next| *next <= envelope)
+            });
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(current) if current & RESERVATION_CLOSED != 0 => Err(DirectDebitError::Closed),
+            Err(_) => Err(DirectDebitError::CapacityExceeded),
+        }
+    }
+
+    /// Closes direct acquisition and returns the outstanding count it observed.
+    fn close(&self) -> Option<CarrierCount> {
+        let previous = self.packed.fetch_or(RESERVATION_CLOSED, Ordering::AcqRel);
+        if previous & RESERVATION_CLOSED != 0 {
+            return None;
+        }
+        Some(CarrierCount::new(
+            usize::try_from(previous & DIRECT_OUTSTANDING_MASK)
+                .expect("direct owner count must fit usize"),
+        ))
+    }
+
+    /// Retires direct owners or rolls back an in-flight debit.
+    ///
+    /// Returns `true` when the reservation remains open. Release preserves the
+    /// closed bit and cannot restore acquisition authority after close.
+    fn release(&self, count: CarrierCount) -> bool {
+        let count = u64::try_from(count.get()).expect("direct release count must fit owner state");
+        let previous = self
+            .packed
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                let outstanding = current & DIRECT_OUTSTANDING_MASK;
+                outstanding
+                    .checked_sub(count)
+                    .map(|next| (current & RESERVATION_CLOSED) | next)
+            })
+            .expect("direct release exceeds outstanding ownership");
+        previous & RESERVATION_CLOSED == 0
+    }
+
+    /// Loads one coherent owner-state sample.
+    fn snapshot(&self) -> ReservationOwnerSnapshot {
+        let packed = self.packed.load(Ordering::Acquire);
+        ReservationOwnerSnapshot {
+            closed: packed & RESERVATION_CLOSED != 0,
+            direct_outstanding: CarrierCount::new(
+                usize::try_from(packed & DIRECT_OUTSTANDING_MASK)
+                    .expect("direct owner count must fit usize"),
+            ),
+        }
+    }
+}
+
+#[cfg(all(test, not(s3_tm_loom)))]
+mod tests {
+    use super::super::geometry::PoolGeometry;
+    use super::super::virtual_memory::{page_size, VirtualMemoryOperation};
+    use super::super::BufferPool;
+    use super::*;
+
+    fn test_pool(block_carriers: usize, configured: usize) -> (BufferPool, usize) {
+        let page_size = page_size().unwrap().get();
+        let geometry = PoolGeometry::new(
+            page_size,
+            page_size.checked_mul(block_carriers).unwrap(),
+            page_size,
+        )
+        .unwrap();
+        let pool =
+            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
+        (pool, page_size)
+    }
+
+    #[test]
+    fn test_immediate_grant_prepares_before_publication() {
+        let (pool, carrier_size) = test_pool(2, 4);
+
+        let reservation = pool.try_reserve(carrier_size).unwrap().unwrap();
+
+        {
+            let admission = pool.inner.admission.lock();
+            let coverage = pool.inner.coverage.snapshot();
+            assert_eq!(admission.ledger.prepared_capacity, CarrierCount::new(2));
+            assert_eq!(admission.ledger.active_planned_demand, CarrierCount::new(1));
+            assert_eq!(coverage.available, CarrierCount::new(1));
+            assert_eq!(coverage.uncovered, CarrierCount::ZERO);
+        }
+
+        drop(reservation);
+        let admission = pool.inner.admission.lock();
+        assert_eq!(admission.ledger.active_planned_demand, CarrierCount::ZERO);
+        assert_eq!(admission.ledger.prepared_capacity, CarrierCount::new(2));
+        assert_eq!(
+            pool.inner.coverage.snapshot(),
+            CoverageSnapshot {
+                available: CarrierCount::ZERO,
+                uncovered: CarrierCount::ZERO,
+            }
+        );
+    }
+
+    #[test]
+    fn test_grant_cannot_publish_before_preparing_its_floor() {
+        let mut admission = AdmissionState::new(CarrierCount::new(1));
+        let coverage = CoverageState::new();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            admission
+                .ledger
+                .commit_grant(&coverage, CarrierCount::new(1))
+                .unwrap();
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(admission.ledger.active_planned_demand, CarrierCount::ZERO);
+        assert_eq!(
+            coverage.snapshot(),
+            CoverageSnapshot {
+                available: CarrierCount::ZERO,
+                uncovered: CarrierCount::ZERO,
+            }
+        );
+    }
+
+    #[test]
+    fn test_normal_grant_respects_configured_capacity() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let reservation = pool.try_reserve(carrier_size * 2).unwrap().unwrap();
+
+        assert!(pool.try_reserve(carrier_size).unwrap().is_none());
+        assert_eq!(pool.inner.arena.diagnostics().blocks_prepared, 1);
+
+        drop(reservation);
+    }
+
+    #[test]
+    fn test_idle_only_grant_can_exceed_configured_capacity() {
+        let (pool, carrier_size) = test_pool(2, 1);
+
+        let reservation = pool.try_reserve(carrier_size * 3).unwrap().unwrap();
+
+        let admission = pool.inner.admission.lock();
+        assert_eq!(admission.ledger.active_planned_demand, CarrierCount::new(3));
+        assert_eq!(admission.ledger.prepared_capacity, CarrierCount::new(4));
+        drop(admission);
+        drop(reservation);
+    }
+
+    #[test]
+    fn test_idle_only_grant_can_progress_past_uncovered_ownership() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        {
+            let mut admission = AdmissionGuard::new(pool.inner.admission.lock());
+            pool.inner
+                .coverage
+                .debit(CarrierCount::new(1), MAX_PACKED_CARRIERS)
+                .unwrap();
+            pool.inner
+                .arena
+                .prepare_to(&mut admission, CarrierCount::new(1))
+                .unwrap();
+        }
+
+        let reservation = pool.try_reserve(carrier_size).unwrap().unwrap();
+
+        {
+            let admission = pool.inner.admission.lock();
+            assert_eq!(admission.ledger.active_planned_demand, CarrierCount::new(1));
+            assert_eq!(admission.ledger.prepared_capacity, CarrierCount::new(2));
+            assert_eq!(
+                pool.inner.coverage.snapshot().uncovered,
+                CarrierCount::new(1)
+            );
+        }
+        drop(reservation);
+        pool.inner.coverage.release(CarrierCount::new(1));
+    }
+
+    #[test]
+    fn test_preparation_failure_publishes_no_grant() {
+        let (pool, carrier_size) = test_pool(2, 4);
+        let first = pool.inner.arena.reserve_slot().unwrap();
+        let second = pool.inner.arena.reserve_slot().unwrap();
+        second.inject_failure_once(VirtualMemoryOperation::Prepare);
+
+        assert!(matches!(
+            pool.try_reserve(carrier_size * 3),
+            Err(ReserveError::PhysicalPreparationFailed)
+        ));
+        {
+            let admission = pool.inner.admission.lock();
+            assert_eq!(admission.ledger.prepared_capacity, CarrierCount::new(2));
+            assert_eq!(admission.ledger.active_planned_demand, CarrierCount::ZERO);
+            assert_eq!(
+                pool.inner.coverage.snapshot(),
+                CoverageSnapshot {
+                    available: CarrierCount::ZERO,
+                    uncovered: CarrierCount::ZERO,
+                }
+            );
+        }
+
+        let reservation = pool.try_reserve(carrier_size * 3).unwrap().unwrap();
+        assert_eq!(
+            pool.inner.admission.lock().ledger.prepared_capacity,
+            CarrierCount::new(4)
+        );
+        drop(reservation);
+        drop(first);
+    }
+
+    #[test]
+    fn test_close_reclassifies_occupied_coverage() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let reservation = pool.try_reserve(carrier_size * 2).unwrap().unwrap();
+        assert!(pool
+            .inner
+            .coverage
+            .try_debit_covered(CarrierCount::new(1))
+            .unwrap());
+
+        reservation.close_acquisition();
+
+        assert_eq!(
+            pool.inner.coverage.snapshot(),
+            CoverageSnapshot {
+                available: CarrierCount::ZERO,
+                uncovered: CarrierCount::new(1),
+            }
+        );
+        assert_eq!(
+            pool.inner.admission.lock().ledger.active_planned_demand,
+            CarrierCount::ZERO
+        );
+        pool.inner.coverage.release(CarrierCount::new(1));
+    }
+
+    #[test]
+    fn test_invalid_reservation_sizes_fail_before_preparation() {
+        let (pool, carrier_size) = test_pool(1, 1);
+
+        assert!(matches!(
+            pool.try_reserve(0),
+            Err(ReserveError::InvalidSize)
+        ));
+        if let Some(bytes) = (u32::MAX as usize)
+            .checked_add(1)
+            .and_then(|carriers| carriers.checked_mul(carrier_size))
+        {
+            assert!(matches!(
+                pool.try_reserve(bytes),
+                Err(ReserveError::CapacityOverflow)
+            ));
+        }
+        assert_eq!(pool.inner.arena.diagnostics().blocks_prepared, 0);
+    }
+
+    #[test]
+    fn test_pool_ownership_spine_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<BufferPool>();
+        assert_send_sync::<Reservation>();
+        assert_send_sync::<ReservationState>();
+    }
+
+    #[test]
+    fn test_close_is_idempotent() {
+        let state = ReservationOwnerState::new();
+
+        assert_eq!(state.close(), Some(CarrierCount::ZERO));
+        assert_eq!(state.close(), None);
+        assert_eq!(
+            state.snapshot(),
+            ReservationOwnerSnapshot {
+                closed: true,
+                direct_outstanding: CarrierCount::ZERO,
+            }
+        );
+    }
+
+    #[test]
+    fn test_direct_debit_cannot_exceed_envelope() {
+        let state = ReservationOwnerState::new();
+        state
+            .try_debit(CarrierCount::new(3), CarrierCount::new(2))
+            .unwrap();
+
+        assert_eq!(
+            state.try_debit(CarrierCount::new(3), CarrierCount::new(2)),
+            Err(DirectDebitError::CapacityExceeded)
+        );
+        assert_eq!(state.snapshot().direct_outstanding, CarrierCount::new(2));
+    }
+
+    #[test]
+    fn test_release_after_close_does_not_reopen_reservation() {
+        let state = ReservationOwnerState::new();
+        state
+            .try_debit(CarrierCount::new(2), CarrierCount::new(2))
+            .unwrap();
+        assert_eq!(state.close(), Some(CarrierCount::new(2)));
+
+        assert!(!state.release(CarrierCount::new(2)));
+        assert_eq!(
+            state.snapshot(),
+            ReservationOwnerSnapshot {
+                closed: true,
+                direct_outstanding: CarrierCount::ZERO,
+            }
+        );
+        assert_eq!(
+            state.try_debit(CarrierCount::new(2), CarrierCount::new(1)),
+            Err(DirectDebitError::Closed)
+        );
+    }
+
+    #[test]
+    fn test_invalid_release_leaves_owner_state_unchanged() {
+        let state = ReservationOwnerState::new();
+
+        let result = std::panic::catch_unwind(|| state.release(CarrierCount::new(1)));
+
+        assert!(result.is_err());
+        assert_eq!(
+            state.snapshot(),
+            ReservationOwnerSnapshot {
+                closed: false,
+                direct_outstanding: CarrierCount::ZERO,
+            }
+        );
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use super::super::geometry::PoolGeometry;
+    use super::super::virtual_memory::page_size;
+    use super::super::BufferPool;
+    use crate::runtime::sync::sync::Arc;
+    use crate::runtime::sync::thread;
+
+    use super::*;
+
+    fn test_pool(configured: usize) -> (BufferPool, usize) {
+        let page_size = page_size().unwrap().get();
+        let geometry = PoolGeometry::new(page_size, page_size, page_size).unwrap();
+        let pool =
+            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
+        (pool, page_size)
+    }
+
+    #[test]
+    fn test_concurrent_immediate_grants_respect_normal_capacity() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(1);
+
+            let first_pool = pool.clone();
+            let first = thread::spawn(move || first_pool.try_reserve(carrier_size).unwrap());
+            let second_pool = pool.clone();
+            let second = thread::spawn(move || second_pool.try_reserve(carrier_size).unwrap());
+
+            let first = first.join().unwrap();
+            let second = second.join().unwrap();
+            assert_eq!(
+                usize::from(first.is_some()) + usize::from(second.is_some()),
+                1
+            );
+            drop(first);
+            drop(second);
+            assert_eq!(
+                pool.inner.admission.lock().ledger.active_planned_demand,
+                CarrierCount::ZERO
+            );
+        });
+    }
+
+    #[test]
+    fn test_concurrent_idle_only_grants_do_not_compound_overage() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(1);
+
+            let first_pool = pool.clone();
+            let first = thread::spawn(move || first_pool.try_reserve(carrier_size * 2).unwrap());
+            let second_pool = pool.clone();
+            let second = thread::spawn(move || second_pool.try_reserve(carrier_size * 2).unwrap());
+
+            let first = first.join().unwrap();
+            let second = second.join().unwrap();
+            assert_eq!(
+                usize::from(first.is_some()) + usize::from(second.is_some()),
+                1
+            );
+            drop(first);
+            drop(second);
+            assert_eq!(
+                pool.inner.admission.lock().ledger.active_planned_demand,
+                CarrierCount::ZERO
+            );
+        });
+    }
+
+    #[test]
+    fn test_direct_debit_racing_close_has_one_linearization() {
+        loom::model(|| {
+            let state = Arc::new(ReservationOwnerState::new());
+
+            let debiting = Arc::clone(&state);
+            let debit = thread::spawn(move || {
+                debiting.try_debit(CarrierCount::new(1), CarrierCount::new(1))
+            });
+            let closing = Arc::clone(&state);
+            let close = thread::spawn(move || closing.close());
+
+            let debit = debit.join().unwrap();
+            let closed_outstanding = close.join().unwrap();
+            let snapshot = state.snapshot();
+            assert!(snapshot.closed);
+            match debit {
+                Ok(()) => {
+                    assert_eq!(closed_outstanding, Some(CarrierCount::new(1)));
+                    assert_eq!(snapshot.direct_outstanding, CarrierCount::new(1));
+                }
+                Err(DirectDebitError::Closed) => {
+                    assert_eq!(closed_outstanding, Some(CarrierCount::ZERO));
+                    assert_eq!(snapshot.direct_outstanding, CarrierCount::ZERO);
+                }
+                Err(error) => panic!("unexpected debit error: {error:?}"),
+            }
+        });
+    }
+
+    #[test]
+    fn test_concurrent_direct_debits_consume_authority_once() {
+        loom::model(|| {
+            let state = Arc::new(ReservationOwnerState::new());
+
+            let first_state = Arc::clone(&state);
+            let first = thread::spawn(move || {
+                first_state.try_debit(CarrierCount::new(1), CarrierCount::new(1))
+            });
+            let second_state = Arc::clone(&state);
+            let second = thread::spawn(move || {
+                second_state.try_debit(CarrierCount::new(1), CarrierCount::new(1))
+            });
+
+            let successes = usize::from(first.join().unwrap().is_ok())
+                + usize::from(second.join().unwrap().is_ok());
+            assert_eq!(successes, 1);
+            assert_eq!(state.snapshot().direct_outstanding, CarrierCount::new(1));
+        });
+    }
+
+    #[test]
+    fn test_release_racing_close_cannot_reopen_reservation() {
+        loom::model(|| {
+            let state = Arc::new(ReservationOwnerState::new());
+            state
+                .try_debit(CarrierCount::new(1), CarrierCount::new(1))
+                .unwrap();
+
+            let releasing = Arc::clone(&state);
+            let release = thread::spawn(move || releasing.release(CarrierCount::new(1)));
+            let closing = Arc::clone(&state);
+            let close = thread::spawn(move || closing.close());
+
+            release.join().unwrap();
+            close.join().unwrap();
+            assert_eq!(
+                state.snapshot(),
+                ReservationOwnerSnapshot {
+                    closed: true,
+                    direct_outstanding: CarrierCount::ZERO,
+                }
+            );
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission/coverage.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission/coverage.rs
@@ -1,0 +1,562 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Lock-free aggregate acquisition accounting.
+//!
+//! Active planned demand remains under admission serialization. Available
+//! coverage and uncovered charges share one atomic word so debit, return,
+//! grant, and close cannot observe or publish a torn pair.
+
+use crate::runtime::sync::sync::atomic::{AtomicU64, Ordering};
+
+use super::super::CarrierCount;
+
+/// Number of bits in one packed accounting lane.
+const LANE_BITS: u32 = u32::BITS;
+
+/// Largest count represented by one packed accounting lane.
+pub(in crate::runtime::buffer_pool) const MAX_PACKED_CARRIERS: CarrierCount =
+    CarrierCount::new(u32::MAX as usize);
+
+/// A packed transition cannot represent its result.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct CoverageOverflow;
+
+/// Aggregate state changed at carrier-acquisition frequency.
+pub(in crate::runtime::buffer_pool) struct CoverageState {
+    /// Low lane: available coverage. High lane: uncovered charges.
+    packed: AtomicU64,
+}
+
+/// One coherent sample of [`CoverageState`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct CoverageSnapshot {
+    /// Open-envelope capacity not occupied by an acquisition.
+    pub(super) available: CarrierCount,
+    /// Ownership pressure outside open-envelope coverage.
+    pub(super) uncovered: CarrierCount,
+}
+
+/// Result of installing aggregate acquisition charges.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct CoverageDebit {
+    /// Uncovered charges introduced by this transition.
+    pub(super) uncovered_added: CarrierCount,
+}
+
+/// Result of retiring aggregate acquisition charges.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct CoverageReturn {
+    /// Uncovered charges removed by this transition.
+    pub(super) uncovered_removed: CarrierCount,
+}
+
+impl CoverageState {
+    /// Creates empty aggregate accounting.
+    pub(in crate::runtime::buffer_pool) fn new() -> Self {
+        Self {
+            packed: AtomicU64::new(0),
+        }
+    }
+
+    /// Debits only when available coverage satisfies the complete request.
+    ///
+    /// `Ok(false)` leaves state unchanged. The caller must enter admission
+    /// serialization before installing an uncovered charge.
+    pub(super) fn try_debit_covered(&self, count: CarrierCount) -> Result<bool, CoverageOverflow> {
+        checked_lane(count)?;
+        let mut current = self.packed.load(Ordering::Acquire);
+
+        loop {
+            let snapshot = unpack(current);
+            let Some(available) = snapshot.available.checked_sub(count) else {
+                return Ok(false);
+            };
+            let next = pack(available, snapshot.uncovered)?;
+            match self.packed.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Ok(true),
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    /// Installs acquisition charges, consuming coverage before adding overage.
+    ///
+    /// Callers that may add an uncovered charge hold admission serialization.
+    /// `maximum_uncovered` enforces the packed global admission bound.
+    pub(super) fn debit(
+        &self,
+        count: CarrierCount,
+        maximum_uncovered: CarrierCount,
+    ) -> Result<CoverageDebit, CoverageOverflow> {
+        checked_lane(count)?;
+        checked_lane(maximum_uncovered)?;
+        self.update(|snapshot| {
+            let covered = CarrierCount::new(count.get().min(snapshot.available.get()));
+            let uncovered_added = count.checked_sub(covered).ok_or(CoverageOverflow)?;
+            let available = snapshot
+                .available
+                .checked_sub(covered)
+                .ok_or(CoverageOverflow)?;
+            let uncovered = snapshot
+                .uncovered
+                .checked_add(uncovered_added)
+                .filter(|next| *next <= maximum_uncovered)
+                .ok_or(CoverageOverflow)?;
+            Ok((
+                CoverageSnapshot {
+                    available,
+                    uncovered,
+                },
+                CoverageDebit { uncovered_added },
+            ))
+        })
+    }
+
+    /// Retires charges, removing uncovered charges before restoring coverage.
+    pub(super) fn release(&self, count: CarrierCount) -> CoverageReturn {
+        checked_lane(count).expect("released carrier count must fit packed accounting");
+        self.update(|snapshot| {
+            let uncovered_removed = CarrierCount::new(count.get().min(snapshot.uncovered.get()));
+            let restored = count
+                .checked_sub(uncovered_removed)
+                .ok_or(CoverageOverflow)?;
+            let available = snapshot
+                .available
+                .checked_add(restored)
+                .ok_or(CoverageOverflow)?;
+            let uncovered = snapshot
+                .uncovered
+                .checked_sub(uncovered_removed)
+                .ok_or(CoverageOverflow)?;
+            Ok((
+                CoverageSnapshot {
+                    available,
+                    uncovered,
+                },
+                CoverageReturn { uncovered_removed },
+            ))
+        })
+        .expect("aggregate return must fit packed accounting")
+    }
+
+    /// Publishes unused coverage from one newly active envelope.
+    ///
+    /// Existing uncovered charges remain unchanged. A later grant cannot
+    /// absorb ownership that predates it.
+    pub(super) fn add_coverage(&self, count: CarrierCount) -> Result<(), CoverageOverflow> {
+        checked_lane(count)?;
+        self.update(|snapshot| {
+            let available = snapshot
+                .available
+                .checked_add(count)
+                .ok_or(CoverageOverflow)?;
+            Ok((
+                CoverageSnapshot {
+                    available,
+                    uncovered: snapshot.uncovered,
+                },
+                (),
+            ))
+        })
+    }
+
+    /// Withdraws one closing envelope without consuming another envelope's coverage.
+    ///
+    /// Direct outstanding charges are already present in aggregate accounting.
+    /// Availability above remaining active demand belongs to a return that
+    /// raced the direct snapshot and must also leave with this envelope.
+    pub(super) fn remove_coverage(
+        &self,
+        envelope: CarrierCount,
+        direct_outstanding: CarrierCount,
+        remaining_active: CarrierCount,
+    ) {
+        checked_lane(envelope).expect("closed envelope must fit packed accounting");
+        checked_lane(direct_outstanding)
+            .expect("closing direct outstanding must fit packed accounting");
+        checked_lane(remaining_active).expect("remaining active demand must fit packed accounting");
+        let potentially_unused = envelope
+            .checked_sub(direct_outstanding)
+            .expect("closing direct outstanding exceeds its envelope");
+        self.update(|snapshot| {
+            let nominally_unused =
+                CarrierCount::new(potentially_unused.get().min(snapshot.available.get()));
+            let required_for_active = CarrierCount::new(
+                snapshot
+                    .available
+                    .get()
+                    .saturating_sub(remaining_active.get()),
+            );
+            let removed = nominally_unused.max(required_for_active);
+            let reclassified = envelope.checked_sub(removed).ok_or(CoverageOverflow)?;
+            let available = snapshot
+                .available
+                .checked_sub(removed)
+                .ok_or(CoverageOverflow)?;
+            let uncovered = snapshot
+                .uncovered
+                .checked_add(reclassified)
+                .ok_or(CoverageOverflow)?;
+            Ok((
+                CoverageSnapshot {
+                    available,
+                    uncovered,
+                },
+                (),
+            ))
+        })
+        .expect("reservation close must fit packed accounting");
+    }
+
+    /// Loads one coherent accounting sample.
+    pub(super) fn snapshot(&self) -> CoverageSnapshot {
+        unpack(self.packed.load(Ordering::Acquire))
+    }
+
+    fn update<T>(
+        &self,
+        mut transition: impl FnMut(CoverageSnapshot) -> Result<(CoverageSnapshot, T), CoverageOverflow>,
+    ) -> Result<T, CoverageOverflow> {
+        let mut current = self.packed.load(Ordering::Acquire);
+        loop {
+            let (next, result) = transition(unpack(current))?;
+            let next = pack(next.available, next.uncovered)?;
+            match self.packed.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Ok(result),
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
+fn checked_lane(count: CarrierCount) -> Result<u32, CoverageOverflow> {
+    count.try_as_u32().ok_or(CoverageOverflow)
+}
+
+fn pack(available: CarrierCount, uncovered: CarrierCount) -> Result<u64, CoverageOverflow> {
+    let available = checked_lane(available)?;
+    let uncovered = checked_lane(uncovered)?;
+    Ok(u64::from(available) | (u64::from(uncovered) << LANE_BITS))
+}
+
+fn unpack(packed: u64) -> CoverageSnapshot {
+    CoverageSnapshot {
+        available: CarrierCount::new((packed as u32) as usize),
+        uncovered: CarrierCount::new((packed >> LANE_BITS) as usize),
+    }
+}
+
+#[cfg(all(test, not(s3_tm_loom)))]
+mod tests {
+    use super::*;
+
+    fn state_with(available: usize, uncovered: usize) -> CoverageState {
+        CoverageState {
+            packed: AtomicU64::new(
+                pack(CarrierCount::new(available), CarrierCount::new(uncovered)).unwrap(),
+            ),
+        }
+    }
+
+    #[test]
+    fn test_debit_consumes_coverage_before_adding_uncovered_charge() {
+        let state = state_with(3, 0);
+
+        let debit = state
+            .debit(CarrierCount::new(5), CarrierCount::new(8))
+            .unwrap();
+
+        assert_eq!(debit.uncovered_added, CarrierCount::new(2));
+        assert_eq!(
+            state.snapshot(),
+            CoverageSnapshot {
+                available: CarrierCount::ZERO,
+                uncovered: CarrierCount::new(2),
+            }
+        );
+    }
+
+    #[test]
+    fn test_covered_debit_miss_leaves_state_unchanged() {
+        let state = state_with(1, 2);
+        let before = state.snapshot();
+
+        assert!(!state.try_debit_covered(CarrierCount::new(2)).unwrap());
+        assert_eq!(state.snapshot(), before);
+    }
+
+    #[test]
+    fn test_return_removes_uncovered_before_restoring_coverage() {
+        let state = state_with(0, 3);
+
+        let returned = state.release(CarrierCount::new(5));
+
+        assert_eq!(returned.uncovered_removed, CarrierCount::new(3));
+        assert_eq!(
+            state.snapshot(),
+            CoverageSnapshot {
+                available: CarrierCount::new(2),
+                uncovered: CarrierCount::ZERO,
+            }
+        );
+    }
+
+    #[test]
+    fn test_new_envelope_does_not_absorb_existing_uncovered_charge() {
+        let state = state_with(0, 1);
+
+        state.add_coverage(CarrierCount::new(1)).unwrap();
+
+        assert_eq!(
+            state.snapshot(),
+            CoverageSnapshot {
+                available: CarrierCount::new(1),
+                uncovered: CarrierCount::new(1),
+            }
+        );
+    }
+
+    #[test]
+    fn test_close_reclassifies_occupied_coverage() {
+        let state = state_with(4, 0);
+        assert!(state.try_debit_covered(CarrierCount::new(3)).unwrap());
+
+        state.remove_coverage(
+            CarrierCount::new(4),
+            CarrierCount::new(3),
+            CarrierCount::ZERO,
+        );
+
+        assert_eq!(
+            state.snapshot(),
+            CoverageSnapshot {
+                available: CarrierCount::ZERO,
+                uncovered: CarrierCount::new(3),
+            }
+        );
+    }
+
+    #[test]
+    fn test_close_preserves_coverage_needed_by_other_direct_authority() {
+        let state = state_with(3, 0);
+
+        state.remove_coverage(
+            CarrierCount::new(3),
+            CarrierCount::new(3),
+            CarrierCount::new(3),
+        );
+
+        assert_eq!(
+            state.snapshot(),
+            CoverageSnapshot {
+                available: CarrierCount::new(3),
+                uncovered: CarrierCount::new(3),
+            }
+        );
+    }
+
+    #[test]
+    fn test_close_reclassifies_nominally_unused_coverage_consumed_by_unreserved_acquisition() {
+        let state = state_with(1, 0);
+
+        state.remove_coverage(CarrierCount::new(3), CarrierCount::ZERO, CarrierCount::ZERO);
+
+        assert_eq!(
+            state.snapshot(),
+            CoverageSnapshot {
+                available: CarrierCount::ZERO,
+                uncovered: CarrierCount::new(2),
+            }
+        );
+    }
+
+    #[test]
+    fn test_small_debit_space_matches_transition_equations() {
+        for available in 0..=4 {
+            for uncovered in 0..=4 {
+                for count in 0..=6 {
+                    let state = state_with(available, uncovered);
+                    let debit = state
+                        .debit(CarrierCount::new(count), CarrierCount::new(10))
+                        .unwrap();
+                    let covered = count.min(available);
+
+                    assert_eq!(debit.uncovered_added, CarrierCount::new(count - covered));
+                    assert_eq!(
+                        state.snapshot(),
+                        CoverageSnapshot {
+                            available: CarrierCount::new(available - covered),
+                            uncovered: CarrierCount::new(uncovered + count - covered),
+                        }
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_small_return_space_matches_transition_equations() {
+        for available in 0..=4 {
+            for uncovered in 0..=4 {
+                for count in 0..=4 {
+                    let state = state_with(available, uncovered);
+                    let returned = state.release(CarrierCount::new(count));
+                    let uncovered_removed = count.min(uncovered);
+
+                    assert_eq!(
+                        returned.uncovered_removed,
+                        CarrierCount::new(uncovered_removed)
+                    );
+                    assert_eq!(
+                        state.snapshot(),
+                        CoverageSnapshot {
+                            available: CarrierCount::new(available + count - uncovered_removed),
+                            uncovered: CarrierCount::new(uncovered - uncovered_removed),
+                        }
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_small_close_space_matches_transition_equations() {
+        for available in 0..=4 {
+            for uncovered in 0..=4 {
+                for envelope in 0..=6 {
+                    for direct_outstanding in 0..=envelope {
+                        for remaining_active in 0..=4 {
+                            if available + direct_outstanding > remaining_active + envelope {
+                                continue;
+                            }
+                            let state = state_with(available, uncovered);
+                            state.remove_coverage(
+                                CarrierCount::new(envelope),
+                                CarrierCount::new(direct_outstanding),
+                                CarrierCount::new(remaining_active),
+                            );
+                            let potentially_unused = envelope - direct_outstanding;
+                            let nominally_unused = potentially_unused.min(available);
+                            let required_for_active = available.saturating_sub(remaining_active);
+                            let removed = nominally_unused.max(required_for_active);
+
+                            assert_eq!(
+                                state.snapshot(),
+                                CoverageSnapshot {
+                                    available: CarrierCount::new(available - removed),
+                                    uncovered: CarrierCount::new(uncovered + envelope - removed),
+                                }
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_packed_lane_boundary_is_checked() {
+        let state = state_with(u32::MAX as usize, 0);
+
+        assert_eq!(
+            state.add_coverage(CarrierCount::new(1)),
+            Err(CoverageOverflow)
+        );
+        if let Ok(too_large) = usize::try_from(u64::from(u32::MAX) + 1) {
+            assert_eq!(
+                state.try_debit_covered(CarrierCount::new(too_large)),
+                Err(CoverageOverflow)
+            );
+        }
+        assert_eq!(
+            state.snapshot().available,
+            CarrierCount::new(u32::MAX as usize)
+        );
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use crate::runtime::sync::sync::Arc;
+    use crate::runtime::sync::thread;
+
+    use super::*;
+
+    #[test]
+    fn test_debit_racing_close_preserves_one_live_charge() {
+        loom::model(|| {
+            let state = Arc::new(CoverageState::new());
+            state.add_coverage(CarrierCount::new(1)).unwrap();
+
+            let debiting = Arc::clone(&state);
+            let debit = thread::spawn(move || {
+                if !debiting.try_debit_covered(CarrierCount::new(1)).unwrap() {
+                    debiting
+                        .debit(CarrierCount::new(1), MAX_PACKED_CARRIERS)
+                        .unwrap();
+                }
+            });
+            let closing = Arc::clone(&state);
+            let close = thread::spawn(move || {
+                closing.remove_coverage(
+                    CarrierCount::new(1),
+                    CarrierCount::ZERO,
+                    CarrierCount::ZERO,
+                )
+            });
+
+            debit.join().unwrap();
+            close.join().unwrap();
+            assert_eq!(
+                state.snapshot(),
+                CoverageSnapshot {
+                    available: CarrierCount::ZERO,
+                    uncovered: CarrierCount::new(1),
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn test_return_racing_close_retires_live_charge() {
+        loom::model(|| {
+            let state = Arc::new(CoverageState::new());
+            state.add_coverage(CarrierCount::new(1)).unwrap();
+            assert!(state.try_debit_covered(CarrierCount::new(1)).unwrap());
+
+            let returning = Arc::clone(&state);
+            let release = thread::spawn(move || returning.release(CarrierCount::new(1)));
+            let closing = Arc::clone(&state);
+            let close = thread::spawn(move || {
+                closing.remove_coverage(
+                    CarrierCount::new(1),
+                    CarrierCount::new(1),
+                    CarrierCount::ZERO,
+                )
+            });
+
+            release.join().unwrap();
+            close.join().unwrap();
+            assert_eq!(
+                state.snapshot(),
+                CoverageSnapshot {
+                    available: CarrierCount::ZERO,
+                    uncovered: CarrierCount::ZERO,
+                }
+            );
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission/coverage.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission/coverage.rs
@@ -11,7 +11,7 @@
 
 use crate::runtime::sync::sync::atomic::{AtomicU64, Ordering};
 
-use super::super::CarrierCount;
+use super::super::{invariant_violation, CarrierCount};
 
 /// Number of bits in one packed accounting lane.
 const LANE_BITS: u32 = u32::BITS;
@@ -22,9 +22,9 @@ pub(in crate::runtime::buffer_pool) const MAX_PACKED_CARRIERS: CarrierCount =
 
 /// A packed transition cannot represent its result.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) struct CoverageOverflow;
+pub(in crate::runtime::buffer_pool) struct CoverageOverflow;
 
-/// Aggregate state changed at carrier-acquisition frequency.
+/// Packed coverage and ownership pressure updated by acquisition and return.
 pub(in crate::runtime::buffer_pool) struct CoverageState {
     /// Low lane: available coverage. High lane: uncovered charges.
     packed: AtomicU64,
@@ -32,25 +32,25 @@ pub(in crate::runtime::buffer_pool) struct CoverageState {
 
 /// One coherent sample of [`CoverageState`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) struct CoverageSnapshot {
+pub(in crate::runtime::buffer_pool) struct CoverageSnapshot {
     /// Open-envelope capacity not occupied by an acquisition.
-    pub(super) available: CarrierCount,
+    pub(in crate::runtime::buffer_pool) available: CarrierCount,
     /// Ownership pressure outside open-envelope coverage.
-    pub(super) uncovered: CarrierCount,
+    pub(in crate::runtime::buffer_pool) uncovered: CarrierCount,
 }
 
 /// Result of installing aggregate acquisition charges.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) struct CoverageDebit {
+pub(in crate::runtime::buffer_pool) struct CoverageDebit {
     /// Uncovered charges introduced by this transition.
-    pub(super) uncovered_added: CarrierCount,
+    pub(in crate::runtime::buffer_pool) uncovered_added: CarrierCount,
 }
 
 /// Result of retiring aggregate acquisition charges.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) struct CoverageReturn {
+pub(in crate::runtime::buffer_pool) struct CoverageReturn {
     /// Uncovered charges removed by this transition.
-    pub(super) uncovered_removed: CarrierCount,
+    pub(in crate::runtime::buffer_pool) uncovered_removed: CarrierCount,
 }
 
 impl CoverageState {
@@ -65,7 +65,10 @@ impl CoverageState {
     ///
     /// `Ok(false)` leaves state unchanged. The caller must enter admission
     /// serialization before installing an uncovered charge.
-    pub(super) fn try_debit_covered(&self, count: CarrierCount) -> Result<bool, CoverageOverflow> {
+    pub(in crate::runtime::buffer_pool) fn try_debit_covered(
+        &self,
+        count: CarrierCount,
+    ) -> Result<bool, CoverageOverflow> {
         checked_lane(count)?;
         let mut current = self.packed.load(Ordering::Acquire);
 
@@ -91,7 +94,7 @@ impl CoverageState {
     ///
     /// Callers that may add an uncovered charge hold admission serialization.
     /// `maximum_uncovered` enforces the packed global admission bound.
-    pub(super) fn debit(
+    pub(in crate::runtime::buffer_pool) fn debit(
         &self,
         count: CarrierCount,
         maximum_uncovered: CarrierCount,
@@ -121,8 +124,10 @@ impl CoverageState {
     }
 
     /// Retires charges, removing uncovered charges before restoring coverage.
-    pub(super) fn release(&self, count: CarrierCount) -> CoverageReturn {
-        checked_lane(count).expect("released carrier count must fit packed accounting");
+    pub(in crate::runtime::buffer_pool) fn release(&self, count: CarrierCount) -> CoverageReturn {
+        if checked_lane(count).is_err() {
+            invariant_violation("released carrier count exceeds packed accounting");
+        }
         self.update(|snapshot| {
             let uncovered_removed = CarrierCount::new(count.get().min(snapshot.uncovered.get()));
             let restored = count
@@ -144,14 +149,17 @@ impl CoverageState {
                 CoverageReturn { uncovered_removed },
             ))
         })
-        .expect("aggregate return must fit packed accounting")
+        .unwrap_or_else(|_| invariant_violation("aggregate return exceeds packed accounting"))
     }
 
     /// Publishes unused coverage from one newly active envelope.
     ///
     /// Existing uncovered charges remain unchanged. A later grant cannot
     /// absorb ownership that predates it.
-    pub(super) fn add_coverage(&self, count: CarrierCount) -> Result<(), CoverageOverflow> {
+    pub(in crate::runtime::buffer_pool) fn add_coverage(
+        &self,
+        count: CarrierCount,
+    ) -> Result<(), CoverageOverflow> {
         checked_lane(count)?;
         self.update(|snapshot| {
             let available = snapshot
@@ -173,19 +181,24 @@ impl CoverageState {
     /// Direct outstanding charges are already present in aggregate accounting.
     /// Availability above remaining active demand belongs to a return that
     /// raced the direct snapshot and must also leave with this envelope.
-    pub(super) fn remove_coverage(
+    pub(in crate::runtime::buffer_pool) fn remove_coverage(
         &self,
         envelope: CarrierCount,
         direct_outstanding: CarrierCount,
         remaining_active: CarrierCount,
     ) {
-        checked_lane(envelope).expect("closed envelope must fit packed accounting");
-        checked_lane(direct_outstanding)
-            .expect("closing direct outstanding must fit packed accounting");
-        checked_lane(remaining_active).expect("remaining active demand must fit packed accounting");
-        let potentially_unused = envelope
-            .checked_sub(direct_outstanding)
-            .expect("closing direct outstanding exceeds its envelope");
+        if checked_lane(envelope).is_err() {
+            invariant_violation("closed envelope exceeds packed accounting");
+        }
+        if checked_lane(direct_outstanding).is_err() {
+            invariant_violation("closing direct outstanding exceeds packed accounting");
+        }
+        if checked_lane(remaining_active).is_err() {
+            invariant_violation("remaining active demand exceeds packed accounting");
+        }
+        let potentially_unused = envelope.checked_sub(direct_outstanding).unwrap_or_else(|| {
+            invariant_violation("closing direct outstanding exceeds its envelope")
+        });
         self.update(|snapshot| {
             let nominally_unused =
                 CarrierCount::new(potentially_unused.get().min(snapshot.available.get()));
@@ -213,11 +226,11 @@ impl CoverageState {
                 (),
             ))
         })
-        .expect("reservation close must fit packed accounting");
+        .unwrap_or_else(|_| invariant_violation("reservation close exceeds packed accounting"));
     }
 
     /// Loads one coherent accounting sample.
-    pub(super) fn snapshot(&self) -> CoverageSnapshot {
+    pub(in crate::runtime::buffer_pool) fn snapshot(&self) -> CoverageSnapshot {
         unpack(self.packed.load(Ordering::Acquire))
     }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission/waiter.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission/waiter.rs
@@ -1,0 +1,698 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Reservation future and FIFO result-slot ownership.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll, Waker};
+
+use crate::runtime::sync::sync::{Arc, Mutex};
+
+use super::super::{BufferPool, CarrierCount, PoolInner};
+use super::{wake_all, Reservation, ReserveError};
+
+/// One reservation request retained in FIFO order.
+pub(super) struct Waiter {
+    /// Complete requested envelope.
+    pub(super) envelope: CarrierCount,
+    /// Grant-versus-cancellation linearization point.
+    pub(super) slot: Arc<WaitSlot>,
+}
+
+/// Result slot shared by admission and one reservation future.
+pub(super) struct WaitSlot {
+    /// Serializes grant, cancellation, and result consumption.
+    pub(super) state: Mutex<WaitState>,
+}
+
+/// Lifecycle of one queued reservation result.
+pub(super) enum WaitState {
+    /// Admission owns the queue link and may transfer a terminal result.
+    Queued { waker: Waker },
+    /// Admission transferred one prepared reservation.
+    Granted(Reservation),
+    /// Admission transferred one terminal failure.
+    Failed(ReserveError),
+    /// The future cancelled or consumed the terminal result.
+    Taken,
+}
+
+/// Result of the first reservation poll under admission serialization.
+pub(super) enum ReservationPoll {
+    /// The request was granted without entering the FIFO.
+    Ready(Reservation),
+    /// The request was linked behind existing or ineligible work.
+    Queued(Arc<WaitSlot>),
+}
+
+/// State owned by one reservation future.
+enum ReserveFutureState {
+    /// The request has not entered admission.
+    New { pool: BufferPool, bytes: usize },
+    /// The request owns one FIFO result slot.
+    Queued {
+        pool: BufferPool,
+        slot: Arc<WaitSlot>,
+    },
+    /// The result was returned or the future was cancelled.
+    Complete,
+}
+
+/// A cancellation-safe request for one reservation.
+///
+/// The first poll either returns an immediate result or enters the pool-wide
+/// FIFO. Dropping a queued future cancels it. Dropping a granted but unobserved
+/// future retires the transferred reservation. Invalid requests and physical
+/// preparation failures resolve to [`ReserveError`].
+#[must_use = "a reservation request does nothing unless polled or awaited"]
+pub(crate) struct ReserveFuture {
+    state: ReserveFutureState,
+}
+
+impl WaitSlot {
+    /// Creates one queued result slot with its initial task waker.
+    pub(super) fn new(waker: Waker) -> Self {
+        Self {
+            state: Mutex::new(WaitState::Queued { waker }),
+        }
+    }
+}
+
+impl ReserveFuture {
+    /// Creates a lazy reservation request.
+    pub(in crate::runtime::buffer_pool) fn new(pool: BufferPool, bytes: usize) -> Self {
+        Self {
+            state: ReserveFutureState::New { pool, bytes },
+        }
+    }
+}
+
+impl Future for ReserveFuture {
+    type Output = Result<Reservation, ReserveError>;
+
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let state = std::mem::replace(&mut this.state, ReserveFutureState::Complete);
+
+        match state {
+            ReserveFutureState::New { pool, bytes } => {
+                let envelope = match pool.reservation_envelope(bytes) {
+                    Ok(envelope) => envelope,
+                    Err(error) => return Poll::Ready(Err(error)),
+                };
+                match PoolInner::reserve_or_enqueue(&pool.inner, envelope, context.waker().clone())
+                {
+                    Ok(ReservationPoll::Ready(reservation)) => Poll::Ready(Ok(reservation)),
+                    Ok(ReservationPoll::Queued(slot)) => {
+                        this.state = ReserveFutureState::Queued { pool, slot };
+                        Poll::Pending
+                    }
+                    Err(error) => Poll::Ready(Err(error)),
+                }
+            }
+            ReserveFutureState::Queued { pool, slot } => {
+                let result = poll_slot(&slot, context.waker());
+                if result.is_pending() {
+                    this.state = ReserveFutureState::Queued { pool, slot };
+                }
+                result
+            }
+            ReserveFutureState::Complete => panic!("reservation future polled after completion"),
+        }
+    }
+}
+
+impl Drop for ReserveFuture {
+    fn drop(&mut self) {
+        let ReserveFutureState::Queued { pool, slot } =
+            std::mem::replace(&mut self.state, ReserveFutureState::Complete)
+        else {
+            return;
+        };
+
+        let state = {
+            let mut state = slot.state.lock();
+            std::mem::replace(&mut *state, WaitState::Taken)
+        };
+        match state {
+            WaitState::Queued { .. } => {
+                let wakers = PoolInner::cancel_waiter(&pool.inner, &slot);
+                wake_all(wakers);
+            }
+            WaitState::Granted(reservation) => drop(reservation),
+            WaitState::Failed(_) | WaitState::Taken => {}
+        }
+    }
+}
+
+/// Polls one linked result slot and refreshes its registered waker.
+fn poll_slot(
+    slot: &Arc<WaitSlot>,
+    current_waker: &Waker,
+) -> Poll<Result<Reservation, ReserveError>> {
+    let mut state = slot.state.lock();
+    let previous = std::mem::replace(&mut *state, WaitState::Taken);
+    match previous {
+        WaitState::Queued { waker } => {
+            let waker = if waker.will_wake(current_waker) {
+                waker
+            } else {
+                current_waker.clone()
+            };
+            *state = WaitState::Queued { waker };
+            Poll::Pending
+        }
+        WaitState::Granted(reservation) => Poll::Ready(Ok(reservation)),
+        WaitState::Failed(error) => Poll::Ready(Err(error)),
+        WaitState::Taken => panic!("reservation result was already consumed"),
+    }
+}
+
+#[cfg(all(test, not(s3_tm_loom)))]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering as StdOrdering};
+    use std::sync::Arc as StdArc;
+    use std::task::Wake;
+
+    use super::super::super::geometry::PoolGeometry;
+    use super::super::super::virtual_memory::{page_size, VirtualMemoryOperation};
+    use super::*;
+
+    struct CountingWake {
+        count: AtomicUsize,
+    }
+
+    impl Wake for CountingWake {
+        fn wake(self: StdArc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &StdArc<Self>) {
+            self.count.fetch_add(1, StdOrdering::Release);
+        }
+    }
+
+    fn counting_waker() -> (Waker, StdArc<CountingWake>) {
+        let state = StdArc::new(CountingWake {
+            count: AtomicUsize::new(0),
+        });
+        (Waker::from(StdArc::clone(&state)), state)
+    }
+
+    fn wake_count(state: &CountingWake) -> usize {
+        state.count.load(StdOrdering::Acquire)
+    }
+
+    fn test_pool(block_carriers: usize, configured: usize) -> (BufferPool, usize) {
+        let page_size = page_size().unwrap().get();
+        let geometry = PoolGeometry::new(
+            page_size,
+            page_size.checked_mul(block_carriers).unwrap(),
+            page_size,
+        )
+        .unwrap();
+        let pool =
+            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
+        (pool, page_size)
+    }
+
+    fn poll_reserve(
+        future: &mut ReserveFuture,
+        waker: &Waker,
+    ) -> Poll<Result<Reservation, ReserveError>> {
+        let mut context = Context::from_waker(waker);
+        Pin::new(future).poll(&mut context)
+    }
+
+    fn assert_pending(future: &mut ReserveFuture, waker: &Waker) {
+        assert!(poll_reserve(future, waker).is_pending());
+    }
+
+    fn take_ready(future: &mut ReserveFuture, waker: &Waker) -> Reservation {
+        match poll_reserve(future, waker) {
+            Poll::Ready(Ok(reservation)) => reservation,
+            Poll::Ready(Err(error)) => panic!("reservation failed: {error}"),
+            Poll::Pending => panic!("reservation remained pending"),
+        }
+    }
+
+    #[test]
+    fn test_reserve_future_is_lazy_until_first_poll() {
+        let (pool, carrier_size) = test_pool(1, 1);
+
+        let future = pool.reserve(carrier_size);
+
+        let admission = pool.inner.admission.lock();
+        assert_eq!(admission.ledger.prepared_capacity, CarrierCount::ZERO);
+        assert_eq!(admission.ledger.active_planned_demand, CarrierCount::ZERO);
+        assert!(admission.waiters.is_empty());
+        assert_eq!(admission.parked_reservations_total, 0);
+        drop(admission);
+        drop(future);
+    }
+
+    #[test]
+    fn test_first_poll_returns_an_immediate_prepared_grant() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let (waker, wake_state) = counting_waker();
+        let mut future = pool.reserve(carrier_size);
+
+        let reservation = take_ready(&mut future, &waker);
+
+        let admission = pool.inner.admission.lock();
+        assert_eq!(admission.ledger.prepared_capacity, CarrierCount::new(1));
+        assert_eq!(admission.ledger.active_planned_demand, CarrierCount::new(1));
+        assert!(admission.waiters.is_empty());
+        assert_eq!(admission.parked_reservations_total, 0);
+        assert_eq!(wake_count(&wake_state), 0);
+        drop(admission);
+        drop(reservation);
+    }
+
+    #[test]
+    fn test_fifo_transfers_grants_in_arrival_order() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let holder = pool
+            .try_reserve(carrier_size * 2)
+            .unwrap()
+            .expect("initial reservation");
+        let (first_waker, first_wakes) = counting_waker();
+        let (second_waker, second_wakes) = counting_waker();
+        let mut first = pool.reserve(carrier_size * 2);
+        let mut second = pool.reserve(carrier_size);
+        assert_pending(&mut first, &first_waker);
+        assert_pending(&mut second, &second_waker);
+
+        assert!(pool.try_reserve(carrier_size).unwrap().is_none());
+        assert_eq!(pool.inner.admission.lock().waiters.len(), 2);
+        drop(holder);
+
+        assert_eq!(wake_count(&first_wakes), 1);
+        assert_eq!(wake_count(&second_wakes), 0);
+        let first_reservation = take_ready(&mut first, &first_waker);
+        assert_eq!(pool.inner.admission.lock().waiters.len(), 1);
+
+        drop(first_reservation);
+        assert_eq!(wake_count(&second_wakes), 1);
+        let second_reservation = take_ready(&mut second, &second_waker);
+        let admission = pool.inner.admission.lock();
+        assert!(admission.waiters.is_empty());
+        assert_eq!(admission.parked_reservations_total, 2);
+        drop(admission);
+        drop(second_reservation);
+    }
+
+    #[test]
+    fn test_oversized_fifo_head_waits_for_idle_and_blocks_later_work() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let holder = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("initial reservation");
+        let (large_waker, large_wakes) = counting_waker();
+        let (small_waker, small_wakes) = counting_waker();
+        let mut large = pool.reserve(carrier_size * 2);
+        let mut small = pool.reserve(carrier_size);
+        assert_pending(&mut large, &large_waker);
+        assert_pending(&mut small, &small_waker);
+
+        drop(holder);
+
+        assert_eq!(wake_count(&large_wakes), 1);
+        assert_eq!(wake_count(&small_wakes), 0);
+        let large_reservation = take_ready(&mut large, &large_waker);
+        assert_eq!(pool.inner.admission.lock().waiters.len(), 1);
+
+        drop(large_reservation);
+        assert_eq!(wake_count(&small_wakes), 1);
+        drop(take_ready(&mut small, &small_waker));
+    }
+
+    #[test]
+    fn test_cancelling_fifo_head_grants_next_eligible_waiter() {
+        let (pool, carrier_size) = test_pool(4, 4);
+        let holder = pool
+            .try_reserve(carrier_size * 3)
+            .unwrap()
+            .expect("initial reservation");
+        let (front_waker, front_wakes) = counting_waker();
+        let (next_waker, next_wakes) = counting_waker();
+        let mut front = pool.reserve(carrier_size * 2);
+        let mut next = pool.reserve(carrier_size);
+        assert_pending(&mut front, &front_waker);
+        assert_pending(&mut next, &next_waker);
+
+        drop(front);
+
+        assert_eq!(wake_count(&front_wakes), 0);
+        assert_eq!(wake_count(&next_wakes), 1);
+        assert!(pool.inner.admission.lock().waiters.is_empty());
+        drop(take_ready(&mut next, &next_waker));
+        drop(holder);
+    }
+
+    #[test]
+    fn test_cancelling_middle_waiter_preserves_neighbor_order() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let holder = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("initial reservation");
+        let (first_waker, first_wakes) = counting_waker();
+        let (middle_waker, middle_wakes) = counting_waker();
+        let (last_waker, last_wakes) = counting_waker();
+        let mut first = pool.reserve(carrier_size);
+        let mut middle = pool.reserve(carrier_size);
+        let mut last = pool.reserve(carrier_size);
+        assert_pending(&mut first, &first_waker);
+        assert_pending(&mut middle, &middle_waker);
+        assert_pending(&mut last, &last_waker);
+
+        drop(middle);
+        drop(holder);
+
+        assert_eq!(wake_count(&first_wakes), 1);
+        assert_eq!(wake_count(&middle_wakes), 0);
+        assert_eq!(wake_count(&last_wakes), 0);
+        let first_reservation = take_ready(&mut first, &first_waker);
+        drop(first_reservation);
+        assert_eq!(wake_count(&last_wakes), 1);
+        drop(take_ready(&mut last, &last_waker));
+    }
+
+    #[test]
+    fn test_repoll_replaces_waker_without_recounting_parked_request() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let holder = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("initial reservation");
+        let (first_waker, first_wakes) = counting_waker();
+        let (replacement_waker, replacement_wakes) = counting_waker();
+        let mut future = pool.reserve(carrier_size);
+
+        assert_pending(&mut future, &first_waker);
+        assert_pending(&mut future, &replacement_waker);
+        assert_eq!(pool.inner.admission.lock().parked_reservations_total, 1);
+        drop(holder);
+
+        assert_eq!(wake_count(&first_wakes), 0);
+        assert_eq!(wake_count(&replacement_wakes), 1);
+        drop(take_ready(&mut future, &replacement_waker));
+    }
+
+    #[test]
+    fn test_dropping_untaken_grant_reconsiders_fifo() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let holder = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("initial reservation");
+        let (first_waker, first_wakes) = counting_waker();
+        let (second_waker, second_wakes) = counting_waker();
+        let mut first = pool.reserve(carrier_size);
+        let mut second = pool.reserve(carrier_size);
+        assert_pending(&mut first, &first_waker);
+        assert_pending(&mut second, &second_waker);
+        drop(holder);
+        assert_eq!(wake_count(&first_wakes), 1);
+
+        drop(first);
+
+        assert_eq!(wake_count(&second_wakes), 1);
+        drop(take_ready(&mut second, &second_waker));
+    }
+
+    #[test]
+    fn test_queued_preparation_failure_fails_head_and_grants_next() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let holder = pool
+            .try_reserve(carrier_size * 2)
+            .unwrap()
+            .expect("initial reservation");
+        let failed_slot = pool.inner.arena.reserve_slot().unwrap();
+        failed_slot.inject_failure_once(VirtualMemoryOperation::Prepare);
+        let (front_waker, front_wakes) = counting_waker();
+        let (next_waker, next_wakes) = counting_waker();
+        let mut front = pool.reserve(carrier_size * 3);
+        let mut next = pool.reserve(carrier_size);
+        assert_pending(&mut front, &front_waker);
+        assert_pending(&mut next, &next_waker);
+
+        drop(holder);
+
+        assert_eq!(wake_count(&front_wakes), 1);
+        assert_eq!(wake_count(&next_wakes), 1);
+        assert!(matches!(
+            poll_reserve(&mut front, &front_waker),
+            Poll::Ready(Err(ReserveError::PhysicalPreparationFailed))
+        ));
+        let next_reservation = take_ready(&mut next, &next_waker);
+        assert_eq!(
+            pool.inner.admission.lock().ledger.active_planned_demand,
+            CarrierCount::new(1)
+        );
+        drop(next_reservation);
+    }
+
+    #[test]
+    fn test_invalid_request_fails_on_first_poll_without_parking() {
+        let (pool, _) = test_pool(1, 1);
+        let (waker, wake_state) = counting_waker();
+        let mut future = pool.reserve(0);
+
+        assert!(matches!(
+            poll_reserve(&mut future, &waker),
+            Poll::Ready(Err(ReserveError::InvalidSize))
+        ));
+        let admission = pool.inner.admission.lock();
+        assert!(admission.waiters.is_empty());
+        assert_eq!(admission.parked_reservations_total, 0);
+        assert_eq!(wake_count(&wake_state), 0);
+    }
+
+    #[test]
+    fn test_parked_counter_saturates_and_counts_one_fifo_entry_once() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let holder = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("initial reservation");
+        pool.inner.admission.lock().parked_reservations_total = u64::MAX;
+        let (waker, _) = counting_waker();
+        let mut future = pool.reserve(carrier_size);
+
+        assert_pending(&mut future, &waker);
+        assert_pending(&mut future, &waker);
+
+        let admission = pool.inner.admission.lock();
+        assert_eq!(admission.parked_reservations_total, u64::MAX);
+        assert_eq!(admission.waiters.len(), 1);
+        drop(admission);
+        drop(future);
+        drop(holder);
+    }
+
+    #[test]
+    fn test_dropping_manager_owned_waiter_preserves_shared_pool() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let manager_pool = pool.clone();
+        let holder = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("initial reservation");
+        let (waker, _) = counting_waker();
+        let mut future = manager_pool.reserve(carrier_size);
+        assert_pending(&mut future, &waker);
+
+        drop(manager_pool);
+        drop(future);
+        drop(holder);
+
+        let reservation = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("shared pool remains operational");
+        drop(reservation);
+    }
+
+    #[test]
+    fn test_reserve_future_is_send() {
+        fn assert_send<T: Send>() {}
+
+        assert_send::<ReserveFuture>();
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use std::sync::Arc as StdArc;
+    use std::task::Wake;
+
+    use super::super::super::geometry::PoolGeometry;
+    use super::super::super::virtual_memory::page_size;
+    use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
+    use crate::runtime::sync::thread;
+
+    use super::*;
+
+    struct CountingWake {
+        count: Arc<AtomicUsize>,
+    }
+
+    impl Wake for CountingWake {
+        fn wake(self: StdArc<Self>) {
+            self.wake_by_ref();
+        }
+
+        fn wake_by_ref(self: &StdArc<Self>) {
+            self.count.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    struct PollingWake {
+        future: Arc<Mutex<Option<ReserveFuture>>>,
+        count: Arc<AtomicUsize>,
+    }
+
+    impl PollingWake {
+        fn poll_terminal(self: &StdArc<Self>) {
+            let mut future = self
+                .future
+                .lock()
+                .take()
+                .expect("future installed before wake");
+            let waker = Waker::from(StdArc::clone(self));
+            match poll_reserve(&mut future, &waker) {
+                Poll::Ready(Ok(reservation)) => drop(reservation),
+                Poll::Ready(Err(error)) => panic!("reservation failed: {error}"),
+                Poll::Pending => panic!("waker ran before terminal result publication"),
+            }
+            self.count.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    impl Wake for PollingWake {
+        fn wake(self: StdArc<Self>) {
+            self.poll_terminal();
+        }
+
+        fn wake_by_ref(self: &StdArc<Self>) {
+            self.poll_terminal();
+        }
+    }
+
+    fn counting_waker() -> (Waker, Arc<AtomicUsize>) {
+        let count = Arc::new(AtomicUsize::new(0));
+        let state = CountingWake {
+            count: Arc::clone(&count),
+        };
+        (Waker::from(StdArc::new(state)), count)
+    }
+
+    fn test_pool(configured: usize) -> (BufferPool, usize) {
+        let page_size = page_size().unwrap().get();
+        let geometry = PoolGeometry::new(page_size, page_size, page_size).unwrap();
+        let pool =
+            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
+        (pool, page_size)
+    }
+
+    fn poll_reserve(
+        future: &mut ReserveFuture,
+        waker: &Waker,
+    ) -> Poll<Result<Reservation, ReserveError>> {
+        let mut context = Context::from_waker(waker);
+        Pin::new(future).poll(&mut context)
+    }
+
+    #[test]
+    fn test_grant_racing_cancellation_retires_admission_once() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(1);
+            let holder = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("initial reservation");
+            let (waker, _) = counting_waker();
+            let mut future = pool.reserve(carrier_size * 2);
+            assert!(poll_reserve(&mut future, &waker).is_pending());
+
+            let granting = thread::spawn(move || drop(holder));
+            let cancelling = thread::spawn(move || drop(future));
+            granting.join().unwrap();
+            cancelling.join().unwrap();
+
+            let admission = pool.inner.admission.lock();
+            assert_eq!(admission.ledger.active_planned_demand, CarrierCount::ZERO);
+            assert!(admission.waiters.is_empty());
+        });
+    }
+
+    #[test]
+    fn test_grant_racing_poll_has_one_terminal_result() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(1);
+            let holder = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("initial reservation");
+            let (waker, wake_count) = counting_waker();
+            let mut future = pool.reserve(carrier_size);
+            assert!(poll_reserve(&mut future, &waker).is_pending());
+
+            let granting = thread::spawn(move || drop(holder));
+            let first_poll = poll_reserve(&mut future, &waker);
+            granting.join().unwrap();
+            let reservation = match first_poll {
+                Poll::Ready(Ok(reservation)) => reservation,
+                Poll::Ready(Err(error)) => panic!("reservation failed: {error}"),
+                Poll::Pending => match poll_reserve(&mut future, &waker) {
+                    Poll::Ready(Ok(reservation)) => reservation,
+                    Poll::Ready(Err(error)) => panic!("reservation failed: {error}"),
+                    Poll::Pending => panic!("reservation remained pending after close"),
+                },
+            };
+
+            assert_eq!(wake_count.load(Ordering::Acquire), 1);
+            drop(reservation);
+            assert_eq!(
+                pool.inner.admission.lock().ledger.active_planned_demand,
+                CarrierCount::ZERO
+            );
+        });
+    }
+
+    #[test]
+    fn test_terminal_waker_reenters_after_admission_unlock() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(1);
+            let holder = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("initial reservation");
+            let wake_count = Arc::new(AtomicUsize::new(0));
+            let future_slot = Arc::new(Mutex::new(None));
+            let wake_state = StdArc::new(PollingWake {
+                future: Arc::clone(&future_slot),
+                count: Arc::clone(&wake_count),
+            });
+            let waker = Waker::from(StdArc::clone(&wake_state));
+            let mut future = pool.reserve(carrier_size);
+            assert!(poll_reserve(&mut future, &waker).is_pending());
+            *future_slot.lock() = Some(future);
+
+            drop(holder);
+
+            assert_eq!(wake_count.load(Ordering::Acquire), 1);
+            assert!(future_slot.lock().is_none());
+            assert_eq!(
+                pool.inner.admission.lock().ledger.active_planned_demand,
+                CarrierCount::ZERO
+            );
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission/waiter.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission/waiter.rs
@@ -15,21 +15,21 @@ use super::super::{BufferPool, CarrierCount, PoolInner};
 use super::{wake_all, Reservation, ReserveError};
 
 /// One reservation request retained in FIFO order.
-pub(super) struct Waiter {
+pub(in crate::runtime::buffer_pool) struct Waiter {
     /// Complete requested envelope.
-    pub(super) envelope: CarrierCount,
+    pub(in crate::runtime::buffer_pool) envelope: CarrierCount,
     /// Grant-versus-cancellation linearization point.
-    pub(super) slot: Arc<WaitSlot>,
+    pub(in crate::runtime::buffer_pool) slot: Arc<WaitSlot>,
 }
 
 /// Result slot shared by admission and one reservation future.
-pub(super) struct WaitSlot {
+pub(in crate::runtime::buffer_pool) struct WaitSlot {
     /// Serializes grant, cancellation, and result consumption.
-    pub(super) state: Mutex<WaitState>,
+    pub(in crate::runtime::buffer_pool) state: Mutex<WaitState>,
 }
 
 /// Lifecycle of one queued reservation result.
-pub(super) enum WaitState {
+pub(in crate::runtime::buffer_pool) enum WaitState {
     /// Admission owns the queue link and may transfer a terminal result.
     Queued { waker: Waker },
     /// Admission transferred one prepared reservation.
@@ -41,7 +41,7 @@ pub(super) enum WaitState {
 }
 
 /// Result of the first reservation poll under admission serialization.
-pub(super) enum ReservationPoll {
+pub(in crate::runtime::buffer_pool) enum ReservationPoll {
     /// The request was granted without entering the FIFO.
     Ready(Reservation),
     /// The request was linked behind existing or ineligible work.
@@ -74,7 +74,7 @@ pub(crate) struct ReserveFuture {
 
 impl WaitSlot {
     /// Creates one queued result slot with its initial task waker.
-    pub(super) fn new(waker: Waker) -> Self {
+    pub(in crate::runtime::buffer_pool) fn new(waker: Waker) -> Self {
         Self {
             state: Mutex::new(WaitState::Queued { waker }),
         }
@@ -173,59 +173,9 @@ fn poll_slot(
 
 #[cfg(all(test, not(s3_tm_loom)))]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering as StdOrdering};
-    use std::sync::Arc as StdArc;
-    use std::task::Wake;
-
-    use super::super::super::geometry::PoolGeometry;
-    use super::super::super::virtual_memory::{page_size, VirtualMemoryOperation};
+    use super::super::super::test_util::{counting_waker, poll_reserve, test_pool, wake_count};
+    use super::super::super::virtual_memory::VirtualMemoryOperation;
     use super::*;
-
-    struct CountingWake {
-        count: AtomicUsize,
-    }
-
-    impl Wake for CountingWake {
-        fn wake(self: StdArc<Self>) {
-            self.wake_by_ref();
-        }
-
-        fn wake_by_ref(self: &StdArc<Self>) {
-            self.count.fetch_add(1, StdOrdering::Release);
-        }
-    }
-
-    fn counting_waker() -> (Waker, StdArc<CountingWake>) {
-        let state = StdArc::new(CountingWake {
-            count: AtomicUsize::new(0),
-        });
-        (Waker::from(StdArc::clone(&state)), state)
-    }
-
-    fn wake_count(state: &CountingWake) -> usize {
-        state.count.load(StdOrdering::Acquire)
-    }
-
-    fn test_pool(block_carriers: usize, configured: usize) -> (BufferPool, usize) {
-        let page_size = page_size().unwrap().get();
-        let geometry = PoolGeometry::new(
-            page_size,
-            page_size.checked_mul(block_carriers).unwrap(),
-            page_size,
-        )
-        .unwrap();
-        let pool =
-            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
-        (pool, page_size)
-    }
-
-    fn poll_reserve(
-        future: &mut ReserveFuture,
-        waker: &Waker,
-    ) -> Poll<Result<Reservation, ReserveError>> {
-        let mut context = Context::from_waker(waker);
-        Pin::new(future).poll(&mut context)
-    }
 
     fn assert_pending(future: &mut ReserveFuture, waker: &Waker) {
         assert!(poll_reserve(future, waker).is_pending());
@@ -532,26 +482,13 @@ mod loom_tests {
     use std::sync::Arc as StdArc;
     use std::task::Wake;
 
-    use super::super::super::geometry::PoolGeometry;
-    use super::super::super::virtual_memory::page_size;
+    use super::super::super::test_util::{
+        counting_waker, poll_reserve, test_single_carrier_pool as test_pool,
+    };
     use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
     use crate::runtime::sync::thread;
 
     use super::*;
-
-    struct CountingWake {
-        count: Arc<AtomicUsize>,
-    }
-
-    impl Wake for CountingWake {
-        fn wake(self: StdArc<Self>) {
-            self.wake_by_ref();
-        }
-
-        fn wake_by_ref(self: &StdArc<Self>) {
-            self.count.fetch_add(1, Ordering::AcqRel);
-        }
-    }
 
     struct PollingWake {
         future: Arc<Mutex<Option<ReserveFuture>>>,
@@ -583,30 +520,6 @@ mod loom_tests {
         fn wake_by_ref(self: &StdArc<Self>) {
             self.poll_terminal();
         }
-    }
-
-    fn counting_waker() -> (Waker, Arc<AtomicUsize>) {
-        let count = Arc::new(AtomicUsize::new(0));
-        let state = CountingWake {
-            count: Arc::clone(&count),
-        };
-        (Waker::from(StdArc::new(state)), count)
-    }
-
-    fn test_pool(configured: usize) -> (BufferPool, usize) {
-        let page_size = page_size().unwrap().get();
-        let geometry = PoolGeometry::new(page_size, page_size, page_size).unwrap();
-        let pool =
-            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
-        (pool, page_size)
-    }
-
-    fn poll_reserve(
-        future: &mut ReserveFuture,
-        waker: &Waker,
-    ) -> Poll<Result<Reservation, ReserveError>> {
-        let mut context = Context::from_waker(waker);
-        Pin::new(future).poll(&mut context)
     }
 
     #[test]

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
@@ -17,8 +17,8 @@ use std::sync::atomic::{AtomicU64, Ordering as DiagnosticOrdering};
 
 use super::admission::AdmissionGuard;
 use super::block::{BlockError, BlockSlot, CarrierAllocation, ProvisionalBits};
-use super::geometry::{GeometryError, PoolGeometry};
-use super::CarrierCount;
+use super::geometry::PoolGeometry;
+use super::{invariant_violation, CarrierCount};
 use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
 use crate::runtime::sync::sync::{Arc, Mutex};
 
@@ -116,22 +116,14 @@ impl Arena {
         self.diagnostics.snapshot()
     }
 
-    /// Converts a nonzero byte request to whole carriers.
-    pub(super) fn carriers_for_bytes(&self, bytes: usize) -> Result<CarrierCount, GeometryError> {
-        self.geometry.carriers_for_bytes(bytes)
-    }
-
-    /// Returns the fixed byte capacity of one carrier.
-    pub(super) fn carrier_size(&self) -> usize {
-        self.geometry.carrier_size()
-    }
-
     /// Prepares capacity through `target` under admission serialization.
     ///
     /// Whole-block preparation may raise prepared capacity above `target`.
-    /// Existing inactive slots are retried before another stable range is
-    /// reserved. A failure retains capacity prepared by earlier iterations but
-    /// publishes no admission grant.
+    /// Stable slots remain in the arena after trim. This operation scans those
+    /// slots, skips capacity that is already prepared, and revives inactive or
+    /// recovery-pending slots before reserving another virtual range. A failure
+    /// retains capacity prepared by earlier iterations but publishes no
+    /// admission grant.
     pub(super) fn prepare_to(
         &self,
         admission: &mut AdmissionGuard<'_>,
@@ -918,25 +910,6 @@ mod registry_cell {
         pub(super) fn as_ref(&self) -> &RegistryGeneration {
             &self.inner
         }
-    }
-}
-
-/// Stops execution after a registry invariant fails.
-#[cold]
-fn invariant_violation(message: &'static str) -> ! {
-    tracing::error!(
-        target: crate::telemetry::TARGET_MEMORY,
-        reason = message,
-        "buffer-pool registry invariant violated; aborting"
-    );
-
-    #[cfg(test)]
-    panic!("buffer-pool registry invariant violated: {message}");
-
-    #[cfg(not(test))]
-    {
-        let _ = message;
-        std::process::abort()
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
@@ -15,8 +15,9 @@ use std::collections::TryReserveError;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering as DiagnosticOrdering};
 
+use super::admission::AdmissionGuard;
 use super::block::{BlockError, BlockSlot, CarrierAllocation, ProvisionalBits};
-use super::geometry::PoolGeometry;
+use super::geometry::{GeometryError, PoolGeometry};
 use super::CarrierCount;
 use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
 use crate::runtime::sync::sync::{Arc, Mutex};
@@ -63,7 +64,7 @@ impl Arena {
     ///
     /// Failure leaves the registry and slot identifier unchanged.
     #[cfg(test)]
-    fn reserve_slot(&self) -> Result<Arc<BlockSlot>, ArenaError> {
+    pub(super) fn reserve_slot(&self) -> Result<Arc<BlockSlot>, ArenaError> {
         let mut state = self.state.lock();
         self.reserve_slot_locked(&mut state)
     }
@@ -113,6 +114,51 @@ impl Arena {
     /// Returns one private arena diagnostic sample.
     pub(super) fn diagnostics(&self) -> ArenaDiagnosticSnapshot {
         self.diagnostics.snapshot()
+    }
+
+    /// Converts a nonzero byte request to whole carriers.
+    pub(super) fn carriers_for_bytes(&self, bytes: usize) -> Result<CarrierCount, GeometryError> {
+        self.geometry.carriers_for_bytes(bytes)
+    }
+
+    /// Returns the fixed byte capacity of one carrier.
+    pub(super) fn carrier_size(&self) -> usize {
+        self.geometry.carrier_size()
+    }
+
+    /// Prepares capacity through `target` under admission serialization.
+    ///
+    /// Whole-block preparation may raise prepared capacity above `target`.
+    /// Existing inactive slots are retried before another stable range is
+    /// reserved. A failure retains capacity prepared by earlier iterations but
+    /// publishes no admission grant.
+    pub(super) fn prepare_to(
+        &self,
+        admission: &mut AdmissionGuard<'_>,
+        target: CarrierCount,
+    ) -> Result<(), ArenaError> {
+        if admission.prepared_capacity() >= target {
+            return Ok(());
+        }
+
+        let mut state = self.state.lock();
+        for slot in &state.slots {
+            if admission.prepared_capacity() >= target {
+                return Ok(());
+            }
+            match slot.prepare(admission.prepared_capacity_mut()) {
+                Ok(()) => self.diagnostics.record_block_prepared(),
+                Err(BlockError::AlreadyPrepared) => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+
+        while admission.prepared_capacity() < target {
+            let slot = self.reserve_slot_locked(&mut state)?;
+            slot.prepare(admission.prepared_capacity_mut())?;
+            self.diagnostics.record_block_prepared();
+        }
+        Ok(())
     }
 
     /// Claims a complete or partial batch within the optimistic scan budget.
@@ -174,13 +220,13 @@ impl Arena {
 
     /// Completes a partial batch through exhaustive reuse and private growth.
     ///
-    /// The caller serializes `prepared` with the pool-wide admission floor.
-    /// This method then holds arena serialization through the full registry
-    /// recheck and every preparation. Existing inactive slots are reused
-    /// before another stable range is reserved.
+    /// `admission` proves that the caller owns the prepared-capacity floor.
+    /// This method holds arena serialization through the full registry recheck
+    /// and every preparation. Existing inactive slots are reused before
+    /// another stable range is reserved.
     pub(super) fn complete_claim_serialized(
         &self,
-        prepared: &mut CarrierCount,
+        admission: &mut AdmissionGuard<'_>,
         batch: &mut ClaimBatch,
     ) -> Result<(), ArenaError> {
         if batch.is_complete() {
@@ -203,9 +249,11 @@ impl Arena {
                 return Ok(());
             }
             let count = std::cmp::min(batch.remaining(), slot.carrier_count());
-            if let Some(provisional) =
-                BlockSlot::prepare_and_claim_if_inactive(slot, prepared, count)?
-            {
+            if let Some(provisional) = BlockSlot::prepare_and_claim_if_inactive(
+                slot,
+                admission.prepared_capacity_mut(),
+                count,
+            )? {
                 self.diagnostics.record_block_prepared();
                 batch.push(provisional)?;
             }
@@ -214,10 +262,14 @@ impl Arena {
         while !batch.is_complete() {
             let slot = self.reserve_slot_locked(&mut state)?;
             let count = std::cmp::min(batch.remaining(), slot.carrier_count());
-            let provisional = BlockSlot::prepare_and_claim_if_inactive(&slot, prepared, count)?
-                .unwrap_or_else(|| {
-                    invariant_violation("new arena slot was not reusable for private growth")
-                });
+            let provisional = BlockSlot::prepare_and_claim_if_inactive(
+                &slot,
+                admission.prepared_capacity_mut(),
+                count,
+            )?
+            .unwrap_or_else(|| {
+                invariant_violation("new arena slot was not reusable for private growth")
+            });
             self.diagnostics.record_block_prepared();
             batch.push(provisional)?;
         }
@@ -890,9 +942,10 @@ fn invariant_violation(message: &'static str) -> ! {
 
 #[cfg(all(test, not(s3_tm_loom)))]
 mod tests {
-    use std::sync::{Barrier, Mutex as StdMutex};
+    use std::sync::Barrier;
     use std::thread;
 
+    use super::super::admission::{AdmissionGuard, AdmissionState, MAX_PACKED_CARRIERS};
     use super::super::block::TrimBlocked;
     use super::super::virtual_memory::{page_size, VirtualMemoryOperation};
     use super::super::CarrierCount;
@@ -910,6 +963,15 @@ mod tests {
             page_size,
         )
         .unwrap()
+    }
+
+    fn admission_with_prepared(prepared: CarrierCount) -> Mutex<AdmissionState> {
+        let state = Mutex::new(AdmissionState::new(MAX_PACKED_CARRIERS));
+        {
+            let mut admission = AdmissionGuard::new(state.lock());
+            *admission.prepared_capacity_mut() = prepared;
+        }
+        state
     }
 
     fn prepare_slots(arena: &Arena, count: usize) -> Vec<Arc<BlockSlot>> {
@@ -1333,6 +1395,73 @@ mod tests {
     }
 
     #[test]
+    fn test_prepare_to_rounds_to_blocks_and_is_idempotent() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let admission = admission_with_prepared(CarrierCount::ZERO);
+        let mut admission = AdmissionGuard::new(admission.lock());
+
+        arena
+            .prepare_to(&mut admission, CarrierCount::new(3))
+            .unwrap();
+
+        assert_eq!(admission.prepared_capacity(), CarrierCount::new(4));
+        assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 2);
+        assert_eq!(arena.diagnostics().blocks_prepared, 2);
+
+        arena
+            .prepare_to(&mut admission, CarrierCount::new(4))
+            .unwrap();
+        assert_eq!(arena.diagnostics().blocks_prepared, 2);
+    }
+
+    #[test]
+    fn test_prepare_to_reuses_an_inactive_slot_before_reserving() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let slot = arena.reserve_slot().unwrap();
+        let admission = admission_with_prepared(CarrierCount::ZERO);
+        let mut admission = AdmissionGuard::new(admission.lock());
+
+        arena
+            .prepare_to(&mut admission, CarrierCount::new(1))
+            .unwrap();
+
+        assert_eq!(admission.prepared_capacity(), CarrierCount::new(2));
+        assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 1);
+        assert_fully_free(&slot);
+    }
+
+    #[test]
+    fn test_prepare_to_failure_retains_earlier_preparation() {
+        let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
+        let first = arena.reserve_slot().unwrap();
+        let second = arena.reserve_slot().unwrap();
+        second.inject_failure_once(VirtualMemoryOperation::Prepare);
+        let admission = admission_with_prepared(CarrierCount::ZERO);
+        let mut admission = AdmissionGuard::new(admission.lock());
+
+        let error = arena
+            .prepare_to(&mut admission, CarrierCount::new(3))
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ArenaError::Block(BlockError::VirtualMemory(ref error))
+                if error.operation() == VirtualMemoryOperation::Prepare
+        ));
+        assert_eq!(admission.prepared_capacity(), CarrierCount::new(2));
+        assert_fully_free(&first);
+        assert!(BlockSlot::try_claim(&second, CarrierCount::new(1))
+            .unwrap()
+            .is_none());
+
+        arena
+            .prepare_to(&mut admission, CarrierCount::new(3))
+            .unwrap();
+        assert_eq!(admission.prepared_capacity(), CarrierCount::new(4));
+        assert_fully_free(&second);
+    }
+
+    #[test]
     fn serialized_fallback_rechecks_active_capacity_before_growth() {
         let arena = Arena::new(geometry_with_carriers(65), 1).unwrap();
         let slot = prepare_slots(&arena, 1).pop().unwrap();
@@ -1342,14 +1471,15 @@ mod tests {
             .unwrap();
         let mut batch = arena.claim_optimistic(CarrierCount::new(1)).unwrap();
         assert_eq!(batch.claimed(), CarrierCount::ZERO);
-        let mut prepared = CarrierCount::new(65);
+        let admission = admission_with_prepared(CarrierCount::new(65));
+        let mut admission = AdmissionGuard::new(admission.lock());
 
         arena
-            .complete_claim_serialized(&mut prepared, &mut batch)
+            .complete_claim_serialized(&mut admission, &mut batch)
             .unwrap();
 
         assert!(batch.is_complete());
-        assert_eq!(prepared, CarrierCount::new(65));
+        assert_eq!(admission.prepared_capacity(), CarrierCount::new(65));
         assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 1);
         let carriers = batch.finish().unwrap();
         assert_eq!(carriers[0].carrier_index(), 64);
@@ -1372,14 +1502,15 @@ mod tests {
             .collect::<Vec<_>>();
         let mut batch = arena.claim_optimistic(CarrierCount::new(3)).unwrap();
         assert_eq!(batch.claimed(), CarrierCount::new(1));
-        let mut prepared = CarrierCount::new(6);
+        let admission = admission_with_prepared(CarrierCount::new(6));
+        let mut admission = AdmissionGuard::new(admission.lock());
 
         arena
-            .complete_claim_serialized(&mut prepared, &mut batch)
+            .complete_claim_serialized(&mut admission, &mut batch)
             .unwrap();
 
         assert!(batch.is_complete());
-        assert_eq!(prepared, CarrierCount::new(6));
+        assert_eq!(admission.prepared_capacity(), CarrierCount::new(6));
         assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 3);
         let carriers = batch.finish().unwrap();
         assert!(slots.iter().all(|slot| {
@@ -1401,13 +1532,14 @@ mod tests {
         let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
         let inactive = arena.reserve_slot().unwrap();
         let mut batch = arena.claim_optimistic(CarrierCount::new(1)).unwrap();
-        let mut prepared = CarrierCount::ZERO;
+        let admission = admission_with_prepared(CarrierCount::ZERO);
+        let mut admission = AdmissionGuard::new(admission.lock());
 
         arena
-            .complete_claim_serialized(&mut prepared, &mut batch)
+            .complete_claim_serialized(&mut admission, &mut batch)
             .unwrap();
 
-        assert_eq!(prepared, CarrierCount::new(2));
+        assert_eq!(admission.prepared_capacity(), CarrierCount::new(2));
         assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 1);
         let carriers = batch.finish().unwrap();
         assert_eq!(carriers[0].slot_id(), inactive.id());
@@ -1419,14 +1551,15 @@ mod tests {
     fn serialized_fallback_grows_whole_blocks_until_complete() {
         let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
         let mut batch = arena.claim_optimistic(CarrierCount::new(5)).unwrap();
-        let mut prepared = CarrierCount::ZERO;
+        let admission = admission_with_prepared(CarrierCount::ZERO);
+        let mut admission = AdmissionGuard::new(admission.lock());
 
         arena
-            .complete_claim_serialized(&mut prepared, &mut batch)
+            .complete_claim_serialized(&mut admission, &mut batch)
             .unwrap();
 
         assert!(batch.is_complete());
-        assert_eq!(prepared, CarrierCount::new(6));
+        assert_eq!(admission.prepared_capacity(), CarrierCount::new(6));
         assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 3);
         let carriers = batch.finish().unwrap();
         assert_eq!(carriers.len(), 5);
@@ -1447,10 +1580,11 @@ mod tests {
         let second = arena.reserve_slot().unwrap();
         second.inject_failure_once(VirtualMemoryOperation::Prepare);
         let mut batch = arena.claim_optimistic(CarrierCount::new(3)).unwrap();
-        let mut prepared = CarrierCount::ZERO;
+        let admission = admission_with_prepared(CarrierCount::ZERO);
+        let mut admission = AdmissionGuard::new(admission.lock());
 
         let error = arena
-            .complete_claim_serialized(&mut prepared, &mut batch)
+            .complete_claim_serialized(&mut admission, &mut batch)
             .unwrap_err();
 
         assert!(matches!(
@@ -1458,7 +1592,7 @@ mod tests {
             ArenaError::Block(BlockError::VirtualMemory(ref error))
                 if error.operation() == VirtualMemoryOperation::Prepare
         ));
-        assert_eq!(prepared, CarrierCount::new(2));
+        assert_eq!(admission.prepared_capacity(), CarrierCount::new(2));
         assert_eq!(batch.claimed(), CarrierCount::new(2));
         assert!(!batch.is_complete());
         assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 2);
@@ -1473,17 +1607,18 @@ mod tests {
     fn serialized_growth_rejects_prepared_capacity_overflow() {
         let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
         let mut batch = arena.claim_optimistic(CarrierCount::new(1)).unwrap();
-        let mut prepared = CarrierCount::new(usize::MAX);
+        let admission = admission_with_prepared(CarrierCount::new(usize::MAX));
+        let mut admission = AdmissionGuard::new(admission.lock());
 
         let error = arena
-            .complete_claim_serialized(&mut prepared, &mut batch)
+            .complete_claim_serialized(&mut admission, &mut batch)
             .unwrap_err();
 
         assert!(matches!(
             error,
             ArenaError::Block(BlockError::PreparedCapacityOverflow)
         ));
-        assert_eq!(prepared, CarrierCount::new(usize::MAX));
+        assert_eq!(admission.prepared_capacity(), CarrierCount::new(usize::MAX));
         assert_eq!(batch.claimed(), CarrierCount::ZERO);
         let generation = arena.registry_generation();
         assert_eq!(generation.slots_in_claim_order().len(), 1);
@@ -1497,36 +1632,39 @@ mod tests {
     #[test]
     fn concurrent_serialized_fallbacks_retain_private_growth() {
         let arena = Arc::new(Arena::new(geometry_with_carriers(2), 1).unwrap());
-        let prepared = Arc::new(StdMutex::new(CarrierCount::ZERO));
+        let admission = Arc::new(admission_with_prepared(CarrierCount::ZERO));
         let start = Arc::new(Barrier::new(2));
 
         let fallback =
-            |arena: Arc<Arena>, prepared: Arc<StdMutex<CarrierCount>>, start: Arc<Barrier>| {
+            |arena: Arc<Arena>, admission: Arc<Mutex<AdmissionState>>, start: Arc<Barrier>| {
                 thread::spawn(move || {
                     let mut batch = arena.claim_optimistic(CarrierCount::new(2)).unwrap();
                     start.wait();
-                    let mut prepared = prepared.lock().unwrap();
+                    let mut admission = AdmissionGuard::new(admission.lock());
                     arena
-                        .complete_claim_serialized(&mut prepared, &mut batch)
+                        .complete_claim_serialized(&mut admission, &mut batch)
                         .unwrap();
-                    drop(prepared);
+                    drop(admission);
                     batch.finish().unwrap()
                 })
             };
         let first = fallback(
             Arc::clone(&arena),
-            Arc::clone(&prepared),
+            Arc::clone(&admission),
             Arc::clone(&start),
         );
         let second = fallback(
             Arc::clone(&arena),
-            Arc::clone(&prepared),
+            Arc::clone(&admission),
             Arc::clone(&start),
         );
 
         let first = first.join().unwrap();
         let second = second.join().unwrap();
-        assert_eq!(*prepared.lock().unwrap(), CarrierCount::new(4));
+        assert_eq!(
+            AdmissionGuard::new(admission.lock()).prepared_capacity(),
+            CarrierCount::new(4)
+        );
         assert_eq!(arena.registry_generation().slots_in_claim_order().len(), 2);
         assert!(first.iter().all(|left| second.iter().all(|right| {
             (left.slot_id(), left.carrier_index()) != (right.slot_id(), right.carrier_index())
@@ -1590,10 +1728,11 @@ mod tests {
         let arena = Arena::new(geometry_with_carriers(2), 1).unwrap();
         arena.reserve_slot().unwrap();
         let mut batch = arena.claim_optimistic(CarrierCount::new(3)).unwrap();
-        let mut prepared = CarrierCount::ZERO;
+        let admission = admission_with_prepared(CarrierCount::ZERO);
+        let mut admission = AdmissionGuard::new(admission.lock());
 
         arena
-            .complete_claim_serialized(&mut prepared, &mut batch)
+            .complete_claim_serialized(&mut admission, &mut batch)
             .unwrap();
         let before_rollback = arena.diagnostics();
 
@@ -1649,9 +1788,19 @@ mod tests {
 
 #[cfg(all(test, s3_tm_loom))]
 mod loom_tests {
+    use super::super::admission::{AdmissionGuard, AdmissionState, MAX_PACKED_CARRIERS};
     use super::super::virtual_memory::page_size;
     use super::*;
     use crate::runtime::sync::thread;
+
+    fn admission_with_prepared(prepared: CarrierCount) -> Mutex<AdmissionState> {
+        let state = Mutex::new(AdmissionState::new(MAX_PACKED_CARRIERS));
+        {
+            let mut admission = AdmissionGuard::new(state.lock());
+            *admission.prepared_capacity_mut() = prepared;
+        }
+        state
+    }
 
     fn assert_coherent(generation: &RegistryGenerationGuard) {
         let generation = generation.inner.as_ref();
@@ -1772,11 +1921,12 @@ mod loom_tests {
                 let mut batch = fallback_arena
                     .claim_optimistic(CarrierCount::new(1))
                     .unwrap();
-                let mut prepared = CarrierCount::ZERO;
+                let admission = admission_with_prepared(CarrierCount::ZERO);
+                let mut admission = AdmissionGuard::new(admission.lock());
                 fallback_arena
-                    .complete_claim_serialized(&mut prepared, &mut batch)
+                    .complete_claim_serialized(&mut admission, &mut batch)
                     .unwrap();
-                assert_eq!(prepared, CarrierCount::new(2));
+                assert_eq!(admission.prepared_capacity(), CarrierCount::new(2));
                 batch.finish().unwrap()
             });
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -13,7 +13,7 @@ use std::ptr::NonNull;
 
 use super::geometry::PoolGeometry;
 use super::virtual_memory::{VirtualMemoryError, VirtualRange};
-use super::CarrierCount;
+use super::{invariant_violation, CarrierCount};
 use crate::runtime::sync::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use crate::runtime::sync::sync::{Arc, Mutex};
 
@@ -1391,25 +1391,6 @@ fn record_won(won: &mut Vec<WonWord>, word_index: usize, mask: u64) {
 fn loom_seq_cst_fence() {
     #[cfg(all(test, s3_tm_loom))]
     loom::sync::atomic::fence(Ordering::SeqCst);
-}
-
-/// Stops execution after an ownership or lifecycle invariant fails.
-#[cold]
-fn invariant_violation(message: &'static str) -> ! {
-    tracing::error!(
-        target: crate::telemetry::TARGET_MEMORY,
-        reason = message,
-        "buffer-pool ownership invariant violated; aborting"
-    );
-
-    #[cfg(test)]
-    panic!("buffer-pool ownership invariant violated: {message}");
-
-    #[cfg(not(test))]
-    {
-        let _ = message;
-        std::process::abort()
-    }
 }
 
 #[cfg(all(test, not(s3_tm_loom)))]

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/metrics.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/metrics.rs
@@ -1,0 +1,251 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Stable memory-pressure metrics derived from one admission sample.
+
+use super::CarrierCount;
+
+/// Point-in-time memory state for one shared pool domain.
+///
+/// The representation remains private so ledger changes do not become API
+/// compatibility constraints. Values are carrier-rounded bytes.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MemoryMetrics {
+    configured_capacity_bytes: u64,
+    admission_used_bytes: u64,
+    active_planned_demand_bytes: u64,
+    charged_capacity_bytes: u64,
+    admission_overage_bytes: u64,
+    prepared_capacity_bytes: u64,
+    queued_reservations: usize,
+    parked_reservations_total: u64,
+}
+
+/// Carrier-count inputs captured under admission serialization.
+pub(super) struct MemoryMetricState {
+    /// Normal admission ceiling.
+    pub(super) configured_capacity: CarrierCount,
+    /// Active planned demand plus uncovered charges.
+    pub(super) admission_used: CarrierCount,
+    /// Complete open envelopes.
+    pub(super) active_planned_demand: CarrierCount,
+    /// Aggregate owner and in-flight acquisition charges.
+    pub(super) charged_capacity: CarrierCount,
+    /// Capacity whose physical preparation completed.
+    pub(super) prepared_capacity: CarrierCount,
+    /// Requests currently retained in the FIFO.
+    pub(super) queued_reservations: usize,
+    /// Cumulative requests that entered the FIFO.
+    pub(super) parked_reservations_total: u64,
+}
+
+impl MemoryMetrics {
+    /// Constructs one sample from validated carrier counts.
+    pub(super) fn from_carriers(carrier_size: usize, state: MemoryMetricState) -> Self {
+        let configured_capacity_bytes = to_bytes(state.configured_capacity, carrier_size);
+        let admission_used_bytes = to_bytes(state.admission_used, carrier_size);
+        Self {
+            configured_capacity_bytes,
+            admission_used_bytes,
+            active_planned_demand_bytes: to_bytes(state.active_planned_demand, carrier_size),
+            charged_capacity_bytes: to_bytes(state.charged_capacity, carrier_size),
+            admission_overage_bytes: admission_used_bytes.saturating_sub(configured_capacity_bytes),
+            prepared_capacity_bytes: to_bytes(state.prepared_capacity, carrier_size),
+            queued_reservations: state.queued_reservations,
+            parked_reservations_total: state.parked_reservations_total,
+        }
+    }
+
+    /// Returns the normal admission ceiling after carrier rounding.
+    pub(crate) fn configured_capacity_bytes(&self) -> u64 {
+        self.configured_capacity_bytes
+    }
+
+    /// Returns active planned demand plus ownership outside active demand.
+    pub(crate) fn admission_used_bytes(&self) -> u64 {
+        self.admission_used_bytes
+    }
+
+    /// Returns complete envelopes whose acquisition authority remains open.
+    pub(crate) fn active_planned_demand_bytes(&self) -> u64 {
+        self.active_planned_demand_bytes
+    }
+
+    /// Returns aggregate charges held by owners or in-flight acquisitions.
+    pub(crate) fn charged_capacity_bytes(&self) -> u64 {
+        self.charged_capacity_bytes
+    }
+
+    /// Returns admission use above the normal configured ceiling.
+    pub(crate) fn admission_overage_bytes(&self) -> u64 {
+        self.admission_overage_bytes
+    }
+
+    /// Returns capacity whose physical preparation completed.
+    pub(crate) fn prepared_capacity_bytes(&self) -> u64 {
+        self.prepared_capacity_bytes
+    }
+
+    /// Returns reservation requests currently retained in FIFO order.
+    pub(crate) fn queued_reservations(&self) -> usize {
+        self.queued_reservations
+    }
+
+    /// Returns the saturating count of requests that entered the FIFO.
+    pub(crate) fn parked_reservations_total(&self) -> u64 {
+        self.parked_reservations_total
+    }
+}
+
+/// Converts a validated carrier count to its public byte representation.
+fn to_bytes(count: CarrierCount, carrier_size: usize) -> u64 {
+    let count = u64::try_from(count.get()).expect("carrier count must fit metric representation");
+    let carrier_size =
+        u64::try_from(carrier_size).expect("carrier size must fit metric representation");
+    count
+        .checked_mul(carrier_size)
+        .expect("carrier capacity must fit metric representation")
+}
+
+#[cfg(all(test, not(s3_tm_loom)))]
+mod tests {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll, Waker};
+
+    use futures_test::task::new_count_waker;
+
+    use super::super::geometry::PoolGeometry;
+    use super::super::virtual_memory::page_size;
+    use super::super::{BufferPool, CarrierCount, Reservation, ReserveError, ReserveFuture};
+
+    fn test_pool(block_carriers: usize, configured: usize) -> (BufferPool, usize) {
+        let page_size = page_size().unwrap().get();
+        let geometry = PoolGeometry::new(
+            page_size,
+            page_size.checked_mul(block_carriers).unwrap(),
+            page_size,
+        )
+        .unwrap();
+        let pool =
+            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
+        (pool, page_size)
+    }
+
+    fn poll_reserve(
+        future: &mut ReserveFuture,
+        waker: &Waker,
+    ) -> Poll<Result<Reservation, ReserveError>> {
+        let mut context = Context::from_waker(waker);
+        Pin::new(future).poll(&mut context)
+    }
+
+    #[test]
+    fn test_metrics_report_admission_ownership_and_queue_state() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let initial = pool.metrics();
+        assert_eq!(initial.configured_capacity_bytes(), carrier_size as u64);
+        assert_eq!(initial.admission_used_bytes(), 0);
+        assert_eq!(initial.active_planned_demand_bytes(), 0);
+        assert_eq!(initial.charged_capacity_bytes(), 0);
+        assert_eq!(initial.admission_overage_bytes(), 0);
+        assert_eq!(initial.prepared_capacity_bytes(), 0);
+        assert_eq!(initial.queued_reservations(), 0);
+        assert_eq!(initial.parked_reservations_total(), 0);
+
+        let reservation = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("reservation");
+        let (waker, _) = new_count_waker();
+        let mut queued = pool.reserve(carrier_size);
+        assert!(poll_reserve(&mut queued, &waker).is_pending());
+
+        let parked = pool.metrics();
+        assert_eq!(parked.admission_used_bytes(), carrier_size as u64);
+        assert_eq!(parked.active_planned_demand_bytes(), carrier_size as u64);
+        assert_eq!(parked.charged_capacity_bytes(), 0);
+        assert_eq!(parked.prepared_capacity_bytes(), carrier_size as u64);
+        assert_eq!(parked.queued_reservations(), 1);
+        assert_eq!(parked.parked_reservations_total(), 1);
+
+        drop(queued);
+        let acquired = pool.acquire(&reservation, carrier_size).unwrap();
+        let charged = pool.metrics();
+        assert_eq!(charged.charged_capacity_bytes(), carrier_size as u64);
+        assert_eq!(charged.queued_reservations(), 0);
+        assert_eq!(charged.parked_reservations_total(), 1);
+
+        reservation.close_acquisition();
+        let closed = pool.metrics();
+        assert_eq!(closed.active_planned_demand_bytes(), 0);
+        assert_eq!(closed.admission_used_bytes(), carrier_size as u64);
+        assert_eq!(closed.charged_capacity_bytes(), carrier_size as u64);
+        drop(acquired);
+    }
+
+    #[test]
+    fn test_metrics_report_idle_only_overage_without_exposing_ledger_fields() {
+        let (pool, carrier_size) = test_pool(2, 1);
+
+        let acquired = pool.acquire_unreserved(carrier_size * 2).unwrap();
+        let metrics = pool.metrics();
+
+        assert_eq!(metrics.configured_capacity_bytes(), carrier_size as u64);
+        assert_eq!(metrics.admission_used_bytes(), (carrier_size * 2) as u64);
+        assert_eq!(metrics.active_planned_demand_bytes(), 0);
+        assert_eq!(metrics.charged_capacity_bytes(), (carrier_size * 2) as u64);
+        assert_eq!(metrics.admission_overage_bytes(), carrier_size as u64);
+        assert_eq!(metrics.prepared_capacity_bytes(), (carrier_size * 2) as u64);
+        drop(acquired);
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use super::super::geometry::PoolGeometry;
+    use super::super::virtual_memory::page_size;
+    use super::super::{BufferPool, CarrierCount};
+    use crate::runtime::sync::thread;
+
+    fn test_pool() -> (BufferPool, usize) {
+        let page_size = page_size().unwrap().get();
+        let geometry = PoolGeometry::new(page_size, page_size, page_size).unwrap();
+        let pool = BufferPool::from_validated_parts(geometry, CarrierCount::new(1), 1).unwrap();
+        (pool, page_size)
+    }
+
+    #[test]
+    fn test_metrics_sample_close_and_return_as_complete_states() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool();
+            let reservation = pool
+                .try_reserve(carrier_size)
+                .unwrap()
+                .expect("reservation");
+            let acquired = pool.acquire(&reservation, carrier_size).unwrap();
+
+            let closing = thread::spawn(move || reservation.close_acquisition());
+            let returning = thread::spawn(move || drop(acquired));
+            let sample = pool.metrics();
+            closing.join().unwrap();
+            returning.join().unwrap();
+
+            let carrier_size = carrier_size as u64;
+            assert_eq!(sample.configured_capacity_bytes(), carrier_size);
+            assert!([0, carrier_size].contains(&sample.admission_used_bytes()));
+            assert!([0, carrier_size].contains(&sample.active_planned_demand_bytes()));
+            assert!([0, carrier_size].contains(&sample.charged_capacity_bytes()));
+            assert!(sample.charged_capacity_bytes() <= sample.admission_used_bytes());
+            assert_eq!(sample.admission_overage_bytes(), 0);
+            assert_eq!(sample.prepared_capacity_bytes(), carrier_size);
+
+            let final_sample = pool.metrics();
+            assert_eq!(final_sample.admission_used_bytes(), 0);
+            assert_eq!(final_sample.active_planned_demand_bytes(), 0);
+            assert_eq!(final_sample.charged_capacity_bytes(), 0);
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/metrics.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/metrics.rs
@@ -44,15 +44,18 @@ pub(super) struct MemoryMetricState {
 impl MemoryMetrics {
     /// Constructs one sample from validated carrier counts.
     pub(super) fn from_carriers(carrier_size: usize, state: MemoryMetricState) -> Self {
-        let configured_capacity_bytes = to_bytes(state.configured_capacity, carrier_size);
-        let admission_used_bytes = to_bytes(state.admission_used, carrier_size);
+        let configured_capacity_bytes = carriers_to_bytes(state.configured_capacity, carrier_size);
+        let admission_used_bytes = carriers_to_bytes(state.admission_used, carrier_size);
         Self {
             configured_capacity_bytes,
             admission_used_bytes,
-            active_planned_demand_bytes: to_bytes(state.active_planned_demand, carrier_size),
-            charged_capacity_bytes: to_bytes(state.charged_capacity, carrier_size),
+            active_planned_demand_bytes: carriers_to_bytes(
+                state.active_planned_demand,
+                carrier_size,
+            ),
+            charged_capacity_bytes: carriers_to_bytes(state.charged_capacity, carrier_size),
             admission_overage_bytes: admission_used_bytes.saturating_sub(configured_capacity_bytes),
-            prepared_capacity_bytes: to_bytes(state.prepared_capacity, carrier_size),
+            prepared_capacity_bytes: carriers_to_bytes(state.prepared_capacity, carrier_size),
             queued_reservations: state.queued_reservations,
             parked_reservations_total: state.parked_reservations_total,
         }
@@ -100,7 +103,7 @@ impl MemoryMetrics {
 }
 
 /// Converts a validated carrier count to its public byte representation.
-fn to_bytes(count: CarrierCount, carrier_size: usize) -> u64 {
+fn carriers_to_bytes(count: CarrierCount, carrier_size: usize) -> u64 {
     let count = u64::try_from(count.get()).expect("carrier count must fit metric representation");
     let carrier_size =
         u64::try_from(carrier_size).expect("carrier size must fit metric representation");
@@ -111,36 +114,9 @@ fn to_bytes(count: CarrierCount, carrier_size: usize) -> u64 {
 
 #[cfg(all(test, not(s3_tm_loom)))]
 mod tests {
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::task::{Context, Poll, Waker};
-
     use futures_test::task::new_count_waker;
 
-    use super::super::geometry::PoolGeometry;
-    use super::super::virtual_memory::page_size;
-    use super::super::{BufferPool, CarrierCount, Reservation, ReserveError, ReserveFuture};
-
-    fn test_pool(block_carriers: usize, configured: usize) -> (BufferPool, usize) {
-        let page_size = page_size().unwrap().get();
-        let geometry = PoolGeometry::new(
-            page_size,
-            page_size.checked_mul(block_carriers).unwrap(),
-            page_size,
-        )
-        .unwrap();
-        let pool =
-            BufferPool::from_validated_parts(geometry, CarrierCount::new(configured), 1).unwrap();
-        (pool, page_size)
-    }
-
-    fn poll_reserve(
-        future: &mut ReserveFuture,
-        waker: &Waker,
-    ) -> Poll<Result<Reservation, ReserveError>> {
-        let mut context = Context::from_waker(waker);
-        Pin::new(future).poll(&mut context)
-    }
+    use super::super::test_util::{poll_reserve, test_pool};
 
     #[test]
     fn test_metrics_report_admission_ownership_and_queue_state() {
@@ -205,22 +181,13 @@ mod tests {
 
 #[cfg(all(test, s3_tm_loom))]
 mod loom_tests {
-    use super::super::geometry::PoolGeometry;
-    use super::super::virtual_memory::page_size;
-    use super::super::{BufferPool, CarrierCount};
+    use super::super::test_util::test_single_carrier_pool;
     use crate::runtime::sync::thread;
-
-    fn test_pool() -> (BufferPool, usize) {
-        let page_size = page_size().unwrap().get();
-        let geometry = PoolGeometry::new(page_size, page_size, page_size).unwrap();
-        let pool = BufferPool::from_validated_parts(geometry, CarrierCount::new(1), 1).unwrap();
-        (pool, page_size)
-    }
 
     #[test]
     fn test_metrics_sample_close_and_return_as_complete_states() {
         loom::model(|| {
-            let (pool, carrier_size) = test_pool();
+            let (pool, carrier_size) = test_single_carrier_pool(1);
             let reservation = pool
                 .try_reserve(carrier_size)
                 .unwrap()

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
@@ -1,0 +1,160 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Shared construction, polling, observation, and failure injection for tests.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc as StdArc;
+use std::task::Wake;
+use std::task::{Context, Poll, Waker};
+
+use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
+use crate::runtime::sync::sync::Arc;
+
+use super::admission::{Reservation, ReserveError, ReserveFuture};
+use super::geometry::PoolGeometry;
+use super::virtual_memory::page_size;
+use super::{BufferPool, CarrierCount, PoolInner};
+
+/// Waker state that records each wake through the active atomic backend.
+struct CountingWake {
+    count: Arc<AtomicUsize>,
+}
+
+impl Wake for CountingWake {
+    fn wake(self: StdArc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &StdArc<Self>) {
+        self.count.fetch_add(1, Ordering::AcqRel);
+    }
+}
+
+/// Per-pool hooks that keep parallel and Loom tests isolated.
+pub(super) struct TestHooks {
+    /// Remaining metadata boundaries before one acquisition failure.
+    acquisition_allocation_failure: AtomicUsize,
+}
+
+impl TestHooks {
+    /// Creates a pool with every test hook disabled.
+    pub(super) fn new() -> Self {
+        Self {
+            acquisition_allocation_failure: AtomicUsize::new(0),
+        }
+    }
+
+    /// Fails the `boundary`th subsequent acquisition metadata reservation.
+    fn inject_acquisition_allocation_failure(&self, boundary: usize) {
+        assert!(boundary != 0, "failure boundary must be nonzero");
+        self.acquisition_allocation_failure
+            .compare_exchange(0, boundary, Ordering::AcqRel, Ordering::Acquire)
+            .expect("an acquisition allocation failure is already pending");
+    }
+
+    /// Returns whether this metadata boundary consumes the injected failure.
+    pub(super) fn take_acquisition_allocation_failure(&self) -> bool {
+        self.acquisition_allocation_failure
+            .fetch_update(
+                Ordering::AcqRel,
+                Ordering::Acquire,
+                |remaining| match remaining {
+                    0 => None,
+                    1 => Some(0),
+                    remaining => Some(remaining - 1),
+                },
+            )
+            .is_ok_and(|previous| previous == 1)
+    }
+}
+
+impl BufferPool {
+    /// Injects one acquisition metadata allocation failure.
+    pub(super) fn inject_acquisition_allocation_failure(&self, boundary: usize) {
+        self.inner
+            .test_hooks
+            .inject_acquisition_allocation_failure(boundary);
+    }
+}
+
+impl PoolInner {
+    /// Returns one coherent admission and aggregate sample.
+    pub(super) fn test_accounting_state(
+        &self,
+    ) -> (
+        CarrierCount,
+        CarrierCount,
+        CarrierCount,
+        CarrierCount,
+        usize,
+    ) {
+        let admission = self.admission.lock();
+        let coverage = self.coverage.snapshot();
+        (
+            admission.ledger.prepared_capacity,
+            admission.ledger.active_planned_demand,
+            coverage.available,
+            coverage.uncovered,
+            admission.waiters.len(),
+        )
+    }
+}
+
+/// Constructs a waker and its shared wake counter.
+pub(super) fn counting_waker() -> (Waker, Arc<AtomicUsize>) {
+    let count = Arc::new(AtomicUsize::new(0));
+    let state = CountingWake {
+        count: Arc::clone(&count),
+    };
+    (Waker::from(StdArc::new(state)), count)
+}
+
+/// Loads a counting waker's observed wake count.
+pub(super) fn wake_count(count: &AtomicUsize) -> usize {
+    count.load(Ordering::Acquire)
+}
+
+/// Constructs a pool with a one-word optimistic scan budget.
+pub(super) fn test_pool(block_carriers: usize, configured: usize) -> (BufferPool, usize) {
+    test_pool_with_scan(block_carriers, configured, 1)
+}
+
+/// Constructs a pool with explicit block and optimistic-scan geometry.
+pub(super) fn test_pool_with_scan(
+    block_carriers: usize,
+    configured: usize,
+    optimistic_scan_words: usize,
+) -> (BufferPool, usize) {
+    let page_size = page_size().unwrap().get();
+    let geometry = PoolGeometry::new(
+        page_size,
+        page_size.checked_mul(block_carriers).unwrap(),
+        page_size,
+    )
+    .unwrap();
+    let pool = BufferPool::from_parts(
+        geometry,
+        CarrierCount::new(configured),
+        optimistic_scan_words,
+    )
+    .unwrap();
+    (pool, page_size)
+}
+
+/// Constructs a pool whose block and carrier are one runtime page.
+pub(super) fn test_single_carrier_pool(configured: usize) -> (BufferPool, usize) {
+    test_pool(1, configured)
+}
+
+/// Polls one reservation future with an explicit waker.
+pub(super) fn poll_reserve(
+    future: &mut ReserveFuture,
+    waker: &Waker,
+) -> Poll<Result<Reservation, ReserveError>> {
+    let mut context = Context::from_waker(waker);
+    Pin::new(future).poll(&mut context)
+}

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -540,9 +540,19 @@ Available coverage never exceeds the demand that created it:
 available_coverage <= active_planned_demand
 ```
 
-Grant adds equal planned demand and available coverage. Acquisition only lowers coverage. Close
-lowers planned demand and removes no more coverage than its envelope. Return restores coverage only
-after uncovered charges have been removed.
+The sum of direct outstanding charges across open reservations also cannot overlap available
+coverage:
+
+```text
+available_coverage + open_direct_outstanding <= active_planned_demand
+```
+
+Grant adds equal planned demand and available coverage. Acquisition publishes its aggregate charge
+before adding direct outstanding authority, so that direct addition is already reflected by lower
+coverage or a new uncovered charge. Close uses the closing reservation's direct outstanding count
+and the remaining active demand to distinguish coverage it may withdraw. Return lowers direct
+outstanding before restoring coverage. Unreserved acquisition only lowers coverage and does not
+affect the direct term.
 
 A carrier is never live before it is charged:
 
@@ -833,17 +843,24 @@ Reserved growth never switches to unreserved acquisition or expands its envelope
 existing initialized data when the surrounding protocol permits a partial value; a complete part,
 range, or other indivisible value fails when its buffer cannot grow to the required size.
 
-Initial direct acquisition and reserved buffer growth first debit direct-acquisition authority.
-Unreserved buffers retain only pool authority and cannot switch to reserved growth; reserved
-buffers cannot switch to unreserved growth. Both modes then debit the complete new carrier count
-from aggregate accounting before asking the arena for physical storage:
+Initial direct acquisition and reserved buffer growth publish the complete aggregate charge before
+debiting direct-acquisition authority. Unreserved buffers retain only pool authority and cannot
+switch to reserved growth; reserved buffers cannot switch to unreserved growth. Both modes debit
+aggregate accounting before asking the arena for physical storage:
 
 1. Consume as much `available_coverage` as remains.
 2. Add any shortfall to `uncovered_charges` while admission is serialized.
 3. Prepare physical capacity for the resulting `admission_used`.
-4. Release admission before optimistic physical claim.
-5. On an optimistic miss, acquire a fresh `AdmissionGuard` before serialized arena fallback.
-6. Transfer one aggregate charge and optional direct provenance to each `CarrierGuard`.
+4. Release admission after any required preparation.
+5. For reserved acquisition, atomically debit direct-acquisition authority. If close or capacity
+   exhaustion rejects the debit, roll back the aggregate charge.
+6. Perform optimistic physical claim.
+7. On an optimistic miss, acquire a fresh `AdmissionGuard` before serialized arena fallback.
+8. Transfer one aggregate charge and optional direct provenance to each `CarrierGuard`.
+
+Reserved acquisition may first load the direct state to reject authority that is already closed or
+exhausted before aggregate preparation. That precheck does not reserve authority; the atomic debit
+after aggregate publication remains authoritative.
 
 An acquisition fully covered by available coverage performs the aggregate debit through
 `CoverageState` without the admission mutex. A shortfall enters admission serialization before
@@ -855,11 +872,12 @@ cannot reduce aggregate prepared capacity below a floor that includes the in-fli
 The claim-trim gate protects any particular block selected concurrently. Deferring charge
 publication until after claim would remove the aggregate protection.
 
-Preparation failure applies the inverse transition and restores direct-acquisition authority before
-returning an error. A later physical failure rolls back owned bits before reversing the published
-charge. If that reversal removes an uncovered charge, it uses the same admission-drain escalation as
-[final return](#close-and-return). No writable memory is exposed before the complete acquisition
-commits.
+Aggregate preparation failure changes no direct-acquisition authority. If the later direct debit is
+rejected, the acquisition reverses its aggregate charge before returning the direct-authority
+error. A later physical failure rolls back owned bits, retires direct authority, and then reverses
+the aggregate charge. If that reversal removes an uncovered charge, it uses the same
+admission-drain escalation as [final return](#close-and-return). No writable memory is exposed
+before the complete acquisition commits.
 
 `AcquisitionDebit` owns charges awaiting transfer to carrier guards:
 
@@ -898,12 +916,12 @@ impl Drop for Reservation {
 
 `acquire` is synchronous and borrows the non-cloneable public `Reservation`, so consuming that
 handle makes another initial acquire structurally impossible. Existing reserved buffers retain
-private `Arc<ReservationState>` values and may race growth with close. The packed reservation owner
-state linearizes that race:
+private `Arc<ReservationState>` values and may race growth with close. The aggregate charge is
+published before the packed reservation owner state linearizes that race:
 
 ```text
 growth debit wins  -> growth may complete; close prevents later growth
-close wins         -> growth requiring carriers returns ReservationClosed
+close wins         -> growth rolls back its aggregate charge and returns ReservationClosed
 ```
 
 A growth debit can win this race and then fail physical allocation after close. Its rollback retires
@@ -911,10 +929,13 @@ that in-flight debit but leaves the reservation state closed. A buffer operation
 by its existing writable tail does not debit direct-acquisition authority and remains valid after
 close.
 
-Coverage is aggregate rather than attributed to individual reservations. Closing envelope `E`
-therefore removes `E` units from aggregate planned demand. It removes available units first. If
-fewer than `E` units remain available, the rest are occupied by charges that must remain accounted
-after close. [Appendix A](#reservation-close) gives the complete transition.
+Coverage remains aggregate rather than partitioned by reservation. The packed close transition
+returns the closing reservation's direct outstanding count `D`. At most `E - D` units of its
+envelope are nominally unused at that point. Close removes those available units while preserving
+coverage attributable to remaining active demand. A direct return may lower `D` and restore
+coverage after the close snapshot; availability above remaining active demand is removed as part of
+the closing envelope. If unreserved acquisition consumed some nominally unused coverage, close
+reclassifies that deficit instead. [Appendix A](#reservation-close) gives the complete transition.
 
 Close and aggregate return may execute concurrently. If return linearizes first, it restores
 coverage for close to withdraw. If close linearizes first, close records uncovered charges for
@@ -3015,16 +3036,22 @@ available_coverage -= covered
 uncovered_charges += N - covered
 ```
 
-A direct initial acquisition or reserved-buffer growth first reserves `N` units of
-direct-acquisition authority and rejects the request when `direct_outstanding + N > envelope`.
-Consuming the public `Reservation` prevents another initial acquisition after close. Existing
-buffers retain private state, so close races growth through the packed reservation owner state:
-either the complete debit precedes close or growth observes `CLOSED` and returns
-`ReservationClosed`. An unreserved acquisition has no direct-acquisition-authority transition. If
-`N - covered` is nonzero, the acquisition publishes the complete charge and prepares to the new
-`admission_used` while holding admission, then releases admission before optimistic physical claim.
-The published charge keeps the prepared-capacity floor in force across that unlocked window. Both
-covered and shortfall acquisitions acquire a fresh guard only if optimistic physical claim misses.
+A direct initial acquisition or reserved-buffer growth first publishes the aggregate debit, then
+atomically reserves `N` units of direct-acquisition authority. It rejects the request when
+`direct_outstanding + N > envelope` or the owner state is `CLOSED`, and rolls back the aggregate
+debit before returning that error. Consuming the public `Reservation` prevents another initial
+acquisition after close. Existing buffers retain private state, so close races growth through the
+packed reservation owner state: either the direct debit precedes close, with its aggregate charge
+already published, or growth observes `CLOSED` and reverses that charge. An unreserved acquisition
+has no direct-acquisition-authority transition. If `N - covered` is nonzero, the acquisition
+publishes the complete charge and prepares to the new `admission_used` while holding admission,
+then releases admission before the direct debit and optimistic physical claim. The published charge
+keeps the prepared-capacity floor in force across that unlocked window. Both covered and shortfall
+acquisitions acquire a fresh guard only if optimistic physical claim misses.
+
+An advisory direct-state load may reject an already closed or exhausted reservation before the
+aggregate debit. It does not authorize acquisition and cannot replace the post-aggregate atomic
+debit.
 
 Mutable-buffer growth computes `N` from only the shortfall below the requested writable capacity:
 
@@ -3068,18 +3095,26 @@ held guard before entering arena state.
 Closing an envelope `E` consumes its public direct-acquisition authority exactly once:
 
 ```text
-unused_removed = min(E, available_coverage)
-occupied_reclassified = E - unused_removed
+D = direct_outstanding observed by the close transition
+potentially_unused = E - D
+remaining_active = active_planned_demand - E
 
-active_planned_demand -= E
+nominally_unused = min(potentially_unused, available_coverage)
+required_for_active = available_coverage.saturating_sub(remaining_active)
+unused_removed = max(nominally_unused, required_for_active)
+reclassified = E - unused_removed
+
+active_planned_demand = remaining_active
 available_coverage -= unused_removed
-uncovered_charges += occupied_reclassified
+uncovered_charges += reclassified
 ```
 
-Close creates no owner and removes no charge. It withdraws unused planned demand and leaves
-occupied demand represented as uncovered charges. Close racing final return produces the same
-state in either linearization order because each operation changes available coverage and uncovered
-charges as one packed transition.
+Without a concurrent direct return, `reclassified` is at least `D`. If return lowers direct
+outstanding after close observes `D` and restores aggregate coverage before the close CAS,
+`required_for_active` removes that newly unused coverage. Close creates no owner and removes no
+charge. It cannot withdraw available coverage needed by another open reservation's direct
+authority. Close racing final return produces the same state in every interleaving because each
+operation changes available coverage and uncovered charges as one packed transition.
 
 ### Prepared-capacity transitions
 
@@ -3168,6 +3203,11 @@ as a search hint may use `Relaxed`; ownership is decided by the gated `fetch_or`
 The packed accounting CAS that releases a charge is ordered after physical bitmap return. A grant
 or metrics sample that observes the accounting release therefore cannot precede the physical return
 that made the carrier reusable.
+
+Reserved acquisition publishes its packed aggregate debit before its reservation-local direct
+debit. Close reads the direct count from the same atomic transition that sets `CLOSED`; a direct
+debit that loses this race reverses its already-published aggregate charge. A successful direct
+debit therefore names a published charge until its corresponding return retires it.
 
 Prepared-capacity accounting precedes `Active` publication. Deactivation follows `Draining`,
 all-free confirmation, and prepared-capacity removal. Immutable byte publication requires no
@@ -3278,6 +3318,7 @@ section; one property may discharge several contracts.
 | A3         | Partial acquisition failure restores every debit and direct-acquisition authority | Failure injection after each claim and conversion      | Drop the debit before provisional and completed carriers          |
 | A4         | Close racing buffer growth has one complete outcome                               | Loom over authority, debit, rollback, and close        | Split `CLOSED` from the direct-authority debit                    |
 | A4         | Concurrent acquisitions consume direct-acquisition authority exactly once         | Loom over packed reservation owner state               | Load and store authority without compare-and-exchange             |
+| A4, A5     | Close preserves another open reservation's coverage and every surviving charge     | Multi-reservation regression and composed Loom         | Derive unused coverage only from the global available lane        |
 | A1         | Count conversion and packed lanes never overflow                                  | Boundary property tests over byte and carrier counts   | Remove one checked conversion                                     |
 
 ### Physical-storage verification


### PR DESCRIPTION
## Summary

This is the third implementation PR in the eight-PR [buffer-pool design and implementation series](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/165). It composes the arena from [#167](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/167) into a `BufferPool` with planned-demand admission, cancellation-safe FIFO reservations, reserved and unreserved carrier acquisition, physical-first return, and coherent memory metrics.

The series is:

1. [Buffer-pool design](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/165)
2. [Physical-storage foundation](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/166)
3. [Arena acquisition and growth](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/167)
4. **This PR: Admission and pool composition**
5. Mutable buffers and segmented delivery
6. Maintenance, configuration, and operations
7. Scheduler and download integration
8. Upload staging and retry integration

This PR is stacked on #167 and does not change transfer-manager behavior.

## Why

The arena can return physical carriers, but it does not decide which work may consume memory or keep enough capacity prepared for admitted work. The transfer manager needs to admit planned demand against a normal memory ceiling, let an otherwise idle oversized request make progress, support acquisitions that are not backed by a reservation, and preserve accounting while reservations close independently of retained byte owners.

A reservation is granted once for an admitted work item. That work may acquire and return many carriers over its lifetime. Acquisitions covered by open reservation envelopes and returns that restore their coverage use one packed atomic state. Operations that can change reservation eligibility or prepared capacity use the admission mutex: grants, close, FIFO mutation, uncovered shortfalls and repayments, physical preparation, and serialized arena fallback.

The composed path also introduces failure boundaries after accounting has changed or bitmap bits have been claimed. Those paths must return physical ownership before releasing its charge, prevent a close race from reopening acquisition authority, and avoid waking reservation futures while pool locks are held.

## Overview

### Pool state

`BufferPool` is a cloneable handle to one `Arc<PoolInner>`. Reservations and carrier owners retain the same shared state, so dropping one manager-local handle does not invalidate ownership that escaped it.

```text
BufferPool
`-- Arc<PoolInner>
    |-- admission: Mutex<AdmissionState>
    |   |-- configured capacity
    |   |-- prepared capacity
    |   |-- active planned demand
    |   `-- FIFO waiters
    |-- coverage: AtomicU64
    |   |-- available coverage
    |   `-- uncovered charges
    `-- arena: physical carrier storage
```

The accounting terms describe different parts of one memory state:

| Term                    | Meaning                                                                 |
| ----------------------- | ----------------------------------------------------------------------- |
| Active planned demand   | Sum of open reservation envelopes                                       |
| Available coverage      | Unused portion of active planned demand                                 |
| Covered charges         | Portion of active planned demand currently held by acquisitions         |
| Uncovered charges       | Carrier charges not represented by active planned demand                |
| Outstanding charges     | All covered and uncovered carrier ownership, including in-flight claims |
| Admission used          | Active planned demand plus uncovered charges                            |
| Prepared capacity       | Carrier capacity whose physical preparation completed                   |

```text
covered charges     = active planned demand - available coverage
outstanding charges = covered charges + uncovered charges
```

The normal grant rule keeps `admission_used + new_envelope` within configured capacity. When no reservation envelope remains active, one fresh request or the FIFO head may exceed that ceiling so work can make progress. Every grant prepares the arena through its complete post-grant admission floor before publishing the reservation. Block-sized preparation may leave prepared capacity above that floor.

The corresponding design sections are **Admission and accounting**, **Reservation admission**, and **Wait queue**.

### Reservation admission

`BufferPool::try_reserve` attempts an immediate grant without bypassing older waiters. `BufferPool::reserve` creates a lazy `ReserveFuture`; its first poll either receives an immediate prepared reservation or enters the pool-wide FIFO.

```text
try_reserve(bytes)                  reserve(bytes).poll()
        |                                  |
        `---------- carrier envelope ------'
                           |
                    lock admission
                           |
             queue empty and eligible?
                    /              \
                  yes               no
                   |                 |
       prepare post-grant floor      `--> FIFO WaitSlot --> Pending
                   |
       publish planned demand
       and available coverage
                   |
             Reservation
```

The FIFO is strict: an ineligible head blocks later requests that would fit. `WaitSlot` is the linearization point between grant, cancellation, and result consumption. Admission stores a terminal grant or failure before unlinking the head, then invokes its waker after releasing pool locks. Dropping a queued future removes its link and reconsiders the exposed head. Dropping a granted but unobserved future closes the transferred reservation.

`Reservation` is non-cloneable. Its private `ReservationState` carries the complete envelope and one packed atomic containing the closed bit plus direct owners and in-flight direct debits. `Reservation::close_acquisition` and `Drop` perform the same idempotent close: new direct debits stop, the envelope leaves active planned demand, unused coverage is removed, and surviving charges become uncovered. Close uses the reservation's direct count and remaining active demand so it cannot consume coverage needed by another open reservation. Existing carrier owners remain valid until their final drops.

### Acquisition

`BufferPool::acquire` uses a reservation and enforces its direct carrier envelope. `BufferPool::acquire_unreserved` skips reservation-local authority but uses the same aggregate accounting and physical transaction. Both round the byte request to complete carriers and return `AcquiredRuns`, which groups adjacent carrier owners for the mutable-buffer layer.

```text
acquire(reservation, bytes)          acquire_unreserved(bytes)
              |                                |
              | advisory direct precheck       |
              `------------- aggregate debit --'
                                  |
                   available coverage sufficient?
                         /                  \
                       yes                   no
                        |                     |
                 packed CAS fast path    lock admission
                                           publish shortfall charge
                                           prepare admission floor
                                           unlock
                        \                     /
                         `-- aggregate charge published
                                      |
                         reserved direct debit?
                           |             |
                         reject        authorized or unreserved
                           |             |
                    aggregate rollback  optimistic arena claim
                                      |
                              complete batch?
                              /             \
                            yes              no
                             |                |
                             |          lock admission
                             |          serialized fallback
                             |          unlock
                             `------- ClaimBatch::finish
                                      |
                                  CarrierGuard[]
                                      |
                                  AcquiredRuns
```

`acquire` can cheaply reject a reservation already known to be closed or out of capacity. Close may race that check, so the later atomic direct debit decides whether the acquisition is authorized. If it loses, the pool rolls back the aggregate charge already published for the attempt.

The shortfall path publishes its charge before releasing admission. That charge raises the prepared-capacity floor while the optimistic bitmap claim is in flight, so trim cannot reclaim the capacity being acquired. A partial optimistic claim later reacquires admission and passes the held `AdmissionGuard` into arena fallback; the arena cannot acquire admission recursively.

`PendingAcquisition` owns the accounting debit, provisional bitmap claim, and any converted guards until the complete transaction commits. Every failure path drops guards and provisional physical ownership before releasing aggregate and reservation-local charges. Collection allocation for guard and run metadata is fallible, and failure injection exercises rollback after each commit boundary.

The corresponding design sections are **Mutable buffer acquisition and growth**, **Carrier claiming and fallback**, and Appendix A's **Acquisition transitions**.

### Return and progress

Each `CarrierGuard` owns one physical `CarrierAllocation`, one aggregate charge, and optional reservation-local provenance. Its final drop clears the physical bitmap bit first, retires direct authority second, and releases the aggregate charge last.

```text
CarrierGuard::drop
        |
        +-- return CarrierAllocation to the bitmap
        +-- retire reservation-local ownership
        `-- release aggregate charge
                    |
           removed uncovered charge?
              /                \
            no                  yes
             |                   |
      lock-free return      lock admission
                            drain eligible FIFO heads
                            unlock
                            wake terminal futures
```

A carrier acquired within an open envelope is covered, not uncovered. Its return restores available coverage through the packed atomic without taking admission. Ownership becomes uncovered when it exceeds available coverage or remains live after its reservation closes. A return that removes such a charge takes admission because the reduced pressure may make the FIFO head eligible. Closing a reservation while many carriers remain live therefore makes their later returns use the serialized path. Close and return may occur in either order and converge on the same final accounting state.

### Metrics

`BufferPool::metrics` returns a private, getter-only `MemoryMetrics` value. It holds admission serialization and loads the packed coverage state once, producing one sample of configured capacity, admission use, active planned demand, charged capacity, overage, prepared capacity, queue depth, and cumulative parked reservations. The representation does not expose ledger fields, pool authority, bitmap population, or arena policy.

The corresponding design section is **Observability**.

## How to review

Start with one reservation and the carriers acquired through it. Let `C` be one carrier's byte capacity. This sequential lifecycle establishes the accounting model before concurrency and rollback add more paths:

| Operation on the same reservation | Active planned demand | Available coverage | Covered live carriers | Uncovered live carriers |
| --- | ---: | ---: | ---: | ---: |
| `reservation = pool.try_reserve(4 * C)` | 4 | 4 | 0 | 0 |
| `pool.acquire(&reservation, 3 * C)` | 4 | 1 | 3 | 0 |
| `drop(one CarrierGuard)` while the reservation is open | 4 | 2 | 2 | 0 |
| `reservation.close_acquisition()` with two guards still live | 0 | 0 | 0 | 2 |
| `drop(the remaining two CarrierGuards)` | 0 | 0 | 0 | 0 |

`Available coverage` is unused capacity inside open reservation envelopes, not free physical capacity. Close withdraws the complete envelope: its two unused units disappear, while its two live covered carriers become uncovered. Those later returns reduce uncovered ownership because no open envelope remains whose available coverage could be restored.

Trace that lifecycle through the implementation in the same order:

1. Begin with the grant at `BufferPool::try_reserve`. Follow the request through eligibility, arena preparation, and grant publication. The reservation must not become visible until physical capacity covers the complete post-grant admission floor. Then inspect `ReserveFuture` as the queued form of that same transition: a terminal grant or failure is stored in its `WaitSlot` before the FIFO link is removed, and the waker runs only after pool locks are released.
2. Follow `BufferPool::acquire` for the three-carrier request. The aggregate debit first converts three units of available coverage into covered ownership. The reservation-local debit independently proves that this reservation still authorizes those carriers. Only then does the transaction claim bitmap ownership and transfer the accounting and physical capabilities into `CarrierGuard`s. Compare the covered fast path with a shortfall path: shortfall publishes its charge and prepares its floor under admission, releases admission for the optimistic claim, and reacquires one guard only if serialized arena fallback is required.
3. Follow the first `CarrierGuard` return while the reservation remains open. Drop returns the physical bitmap bit, retires reservation-local ownership, and finally releases the aggregate charge. That packed return restores one unit of available coverage without taking admission because active planned demand has not changed.
4. Close the reservation while two guards remain live. `ReservationState::close_acquisition` first prevents new direct debits, then removes the four-unit envelope under admission. The two unused units leave available coverage and the two live covered charges become uncovered. Trace the multi-reservation regression alongside this step: closing one reservation must not consume unused coverage that belongs to another open reservation.
5. Return the final two guards after close. The physical-first drop order is unchanged, but each aggregate return now removes uncovered ownership. That reduction can make the FIFO head eligible, so the return enters admission, drains eligible heads, unlocks, and only then invokes their wakers.

After the sequential trace is clear, inspect the seams where another operation may observe an intermediate state: direct debit versus close, close versus return, repayment versus waiter enqueue, and unlocked shortfall claim versus trim. The Loom models cover those linearization points. Allocation-failure tests exercise rollback after accounting, provisional bits, guards, or run metadata have been created and verify that physical ownership returns before its charges.

The small-state tests in `coverage.rs` validate each transition equation. The multi-reservation composition test validates the outcome those equations must collectively preserve: live ownership remains within the normal configured ceiling, charged capacity equals live ownership, and active planned demand equals the sum of open envelopes after every operation.

## Future

The next PR consumes `AcquiredRuns` into `PooledBufMut`, adds retained reservation-backed growth, publishes owner-backed immutable byte views, and builds segmented delivery. Public configuration, maintenance, transfer-manager wiring, and transport integration remain outside this PR.
