### PR TITLE
buffer pool: add mutable and segmented buffers

### DIFF
--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -15,11 +15,14 @@ mod arena;
 mod block;
 mod geometry;
 mod metrics;
+mod pooled_buf;
+mod segmented_bytes;
 #[cfg(test)]
 mod test_util;
 mod virtual_memory;
 
-use acquisition::{acquire_count, AcquireError, AcquiredRuns};
+use acquisition::acquire_count;
+pub(crate) use acquisition::AcquireError;
 use admission::{
     wake_all, AdmissionGuard, AdmissionState, CoverageState, ReservationPoll, WaitSlot, WaitState,
     Waiter, MAX_PACKED_CARRIERS,
@@ -29,6 +32,9 @@ use arena::{Arena, ArenaError};
 use block::BlockError;
 use geometry::{GeometryError, PoolGeometry};
 use metrics::{MemoryMetricState, MemoryMetrics};
+use pooled_buf::GrowthAuthority;
+pub(crate) use pooled_buf::PooledBufMut;
+pub(crate) use segmented_bytes::SegmentedBytes;
 
 #[cfg(test)]
 use test_util::TestHooks;
@@ -100,7 +106,7 @@ impl BufferPool {
         &self,
         reservation: &Reservation,
         min_bytes: usize,
-    ) -> Result<AcquiredRuns, AcquireError> {
+    ) -> Result<PooledBufMut, AcquireError> {
         let count = self.acquisition_count(min_bytes)?;
         let direct = reservation
             .acquisition_state()
@@ -108,7 +114,9 @@ impl BufferPool {
         if !direct.belongs_to(&self.inner) {
             return Err(AcquireError::ForeignReservation);
         }
-        acquire_count(&self.inner, Some(Arc::clone(direct)), count)
+        let direct = Arc::clone(direct);
+        let guards = acquire_count(&self.inner, Some(Arc::clone(&direct)), count)?;
+        PooledBufMut::try_new(GrowthAuthority::reserved(direct), guards)
     }
 
     /// Acquires at least `min_bytes` without reservation-local authority.
@@ -120,9 +128,10 @@ impl BufferPool {
     pub(crate) fn acquire_unreserved(
         &self,
         min_bytes: usize,
-    ) -> Result<AcquiredRuns, AcquireError> {
+    ) -> Result<PooledBufMut, AcquireError> {
         let count = self.acquisition_count(min_bytes)?;
-        acquire_count(&self.inner, None, count)
+        let guards = acquire_count(&self.inner, None, count)?;
+        PooledBufMut::try_new(GrowthAuthority::unreserved(Arc::clone(&self.inner)), guards)
     }
 
     /// Converts one public byte request to its checked carrier envelope.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -311,7 +311,7 @@ impl PoolInner {
             .inner
             .waiters
             .try_reserve(1)
-            .map_err(|_| ReserveError::PhysicalPreparationFailed)?;
+            .map_err(|_| ReserveError::MetadataAllocationFailed)?;
         let slot = Arc::new(WaitSlot::new(waker));
         admission.inner.waiters.push_back(Waiter {
             envelope,
@@ -434,8 +434,10 @@ fn map_preparation_error(error: ArenaError) -> ReserveError {
         | ArenaError::RegistryCapacityOverflow
         | ArenaError::AddressOverflow { .. }
         | ArenaError::ScanSpaceOverflow { .. } => ReserveError::CapacityOverflow,
+        ArenaError::Block(BlockError::Allocation(_)) | ArenaError::Allocation(_) => {
+            ReserveError::MetadataAllocationFailed
+        }
         ArenaError::Block(_)
-        | ArenaError::Allocation(_)
         | ArenaError::InvalidScanBudget
         | ArenaError::InvalidClaimCount
         | ArenaError::IncompleteClaim { .. }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/acquisition.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/acquisition.rs
@@ -13,7 +13,7 @@ use std::fmt;
 
 use super::admission::{AdmissionGuard, DirectDebitError, ReservationState, ReserveError};
 use super::arena::{ArenaError, ClaimBatch};
-use super::block::{BlockError, BlockSlot, CarrierAllocation};
+use super::block::{BlockError, BlockSlot, CarrierAllocation, CarrierLocation};
 use super::{invariant_violation, CarrierCount, PoolInner};
 use crate::runtime::sync::sync::Arc;
 
@@ -31,8 +31,10 @@ pub(crate) enum AcquireError {
     ReservationCapacityExceeded,
     /// Geometry or accounting cannot represent the request.
     CapacityOverflow,
-    /// Physical storage or ownership metadata could not be allocated.
+    /// Physical storage could not be reserved or prepared.
     PhysicalAllocationFailed,
+    /// Ownership metadata could not reserve the required capacity.
+    MetadataAllocationFailed,
 }
 
 impl fmt::Display for AcquireError {
@@ -48,6 +50,9 @@ impl fmt::Display for AcquireError {
                 f.write_str("acquisition exceeds buffer-pool accounting capacity")
             }
             Self::PhysicalAllocationFailed => f.write_str("physical buffer-pool allocation failed"),
+            Self::MetadataAllocationFailed => {
+                f.write_str("buffer-pool ownership metadata allocation failed")
+            }
         }
     }
 }
@@ -162,11 +167,11 @@ impl PendingAcquisition {
             .unwrap_or_else(|| invariant_violation("pending acquisition lost its accounting debit"))
             .pool;
         if allocation_failure_injected(pool) {
-            return Err(AcquireError::PhysicalAllocationFailed);
+            return Err(AcquireError::MetadataAllocationFailed);
         }
         self.guards
             .try_reserve_exact(allocations.len())
-            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+            .map_err(|_| AcquireError::MetadataAllocationFailed)?;
 
         let debit = self.debit.as_mut().unwrap_or_else(|| {
             invariant_violation("pending acquisition lost its accounting debit")
@@ -201,13 +206,13 @@ pub(super) struct CarrierGuard {
 }
 
 impl CarrierGuard {
-    /// Returns pool-local indices used to group carriers within one buffer.
-    pub(super) fn identity(&self) -> (u32, u32) {
+    /// Returns the physical location used to group adjacent carriers.
+    pub(super) fn location(&self) -> CarrierLocation {
         let allocation = self
             .allocation
             .as_ref()
             .unwrap_or_else(|| invariant_violation("live carrier guard lost its allocation"));
-        (allocation.slot_id(), allocation.carrier_index())
+        allocation.location()
     }
 
     /// Returns the concrete slot that roots this carrier's pointer provenance.
@@ -285,17 +290,17 @@ pub(super) fn acquire_count(
     pending.finish()
 }
 
-/// Returns whether test injection fails this fallible allocation boundary.
+/// Returns whether test injection fails this metadata allocation boundary.
+#[cfg(test)]
 pub(super) fn allocation_failure_injected(pool: &PoolInner) -> bool {
-    #[cfg(test)]
-    {
-        pool.test_hooks.take_acquisition_allocation_failure()
-    }
-    #[cfg(not(test))]
-    {
-        let _ = pool;
-        false
-    }
+    pool.test_hooks.take_acquisition_allocation_failure()
+}
+
+/// Removes the metadata failure-injection seam from production paths.
+#[cfg(not(test))]
+#[inline(always)]
+pub(super) fn allocation_failure_injected(_pool: &PoolInner) -> bool {
+    false
 }
 
 fn map_direct_debit_error(error: DirectDebitError) -> AcquireError {
@@ -310,6 +315,7 @@ fn map_reserve_error(error: ReserveError) -> AcquireError {
     match error {
         ReserveError::InvalidSize => AcquireError::InvalidSize,
         ReserveError::PhysicalPreparationFailed => AcquireError::PhysicalAllocationFailed,
+        ReserveError::MetadataAllocationFailed => AcquireError::MetadataAllocationFailed,
         ReserveError::CapacityOverflow => AcquireError::CapacityOverflow,
     }
 }
@@ -321,8 +327,10 @@ fn map_arena_error(error: ArenaError) -> AcquireError {
         | ArenaError::RegistryCapacityOverflow
         | ArenaError::AddressOverflow { .. }
         | ArenaError::ScanSpaceOverflow { .. } => AcquireError::CapacityOverflow,
+        ArenaError::Block(BlockError::Allocation(_)) | ArenaError::Allocation(_) => {
+            AcquireError::MetadataAllocationFailed
+        }
         ArenaError::Block(_)
-        | ArenaError::Allocation(_)
         | ArenaError::InvalidScanBudget
         | ArenaError::InvalidClaimCount
         | ArenaError::IncompleteClaim { .. }
@@ -365,6 +373,32 @@ mod tests {
             self.claimed.store(claim.is_complete(), Ordering::Release);
             self.wakes.fetch_add(1, Ordering::Release);
         }
+    }
+
+    #[test]
+    fn test_metadata_failures_retain_their_error_classification() {
+        assert_eq!(
+            map_reserve_error(ReserveError::MetadataAllocationFailed),
+            AcquireError::MetadataAllocationFailed
+        );
+
+        let arena_error = Vec::<u8>::new().try_reserve(usize::MAX).unwrap_err();
+        assert_eq!(
+            map_arena_error(ArenaError::Allocation(arena_error)),
+            AcquireError::MetadataAllocationFailed
+        );
+
+        let block_error = Vec::<u8>::new().try_reserve(usize::MAX).unwrap_err();
+        assert_eq!(
+            map_arena_error(ArenaError::Block(BlockError::Allocation(block_error))),
+            AcquireError::MetadataAllocationFailed
+        );
+
+        let preparation_error = Vec::<u8>::new().try_reserve(usize::MAX).unwrap_err();
+        assert_eq!(
+            super::super::map_preparation_error(ArenaError::Allocation(preparation_error)),
+            ReserveError::MetadataAllocationFailed
+        );
     }
 
     #[test]
@@ -883,7 +917,7 @@ mod tests {
             assert!(
                 matches!(
                     pool.acquire(&reservation, carrier_size * 2),
-                    Err(AcquireError::PhysicalAllocationFailed)
+                    Err(AcquireError::MetadataAllocationFailed)
                 ),
                 "metadata boundary {boundary} did not fail"
             );

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/acquisition.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/acquisition.rs
@@ -11,19 +11,11 @@
 
 use std::fmt;
 
-use smallvec::SmallVec;
-
 use super::admission::{AdmissionGuard, DirectDebitError, ReservationState, ReserveError};
 use super::arena::{ArenaError, ClaimBatch};
-use super::block::{BlockError, CarrierAllocation};
+use super::block::{BlockError, BlockSlot, CarrierAllocation};
 use super::{invariant_violation, CarrierCount, PoolInner};
 use crate::runtime::sync::sync::Arc;
-
-/// Carrier runs stored inline before metadata spills to the heap.
-const INLINE_CARRIER_RUNS: usize = 4;
-
-/// Fallible carrier-run storage shared with the mutable-buffer layer.
-type CarrierRuns = SmallVec<[CarrierRun; INLINE_CARRIER_RUNS]>;
 
 /// Failure to acquire a complete mutable carrier batch.
 #[non_exhaustive]
@@ -158,7 +150,7 @@ impl PendingAcquisition {
     }
 
     /// Converts one complete physical batch into grouped carrier ownership.
-    fn finish(mut self) -> Result<AcquiredRuns, AcquireError> {
+    fn finish(mut self) -> Result<Vec<Arc<CarrierGuard>>, AcquireError> {
         let claim = self
             .claim
             .take()
@@ -186,7 +178,7 @@ impl PendingAcquisition {
             invariant_violation("complete acquisition left untransferred charges");
         }
 
-        AcquiredRuns::try_from_guards(std::mem::take(&mut self.guards))
+        Ok(std::mem::take(&mut self.guards))
     }
 }
 
@@ -195,143 +187,6 @@ impl Drop for PendingAcquisition {
         self.guards.clear();
         drop(self.claim.take());
         drop(self.debit.take());
-    }
-}
-
-/// Complete carrier runs returned by one acquisition transaction.
-pub(crate) struct AcquiredRuns {
-    /// Contiguous physical runs in ascending slot and carrier order.
-    runs: CarrierRuns,
-    /// Complete carrier-rounded capacity.
-    capacity: usize,
-}
-
-impl AcquiredRuns {
-    /// Groups physical owners into ascending adjacent carrier runs.
-    fn try_from_guards(mut guards: Vec<Arc<CarrierGuard>>) -> Result<AcquiredRuns, AcquireError> {
-        guards.sort_unstable_by_key(|guard| guard.identity());
-        let pool = Arc::clone(
-            &guards
-                .first()
-                .unwrap_or_else(|| invariant_violation("complete acquisition contains no carrier"))
-                .pool,
-        );
-
-        let mut runs = CarrierRuns::new();
-        let mut capacity = 0usize;
-        for guard in guards {
-            capacity = capacity
-                .checked_add(guard.capacity())
-                .ok_or(AcquireError::CapacityOverflow)?;
-            if let Some(run) = runs.last_mut() {
-                if run.can_append(&guard) {
-                    run.try_append(guard)?;
-                    continue;
-                }
-            }
-            if allocation_failure_injected(&pool) {
-                return Err(AcquireError::PhysicalAllocationFailed);
-            }
-            runs.try_reserve(1)
-                .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
-            runs.push(CarrierRun::try_new(guard)?);
-        }
-
-        Ok(Self { runs, capacity })
-    }
-
-    /// Returns the complete carrier-rounded byte capacity.
-    pub(crate) fn capacity(&self) -> usize {
-        self.capacity
-    }
-
-    /// Returns the number of contiguous carrier runs.
-    pub(crate) fn run_count(&self) -> usize {
-        self.runs.len()
-    }
-
-    /// Transfers the grouped carrier owners to the mutable-buffer layer.
-    pub(super) fn into_runs(self) -> CarrierRuns {
-        self.runs
-    }
-}
-
-/// Adjacent carriers within one stable block slot.
-pub(super) struct CarrierRun {
-    /// Stable block slot containing the run.
-    slot_id: u32,
-    /// First carrier index within the slot.
-    first_carrier: u32,
-    /// Total run capacity in bytes.
-    capacity: usize,
-    /// Per-carrier owners in ascending address order.
-    carriers: Vec<Arc<CarrierGuard>>,
-}
-
-impl CarrierRun {
-    /// Creates a run containing one carrier.
-    fn try_new(guard: Arc<CarrierGuard>) -> Result<Self, AcquireError> {
-        let (slot_id, first_carrier) = guard.identity();
-        let capacity = guard.capacity();
-        let mut carriers = Vec::new();
-        if allocation_failure_injected(&guard.pool) {
-            return Err(AcquireError::PhysicalAllocationFailed);
-        }
-        carriers
-            .try_reserve_exact(1)
-            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
-        carriers.push(guard);
-        Ok(Self {
-            slot_id,
-            first_carrier,
-            capacity,
-            carriers,
-        })
-    }
-
-    /// Returns whether `guard` immediately follows this run.
-    fn can_append(&self, guard: &CarrierGuard) -> bool {
-        let run_len = u32::try_from(self.carriers.len())
-            .unwrap_or_else(|_| invariant_violation("carrier run length exceeds block geometry"));
-        let next = self
-            .first_carrier
-            .checked_add(run_len)
-            .unwrap_or_else(|| invariant_violation("carrier run end exceeds block geometry"));
-        guard.identity() == (self.slot_id, next)
-    }
-
-    /// Appends one adjacent carrier without exposing a partial run on failure.
-    fn try_append(&mut self, guard: Arc<CarrierGuard>) -> Result<(), AcquireError> {
-        if allocation_failure_injected(&guard.pool) {
-            return Err(AcquireError::PhysicalAllocationFailed);
-        }
-        self.carriers
-            .try_reserve(1)
-            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
-        self.capacity = self
-            .capacity
-            .checked_add(guard.capacity())
-            .ok_or(AcquireError::CapacityOverflow)?;
-        self.carriers.push(guard);
-        Ok(())
-    }
-
-    /// Returns the run's total byte capacity.
-    pub(super) fn capacity(&self) -> usize {
-        self.capacity
-    }
-
-    /// Returns the first carrier's checked writable pointer.
-    pub(super) fn ptr(&self) -> std::ptr::NonNull<std::mem::MaybeUninit<u8>> {
-        self.carriers
-            .first()
-            .unwrap_or_else(|| invariant_violation("carrier run contains no carriers"))
-            .ptr()
-    }
-
-    /// Transfers per-carrier ownership in ascending address order.
-    pub(super) fn into_carriers(self) -> Vec<Arc<CarrierGuard>> {
-        self.carriers
     }
 }
 
@@ -346,13 +201,21 @@ pub(super) struct CarrierGuard {
 }
 
 impl CarrierGuard {
-    /// Returns stable identity used only to group adjacent carriers.
-    fn identity(&self) -> (u32, u32) {
+    /// Returns pool-local indices used to group carriers within one buffer.
+    pub(super) fn identity(&self) -> (u32, u32) {
         let allocation = self
             .allocation
             .as_ref()
             .unwrap_or_else(|| invariant_violation("live carrier guard lost its allocation"));
         (allocation.slot_id(), allocation.carrier_index())
+    }
+
+    /// Returns the concrete slot that roots this carrier's pointer provenance.
+    pub(super) fn slot(&self) -> &Arc<BlockSlot> {
+        self.allocation
+            .as_ref()
+            .unwrap_or_else(|| invariant_violation("live carrier guard lost its allocation"))
+            .slot()
     }
 
     /// Returns this carrier's byte capacity.
@@ -391,7 +254,7 @@ pub(super) fn acquire_count(
     pool: &Arc<PoolInner>,
     direct: Option<Arc<ReservationState>>,
     count: CarrierCount,
-) -> Result<AcquiredRuns, AcquireError> {
+) -> Result<Vec<Arc<CarrierGuard>>, AcquireError> {
     let debit = AcquisitionDebit::install(pool, direct, count)?;
     let mut pending = PendingAcquisition::new(debit);
     pending.claim = Some(
@@ -423,7 +286,7 @@ pub(super) fn acquire_count(
 }
 
 /// Returns whether test injection fails this fallible allocation boundary.
-fn allocation_failure_injected(pool: &PoolInner) -> bool {
+pub(super) fn allocation_failure_injected(pool: &PoolInner) -> bool {
     #[cfg(test)]
     {
         pool.test_hooks.take_acquisition_allocation_failure()
@@ -478,7 +341,7 @@ mod tests {
     use super::super::block::{BlockSlot, TrimBlocked};
     use super::super::test_util::{poll_reserve, test_pool_with_scan as test_pool};
     use super::super::virtual_memory::VirtualMemoryOperation;
-    use super::super::{BufferPool, Reservation};
+    use super::super::{BufferPool, PooledBufMut, Reservation};
     use super::*;
 
     struct ClaimingWake {
@@ -556,7 +419,7 @@ mod tests {
         let acquired = pool.acquire(&reservation, carrier_size + 1).unwrap();
 
         assert_eq!(acquired.capacity(), carrier_size * 2);
-        assert_eq!(acquired.run_count(), 1);
+        assert_eq!(acquired.test_run_count(), 1);
         assert_eq!(direct.test_owner_state(), (false, CarrierCount::new(2)));
         assert_eq!(
             pool.inner.test_accounting_state(),
@@ -592,9 +455,9 @@ mod tests {
         let acquired = pool.acquire_unreserved(carrier_size * 3).unwrap();
 
         assert_eq!(acquired.capacity(), carrier_size * 3);
-        assert_eq!(acquired.run_count(), 2);
-        assert_eq!(acquired.runs[0].capacity(), carrier_size * 2);
-        assert_eq!(acquired.runs[1].capacity(), carrier_size);
+        assert_eq!(acquired.test_run_count(), 2);
+        assert_eq!(acquired.test_run_capacity(0), carrier_size * 2);
+        assert_eq!(acquired.test_run_capacity(1), carrier_size);
         assert_eq!(
             pool.inner.test_accounting_state(),
             (
@@ -630,7 +493,7 @@ mod tests {
         let acquired = pool.acquire(&reservation, carrier_size * 65).unwrap();
 
         assert_eq!(acquired.capacity(), carrier_size * 65);
-        assert_eq!(acquired.run_count(), 1);
+        assert_eq!(acquired.test_run_count(), 1);
         assert_eq!(pool.inner.arena.diagnostics().serialized_fallbacks, 1);
     }
 
@@ -851,7 +714,7 @@ mod tests {
         struct Owner {
             actor: usize,
             carriers: usize,
-            runs: AcquiredRuns,
+            runs: PooledBufMut,
         }
 
         fn next(state: &mut u64) -> usize {
@@ -1002,7 +865,7 @@ mod tests {
         fn assert_send<T: Send>() {}
         fn assert_send_sync<T: Send + Sync>() {}
 
-        assert_send::<AcquiredRuns>();
+        assert_send::<PooledBufMut>();
         assert_send_sync::<CarrierGuard>();
     }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission.rs
@@ -252,6 +252,8 @@ pub(crate) enum ReserveError {
     InvalidSize,
     /// Physical storage could not be prepared.
     PhysicalPreparationFailed,
+    /// Queue or ownership metadata could not reserve the required capacity.
+    MetadataAllocationFailed,
     /// The request or resulting accounting state is not representable.
     CapacityOverflow,
 }
@@ -263,6 +265,7 @@ impl fmt::Display for ReserveError {
             Self::PhysicalPreparationFailed => {
                 f.write_str("physical buffer-pool preparation failed")
             }
+            Self::MetadataAllocationFailed => f.write_str("buffer-pool metadata allocation failed"),
             Self::CapacityOverflow => {
                 f.write_str("reservation exceeds buffer-pool accounting capacity")
             }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/admission.rs
@@ -323,6 +323,11 @@ impl Drop for Reservation {
 }
 
 impl ReservationState {
+    /// Returns the pool whose direct authority this state represents.
+    pub(super) fn pool(&self) -> &Arc<PoolInner> {
+        &self.pool
+    }
+
     /// Returns whether this reservation belongs to `pool`.
     pub(super) fn belongs_to(&self, pool: &Arc<PoolInner>) -> bool {
         Arc::ptr_eq(&self.pool, pool)

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -217,6 +217,38 @@ struct CarrierId {
     incarnation: IncarnationIdentity,
 }
 
+/// Stable physical location of one carrier within an arena.
+///
+/// The location orders carriers for run construction. It does not identify the
+/// block incarnation that owns a live carrier bit.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) struct CarrierLocation {
+    /// Pool-local block-slot index.
+    slot_id: u32,
+    /// Carrier index within the slot.
+    carrier_index: u32,
+}
+
+impl CarrierLocation {
+    /// Creates one arena location.
+    pub(super) const fn new(slot_id: u32, carrier_index: u32) -> Self {
+        Self {
+            slot_id,
+            carrier_index,
+        }
+    }
+
+    /// Returns the pool-local block-slot index.
+    pub(super) const fn slot_id(self) -> u32 {
+        self.slot_id
+    }
+
+    /// Returns the carrier index within the slot.
+    pub(super) const fn carrier_index(self) -> u32 {
+        self.carrier_index
+    }
+}
+
 /// Comparison-only identity for one block activation.
 ///
 /// The live carrier bit, not this value, prevents incarnation replacement.
@@ -1349,14 +1381,19 @@ impl CarrierAllocation {
         &self.slot
     }
 
+    /// Returns this carrier's stable physical location within the arena.
+    pub(super) fn location(&self) -> CarrierLocation {
+        CarrierLocation::new(self.id.slot, self.id.index)
+    }
+
     /// Returns the stable block-slot identifier.
     pub(super) fn slot_id(&self) -> u32 {
-        self.id.slot
+        self.location().slot_id()
     }
 
     /// Returns the carrier index within its block.
     pub(super) fn carrier_index(&self) -> u32 {
-        self.id.index
+        self.location().carrier_index()
     }
 
     /// Returns the carrier capacity in bytes.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -459,6 +459,63 @@ impl BlockSlot {
         self.range.len()
     }
 
+    /// Derives a checked immutable pointer from this slot's provenance root.
+    ///
+    /// # Safety
+    ///
+    /// The caller must retain initialized immutable ownership over the
+    /// complete subrange. That ownership must keep its carrier bits live so
+    /// trim cannot deactivate the slot while the pointer is used.
+    pub(super) unsafe fn ptr_for_immutable_range(
+        &self,
+        offset: usize,
+        len: usize,
+    ) -> Option<NonNull<u8>> {
+        // SAFETY: the caller supplies the initialized owner and deactivation
+        // exclusion required by `VirtualRange::ptr_for_range`.
+        unsafe {
+            self.range
+                .ptr_for_range(offset, len)
+                .map(NonNull::cast::<u8>)
+        }
+    }
+
+    /// Debug-checks that every carrier intersecting `offset..offset + len`
+    /// remains live.
+    ///
+    /// This detects violations of the immutable-owner contract. A set bit
+    /// alone does not prove that a particular owner controls that bit.
+    #[cfg(debug_assertions)]
+    pub(super) fn debug_assert_immutable_range_live(&self, offset: usize, len: usize) {
+        let end = offset.checked_add(len);
+        debug_assert!(
+            len != 0 && end.is_some_and(|end| end <= self.geometry.block_size()),
+            "immutable range is outside its block slot"
+        );
+        let Some(end) = end.filter(|end| len != 0 && *end <= self.geometry.block_size()) else {
+            return;
+        };
+        let current = self.current.load();
+        let Some(incarnation) = current.as_ref() else {
+            debug_assert!(false, "immutable range has no current incarnation");
+            return;
+        };
+        let first = offset / self.geometry.carrier_size();
+        let last = (end - 1) / self.geometry.carrier_size();
+        for index in first..=last {
+            let word_index = index / u64::BITS as usize;
+            let mask = 1u64 << (index % u64::BITS as usize);
+            let live = incarnation
+                .in_use
+                .get(word_index)
+                .is_some_and(|word| word.load(Ordering::Acquire) & mask != 0);
+            debug_assert!(
+                live,
+                "immutable range includes a carrier without a live bit"
+            );
+        }
+    }
+
     /// Returns the reserved half-open address range.
     ///
     /// The integer range grants no access to the backing memory. `None`
@@ -1287,6 +1344,11 @@ pub(super) struct CarrierAllocation {
 }
 
 impl CarrierAllocation {
+    /// Returns the concrete slot that roots this carrier's pointer provenance.
+    pub(super) fn slot(&self) -> &Arc<BlockSlot> {
+        &self.slot
+    }
+
     /// Returns the stable block-slot identifier.
     pub(super) fn slot_id(&self) -> u32 {
         self.id.slot
@@ -1456,6 +1518,26 @@ mod tests {
 
         drop(claimed);
         assert_eq!(slot.live_carriers(), 0);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_immutable_range_live_check_covers_each_intersecting_carrier() {
+        let (slot, _) = prepared_slot(3);
+        let carrier_size = slot.geometry.carrier_size();
+        let claimed = BlockSlot::try_claim(&slot, CarrierCount::new(2))
+            .unwrap()
+            .unwrap()
+            .into_carriers()
+            .unwrap();
+
+        slot.debug_assert_immutable_range_live(carrier_size - 1, 2);
+        drop(claimed);
+
+        let missing_live_bit = catch_unwind(AssertUnwindSafe(|| {
+            slot.debug_assert_immutable_range_live(carrier_size - 1, 2);
+        }));
+        assert!(missing_live_bit.is_err());
     }
 
     #[test]

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/pooled_buf.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/pooled_buf.rs
@@ -3,12 +3,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Growable mutable buffers backed by exclusively owned pool carriers.
+//! Mutable byte streams backed by exclusively owned pool carriers.
 //!
-//! Acquisition installs accounting and returns one guard per carrier. This
-//! module arranges those guards in logical write order, tracks initialization,
-//! and transfers initialized prefixes into immutable owners without moving
-//! bytes.
+//! Acquisition returns charged carrier guards without assigning byte-level
+//! meaning to their storage. [`PooledBufMut`] arranges those carriers in logical
+//! write order and implements the remaining ownership transitions:
+//!
+//! - [`BufMut`] exposes only uninitialized storage held exclusively by the
+//!   mutable buffer.
+//! - [`PooledBufMut::publish_prefix`] removes initialized bytes from mutable
+//!   authority and transfers them to an immutable [`Bytes`] owner.
+//! - [`PooledBufMut::freeze`] ends growth and transfers all remaining
+//!   initialized bytes to [`SegmentedBytes`].
+//!
+//! Growth consumes retained writable capacity before acquiring more carriers.
+//! A buffer never changes between reserved and unreserved growth.
 
 use std::mem::MaybeUninit;
 use std::ptr::NonNull;
@@ -19,6 +28,7 @@ use smallvec::SmallVec;
 
 use super::acquisition::{acquire_count, allocation_failure_injected, AcquireError, CarrierGuard};
 use super::admission::ReservationState;
+use super::block::CarrierLocation;
 use super::geometry::GeometryError;
 use super::segmented_bytes::SegmentedBytesBuilder;
 use super::{invariant_violation, CarrierCount, PoolInner, SegmentedBytes};
@@ -30,7 +40,18 @@ const INLINE_CARRIER_RUNS: usize = 4;
 /// Contiguous physical runs in logical byte order.
 type CarrierRuns = SmallVec<[CarrierRun; INLINE_CARRIER_RUNS]>;
 
-/// One growable mutable allocation stream.
+/// One growable, exclusively writable stream of pooled bytes.
+///
+/// `len()` counts initialized bytes that remain owned by this mutable buffer.
+/// `remaining_mut()` counts retained uninitialized capacity, and `capacity()`
+/// is their sum. Publishing bytes reduces both `len()` and `capacity()` because
+/// the immutable result takes ownership of that range.
+///
+/// The buffer implements [`BufMut`] but does not expose its initialized prefix
+/// as one slice. Initialized bytes may cross carrier boundaries; callers use
+/// [`Self::initialized_chunk`] and [`Self::publish_prefix`] to transfer one
+/// contiguous prefix at a time, or [`Self::freeze`] to finish the complete
+/// segmented value.
 pub(crate) struct PooledBufMut {
     /// Selects reserved or unreserved acquisition for every later growth.
     growth: GrowthAuthority,
@@ -47,7 +68,10 @@ pub(crate) struct PooledBufMut {
 }
 
 impl PooledBufMut {
-    /// Builds a mutable stream from one complete carrier acquisition.
+    /// Takes every carrier from one complete acquisition.
+    ///
+    /// Failure drops all guards and returns their physical and accounting
+    /// ownership. No partial mutable buffer escapes.
     pub(super) fn try_new(
         growth: GrowthAuthority,
         guards: Vec<Arc<CarrierGuard>>,
@@ -66,11 +90,17 @@ impl PooledBufMut {
     }
 
     /// Returns initialized and writable bytes retained by this buffer.
+    ///
+    /// This is `len() + remaining_mut()`, not the original allocation size.
+    /// Publishing removes capacity from the mutable buffer.
     pub(crate) fn capacity(&self) -> usize {
         self.retained_capacity
     }
 
     /// Returns initialized bytes that have not been published.
+    ///
+    /// The bytes may span multiple carriers and therefore may not be
+    /// contiguous in memory.
     pub(crate) fn len(&self) -> usize {
         self.initialized
     }
@@ -201,7 +231,7 @@ impl PooledBufMut {
     ///
     /// Wholly unused carriers return immediately. An initialized prefix in a
     /// partially used carrier retains that carrier and discards its writable
-    /// suffix.
+    /// suffix. The operation does not copy initialized bytes.
     pub(crate) fn freeze(self) -> SegmentedBytes {
         let pool = Arc::clone(self.growth.pool());
         let Self { runs, .. } = self;
@@ -248,11 +278,11 @@ impl PooledBufMut {
         let appended_runs = staged.len() - usize::from(merge_first);
 
         if allocation_failure_injected(self.growth.pool()) {
-            return Err(AcquireError::PhysicalAllocationFailed);
+            return Err(AcquireError::MetadataAllocationFailed);
         }
         self.runs
             .try_reserve(appended_runs)
-            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+            .map_err(|_| AcquireError::MetadataAllocationFailed)?;
 
         if merge_first {
             let incoming = staged.remove(0);
@@ -261,12 +291,12 @@ impl PooledBufMut {
                 .last_mut()
                 .unwrap_or_else(|| invariant_violation("merge target disappeared"));
             if allocation_failure_injected(self.growth.pool()) {
-                return Err(AcquireError::PhysicalAllocationFailed);
+                return Err(AcquireError::MetadataAllocationFailed);
             }
             current
                 .carriers
                 .try_reserve(incoming.carriers.len())
-                .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+                .map_err(|_| AcquireError::MetadataAllocationFailed)?;
             current.carriers.extend(incoming.carriers);
         }
         self.runs.extend(staged);
@@ -470,7 +500,10 @@ unsafe impl BufMut for PooledBufMut {
     }
 }
 
-/// Authority retained for every later growth of one buffer.
+/// Fixed acquisition authority for every growth of one mutable buffer.
+///
+/// Retaining the mode prevents a reserved buffer from escaping its envelope
+/// through unreserved growth.
 pub(super) enum GrowthAuthority {
     /// New carriers must debit this reservation.
     Reserved(Arc<ReservationState>),
@@ -507,6 +540,11 @@ impl GrowthAuthority {
 }
 
 /// Adjacent carriers within one stable block slot.
+///
+/// Runs preserve logical byte order and reduce the top-level metadata needed
+/// for the common case where acquisition returns neighboring carriers. A run
+/// groups cursors only; each carrier keeps its own guard and pointer, and
+/// immutable coalescing performs a separate slot-identity check.
 struct CarrierRun {
     /// Stable block slot containing the run.
     slot_id: u32,
@@ -519,18 +557,18 @@ struct CarrierRun {
 impl CarrierRun {
     /// Creates a run containing one carrier.
     fn try_new(pool: &PoolInner, guard: Arc<CarrierGuard>) -> Result<Self, AcquireError> {
-        let (slot_id, first_carrier) = guard.identity();
+        let location = guard.location();
         let mut carriers = Vec::new();
         if allocation_failure_injected(pool) {
-            return Err(AcquireError::PhysicalAllocationFailed);
+            return Err(AcquireError::MetadataAllocationFailed);
         }
         carriers
             .try_reserve_exact(1)
-            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+            .map_err(|_| AcquireError::MetadataAllocationFailed)?;
         carriers.push(WritableCarrier::new(guard));
         Ok(Self {
-            slot_id,
-            first_carrier,
+            slot_id: location.slot_id(),
+            first_carrier: location.carrier_index(),
             carriers,
         })
     }
@@ -543,7 +581,7 @@ impl CarrierRun {
             .first_carrier
             .checked_add(run_len)
             .unwrap_or_else(|| invariant_violation("carrier run end exceeds block geometry"));
-        guard.identity() == (self.slot_id, next)
+        guard.location() == CarrierLocation::new(self.slot_id, next)
     }
 
     /// Returns whether `incoming` immediately follows this run.
@@ -561,17 +599,21 @@ impl CarrierRun {
         guard: Arc<CarrierGuard>,
     ) -> Result<(), AcquireError> {
         if allocation_failure_injected(pool) {
-            return Err(AcquireError::PhysicalAllocationFailed);
+            return Err(AcquireError::MetadataAllocationFailed);
         }
         self.carriers
             .try_reserve(1)
-            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+            .map_err(|_| AcquireError::MetadataAllocationFailed)?;
         self.carriers.push(WritableCarrier::new(guard));
         Ok(())
     }
 }
 
 /// Unique mutable authority over one carrier's unpublished suffix.
+///
+/// `initialized` divides `writable` into an initialized prefix followed by an
+/// uninitialized suffix. Prefix publication advances `writable` and may leave
+/// this positional entry empty so existing cursors remain stable.
 struct WritableCarrier {
     /// Shared physical and accounting ownership while a range remains.
     guard: Option<Arc<CarrierGuard>>,
@@ -666,6 +708,9 @@ impl BufferCursor {
 }
 
 /// Immutable initialized view retained by one carrier guard.
+///
+/// `Bytes::from_owner` may clone or slice this owner. The final owner drop
+/// releases the guard after every derived immutable view is gone.
 struct PooledWindow {
     guard: Arc<CarrierGuard>,
     ptr: NonNull<u8>,
@@ -703,7 +748,7 @@ fn build_runs(
     if guards.is_empty() {
         invariant_violation("complete acquisition contains no carriers");
     }
-    guards.sort_unstable_by_key(|guard| guard.identity());
+    guards.sort_unstable_by_key(|guard| guard.location());
 
     let mut runs = CarrierRuns::new();
     let mut capacity = 0usize;
@@ -718,10 +763,10 @@ fn build_runs(
             }
         }
         if allocation_failure_injected(pool) {
-            return Err(AcquireError::PhysicalAllocationFailed);
+            return Err(AcquireError::MetadataAllocationFailed);
         }
         runs.try_reserve(1)
-            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+            .map_err(|_| AcquireError::MetadataAllocationFailed)?;
         runs.push(CarrierRun::try_new(pool, guard)?);
     }
     Ok((runs, capacity))
@@ -757,6 +802,44 @@ mod tests {
         assert_eq!(buffer.remaining_mut(), carrier_size - 1);
         assert_eq!(buffer.initialized_chunk(), &input[..carrier_size]);
         assert_eq!(buffer.chunk_mut().len(), carrier_size - 1);
+    }
+
+    #[test]
+    fn test_buf_mut_put_slice_crosses_carrier_boundaries() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let mut buffer = pool.acquire_unreserved(carrier_size + 3).unwrap();
+        let input: Vec<u8> = (0..carrier_size + 3)
+            .map(|index| (index.wrapping_mul(19) % 251) as u8)
+            .collect();
+
+        buffer.put_slice(&input);
+
+        assert_eq!(buffer.len(), input.len());
+        assert_eq!(buffer.remaining_mut(), carrier_size - 3);
+        assert_eq!(buffer.initialized_chunk(), &input[..carrier_size]);
+        let first = buffer.publish_prefix(carrier_size);
+        assert_eq!(first, input[..carrier_size]);
+        assert_eq!(buffer.initialized_chunk(), &input[carrier_size..]);
+    }
+
+    #[test]
+    fn test_buf_mut_zero_and_exact_boundary_advance_select_next_carrier() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let mut buffer = pool.acquire_unreserved(carrier_size * 2).unwrap();
+
+        let initial_len = buffer.chunk_mut().len();
+        // SAFETY: advancing by zero initializes no bytes.
+        unsafe { buffer.advance_mut(0) };
+        assert_eq!(buffer.chunk_mut().len(), initial_len);
+
+        let initialized = vec![0x5a; carrier_size];
+        buffer.chunk_mut()[..carrier_size].copy_from_slice(&initialized);
+        // SAFETY: the preceding fill initialized the complete first chunk.
+        unsafe { buffer.advance_mut(carrier_size) };
+
+        assert_eq!(buffer.len(), carrier_size);
+        assert_eq!(buffer.chunk_mut().len(), carrier_size);
+        assert_eq!(buffer.initialized_chunk(), initialized);
     }
 
     #[test]
@@ -878,7 +961,7 @@ mod tests {
                 assert!(result.is_ok(), "boundary {boundary} was not reached");
                 break;
             }
-            assert_eq!(result, Err(AcquireError::PhysicalAllocationFailed));
+            assert_eq!(result, Err(AcquireError::MetadataAllocationFailed));
             assert_eq!(buffer.capacity(), carrier_size);
             assert_eq!(buffer.len(), 3);
             assert_eq!(buffer.remaining_mut(), carrier_size - 3);
@@ -951,6 +1034,23 @@ mod tests {
         assert_eq!(buffer.initialized_chunk(), b"defXYZ");
         let second = buffer.publish_prefix(6);
         assert_eq!(second, b"defXYZ"[..]);
+    }
+
+    #[test]
+    fn test_growth_skips_a_fully_published_carrier_entry() {
+        let (pool, carrier_size) = test_pool(1, 2);
+        let mut buffer = pool.acquire_unreserved(carrier_size).unwrap();
+        buffer.put_slice(&vec![0x11; carrier_size]);
+        let published = buffer.publish_prefix(carrier_size);
+
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.capacity(), 0);
+        buffer.reserve(1).unwrap();
+        buffer.put_slice(b"next");
+        let frozen = buffer.freeze();
+
+        assert_eq!(published, vec![0x11; carrier_size]);
+        assert_eq!(frozen.chunk(), b"next");
     }
 
     #[test]

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/pooled_buf.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/pooled_buf.rs
@@ -52,6 +52,14 @@ type CarrierRuns = SmallVec<[CarrierRun; INLINE_CARRIER_RUNS]>;
 /// [`Self::initialized_chunk`] and [`Self::publish_prefix`] to transfer one
 /// contiguous prefix at a time, or [`Self::freeze`] to finish the complete
 /// segmented value.
+///
+/// Growth reuses this buffer's retained writable tail before acquiring another
+/// carrier. Freezing a partially initialized carrier discards mutable access
+/// to its unused suffix, while the immutable prefix keeps the complete carrier
+/// charged. Several partially filled buffers can therefore exhaust a
+/// reservation's carrier allowance even when their initialized byte lengths
+/// fit within the reservation. The allowance returns when each final immutable
+/// owner drops.
 pub(crate) struct PooledBufMut {
     /// Selects reserved or unreserved acquisition for every later growth.
     growth: GrowthAuthority,
@@ -137,9 +145,8 @@ impl PooledBufMut {
         let carrier = self
             .carrier(self.publish_cursor)
             .filter(|carrier| carrier.initialized != 0)
-            .or_else(|| self.first_carrier_matching(|carrier| carrier.initialized != 0))
             .unwrap_or_else(|| {
-                invariant_violation("initialized buffer has no publication carrier")
+                invariant_violation("publication cursor does not name initialized bytes")
             });
 
         // SAFETY: `initialized` is the prefix written through this buffer's
@@ -155,7 +162,9 @@ impl PooledBufMut {
     /// Ensures that at least `min_writable` uninitialized bytes remain.
     ///
     /// Existing tail capacity is consumed before the shortfall is rounded to
-    /// complete carriers. Failure leaves this buffer unchanged.
+    /// complete carriers. Only capacity retained by this buffer can satisfy
+    /// the guarantee; unused tails discarded by other buffers are not shared.
+    /// Failure leaves this buffer unchanged.
     pub(crate) fn reserve(&mut self, min_writable: usize) -> Result<(), AcquireError> {
         let remaining = self.remaining_mut();
         if min_writable <= remaining {
@@ -302,6 +311,7 @@ impl PooledBufMut {
         self.runs.extend(staged);
         self.retained_capacity = retained_capacity;
         self.reset_write_cursor();
+        self.normalize_publish_cursor();
         Ok(())
     }
 
@@ -332,17 +342,6 @@ impl PooledBufMut {
         self.publish_cursor = self
             .cursor_matching_from(self.publish_cursor, |carrier| carrier.initialized != 0)
             .unwrap_or_else(|| BufferCursor::end(self.runs.len()));
-    }
-
-    /// Returns the first carrier satisfying `predicate`.
-    fn first_carrier_matching(
-        &self,
-        predicate: impl Fn(&WritableCarrier) -> bool,
-    ) -> Option<&WritableCarrier> {
-        self.runs
-            .iter()
-            .flat_map(|run| run.carriers.iter())
-            .find(|carrier| predicate(carrier))
     }
 
     /// Returns the first carrier cursor satisfying `predicate`.
@@ -693,6 +692,7 @@ impl ExclusiveRange {
 
 /// Run and carrier position inside one mutable buffer.
 #[derive(Clone, Copy)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 struct BufferCursor {
     run: usize,
     carrier: usize,
@@ -786,6 +786,59 @@ mod tests {
 
     use super::super::test_util::{test_pool, write_pooled};
     use super::*;
+
+    /// Checks the aggregate fields and cursors against per-carrier state.
+    fn assert_buffer_invariants(buffer: &PooledBufMut) {
+        let mut retained_capacity = 0usize;
+        let mut initialized = 0usize;
+        let mut writable = 0usize;
+
+        for run in &buffer.runs {
+            assert!(!run.carriers.is_empty());
+            for (offset, carrier) in run.carriers.iter().enumerate() {
+                assert!(carrier.initialized <= carrier.writable.len());
+                assert_eq!(carrier.guard.is_some(), !carrier.writable.is_empty());
+
+                if let Some(guard) = carrier.guard.as_ref() {
+                    let offset = u32::try_from(offset).expect("test run exceeds u32");
+                    let carrier_index = run
+                        .first_carrier
+                        .checked_add(offset)
+                        .expect("test run exceeds block geometry");
+                    assert_eq!(
+                        guard.location(),
+                        CarrierLocation::new(run.slot_id, carrier_index)
+                    );
+                }
+
+                retained_capacity = retained_capacity
+                    .checked_add(carrier.writable.len())
+                    .expect("test capacity overflow");
+                initialized = initialized
+                    .checked_add(carrier.initialized)
+                    .expect("test initialization overflow");
+                writable = writable
+                    .checked_add(carrier.remaining_mut())
+                    .expect("test writable capacity overflow");
+            }
+        }
+
+        assert_eq!(buffer.retained_capacity, retained_capacity);
+        assert_eq!(buffer.initialized, initialized);
+        assert_eq!(buffer.remaining_mut(), writable);
+        assert_eq!(
+            buffer.publish_cursor,
+            buffer
+                .first_cursor_matching(|carrier| carrier.initialized != 0)
+                .unwrap_or_else(|| BufferCursor::end(buffer.runs.len()))
+        );
+        assert_eq!(
+            buffer.write_cursor,
+            buffer
+                .first_cursor_matching(|carrier| carrier.remaining_mut() != 0)
+                .unwrap_or_else(|| BufferCursor::end(buffer.runs.len()))
+        );
+    }
 
     #[test]
     fn test_mutable_initialization_crosses_carrier_boundaries() {
@@ -1018,6 +1071,119 @@ mod tests {
     }
 
     #[test]
+    fn test_interleaved_publication_growth_and_freeze_preserve_multirun_state() {
+        let (pool, carrier_size) = test_pool(1, 3);
+        let first_input: Vec<u8> = (0..carrier_size + 3)
+            .map(|index| (index.wrapping_mul(17) % 251) as u8)
+            .collect();
+        let second_input: Vec<u8> = (0..carrier_size + 2)
+            .map(|index| (index.wrapping_mul(29) % 251) as u8)
+            .collect();
+        let mut buffer = pool.acquire_unreserved(first_input.len()).unwrap();
+        assert_eq!(buffer.test_run_count(), 2);
+        assert_buffer_invariants(&buffer);
+
+        write_pooled(&mut buffer, &first_input);
+        assert_buffer_invariants(&buffer);
+        let first = buffer.publish_prefix(carrier_size);
+        assert_buffer_invariants(&buffer);
+        let second_prefix = buffer.publish_prefix(2);
+        assert_buffer_invariants(&buffer);
+
+        buffer.reserve(carrier_size + 2).unwrap();
+        assert_eq!(buffer.test_run_count(), 3);
+        assert_buffer_invariants(&buffer);
+        write_pooled(&mut buffer, &second_input);
+        assert_buffer_invariants(&buffer);
+        let second_rest = buffer.publish_prefix(carrier_size - 2);
+        assert_buffer_invariants(&buffer);
+        let frozen = buffer.freeze().into_contiguous();
+
+        let mut output = BytesMut::with_capacity(first_input.len() + second_input.len());
+        output.extend_from_slice(&first);
+        output.extend_from_slice(&second_prefix);
+        output.extend_from_slice(&second_rest);
+        output.extend_from_slice(&frozen);
+        let mut expected = first_input;
+        expected.extend_from_slice(&second_input);
+        assert_eq!(output, expected.as_slice());
+
+        assert_eq!(
+            pool.metrics().charged_capacity_bytes(),
+            (carrier_size * 3) as u64
+        );
+        drop(first);
+        assert_eq!(
+            pool.metrics().charged_capacity_bytes(),
+            (carrier_size * 2) as u64
+        );
+        drop(second_prefix);
+        assert_eq!(
+            pool.metrics().charged_capacity_bytes(),
+            (carrier_size * 2) as u64
+        );
+        drop(second_rest);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        drop(frozen);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_carrier_runs_spill_preserves_mutable_stream() {
+        let run_count = INLINE_CARRIER_RUNS + 1;
+        let (pool, carrier_size) = test_pool(1, run_count);
+        let input: Vec<u8> = (0..carrier_size * run_count)
+            .map(|index| (index.wrapping_mul(37) % 251) as u8)
+            .collect();
+        let mut buffer = pool.acquire_unreserved(input.len()).unwrap();
+
+        assert_eq!(buffer.test_run_count(), run_count);
+        assert!(buffer.runs.spilled());
+        assert_buffer_invariants(&buffer);
+        write_pooled(&mut buffer, &input);
+        assert_buffer_invariants(&buffer);
+
+        let frozen = buffer.freeze().into_contiguous();
+
+        assert_eq!(frozen, input);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_dropping_empty_mutable_buffer_returns_every_carrier() {
+        let (pool, carrier_size) = test_pool(1, 2);
+        let buffer = pool.acquire_unreserved(carrier_size * 2).unwrap();
+        assert_eq!(
+            pool.metrics().charged_capacity_bytes(),
+            (carrier_size * 2) as u64
+        );
+
+        drop(buffer);
+
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_reserve_overflow_preserves_existing_buffer() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let mut buffer = pool.acquire_unreserved(carrier_size).unwrap();
+        write_pooled(&mut buffer, b"existing");
+        let before = (buffer.capacity(), buffer.len(), buffer.remaining_mut());
+
+        assert_eq!(
+            buffer.reserve(usize::MAX),
+            Err(AcquireError::CapacityOverflow)
+        );
+
+        assert_eq!(
+            (buffer.capacity(), buffer.len(), buffer.remaining_mut()),
+            before
+        );
+        assert_eq!(buffer.initialized_chunk(), b"existing");
+        assert_buffer_invariants(&buffer);
+    }
+
+    #[test]
     fn test_publish_prefix_leaves_a_disjoint_mutable_suffix() {
         let (pool, carrier_size) = test_pool(1, 1);
         let mut buffer = pool.acquire_unreserved(carrier_size).unwrap();
@@ -1046,6 +1212,7 @@ mod tests {
         assert!(buffer.is_empty());
         assert_eq!(buffer.capacity(), 0);
         buffer.reserve(1).unwrap();
+        assert_buffer_invariants(&buffer);
         buffer.put_slice(b"next");
         let frozen = buffer.freeze();
 
@@ -1168,6 +1335,18 @@ mod tests {
                 assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
             }
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "publication cursor does not name initialized bytes")]
+    fn test_initialized_chunk_rejects_a_stale_publication_cursor() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let mut buffer = pool.acquire_unreserved(carrier_size + 1).unwrap();
+        write_pooled(&mut buffer, &vec![0x5a; carrier_size + 1]);
+        let _first = buffer.publish_prefix(carrier_size);
+        buffer.publish_cursor = BufferCursor::START;
+
+        let _ = buffer.initialized_chunk();
     }
 
     #[test]

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/pooled_buf.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/pooled_buf.rs
@@ -1,0 +1,1090 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Growable mutable buffers backed by exclusively owned pool carriers.
+//!
+//! Acquisition installs accounting and returns one guard per carrier. This
+//! module arranges those guards in logical write order, tracks initialization,
+//! and transfers initialized prefixes into immutable owners without moving
+//! bytes.
+
+use std::mem::MaybeUninit;
+use std::ptr::NonNull;
+
+use bytes::buf::UninitSlice;
+use bytes::{BufMut, Bytes};
+use smallvec::SmallVec;
+
+use super::acquisition::{acquire_count, allocation_failure_injected, AcquireError, CarrierGuard};
+use super::admission::ReservationState;
+use super::geometry::GeometryError;
+use super::segmented_bytes::SegmentedBytesBuilder;
+use super::{invariant_violation, CarrierCount, PoolInner, SegmentedBytes};
+use crate::runtime::sync::sync::Arc;
+
+/// Carrier runs stored inline before metadata spills to the heap.
+const INLINE_CARRIER_RUNS: usize = 4;
+
+/// Contiguous physical runs in logical byte order.
+type CarrierRuns = SmallVec<[CarrierRun; INLINE_CARRIER_RUNS]>;
+
+/// One growable mutable allocation stream.
+pub(crate) struct PooledBufMut {
+    /// Selects reserved or unreserved acquisition for every later growth.
+    growth: GrowthAuthority,
+    /// Preserves logical byte order across physical runs.
+    runs: CarrierRuns,
+    /// First carrier with uninitialized writable capacity.
+    write_cursor: BufferCursor,
+    /// First carrier with initialized unpublished bytes.
+    publish_cursor: BufferCursor,
+    /// Initialized bytes awaiting publication.
+    initialized: usize,
+    /// Initialized bytes plus uninitialized writable capacity.
+    retained_capacity: usize,
+}
+
+impl PooledBufMut {
+    /// Builds a mutable stream from one complete carrier acquisition.
+    pub(super) fn try_new(
+        growth: GrowthAuthority,
+        guards: Vec<Arc<CarrierGuard>>,
+    ) -> Result<Self, AcquireError> {
+        let (runs, retained_capacity) = build_runs(growth.pool(), guards)?;
+        let mut buffer = Self {
+            growth,
+            runs,
+            write_cursor: BufferCursor::START,
+            publish_cursor: BufferCursor::START,
+            initialized: 0,
+            retained_capacity,
+        };
+        buffer.reset_cursors();
+        Ok(buffer)
+    }
+
+    /// Returns initialized and writable bytes retained by this buffer.
+    pub(crate) fn capacity(&self) -> usize {
+        self.retained_capacity
+    }
+
+    /// Returns initialized bytes that have not been published.
+    pub(crate) fn len(&self) -> usize {
+        self.initialized
+    }
+
+    /// Returns whether no initialized unpublished bytes remain.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.initialized == 0
+    }
+
+    /// Returns the number of grouped runs for acquisition tests.
+    #[cfg(test)]
+    pub(super) fn test_run_count(&self) -> usize {
+        self.runs.len()
+    }
+
+    /// Returns one grouped run's complete carrier capacity.
+    #[cfg(test)]
+    pub(super) fn test_run_capacity(&self, index: usize) -> usize {
+        self.runs[index]
+            .carriers
+            .iter()
+            .map(|carrier| carrier.writable.len())
+            .sum()
+    }
+
+    /// Returns the next contiguous initialized prefix.
+    ///
+    /// The result is empty exactly when [`Self::len`] is zero. A nonempty
+    /// result never crosses a carrier boundary.
+    pub(crate) fn initialized_chunk(&self) -> &[u8] {
+        if self.initialized == 0 {
+            return &[];
+        }
+        let carrier = self
+            .carrier(self.publish_cursor)
+            .filter(|carrier| carrier.initialized != 0)
+            .or_else(|| self.first_carrier_matching(|carrier| carrier.initialized != 0))
+            .unwrap_or_else(|| {
+                invariant_violation("initialized buffer has no publication carrier")
+            });
+
+        // SAFETY: `initialized` is the prefix written through this buffer's
+        // exclusive range. The carrier guard keeps the mapping prepared.
+        unsafe {
+            std::slice::from_raw_parts(
+                carrier.writable.ptr().as_ptr().cast::<u8>(),
+                carrier.initialized,
+            )
+        }
+    }
+
+    /// Ensures that at least `min_writable` uninitialized bytes remain.
+    ///
+    /// Existing tail capacity is consumed before the shortfall is rounded to
+    /// complete carriers. Failure leaves this buffer unchanged.
+    pub(crate) fn reserve(&mut self, min_writable: usize) -> Result<(), AcquireError> {
+        let remaining = self.remaining_mut();
+        if min_writable <= remaining {
+            return Ok(());
+        }
+
+        let shortfall = min_writable
+            .checked_sub(remaining)
+            .ok_or(AcquireError::CapacityOverflow)?;
+        let count = self
+            .growth
+            .pool()
+            .geometry
+            .carriers_for_bytes(shortfall)
+            .map_err(map_geometry_error)?;
+        let guards = self.growth.acquire(count)?;
+        let (staged, added_capacity) = build_runs(self.growth.pool(), guards)?;
+        self.append_staged(staged, added_capacity)?;
+        Ok(())
+    }
+
+    /// Publishes one contiguous initialized prefix without copying.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless `count` is nonzero and no larger than
+    /// `initialized_chunk().len()`.
+    pub(crate) fn publish_prefix(&mut self, count: usize) -> Bytes {
+        self.normalize_publish_cursor();
+        let available = self.initialized_chunk().len();
+        assert!(
+            count != 0 && count <= available,
+            "published prefix must be nonzero and within initialized_chunk"
+        );
+
+        let cursor = self.publish_cursor;
+        let (range, guard) =
+            {
+                let carrier = self.carrier_mut(cursor).unwrap_or_else(|| {
+                    invariant_violation("publication cursor is outside the buffer")
+                });
+                let range = carrier.writable.take_prefix(count);
+                carrier.initialized = carrier.initialized.checked_sub(count).unwrap_or_else(|| {
+                    invariant_violation("publication exceeds initialized bytes")
+                });
+                let guard =
+                    if carrier.writable.is_empty() {
+                        carrier.guard.take().unwrap_or_else(|| {
+                            invariant_violation("exhausted writable carrier lost its guard")
+                        })
+                    } else {
+                        Arc::clone(carrier.guard.as_ref().unwrap_or_else(|| {
+                            invariant_violation("writable carrier lost its guard")
+                        }))
+                    };
+                (range, guard)
+            };
+
+        self.initialized = self
+            .initialized
+            .checked_sub(count)
+            .unwrap_or_else(|| invariant_violation("buffer initialization underflow"));
+        self.retained_capacity = self
+            .retained_capacity
+            .checked_sub(count)
+            .unwrap_or_else(|| invariant_violation("buffer capacity underflow"));
+        self.normalize_publish_cursor();
+
+        Bytes::from_owner(PooledWindow::new(guard, range))
+    }
+
+    /// Ends growth and transfers initialized unpublished ranges.
+    ///
+    /// Wholly unused carriers return immediately. An initialized prefix in a
+    /// partially used carrier retains that carrier and discards its writable
+    /// suffix.
+    pub(crate) fn freeze(self) -> SegmentedBytes {
+        let pool = Arc::clone(self.growth.pool());
+        let Self { runs, .. } = self;
+        let mut builder = SegmentedBytesBuilder::for_pool(pool);
+
+        for run in runs {
+            for mut carrier in run.carriers {
+                if carrier.initialized == 0 {
+                    continue;
+                }
+                let initialized = carrier.initialized;
+                let range = carrier.writable.take_prefix(initialized);
+                carrier.initialized = 0;
+                let guard = carrier
+                    .guard
+                    .take()
+                    .unwrap_or_else(|| invariant_violation("initialized carrier lost its guard"));
+                builder.push_pooled(range.ptr.cast::<u8>(), range.len, guard);
+            }
+        }
+
+        builder.finish()
+    }
+
+    /// Appends one fully staged growth transaction.
+    fn append_staged(
+        &mut self,
+        mut staged: CarrierRuns,
+        added_capacity: usize,
+    ) -> Result<(), AcquireError> {
+        let retained_capacity = self
+            .retained_capacity
+            .checked_add(added_capacity)
+            .ok_or(AcquireError::CapacityOverflow)?;
+        if staged.is_empty() {
+            invariant_violation("successful growth produced no carrier runs");
+        }
+
+        let merge_first = self
+            .runs
+            .last()
+            .zip(staged.first())
+            .is_some_and(|(current, incoming)| current.can_append_run(incoming));
+        let appended_runs = staged.len() - usize::from(merge_first);
+
+        if allocation_failure_injected(self.growth.pool()) {
+            return Err(AcquireError::PhysicalAllocationFailed);
+        }
+        self.runs
+            .try_reserve(appended_runs)
+            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+
+        if merge_first {
+            let incoming = staged.remove(0);
+            let current = self
+                .runs
+                .last_mut()
+                .unwrap_or_else(|| invariant_violation("merge target disappeared"));
+            if allocation_failure_injected(self.growth.pool()) {
+                return Err(AcquireError::PhysicalAllocationFailed);
+            }
+            current
+                .carriers
+                .try_reserve(incoming.carriers.len())
+                .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+            current.carriers.extend(incoming.carriers);
+        }
+        self.runs.extend(staged);
+        self.retained_capacity = retained_capacity;
+        self.reset_write_cursor();
+        Ok(())
+    }
+
+    /// Finds both cursors after initial construction.
+    fn reset_cursors(&mut self) {
+        self.reset_write_cursor();
+        self.publish_cursor = self
+            .first_cursor_matching(|carrier| carrier.initialized != 0)
+            .unwrap_or_else(|| BufferCursor::end(self.runs.len()));
+    }
+
+    /// Finds the first writable carrier after run topology changes.
+    fn reset_write_cursor(&mut self) {
+        self.write_cursor = self
+            .first_cursor_matching(|carrier| carrier.remaining_mut() != 0)
+            .unwrap_or_else(|| BufferCursor::end(self.runs.len()));
+    }
+
+    /// Advances the write cursor past exhausted carrier entries.
+    fn normalize_write_cursor(&mut self) {
+        self.write_cursor = self
+            .cursor_matching_from(self.write_cursor, |carrier| carrier.remaining_mut() != 0)
+            .unwrap_or_else(|| BufferCursor::end(self.runs.len()));
+    }
+
+    /// Advances the publication cursor past entries with no initialized bytes.
+    fn normalize_publish_cursor(&mut self) {
+        self.publish_cursor = self
+            .cursor_matching_from(self.publish_cursor, |carrier| carrier.initialized != 0)
+            .unwrap_or_else(|| BufferCursor::end(self.runs.len()));
+    }
+
+    /// Returns the first carrier satisfying `predicate`.
+    fn first_carrier_matching(
+        &self,
+        predicate: impl Fn(&WritableCarrier) -> bool,
+    ) -> Option<&WritableCarrier> {
+        self.runs
+            .iter()
+            .flat_map(|run| run.carriers.iter())
+            .find(|carrier| predicate(carrier))
+    }
+
+    /// Returns the first carrier cursor satisfying `predicate`.
+    fn first_cursor_matching(
+        &self,
+        predicate: impl Fn(&WritableCarrier) -> bool,
+    ) -> Option<BufferCursor> {
+        for (run, entry) in self.runs.iter().enumerate() {
+            for (carrier, value) in entry.carriers.iter().enumerate() {
+                if predicate(value) {
+                    return Some(BufferCursor { run, carrier });
+                }
+            }
+        }
+        None
+    }
+
+    /// Returns the next carrier at or after `cursor` satisfying `predicate`.
+    fn cursor_matching_from(
+        &self,
+        mut cursor: BufferCursor,
+        predicate: impl Fn(&WritableCarrier) -> bool,
+    ) -> Option<BufferCursor> {
+        loop {
+            let carrier = self.carrier(cursor)?;
+            if predicate(carrier) {
+                return Some(cursor);
+            }
+            cursor = self.next_cursor(cursor)?;
+        }
+    }
+
+    /// Returns the carrier after `cursor`.
+    fn next_cursor(&self, cursor: BufferCursor) -> Option<BufferCursor> {
+        let run = self.runs.get(cursor.run)?;
+        let carrier = cursor.carrier.checked_add(1)?;
+        if carrier < run.carriers.len() {
+            return Some(BufferCursor {
+                run: cursor.run,
+                carrier,
+            });
+        }
+        let run = cursor.run.checked_add(1)?;
+        (run < self.runs.len()).then_some(BufferCursor { run, carrier: 0 })
+    }
+
+    /// Returns the carrier at `cursor`.
+    fn carrier(&self, cursor: BufferCursor) -> Option<&WritableCarrier> {
+        self.runs
+            .get(cursor.run)
+            .and_then(|run| run.carriers.get(cursor.carrier))
+    }
+
+    /// Returns the mutable carrier at `cursor`.
+    fn carrier_mut(&mut self, cursor: BufferCursor) -> Option<&mut WritableCarrier> {
+        self.runs
+            .get_mut(cursor.run)
+            .and_then(|run| run.carriers.get_mut(cursor.carrier))
+    }
+
+    /// Marks `count` sequential writable bytes initialized.
+    fn advance_initialized(&mut self, mut count: usize) {
+        assert!(
+            count <= self.remaining_mut(),
+            "advanced beyond pooled writable capacity"
+        );
+        if count == 0 {
+            return;
+        }
+
+        self.normalize_write_cursor();
+        while count != 0 {
+            let cursor = self.write_cursor;
+            let publish_was_empty = self.initialized == 0;
+            let (advanced, exhausted) = {
+                let carrier = self.carrier_mut(cursor).unwrap_or_else(|| {
+                    invariant_violation("writable cursor is outside the buffer")
+                });
+                let advanced = count.min(carrier.remaining_mut());
+                if advanced == 0 {
+                    invariant_violation("writable cursor names an exhausted carrier");
+                }
+                carrier.initialized = carrier
+                    .initialized
+                    .checked_add(advanced)
+                    .unwrap_or_else(|| invariant_violation("carrier initialization overflow"));
+                (advanced, carrier.remaining_mut() == 0)
+            };
+            if publish_was_empty {
+                self.publish_cursor = cursor;
+            }
+            self.initialized = self
+                .initialized
+                .checked_add(advanced)
+                .unwrap_or_else(|| invariant_violation("buffer initialization overflow"));
+            count -= advanced;
+            if exhausted {
+                self.write_cursor = self
+                    .next_cursor(cursor)
+                    .unwrap_or_else(|| BufferCursor::end(self.runs.len()));
+                self.normalize_write_cursor();
+            }
+        }
+    }
+}
+
+// SAFETY: moving the buffer transfers every unique `ExclusiveRange`.
+// Carrier and growth state is retained through synchronized shared ownership.
+unsafe impl Send for PooledBufMut {}
+
+// SAFETY: each `ExclusiveRange` is unique to this buffer, every pointer is
+// retained by its carrier guard, and `advance_mut` exposes only initialized
+// state transitions made by the caller.
+unsafe impl BufMut for PooledBufMut {
+    fn remaining_mut(&self) -> usize {
+        self.retained_capacity
+            .checked_sub(self.initialized)
+            .unwrap_or_else(|| invariant_violation("initialized bytes exceed retained capacity"))
+    }
+
+    fn chunk_mut(&mut self) -> &mut UninitSlice {
+        self.normalize_write_cursor();
+        if self.remaining_mut() == 0 {
+            // SAFETY: a dangling pointer is valid for a zero-length slice and
+            // the returned borrow remains tied to `self`.
+            return unsafe {
+                UninitSlice::from_raw_parts_mut(NonNull::<u8>::dangling().as_ptr(), 0)
+            };
+        }
+        let cursor = self.write_cursor;
+        let carrier = self
+            .carrier_mut(cursor)
+            .unwrap_or_else(|| invariant_violation("buffer has no writable carrier"));
+        let remaining = carrier.remaining_mut();
+        if remaining == 0 {
+            invariant_violation("writable cursor names an exhausted carrier");
+        }
+        // SAFETY: the returned range is the uninitialized suffix of one
+        // exclusive carrier range and remains borrowed through `self`.
+        unsafe {
+            UninitSlice::from_raw_parts_mut(
+                carrier
+                    .writable
+                    .ptr()
+                    .as_ptr()
+                    .add(carrier.initialized)
+                    .cast::<u8>(),
+                remaining,
+            )
+        }
+    }
+
+    unsafe fn advance_mut(&mut self, count: usize) {
+        self.advance_initialized(count);
+    }
+}
+
+/// Authority retained for every later growth of one buffer.
+pub(super) enum GrowthAuthority {
+    /// New carriers must debit this reservation.
+    Reserved(Arc<ReservationState>),
+    /// New carriers use aggregate pool authority only.
+    Unreserved(Arc<PoolInner>),
+}
+
+impl GrowthAuthority {
+    /// Creates reserved growth authority.
+    pub(super) fn reserved(state: Arc<ReservationState>) -> Self {
+        Self::Reserved(state)
+    }
+
+    /// Creates unreserved growth authority.
+    pub(super) fn unreserved(pool: Arc<PoolInner>) -> Self {
+        Self::Unreserved(pool)
+    }
+
+    /// Returns the shared pool.
+    fn pool(&self) -> &Arc<PoolInner> {
+        match self {
+            Self::Reserved(state) => state.pool(),
+            Self::Unreserved(pool) => pool,
+        }
+    }
+
+    /// Acquires one complete carrier-rounded growth batch.
+    fn acquire(&self, count: CarrierCount) -> Result<Vec<Arc<CarrierGuard>>, AcquireError> {
+        match self {
+            Self::Reserved(state) => acquire_count(state.pool(), Some(Arc::clone(state)), count),
+            Self::Unreserved(pool) => acquire_count(pool, None, count),
+        }
+    }
+}
+
+/// Adjacent carriers within one stable block slot.
+struct CarrierRun {
+    /// Stable block slot containing the run.
+    slot_id: u32,
+    /// First carrier index within the slot.
+    first_carrier: u32,
+    /// Per-carrier mutable ownership in ascending address order.
+    carriers: Vec<WritableCarrier>,
+}
+
+impl CarrierRun {
+    /// Creates a run containing one carrier.
+    fn try_new(pool: &PoolInner, guard: Arc<CarrierGuard>) -> Result<Self, AcquireError> {
+        let (slot_id, first_carrier) = guard.identity();
+        let mut carriers = Vec::new();
+        if allocation_failure_injected(pool) {
+            return Err(AcquireError::PhysicalAllocationFailed);
+        }
+        carriers
+            .try_reserve_exact(1)
+            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+        carriers.push(WritableCarrier::new(guard));
+        Ok(Self {
+            slot_id,
+            first_carrier,
+            carriers,
+        })
+    }
+
+    /// Returns whether `guard` immediately follows this run.
+    fn can_append(&self, guard: &CarrierGuard) -> bool {
+        let run_len = u32::try_from(self.carriers.len())
+            .unwrap_or_else(|_| invariant_violation("carrier run length exceeds block geometry"));
+        let next = self
+            .first_carrier
+            .checked_add(run_len)
+            .unwrap_or_else(|| invariant_violation("carrier run end exceeds block geometry"));
+        guard.identity() == (self.slot_id, next)
+    }
+
+    /// Returns whether `incoming` immediately follows this run.
+    fn can_append_run(&self, incoming: &Self) -> bool {
+        let run_len = u32::try_from(self.carriers.len())
+            .unwrap_or_else(|_| invariant_violation("carrier run length exceeds block geometry"));
+        self.slot_id == incoming.slot_id
+            && self.first_carrier.checked_add(run_len) == Some(incoming.first_carrier)
+    }
+
+    /// Appends one adjacent carrier.
+    fn try_append(
+        &mut self,
+        pool: &PoolInner,
+        guard: Arc<CarrierGuard>,
+    ) -> Result<(), AcquireError> {
+        if allocation_failure_injected(pool) {
+            return Err(AcquireError::PhysicalAllocationFailed);
+        }
+        self.carriers
+            .try_reserve(1)
+            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+        self.carriers.push(WritableCarrier::new(guard));
+        Ok(())
+    }
+}
+
+/// Unique mutable authority over one carrier's unpublished suffix.
+struct WritableCarrier {
+    /// Shared physical and accounting ownership while a range remains.
+    guard: Option<Arc<CarrierGuard>>,
+    /// Initialized prefix followed by uninitialized writable capacity.
+    writable: ExclusiveRange,
+    /// Initialized prefix length within `writable`.
+    initialized: usize,
+}
+
+impl WritableCarrier {
+    /// Creates a wholly uninitialized writable carrier.
+    fn new(guard: Arc<CarrierGuard>) -> Self {
+        let writable = ExclusiveRange::new(guard.ptr(), guard.capacity());
+        Self {
+            guard: Some(guard),
+            writable,
+            initialized: 0,
+        }
+    }
+
+    /// Returns uninitialized writable bytes.
+    fn remaining_mut(&self) -> usize {
+        self.writable
+            .len()
+            .checked_sub(self.initialized)
+            .unwrap_or_else(|| invariant_violation("carrier initialization exceeds its range"))
+    }
+}
+
+/// Non-cloneable authority over one mutable byte range.
+///
+/// Construction requires a nonempty range. Prefix transfer may later consume
+/// the complete range while its metadata entry remains positionally stable.
+struct ExclusiveRange {
+    ptr: NonNull<MaybeUninit<u8>>,
+    len: usize,
+}
+
+impl ExclusiveRange {
+    /// Creates authority over one complete carrier.
+    fn new(ptr: NonNull<MaybeUninit<u8>>, len: usize) -> Self {
+        if len == 0 {
+            invariant_violation("exclusive range must be nonempty");
+        }
+        Self { ptr, len }
+    }
+
+    /// Returns the first byte.
+    fn ptr(&self) -> NonNull<MaybeUninit<u8>> {
+        self.ptr
+    }
+
+    /// Returns the range length.
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns whether prefix transfer consumed the complete range.
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Removes and returns one prefix, leaving a disjoint suffix.
+    fn take_prefix(&mut self, count: usize) -> Self {
+        assert!(count <= self.len, "split exceeds exclusive range");
+        let prefix = Self {
+            ptr: self.ptr,
+            len: count,
+        };
+        // SAFETY: `count` lies within this range. The resulting pointer is
+        // either within the same allocation or one byte past its end.
+        self.ptr = unsafe { NonNull::new_unchecked(self.ptr.as_ptr().add(count)) };
+        self.len -= count;
+        prefix
+    }
+}
+
+/// Run and carrier position inside one mutable buffer.
+#[derive(Clone, Copy)]
+struct BufferCursor {
+    run: usize,
+    carrier: usize,
+}
+
+impl BufferCursor {
+    const START: Self = Self { run: 0, carrier: 0 };
+
+    /// Creates a sentinel past the final run.
+    fn end(run: usize) -> Self {
+        Self { run, carrier: 0 }
+    }
+}
+
+/// Immutable initialized view retained by one carrier guard.
+struct PooledWindow {
+    guard: Arc<CarrierGuard>,
+    ptr: NonNull<u8>,
+    len: usize,
+}
+
+impl PooledWindow {
+    /// Consumes one exclusive initialized range.
+    fn new(guard: Arc<CarrierGuard>, range: ExclusiveRange) -> Self {
+        Self {
+            guard,
+            ptr: range.ptr.cast::<u8>(),
+            len: range.len,
+        }
+    }
+}
+
+impl AsRef<[u8]> for PooledWindow {
+    fn as_ref(&self) -> &[u8] {
+        let _guard = &self.guard;
+        // SAFETY: publication consumed mutable authority over this initialized
+        // range, and `guard` retains the prepared carrier.
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+// SAFETY: the pointer names immutable initialized storage retained by `guard`.
+unsafe impl Send for PooledWindow {}
+
+/// Groups one acquisition into adjacent physical runs.
+fn build_runs(
+    pool: &PoolInner,
+    mut guards: Vec<Arc<CarrierGuard>>,
+) -> Result<(CarrierRuns, usize), AcquireError> {
+    if guards.is_empty() {
+        invariant_violation("complete acquisition contains no carriers");
+    }
+    guards.sort_unstable_by_key(|guard| guard.identity());
+
+    let mut runs = CarrierRuns::new();
+    let mut capacity = 0usize;
+    for guard in guards {
+        capacity = capacity
+            .checked_add(guard.capacity())
+            .ok_or(AcquireError::CapacityOverflow)?;
+        if let Some(run) = runs.last_mut() {
+            if run.can_append(&guard) {
+                run.try_append(pool, guard)?;
+                continue;
+            }
+        }
+        if allocation_failure_injected(pool) {
+            return Err(AcquireError::PhysicalAllocationFailed);
+        }
+        runs.try_reserve(1)
+            .map_err(|_| AcquireError::PhysicalAllocationFailed)?;
+        runs.push(CarrierRun::try_new(pool, guard)?);
+    }
+    Ok((runs, capacity))
+}
+
+/// Maps byte geometry failures into the acquisition API.
+fn map_geometry_error(error: GeometryError) -> AcquireError {
+    match error {
+        GeometryError::ZeroByteRequest => AcquireError::InvalidSize,
+        _ => AcquireError::CapacityOverflow,
+    }
+}
+
+#[cfg(all(test, not(s3_tm_loom)))]
+mod tests {
+    use bytes::{Buf, BufMut, BytesMut};
+
+    use super::super::test_util::{test_pool, write_pooled};
+    use super::*;
+
+    #[test]
+    fn test_mutable_initialization_crosses_carrier_boundaries() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let mut buffer = pool.acquire_unreserved(carrier_size + 1).unwrap();
+        let input: Vec<u8> = (0..carrier_size + 1)
+            .map(|index| (index % 251) as u8)
+            .collect();
+
+        write_pooled(&mut buffer, &input);
+
+        assert_eq!(buffer.capacity(), carrier_size * 2);
+        assert_eq!(buffer.len(), input.len());
+        assert_eq!(buffer.remaining_mut(), carrier_size - 1);
+        assert_eq!(buffer.initialized_chunk(), &input[..carrier_size]);
+        assert_eq!(buffer.chunk_mut().len(), carrier_size - 1);
+    }
+
+    #[test]
+    fn test_incremental_growth_reuses_one_buffers_writable_tail() {
+        let (pool, carrier_size) = test_pool(4, 3);
+        let total = carrier_size * 2 + 1;
+        let reservation = pool
+            .try_reserve(total)
+            .unwrap()
+            .expect("three-carrier reservation");
+        let mut buffer = pool.acquire(&reservation, 1).unwrap();
+        let increments = [
+            carrier_size / 2,
+            carrier_size / 2,
+            carrier_size / 2,
+            carrier_size / 2 + 1,
+        ];
+
+        let mut next = 0u8;
+        for increment in increments {
+            buffer.reserve(increment).unwrap();
+            let bytes: Vec<u8> = (0..increment)
+                .map(|_| {
+                    let value = next;
+                    next = next.wrapping_add(1);
+                    value
+                })
+                .collect();
+            write_pooled(&mut buffer, &bytes);
+        }
+
+        assert_eq!(buffer.len(), total);
+        assert_eq!(buffer.capacity(), carrier_size * 3);
+        assert_eq!(buffer.remaining_mut(), carrier_size - 1);
+        assert_eq!(buffer.test_run_count(), 1);
+    }
+
+    #[test]
+    fn test_reserve_zero_and_satisfied_tail_do_not_acquire() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let reservation = pool
+            .try_reserve(carrier_size * 2)
+            .unwrap()
+            .expect("reservation");
+        let mut buffer = pool.acquire(&reservation, 1).unwrap();
+        write_pooled(&mut buffer, b"tail");
+        let capacity = buffer.capacity();
+        let metrics = pool.metrics();
+
+        buffer.reserve(0).unwrap();
+        buffer.reserve(buffer.remaining_mut()).unwrap();
+
+        assert_eq!(buffer.capacity(), capacity);
+        assert_eq!(
+            pool.metrics().charged_capacity_bytes(),
+            metrics.charged_capacity_bytes()
+        );
+    }
+
+    #[test]
+    fn test_closed_reservation_allows_tail_use_but_rejects_growth() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let reservation = pool
+            .try_reserve(carrier_size * 2)
+            .unwrap()
+            .expect("reservation");
+        let mut buffer = pool.acquire(&reservation, 1).unwrap();
+        reservation.close_acquisition();
+
+        buffer.reserve(carrier_size).unwrap();
+        let before = (buffer.capacity(), buffer.len(), buffer.remaining_mut());
+        assert_eq!(
+            buffer.reserve(carrier_size + 1),
+            Err(AcquireError::ReservationClosed)
+        );
+        assert_eq!(
+            (buffer.capacity(), buffer.len(), buffer.remaining_mut()),
+            before
+        );
+    }
+
+    #[test]
+    fn test_reservation_exhaustion_preserves_existing_buffer() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let reservation = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("reservation");
+        let mut buffer = pool.acquire(&reservation, 1).unwrap();
+        let input = vec![0x5a; carrier_size];
+        write_pooled(&mut buffer, &input);
+        let before = (buffer.capacity(), buffer.len(), buffer.remaining_mut());
+
+        assert_eq!(
+            buffer.reserve(1),
+            Err(AcquireError::ReservationCapacityExceeded)
+        );
+        assert_eq!(
+            (buffer.capacity(), buffer.len(), buffer.remaining_mut()),
+            before
+        );
+        assert_eq!(buffer.initialized_chunk(), input.as_slice());
+    }
+
+    #[test]
+    fn test_growth_metadata_failure_preserves_bytes_cursors_and_authority() {
+        for boundary in 1.. {
+            let (pool, carrier_size) = test_pool(2, 2);
+            let reservation = pool
+                .try_reserve(carrier_size * 2)
+                .unwrap()
+                .expect("reservation");
+            let mut buffer = pool.acquire(&reservation, 1).unwrap();
+            write_pooled(&mut buffer, b"abc");
+            pool.inject_acquisition_allocation_failure(boundary);
+
+            let result = buffer.reserve(carrier_size);
+            if pool.acquisition_allocation_failure_pending() {
+                assert!(result.is_ok(), "boundary {boundary} was not reached");
+                break;
+            }
+            assert_eq!(result, Err(AcquireError::PhysicalAllocationFailed));
+            assert_eq!(buffer.capacity(), carrier_size);
+            assert_eq!(buffer.len(), 3);
+            assert_eq!(buffer.remaining_mut(), carrier_size - 3);
+            assert_eq!(buffer.initialized_chunk(), b"abc");
+            assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+
+            buffer
+                .reserve(carrier_size)
+                .expect("rollback restored direct authority");
+            assert_eq!(buffer.capacity(), carrier_size * 2);
+        }
+    }
+
+    #[test]
+    fn test_exhausted_buffer_returns_empty_mutable_chunk() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let mut buffer = pool.acquire_unreserved(carrier_size).unwrap();
+        write_pooled(&mut buffer, &vec![0; carrier_size]);
+
+        assert_eq!(buffer.remaining_mut(), 0);
+        assert_eq!(buffer.chunk_mut().len(), 0);
+    }
+
+    #[test]
+    fn test_rounding_is_per_buffer_instead_of_per_growth_call() {
+        let (stream_pool, carrier_size) = test_pool(2, 2);
+        let increment = carrier_size / 2 + 1;
+        let total = increment * 3;
+        assert!(total <= carrier_size * 2);
+        let stream_reservation = stream_pool
+            .try_reserve(total)
+            .unwrap()
+            .expect("two-carrier stream reservation");
+        let mut stream = stream_pool.acquire(&stream_reservation, increment).unwrap();
+        write_pooled(&mut stream, &vec![0; increment]);
+        for _ in 0..2 {
+            stream.reserve(increment).unwrap();
+            write_pooled(&mut stream, &vec![0; increment]);
+        }
+        assert_eq!(stream.capacity(), carrier_size * 2);
+
+        let (split_pool, _) = test_pool(2, 2);
+        let split_reservation = split_pool
+            .try_reserve(total)
+            .unwrap()
+            .expect("two-carrier split reservation");
+        let first = split_pool.acquire(&split_reservation, increment).unwrap();
+        let second = split_pool.acquire(&split_reservation, increment).unwrap();
+        assert!(matches!(
+            split_pool.acquire(&split_reservation, increment),
+            Err(AcquireError::ReservationCapacityExceeded)
+        ));
+        drop((first, second));
+    }
+
+    #[test]
+    fn test_publish_prefix_leaves_a_disjoint_mutable_suffix() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let mut buffer = pool.acquire_unreserved(carrier_size).unwrap();
+        write_pooled(&mut buffer, b"abcdef");
+
+        let first = buffer.publish_prefix(3);
+        assert_eq!(first, b"abc"[..]);
+        assert_eq!(buffer.len(), 3);
+        assert_eq!(buffer.capacity(), carrier_size - 3);
+        assert_eq!(buffer.initialized_chunk(), b"def");
+
+        write_pooled(&mut buffer, b"XYZ");
+        assert_eq!(first, b"abc"[..]);
+        assert_eq!(buffer.initialized_chunk(), b"defXYZ");
+        let second = buffer.publish_prefix(6);
+        assert_eq!(second, b"defXYZ"[..]);
+    }
+
+    #[test]
+    fn test_publication_stops_at_each_carrier_boundary() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let mut buffer = pool.acquire_unreserved(carrier_size + 3).unwrap();
+        let input: Vec<u8> = (0..carrier_size + 3)
+            .map(|index| (index % 251) as u8)
+            .collect();
+        write_pooled(&mut buffer, &input);
+
+        assert_eq!(buffer.initialized_chunk().len(), carrier_size);
+        let first = buffer.publish_prefix(carrier_size);
+        assert_eq!(first, input[..carrier_size]);
+        assert_eq!(buffer.initialized_chunk(), &input[carrier_size..]);
+        assert_eq!(buffer.capacity(), carrier_size);
+        assert_eq!(
+            pool.metrics().charged_capacity_bytes(),
+            (carrier_size * 2) as u64
+        );
+
+        drop(first);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        let second = buffer.publish_prefix(3);
+        drop(buffer);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        drop(second);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_published_clones_and_slices_share_one_carrier_return() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let mut buffer = pool.acquire_unreserved(carrier_size).unwrap();
+        write_pooled(&mut buffer, b"immutable");
+        let published = buffer.publish_prefix(9);
+        let clone = published.clone();
+        let slice = published.slice(2..7);
+        drop(buffer);
+
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        drop(published);
+        drop(clone);
+        assert_eq!(slice, b"mutab"[..]);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        drop(slice);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_published_owner_holds_direct_authority_until_final_drop() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let reservation = pool
+            .try_reserve(carrier_size * 2)
+            .unwrap()
+            .expect("reservation");
+        let mut buffer = pool.acquire(&reservation, carrier_size).unwrap();
+        write_pooled(&mut buffer, &vec![0x11; carrier_size]);
+        let published = buffer.publish_prefix(carrier_size);
+
+        buffer.reserve(1).unwrap();
+        write_pooled(&mut buffer, &vec![0x22; carrier_size]);
+        assert_eq!(
+            buffer.reserve(1),
+            Err(AcquireError::ReservationCapacityExceeded)
+        );
+
+        drop(published);
+        buffer
+            .reserve(1)
+            .expect("final immutable drop restored direct authority");
+    }
+
+    #[test]
+    fn test_publication_and_freeze_preserve_bytes_across_representative_lengths() {
+        for carriers in 1..=3 {
+            let (pool, carrier_size) = test_pool(3, 3);
+            let lengths = [
+                1,
+                carrier_size - 1,
+                carrier_size,
+                carrier_size + 1,
+                carrier_size * carriers - 1,
+            ];
+            for length in lengths {
+                if length == 0 || length > carrier_size * 3 {
+                    continue;
+                }
+                let input: Vec<u8> = (0..length)
+                    .map(|index| (index.wrapping_mul(17) % 251) as u8)
+                    .collect();
+                let mut buffer = pool.acquire_unreserved(length).unwrap();
+                write_pooled(&mut buffer, &input);
+                let publish_target = length / 2;
+                let mut published = 0;
+                let mut views = Vec::new();
+                while published < publish_target {
+                    let count = (publish_target - published)
+                        .min(buffer.initialized_chunk().len())
+                        .min(97);
+                    views.push(buffer.publish_prefix(count));
+                    published += count;
+                }
+                let mut frozen = buffer.freeze();
+                let mut output = BytesMut::with_capacity(length);
+                for view in views {
+                    output.extend_from_slice(&view);
+                }
+                while frozen.has_remaining() {
+                    let count = frozen.chunk().len();
+                    output.extend_from_slice(frozen.chunk());
+                    frozen.advance(count);
+                }
+                assert_eq!(output.as_ref(), input.as_slice(), "length {length}");
+                assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "published prefix must be nonzero")]
+    fn test_publish_prefix_rejects_zero() {
+        let (pool, _) = test_pool(1, 1);
+        let mut buffer = pool.acquire_unreserved(1).unwrap();
+        write_pooled(&mut buffer, b"x");
+        let _ = buffer.publish_prefix(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "published prefix must be nonzero")]
+    fn test_publish_prefix_rejects_cross_carrier_count() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let mut buffer = pool.acquire_unreserved(carrier_size + 1).unwrap();
+        write_pooled(&mut buffer, &vec![0; carrier_size + 1]);
+        let _ = buffer.publish_prefix(carrier_size + 1);
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/segmented_bytes.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/segmented_bytes.rs
@@ -262,7 +262,7 @@ struct Segment {
 }
 
 impl Segment {
-    /// Removes an already consumed prefix and rebases owner boundaries.
+    /// Removes a consumed prefix after its crossed owners were released.
     fn trim_prefix(mut self, count: usize) -> Self {
         assert!(count <= self.len, "trim exceeds segment");
         if count == 0 {
@@ -272,14 +272,17 @@ impl Segment {
             invariant_violation("complete segment must be removed instead of trimmed");
         }
 
-        while self.owners.front().is_some_and(|owner| owner.end <= count) {
-            self.owners.pop_front();
-        }
         if self.owners.is_empty() {
             invariant_violation("remaining segment has no owner");
         }
+        if self.owners.front().is_some_and(|owner| owner.end <= count) {
+            invariant_violation("trimmed segment retained a consumed owner");
+        }
         for owner in &mut self.owners {
-            owner.end -= count;
+            owner.end = owner
+                .end
+                .checked_sub(count)
+                .unwrap_or_else(|| invariant_violation("trim exceeds an owner boundary"));
         }
         // SAFETY: `count` is within the segment retained by the remaining
         // owners.
@@ -562,6 +565,18 @@ mod tests {
     }
 
     #[test]
+    fn test_freeze_of_empty_mutable_buffer_returns_every_carrier() {
+        let (pool, carrier_size) = test_pool(1, 2);
+        let mutable = pool.acquire_unreserved(carrier_size * 2).unwrap();
+
+        let frozen = mutable.freeze();
+
+        assert!(frozen.is_empty());
+        assert_eq!(frozen.segments.len(), 0);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
     fn test_freeze_coalesces_adjacent_carriers_but_preserves_owner_ranges() {
         let (pool, carrier_size) = test_pool(2, 2);
         let input: Vec<u8> = (0..carrier_size * 2)
@@ -704,7 +719,49 @@ mod tests {
         // Supply exact address adjacency without depending on mmap placement.
         let adjacent_start = left_segment.end_address().unwrap();
         assert!(left_segment.can_append(Some(left_slot), adjacent_start));
+        assert!(!left_segment.can_append(Some(left_slot), adjacent_start + 1));
         assert!(!left_segment.can_append(Some(right_slot), adjacent_start));
+    }
+
+    #[test]
+    fn test_same_slot_nonadjacent_ranges_remain_separate_segments() {
+        let (pool, carrier_size) = test_pool(3, 3);
+        let mut left = pool.acquire_unreserved(carrier_size).unwrap();
+        let gap = pool.acquire_unreserved(carrier_size).unwrap();
+        let mut right = pool.acquire_unreserved(carrier_size).unwrap();
+        write_pooled(&mut left, &vec![0x11; carrier_size]);
+        write_pooled(&mut right, &vec![0x22; carrier_size]);
+        let left = left.freeze();
+        let right = right.freeze();
+
+        let left_segment = &left.segments[0];
+        let right_segment = &right.segments[0];
+        assert!(Arc::ptr_eq(
+            left_segment.slot.as_ref().unwrap(),
+            right_segment.slot.as_ref().unwrap()
+        ));
+        assert_ne!(
+            left_segment.end_address(),
+            Some(right_segment.ptr.as_ptr().addr())
+        );
+
+        let mut builder = SegmentedBytesBuilder::new();
+        builder.push_segmented(left);
+        builder.push_segmented(right);
+        let combined = builder.finish();
+
+        assert_eq!(combined.segments.len(), 2);
+        assert_eq!(
+            pool.metrics().charged_capacity_bytes(),
+            (carrier_size * 3) as u64
+        );
+        drop(gap);
+        assert_eq!(
+            pool.metrics().charged_capacity_bytes(),
+            (carrier_size * 2) as u64
+        );
+        drop(combined);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
     }
 
     #[test]
@@ -760,6 +817,28 @@ mod tests {
     }
 
     #[test]
+    fn test_one_advance_crosses_owner_and_segment_boundaries() {
+        let (pool, carrier_size) = test_pool(2, 3);
+        let input: Vec<u8> = (0..carrier_size * 3)
+            .map(|index| (index.wrapping_mul(31) % 251) as u8)
+            .collect();
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+        let mut frozen = mutable.freeze();
+        assert_eq!(frozen.segments.len(), 2);
+        assert_eq!(frozen.segments[0].owners.len(), 2);
+
+        let advanced = carrier_size * 2 + 7;
+        frozen.advance(advanced);
+
+        assert_eq!(frozen.len(), carrier_size - 7);
+        assert_eq!(frozen.chunk(), &input[advanced..]);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        drop(frozen);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
     fn test_clones_advance_independently_and_retain_crossed_owners() {
         let (pool, carrier_size) = test_pool(2, 2);
         let mut mutable = pool.acquire_unreserved(carrier_size * 2).unwrap();
@@ -803,6 +882,43 @@ mod tests {
     }
 
     #[test]
+    fn test_buf_copy_to_bytes_releases_crossed_pooled_owner() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let input: Vec<u8> = (0..carrier_size * 2)
+            .map(|index| (index.wrapping_mul(41) % 251) as u8)
+            .collect();
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+        let mut frozen = mutable.freeze();
+        let copied_len = carrier_size + 3;
+
+        let copied = frozen.copy_to_bytes(copied_len);
+
+        assert_eq!(copied, input[..copied_len]);
+        assert_eq!(frozen.chunk(), &input[copied_len..]);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        drop(frozen);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_buf_get_u32_crosses_pooled_segment_boundary() {
+        let (pool, carrier_size) = test_pool(1, 2);
+        let mut input = vec![0; carrier_size + 2];
+        input[carrier_size - 2..].copy_from_slice(&[0x01, 0x23, 0x45, 0x67]);
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+        let mut frozen = mutable.freeze();
+        frozen.advance(carrier_size - 2);
+
+        let value = frozen.get_u32();
+
+        assert_eq!(value, 0x0123_4567);
+        assert!(frozen.is_empty());
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
     fn test_one_segment_contiguous_conversion_is_zero_copy() {
         let (pool, carrier_size) = test_pool(2, 2);
         let input = vec![0x6b; carrier_size * 2];
@@ -824,6 +940,29 @@ mod tests {
     }
 
     #[test]
+    fn test_partially_consumed_one_segment_conversion_is_zero_copy() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let input: Vec<u8> = (0..carrier_size * 2)
+            .map(|index| (index.wrapping_mul(13) % 251) as u8)
+            .collect();
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+        let mut frozen = mutable.freeze();
+        let advanced = carrier_size + 7;
+        frozen.advance(advanced);
+        let source_ptr = frozen.chunk().as_ptr();
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+
+        let contiguous = frozen.into_contiguous();
+
+        assert_eq!(contiguous.as_ptr(), source_ptr);
+        assert_eq!(contiguous, input[advanced..]);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        drop(contiguous);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
     fn test_multiple_segment_contiguous_conversion_copies_and_releases_pool() {
         let (pool, carrier_size) = test_pool(1, 2);
         let input: Vec<u8> = (0..carrier_size * 2)
@@ -836,6 +975,25 @@ mod tests {
         let contiguous = frozen.into_contiguous();
 
         assert_eq!(contiguous, input);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_partially_consumed_multiple_segment_conversion_copies_remaining_bytes() {
+        let (pool, carrier_size) = test_pool(1, 2);
+        let input: Vec<u8> = (0..carrier_size * 2)
+            .map(|index| (index.wrapping_mul(23) % 251) as u8)
+            .collect();
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+        let mut frozen = mutable.freeze();
+        let advanced = carrier_size - 3;
+        frozen.advance(advanced);
+        assert_eq!(frozen.segments.len(), 2);
+
+        let contiguous = frozen.into_contiguous();
+
+        assert_eq!(contiguous, input[advanced..]);
         assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
     }
 
@@ -906,6 +1064,90 @@ mod tests {
         let mut slices = [IoSlice::new(&[])];
         assert_eq!(value.chunks_vectored(&mut slices), 0);
         assert!(value.into_contiguous().is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "segment owners do not cover its complete range")]
+    fn test_segmented_bytes_rejects_incomplete_owner_coverage() {
+        let source = Bytes::from_static(b"abcd");
+        let ptr = NonNull::new(source.as_ptr().cast_mut()).expect("static bytes are nonempty");
+        let segment = Segment {
+            slot: None,
+            ptr,
+            len: source.len(),
+            owners: VecDeque::from([OwnedRange {
+                end: source.len() - 1,
+                hold: Hold::View(source),
+            }]),
+        };
+
+        let _ = SegmentedBytes::from_parts(VecDeque::from([segment]), 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "segment owner boundaries are not ordered coverage")]
+    fn test_segmented_bytes_rejects_unordered_owner_boundaries() {
+        let source = Bytes::from_static(b"abcd");
+        let ptr = NonNull::new(source.as_ptr().cast_mut()).expect("static bytes are nonempty");
+        let segment = Segment {
+            slot: None,
+            ptr,
+            len: source.len(),
+            owners: VecDeque::from([
+                OwnedRange {
+                    end: 3,
+                    hold: Hold::View(source.clone()),
+                },
+                OwnedRange {
+                    end: 2,
+                    hold: Hold::View(source),
+                },
+            ]),
+        };
+
+        let _ = SegmentedBytes::from_parts(VecDeque::from([segment]), 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "segment lengths do not match remaining bytes")]
+    fn test_segmented_bytes_rejects_remaining_length_mismatch() {
+        let source = Bytes::from_static(b"abcd");
+        let ptr = NonNull::new(source.as_ptr().cast_mut()).expect("static bytes are nonempty");
+        let segment = Segment {
+            slot: None,
+            ptr,
+            len: source.len(),
+            owners: VecDeque::from([OwnedRange {
+                end: source.len(),
+                hold: Hold::View(source),
+            }]),
+        };
+
+        let _ = SegmentedBytes::from_parts(VecDeque::from([segment]), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "trimmed segment retained a consumed owner")]
+    fn test_segment_trim_rejects_a_retained_consumed_owner() {
+        let source = Bytes::from_static(b"abcd");
+        let ptr = NonNull::new(source.as_ptr().cast_mut()).expect("static bytes are nonempty");
+        let segment = Segment {
+            slot: None,
+            ptr,
+            len: source.len(),
+            owners: VecDeque::from([
+                OwnedRange {
+                    end: 2,
+                    hold: Hold::View(source.clone()),
+                },
+                OwnedRange {
+                    end: source.len(),
+                    hold: Hold::View(source),
+                },
+            ]),
+        };
+
+        let _ = segment.trim_prefix(2);
     }
 
     #[test]

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/segmented_bytes.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/segmented_bytes.rs
@@ -3,11 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Immutable segmented byte presentation with explicit owner coverage.
+//! Immutable byte streams with independent presentation and owner boundaries.
 //!
-//! Segments describe contiguous presentation ranges. Owner boundaries remain
-//! independent so advancing a reader can release each carrier as soon as its
-//! final byte is crossed.
+//! A presentation segment is one range that [`Buf::chunk`] or
+//! [`Buf::chunks_vectored`] may expose. An owner boundary records how long one
+//! pooled carrier or opaque [`Bytes`] value must remain live. Several adjacent
+//! owners may share one presentation segment, so vectored I/O sees fewer
+//! ranges while [`Buf::advance`] can still release crossed owners promptly.
+//!
+//! Coalescing is a pointer-provenance operation, not an address-only
+//! optimization. Pooled ranges merge only when they derive from the same
+//! concrete block slot. Opaque views merge only after a pool-aware builder
+//! classifies their complete range and derives a new pointer from that slot.
 
 use std::collections::VecDeque;
 use std::io::IoSlice;
@@ -22,6 +29,13 @@ use super::PoolInner;
 use crate::runtime::sync::sync::Arc;
 
 /// Immutable bytes presented as one or more contiguous segments.
+///
+/// Cloning creates an independent read cursor while sharing the underlying
+/// owners. Advancing one clone releases an owner only after all other clones
+/// and immutable views have released it.
+///
+/// [`Self::into_contiguous`] is zero-copy for zero or one remaining segment.
+/// Multiple remaining segments are copied in logical order.
 #[derive(Clone)]
 pub(crate) struct SegmentedBytes {
     /// Presentation ranges in logical byte order.
@@ -46,7 +60,8 @@ impl SegmentedBytes {
     /// Consumes this value and returns one contiguous immutable buffer.
     ///
     /// Empty and single-segment values do not copy. Multiple segments are
-    /// copied in logical order while each source owner remains live.
+    /// copied in logical order while each source owner remains live until its
+    /// bytes have been copied.
     pub(crate) fn into_contiguous(mut self) -> Bytes {
         match self.segments.len() {
             0 => Bytes::new(),
@@ -230,6 +245,10 @@ impl From<Bytes> for SegmentedBytes {
 }
 
 /// One contiguous initialized presentation range.
+///
+/// `owners` covers this complete range in order. Its boundaries may be finer
+/// than the presentation range so consumption can release backing storage
+/// without splitting the segment exposed through [`Buf`].
 #[derive(Clone)]
 struct Segment {
     /// Concrete slot proving common pointer provenance before coalescing.
@@ -300,6 +319,11 @@ enum Hold {
 }
 
 /// Constructs segmented values while preserving complete owner coverage.
+///
+/// A pool-aware builder may recognize opaque views produced by that pool. It
+/// recovers no return authority from an address: the incoming [`Bytes`] remains
+/// the owner, while classification supplies only a slot-rooted pointer suitable
+/// for safe coalescing.
 pub(super) struct SegmentedBytesBuilder {
     /// Optional pool used to recover canonical pointers for opaque views.
     pool: Option<Arc<PoolInner>>,
@@ -765,6 +789,9 @@ mod tests {
         let mut frozen = mutable.freeze();
         frozen.advance(carrier_size - 2);
 
+        let mut empty = [];
+        assert_eq!(frozen.chunks_vectored(&mut empty), 0);
+
         let mut one = [IoSlice::new(&[])];
         assert_eq!(frozen.chunks_vectored(&mut one), 1);
         assert_eq!(&*one[0], &input[carrier_size - 2..carrier_size]);
@@ -871,11 +898,21 @@ mod tests {
 
     #[test]
     fn test_empty_segmented_value_obeys_buf_contract() {
-        let value = SegmentedBytes::from(Bytes::new());
+        let mut value = SegmentedBytes::from(Bytes::new());
         assert!(value.is_empty());
         assert_eq!(value.remaining(), 0);
         assert!(value.chunk().is_empty());
+        value.advance(0);
+        let mut slices = [IoSlice::new(&[])];
+        assert_eq!(value.chunks_vectored(&mut slices), 0);
         assert!(value.into_contiguous().is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "advanced beyond segmented byte length")]
+    fn test_segmented_bytes_rejects_advance_beyond_remaining() {
+        let mut value = SegmentedBytes::from(Bytes::from_static(b"abc"));
+        value.advance(4);
     }
 
     #[test]

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/segmented_bytes.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/segmented_bytes.rs
@@ -1,0 +1,928 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Immutable segmented byte presentation with explicit owner coverage.
+//!
+//! Segments describe contiguous presentation ranges. Owner boundaries remain
+//! independent so advancing a reader can release each carrier as soon as its
+//! final byte is crossed.
+
+use std::collections::VecDeque;
+use std::io::IoSlice;
+use std::ptr::NonNull;
+
+use bytes::{Buf, Bytes, BytesMut};
+
+use super::acquisition::CarrierGuard;
+use super::block::BlockSlot;
+use super::invariant_violation;
+use super::PoolInner;
+use crate::runtime::sync::sync::Arc;
+
+/// Immutable bytes presented as one or more contiguous segments.
+#[derive(Clone)]
+pub(crate) struct SegmentedBytes {
+    /// Presentation ranges in logical byte order.
+    segments: VecDeque<Segment>,
+    /// Consumed bytes within the front segment.
+    front_offset: usize,
+    /// Bytes remaining from this cursor.
+    remaining: usize,
+}
+
+impl SegmentedBytes {
+    /// Returns the number of bytes remaining from this cursor.
+    pub(crate) fn len(&self) -> usize {
+        self.remaining
+    }
+
+    /// Returns whether this cursor has no remaining bytes.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.remaining == 0
+    }
+
+    /// Consumes this value and returns one contiguous immutable buffer.
+    ///
+    /// Empty and single-segment values do not copy. Multiple segments are
+    /// copied in logical order while each source owner remains live.
+    pub(crate) fn into_contiguous(mut self) -> Bytes {
+        match self.segments.len() {
+            0 => Bytes::new(),
+            1 => {
+                let segment = self
+                    .segments
+                    .pop_front()
+                    .unwrap_or_else(|| invariant_violation("single segment disappeared"))
+                    .trim_prefix(self.front_offset);
+                self.front_offset = 0;
+                self.remaining = 0;
+                Bytes::from_owner(ContiguousOwner::new(segment))
+            }
+            _ => {
+                let mut contiguous = BytesMut::with_capacity(self.remaining);
+                while self.has_remaining() {
+                    let copied = self.chunk().len();
+                    contiguous.extend_from_slice(self.chunk());
+                    self.advance(copied);
+                }
+                contiguous.freeze()
+            }
+        }
+    }
+
+    /// Constructs one segmented value from its private builder.
+    fn from_parts(segments: VecDeque<Segment>, remaining: usize) -> Self {
+        let mut total = 0usize;
+        for segment in &segments {
+            if segment.len == 0 || segment.owners.is_empty() {
+                invariant_violation("segment lacks bytes or owner coverage");
+            }
+            let mut previous = 0usize;
+            for owner in &segment.owners {
+                if owner.end <= previous || owner.end > segment.len {
+                    invariant_violation("segment owner boundaries are not ordered coverage");
+                }
+                previous = owner.end;
+            }
+            if previous != segment.len {
+                invariant_violation("segment owners do not cover its complete range");
+            }
+            total = total
+                .checked_add(segment.len)
+                .unwrap_or_else(|| invariant_violation("segmented byte length overflow"));
+        }
+        if total != remaining {
+            invariant_violation("segment lengths do not match remaining bytes");
+        }
+        let value = Self {
+            segments,
+            front_offset: 0,
+            remaining,
+        };
+        if value.remaining == 0 && !value.segments.is_empty() {
+            invariant_violation("empty segmented value retained presentation ranges");
+        }
+        value
+    }
+}
+
+// SAFETY: methods form slices only over immutable initialized ranges retained
+// by their owners. No such range overlaps mutable authority.
+unsafe impl Send for SegmentedBytes {}
+
+// SAFETY: all shared access is immutable, and each backing owner is safe to
+// share through `Arc<CarrierGuard>` or `Bytes`.
+unsafe impl Sync for SegmentedBytes {}
+
+impl Buf for SegmentedBytes {
+    fn remaining(&self) -> usize {
+        self.remaining
+    }
+
+    fn chunk(&self) -> &[u8] {
+        if self.remaining == 0 {
+            return &[];
+        }
+        let segment = self
+            .segments
+            .front()
+            .unwrap_or_else(|| invariant_violation("remaining bytes have no front segment"));
+        let len = segment
+            .len
+            .checked_sub(self.front_offset)
+            .unwrap_or_else(|| invariant_violation("segment cursor exceeds its range"));
+        if len == 0 {
+            invariant_violation("remaining bytes have an empty front segment");
+        }
+        // SAFETY: owners cover this complete immutable initialized range, and
+        // `front_offset` is within the segment.
+        unsafe { std::slice::from_raw_parts(segment.ptr.as_ptr().add(self.front_offset), len) }
+    }
+
+    fn chunks_vectored<'a>(&'a self, dst: &mut [IoSlice<'a>]) -> usize {
+        if self.remaining == 0 || dst.is_empty() {
+            return 0;
+        }
+
+        let mut written = 0;
+        for (index, segment) in self.segments.iter().enumerate() {
+            if written == dst.len() {
+                break;
+            }
+            let offset = if index == 0 { self.front_offset } else { 0 };
+            let len = segment
+                .len
+                .checked_sub(offset)
+                .unwrap_or_else(|| invariant_violation("segment cursor exceeds its range"));
+            if len == 0 {
+                invariant_violation("segmented value contains an empty presentation range");
+            }
+            // SAFETY: the segment's owners retain this immutable initialized
+            // range for the borrow of `self`.
+            let bytes =
+                unsafe { std::slice::from_raw_parts(segment.ptr.as_ptr().add(offset), len) };
+            dst[written] = IoSlice::new(bytes);
+            written += 1;
+        }
+        written
+    }
+
+    fn advance(&mut self, mut count: usize) {
+        assert!(
+            count <= self.remaining,
+            "advanced beyond segmented byte length"
+        );
+        while count != 0 {
+            let available = self
+                .segments
+                .front()
+                .map(|segment| {
+                    segment
+                        .len
+                        .checked_sub(self.front_offset)
+                        .unwrap_or_else(|| invariant_violation("segment cursor exceeds its range"))
+                })
+                .unwrap_or_else(|| invariant_violation("remaining bytes have no front segment"));
+            let advanced = count.min(available);
+            self.front_offset += advanced;
+            self.remaining -= advanced;
+            count -= advanced;
+
+            let segment = self
+                .segments
+                .front_mut()
+                .unwrap_or_else(|| invariant_violation("front segment disappeared"));
+            while segment
+                .owners
+                .front()
+                .is_some_and(|owner| owner.end <= self.front_offset)
+            {
+                segment.owners.pop_front();
+            }
+
+            if self.front_offset == segment.len {
+                if !segment.owners.is_empty() {
+                    invariant_violation("exhausted segment retained owner ranges");
+                }
+                self.segments.pop_front();
+                self.front_offset = 0;
+            }
+        }
+
+        if self.remaining == 0 && !self.segments.is_empty() {
+            invariant_violation("exhausted segmented value retained segments");
+        }
+    }
+}
+
+impl From<Bytes> for SegmentedBytes {
+    /// Retains one opaque view without assuming that it belongs to a pool.
+    ///
+    /// Pool-aware assembly uses [`SegmentedBytesBuilder::for_pool`] so
+    /// adjacent classified views can share one presentation segment.
+    fn from(bytes: Bytes) -> Self {
+        let mut builder = SegmentedBytesBuilder::new();
+        builder.push_view(bytes);
+        builder.finish()
+    }
+}
+
+/// One contiguous initialized presentation range.
+#[derive(Clone)]
+struct Segment {
+    /// Concrete slot proving common pointer provenance before coalescing.
+    slot: Option<Arc<BlockSlot>>,
+    /// First presented byte.
+    ptr: NonNull<u8>,
+    /// Presented byte length.
+    len: usize,
+    /// Complete ordered owner coverage.
+    owners: VecDeque<OwnedRange>,
+}
+
+impl Segment {
+    /// Removes an already consumed prefix and rebases owner boundaries.
+    fn trim_prefix(mut self, count: usize) -> Self {
+        assert!(count <= self.len, "trim exceeds segment");
+        if count == 0 {
+            return self;
+        }
+        if count == self.len {
+            invariant_violation("complete segment must be removed instead of trimmed");
+        }
+
+        while self.owners.front().is_some_and(|owner| owner.end <= count) {
+            self.owners.pop_front();
+        }
+        if self.owners.is_empty() {
+            invariant_violation("remaining segment has no owner");
+        }
+        for owner in &mut self.owners {
+            owner.end -= count;
+        }
+        // SAFETY: `count` is within the segment retained by the remaining
+        // owners.
+        self.ptr = unsafe { NonNull::new_unchecked(self.ptr.as_ptr().add(count)) };
+        self.len -= count;
+        self
+    }
+
+    /// Returns the first address after this segment.
+    fn end_address(&self) -> Option<usize> {
+        self.ptr.as_ptr().addr().checked_add(self.len)
+    }
+
+    /// Returns whether a range is adjacent and derives from this exact slot.
+    fn can_append(&self, slot: Option<&Arc<BlockSlot>>, start_address: usize) -> bool {
+        let (Some(current), Some(incoming)) = (self.slot.as_ref(), slot) else {
+            return false;
+        };
+        Arc::ptr_eq(current, incoming) && self.end_address() == Some(start_address)
+    }
+}
+
+/// One owner covering bytes through a segment-relative end offset.
+#[derive(Clone)]
+struct OwnedRange {
+    end: usize,
+    hold: Hold,
+}
+
+/// Storage owner for one immutable subrange.
+#[derive(Clone)]
+enum Hold {
+    /// Direct ownership transferred from a mutable pooled carrier.
+    Pooled(Arc<CarrierGuard>),
+    /// Existing immutable producer ownership.
+    View(Bytes),
+}
+
+/// Constructs segmented values while preserving complete owner coverage.
+pub(super) struct SegmentedBytesBuilder {
+    /// Optional pool used to recover canonical pointers for opaque views.
+    pool: Option<Arc<PoolInner>>,
+    /// Presentation ranges assembled so far.
+    segments: VecDeque<Segment>,
+    /// Sum of assembled presentation lengths.
+    remaining: usize,
+}
+
+impl SegmentedBytesBuilder {
+    /// Creates an empty builder.
+    pub(super) fn new() -> Self {
+        Self {
+            pool: None,
+            segments: VecDeque::new(),
+            remaining: 0,
+        }
+    }
+
+    /// Creates a builder that recognizes opaque views backed by `pool`.
+    pub(super) fn for_pool(pool: Arc<PoolInner>) -> Self {
+        Self {
+            pool: Some(pool),
+            segments: VecDeque::new(),
+            remaining: 0,
+        }
+    }
+
+    /// Appends one initialized pooled range.
+    pub(super) fn push_pooled(&mut self, ptr: NonNull<u8>, len: usize, guard: Arc<CarrierGuard>) {
+        let slot = Arc::clone(guard.slot());
+        self.push_range(Some(slot), ptr, len, Hold::Pooled(guard));
+    }
+
+    /// Appends the unconsumed ranges and existing owners from `buffer`.
+    pub(super) fn push_segmented(&mut self, buffer: SegmentedBytes) {
+        let SegmentedBytes {
+            mut segments,
+            front_offset,
+            remaining,
+        } = buffer;
+        if remaining == 0 {
+            return;
+        }
+        let previous = self.remaining;
+        let front = segments
+            .pop_front()
+            .unwrap_or_else(|| invariant_violation("remaining bytes have no front segment"))
+            .trim_prefix(front_offset);
+        self.push_segment(front);
+        for segment in segments {
+            self.push_segment(segment);
+        }
+        if self.remaining.checked_sub(previous) != Some(remaining) {
+            invariant_violation("transferred segments changed remaining byte length");
+        }
+    }
+
+    /// Appends one immutable view without recovering pool return authority.
+    ///
+    /// A pool-aware builder may classify the range and re-derive its pointer
+    /// from the concrete slot. The view remains the initialized owner.
+    pub(super) fn push_view(&mut self, view: Bytes) {
+        if view.is_empty() {
+            return;
+        }
+        let classified = self
+            .pool
+            .as_ref()
+            .and_then(|pool| pool.arena.classify_range(view.as_ptr().addr(), view.len()));
+        let (slot, ptr) = match classified {
+            Some(classified) => {
+                let slot = Arc::clone(classified.slot());
+                #[cfg(debug_assertions)]
+                slot.debug_assert_immutable_range_live(classified.offset(), view.len());
+                // SAFETY: `view` retains initialized immutable access to this
+                // complete classified range. Pool-produced byte owners keep
+                // the carrier bits live until their final clone drops.
+                let ptr = unsafe {
+                    slot.ptr_for_immutable_range(classified.offset(), view.len())
+                        .unwrap_or_else(|| {
+                            invariant_violation("classified view is outside its block slot")
+                        })
+                };
+                (Some(slot), ptr)
+            }
+            None => {
+                let ptr = NonNull::new(view.as_ptr().cast_mut())
+                    .unwrap_or_else(|| invariant_violation("nonempty Bytes has a null pointer"));
+                (None, ptr)
+            }
+        };
+        self.push_range(slot, ptr, view.len(), Hold::View(view));
+    }
+
+    /// Finishes one segmented value.
+    pub(super) fn finish(self) -> SegmentedBytes {
+        SegmentedBytes::from_parts(self.segments, self.remaining)
+    }
+
+    /// Appends one range and coalesces only proven slot-local adjacency.
+    fn push_range(
+        &mut self,
+        slot: Option<Arc<BlockSlot>>,
+        ptr: NonNull<u8>,
+        len: usize,
+        hold: Hold,
+    ) {
+        if len == 0 {
+            invariant_violation("segmented range must be nonempty");
+        }
+        self.remaining = self
+            .remaining
+            .checked_add(len)
+            .unwrap_or_else(|| invariant_violation("segmented byte length overflow"));
+
+        let can_merge = self
+            .segments
+            .back()
+            .is_some_and(|segment| segment.can_append(slot.as_ref(), ptr.as_ptr().addr()));
+        if can_merge {
+            let segment = self
+                .segments
+                .back_mut()
+                .unwrap_or_else(|| invariant_violation("merge target disappeared"));
+            segment.len = segment
+                .len
+                .checked_add(len)
+                .unwrap_or_else(|| invariant_violation("segment length overflow"));
+            segment.owners.push_back(OwnedRange {
+                end: segment.len,
+                hold,
+            });
+            return;
+        }
+
+        let mut owners = VecDeque::new();
+        owners.push_back(OwnedRange { end: len, hold });
+        self.segments.push_back(Segment {
+            slot,
+            ptr,
+            len,
+            owners,
+        });
+    }
+
+    /// Appends one existing segment and preserves its owner boundaries.
+    fn push_segment(&mut self, segment: Segment) {
+        if segment.len == 0 || segment.owners.is_empty() {
+            invariant_violation("existing segment lacks bytes or owners");
+        }
+        self.remaining = self
+            .remaining
+            .checked_add(segment.len)
+            .unwrap_or_else(|| invariant_violation("segmented byte length overflow"));
+
+        let can_merge = self.segments.back().is_some_and(|previous| {
+            previous.can_append(segment.slot.as_ref(), segment.ptr.as_ptr().addr())
+        });
+        if can_merge {
+            let previous = self
+                .segments
+                .back_mut()
+                .unwrap_or_else(|| invariant_violation("merge target disappeared"));
+            let base = previous.len;
+            previous.len = previous
+                .len
+                .checked_add(segment.len)
+                .unwrap_or_else(|| invariant_violation("segment length overflow"));
+            previous
+                .owners
+                .extend(segment.owners.into_iter().map(|mut owner| {
+                    owner.end = owner
+                        .end
+                        .checked_add(base)
+                        .unwrap_or_else(|| invariant_violation("owner boundary overflow"));
+                    owner
+                }));
+        } else {
+            self.segments.push_back(segment);
+        }
+    }
+}
+
+/// Owner used by the zero-copy one-segment conversion.
+struct ContiguousOwner {
+    ptr: NonNull<u8>,
+    len: usize,
+    owners: VecDeque<OwnedRange>,
+}
+
+impl ContiguousOwner {
+    /// Takes complete ownership coverage from one remaining segment.
+    fn new(segment: Segment) -> Self {
+        Self {
+            ptr: segment.ptr,
+            len: segment.len,
+            owners: segment.owners,
+        }
+    }
+}
+
+impl AsRef<[u8]> for ContiguousOwner {
+    fn as_ref(&self) -> &[u8] {
+        let _owners = &self.owners;
+        // SAFETY: `owners` retain every byte in this immutable initialized
+        // range for the lifetime of this owner.
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+    }
+}
+
+// SAFETY: the pointer names immutable initialized storage retained by owners.
+unsafe impl Send for ContiguousOwner {}
+
+#[cfg(all(test, not(s3_tm_loom)))]
+mod tests {
+    use bytes::Buf;
+
+    use super::super::test_util::{test_pool, write_pooled};
+    use super::*;
+
+    #[test]
+    fn test_freeze_returns_wholly_unused_carriers() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let mut mutable = pool.acquire_unreserved(carrier_size * 2).unwrap();
+        write_pooled(&mut mutable, b"abc");
+
+        let frozen = mutable.freeze();
+
+        assert_eq!(frozen.len(), 3);
+        assert_eq!(frozen.chunk(), b"abc");
+        assert_eq!(frozen.segments.len(), 1);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        drop(frozen);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_freeze_coalesces_adjacent_carriers_but_preserves_owner_ranges() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let input: Vec<u8> = (0..carrier_size * 2)
+            .map(|index| (index % 251) as u8)
+            .collect();
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+
+        let frozen = mutable.freeze();
+
+        assert_eq!(frozen.segments.len(), 1);
+        assert_eq!(frozen.segments[0].owners.len(), 2);
+        assert_eq!(frozen.chunk(), input.as_slice());
+    }
+
+    #[test]
+    fn test_freeze_and_published_views_coalesce_and_share_one_final_return() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let mut mutable = pool.acquire_unreserved(carrier_size).unwrap();
+        write_pooled(&mut mutable, b"abcdef");
+        let published = mutable.publish_prefix(3);
+        let frozen = mutable.freeze();
+
+        let mut builder = SegmentedBytesBuilder::for_pool(Arc::clone(&pool.inner));
+        builder.push_view(published);
+        builder.push_segmented(frozen);
+        let mut combined = builder.finish();
+
+        assert_eq!(combined.segments.len(), 1);
+        assert_eq!(combined.segments[0].owners.len(), 2);
+        assert_eq!(combined.chunk(), b"abcdef");
+        combined.advance(3);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        combined.advance(3);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_foreign_adjacent_views_remain_separate_segments() {
+        let (pool, _) = test_pool(1, 1);
+        let source = Bytes::from_static(b"abcdef");
+        let mut builder = SegmentedBytesBuilder::for_pool(Arc::clone(&pool.inner));
+        builder.push_view(source.slice(0..3));
+        builder.push_view(source.slice(3..6));
+        let value = builder.finish();
+
+        assert_eq!(value.segments.len(), 2);
+        let mut slices = [IoSlice::new(&[]), IoSlice::new(&[])];
+        assert_eq!(value.chunks_vectored(&mut slices), 2);
+        assert_eq!(&*slices[0], b"abc");
+        assert_eq!(&*slices[1], b"def");
+    }
+
+    #[test]
+    fn test_pool_backed_views_coalesce_through_slot_rooted_pointer() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let mut mutable = pool.acquire_unreserved(carrier_size).unwrap();
+        write_pooled(&mut mutable, b"abcdef");
+        let first = mutable.publish_prefix(3);
+        let second = mutable.publish_prefix(3);
+        drop(mutable);
+
+        let mut builder = SegmentedBytesBuilder::for_pool(Arc::clone(&pool.inner));
+        builder.push_view(first);
+        builder.push_view(second);
+        let mut value = builder.finish();
+
+        assert_eq!(value.segments.len(), 1);
+        assert_eq!(value.segments[0].owners.len(), 2);
+        assert_eq!(value.chunk(), b"abcdef");
+        assert!(pool.inner.arena.select_trim_candidate().is_none());
+        value.advance(3);
+        assert_eq!(value.chunk(), b"def");
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        value.advance(3);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+        assert!(pool.inner.arena.select_trim_candidate().is_some());
+    }
+
+    #[test]
+    fn test_pool_backed_views_coalesce_across_carriers() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let input: Vec<u8> = (0..carrier_size * 2)
+            .map(|index| (index % 251) as u8)
+            .collect();
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+        let first = mutable.publish_prefix(carrier_size);
+        let second = mutable.publish_prefix(carrier_size);
+
+        let mut builder = SegmentedBytesBuilder::for_pool(Arc::clone(&pool.inner));
+        builder.push_view(first);
+        builder.push_view(second);
+        let mut value = builder.finish();
+
+        assert_eq!(value.segments.len(), 1);
+        assert_eq!(value.segments[0].owners.len(), 2);
+        assert_eq!(value.chunk(), input);
+        value.advance(carrier_size);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        value.advance(carrier_size);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_pool_aware_builder_does_not_classify_another_pools_view() {
+        let (left_pool, _) = test_pool(1, 1);
+        let (right_pool, carrier_size) = test_pool(1, 1);
+        let mut mutable = right_pool.acquire_unreserved(carrier_size).unwrap();
+        write_pooled(&mut mutable, b"right");
+        let view = mutable.publish_prefix(5);
+
+        let mut builder = SegmentedBytesBuilder::for_pool(Arc::clone(&left_pool.inner));
+        builder.push_view(view);
+        let value = builder.finish();
+
+        assert_eq!(value.segments.len(), 1);
+        assert!(value.segments[0].slot.is_none());
+        assert_eq!(value.chunk(), b"right");
+    }
+
+    #[test]
+    fn test_pool_local_slot_indices_do_not_authorize_segment_merge() {
+        let (left_pool, carrier_size) = test_pool(2, 1);
+        let (right_pool, _) = test_pool(2, 1);
+        let mut left = left_pool.acquire_unreserved(carrier_size).unwrap();
+        let mut right = right_pool.acquire_unreserved(carrier_size).unwrap();
+        write_pooled(&mut left, &vec![0x11; carrier_size]);
+        write_pooled(&mut right, &vec![0x22; carrier_size]);
+        let left = left.freeze();
+        let right = right.freeze();
+        let left_segment = &left.segments[0];
+        let right_segment = &right.segments[0];
+        let left_slot = left_segment.slot.as_ref().unwrap();
+        let right_slot = right_segment.slot.as_ref().unwrap();
+
+        assert_eq!(left_slot.id(), right_slot.id());
+        assert!(!Arc::ptr_eq(left_slot, right_slot));
+
+        // Supply exact address adjacency without depending on mmap placement.
+        let adjacent_start = left_segment.end_address().unwrap();
+        assert!(left_segment.can_append(Some(left_slot), adjacent_start));
+        assert!(!left_segment.can_append(Some(right_slot), adjacent_start));
+    }
+
+    #[test]
+    fn test_push_segmented_rejects_forced_cross_pool_adjacency() {
+        let (left_pool, carrier_size) = test_pool(1, 1);
+        let (right_pool, _) = test_pool(1, 1);
+        let mut left = left_pool.acquire_unreserved(carrier_size).unwrap();
+        let mut right = right_pool.acquire_unreserved(carrier_size).unwrap();
+        write_pooled(&mut left, &vec![0x11; carrier_size]);
+        write_pooled(&mut right, &vec![0x22; carrier_size]);
+        let left = left.freeze();
+        let mut right = right.freeze();
+
+        let adjacent_start = left.segments[0].end_address().unwrap();
+        let right_segment = &mut right.segments[0];
+        let right_slot = Arc::clone(right_segment.slot.as_ref().unwrap());
+        // Preserve the right slot's pointer provenance while forcing the
+        // address comparison that previously merged equal pool-local indices.
+        // The synthetic pointer is never dereferenced.
+        let adjacent = right_segment.ptr.as_ptr().map_addr(|_| adjacent_start);
+        right_segment.ptr = NonNull::new(adjacent)
+            .unwrap_or_else(|| invariant_violation("adjacent address is null"));
+
+        let mut builder = SegmentedBytesBuilder::new();
+        builder.push_segmented(left);
+        builder.push_segmented(right);
+        let combined = builder.finish();
+
+        assert_eq!(combined.segments.len(), 2);
+        let left_slot = combined.segments[0].slot.as_ref().unwrap();
+        assert!(!Arc::ptr_eq(left_slot, &right_slot));
+        assert!(Arc::ptr_eq(
+            combined.segments[1].slot.as_ref().unwrap(),
+            &right_slot
+        ));
+    }
+
+    #[test]
+    fn test_advance_releases_crossed_carrier_owners() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let input = vec![0x5a; carrier_size * 2];
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+        let mut frozen = mutable.freeze();
+
+        frozen.advance(carrier_size);
+
+        assert_eq!(frozen.len(), carrier_size);
+        assert_eq!(frozen.chunk(), &input[carrier_size..]);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        drop(frozen);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_clones_advance_independently_and_retain_crossed_owners() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let mut mutable = pool.acquire_unreserved(carrier_size * 2).unwrap();
+        write_pooled(&mut mutable, &vec![0x33; carrier_size * 2]);
+        let mut first = mutable.freeze();
+        let second = first.clone();
+
+        first.advance(carrier_size);
+        assert_eq!(
+            pool.metrics().charged_capacity_bytes(),
+            (carrier_size * 2) as u64
+        );
+        drop(second);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), carrier_size as u64);
+        drop(first);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_chunks_vectored_respects_destination_and_partial_front() {
+        let (pool, carrier_size) = test_pool(1, 2);
+        let input: Vec<u8> = (0..carrier_size * 2)
+            .map(|index| (index % 251) as u8)
+            .collect();
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+        let mut frozen = mutable.freeze();
+        frozen.advance(carrier_size - 2);
+
+        let mut one = [IoSlice::new(&[])];
+        assert_eq!(frozen.chunks_vectored(&mut one), 1);
+        assert_eq!(&*one[0], &input[carrier_size - 2..carrier_size]);
+
+        let mut two = [IoSlice::new(&[]), IoSlice::new(&[])];
+        assert_eq!(frozen.chunks_vectored(&mut two), 2);
+        assert_eq!(&*two[0], &input[carrier_size - 2..carrier_size]);
+        assert_eq!(&*two[1], &input[carrier_size..]);
+    }
+
+    #[test]
+    fn test_one_segment_contiguous_conversion_is_zero_copy() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let input = vec![0x6b; carrier_size * 2];
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+        let frozen = mutable.freeze();
+        let source_ptr = frozen.chunk().as_ptr();
+
+        let contiguous = frozen.into_contiguous();
+
+        assert_eq!(contiguous.as_ptr(), source_ptr);
+        assert_eq!(contiguous, input);
+        assert_eq!(
+            pool.metrics().charged_capacity_bytes(),
+            (carrier_size * 2) as u64
+        );
+        drop(contiguous);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_multiple_segment_contiguous_conversion_copies_and_releases_pool() {
+        let (pool, carrier_size) = test_pool(1, 2);
+        let input: Vec<u8> = (0..carrier_size * 2)
+            .map(|index| (index % 251) as u8)
+            .collect();
+        let mut mutable = pool.acquire_unreserved(input.len()).unwrap();
+        write_pooled(&mut mutable, &input);
+        let frozen = mutable.freeze();
+
+        let contiguous = frozen.into_contiguous();
+
+        assert_eq!(contiguous, input);
+        assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_from_bytes_and_single_segment_conversion_preserve_owner() {
+        let source = Bytes::from_static(b"foreign");
+        let source_ptr = source.as_ptr();
+        let segmented = SegmentedBytes::from(source);
+
+        assert_eq!(segmented.len(), 7);
+        let contiguous = segmented.into_contiguous();
+        assert_eq!(contiguous.as_ptr(), source_ptr);
+        assert_eq!(contiguous, b"foreign"[..]);
+    }
+
+    #[test]
+    fn test_builder_appends_partially_consumed_segmented_values() {
+        let mut first = SegmentedBytes::from(Bytes::from_static(b"abcd"));
+        first.advance(2);
+        let second = SegmentedBytes::from(Bytes::from_static(b"efgh"));
+        let mut builder = SegmentedBytesBuilder::new();
+        builder.push_segmented(first);
+        builder.push_segmented(second);
+        let mut combined = builder.finish();
+
+        assert_eq!(combined.len(), 6);
+        assert_eq!(combined.copy_to_bytes(6), b"cdefgh"[..]);
+    }
+
+    #[test]
+    fn test_segmented_read_and_conversion_match_bytes_for_varied_partitions() {
+        let input: Vec<u8> = (0usize..521)
+            .map(|index| (index.wrapping_mul(29) % 251) as u8)
+            .collect();
+
+        for width in [1, 2, 7, 64, 257, 521] {
+            let mut builder = SegmentedBytesBuilder::new();
+            for chunk in input.chunks(width) {
+                builder.push_view(Bytes::copy_from_slice(chunk));
+            }
+            let value = builder.finish();
+
+            for step in [1, 3, 31, 128, 1024] {
+                let mut cursor = value.clone();
+                let mut consumed = 0;
+                while cursor.has_remaining() {
+                    assert!(!cursor.chunk().is_empty());
+                    let advanced = step.min(cursor.remaining());
+                    cursor.advance(advanced);
+                    consumed += advanced;
+                    assert_eq!(cursor.remaining(), input.len() - consumed);
+                }
+                assert_eq!(consumed, input.len());
+            }
+
+            let contiguous = value.into_contiguous();
+            assert_eq!(contiguous, input);
+        }
+    }
+
+    #[test]
+    fn test_empty_segmented_value_obeys_buf_contract() {
+        let value = SegmentedBytes::from(Bytes::new());
+        assert!(value.is_empty());
+        assert_eq!(value.remaining(), 0);
+        assert!(value.chunk().is_empty());
+        assert!(value.into_contiguous().is_empty());
+    }
+
+    #[test]
+    fn test_segmented_bytes_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SegmentedBytes>();
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use super::super::test_util::{test_single_carrier_pool as test_pool, write_pooled};
+    use crate::runtime::sync::thread;
+
+    #[test]
+    fn test_concurrent_frozen_clone_drops_return_one_carrier_once() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(1);
+            let mut mutable = pool.acquire_unreserved(carrier_size).unwrap();
+            write_pooled(&mut mutable, b"x");
+            let first = mutable.freeze();
+            let second = first.clone();
+
+            let left = thread::spawn(move || drop(first));
+            let right = thread::spawn(move || drop(second));
+            left.join().unwrap();
+            right.join().unwrap();
+
+            assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+        });
+    }
+
+    #[test]
+    fn test_published_and_frozen_drop_race_returns_one_carrier_once() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_pool(1);
+            let mut mutable = pool.acquire_unreserved(carrier_size).unwrap();
+            write_pooled(&mut mutable, b"xy");
+            let published = mutable.publish_prefix(1);
+            let frozen = mutable.freeze();
+
+            let publishing = thread::spawn(move || drop(published));
+            let freezing = thread::spawn(move || drop(frozen));
+            publishing.join().unwrap();
+            freezing.join().unwrap();
+
+            assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
@@ -11,13 +11,15 @@ use std::sync::Arc as StdArc;
 use std::task::Wake;
 use std::task::{Context, Poll, Waker};
 
+use bytes::BufMut;
+
 use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
 use crate::runtime::sync::sync::Arc;
 
 use super::admission::{Reservation, ReserveError, ReserveFuture};
 use super::geometry::PoolGeometry;
 use super::virtual_memory::page_size;
-use super::{BufferPool, CarrierCount, PoolInner};
+use super::{BufferPool, CarrierCount, PoolInner, PooledBufMut};
 
 /// Waker state that records each wake through the active atomic backend.
 struct CountingWake {
@@ -78,6 +80,15 @@ impl BufferPool {
         self.inner
             .test_hooks
             .inject_acquisition_allocation_failure(boundary);
+    }
+
+    /// Returns whether an acquisition metadata failure remains pending.
+    pub(super) fn acquisition_allocation_failure_pending(&self) -> bool {
+        self.inner
+            .test_hooks
+            .acquisition_allocation_failure
+            .load(Ordering::Acquire)
+            != 0
     }
 }
 
@@ -148,6 +159,21 @@ pub(super) fn test_pool_with_scan(
 /// Constructs a pool whose block and carrier are one runtime page.
 pub(super) fn test_single_carrier_pool(configured: usize) -> (BufferPool, usize) {
     test_pool(1, configured)
+}
+
+/// Initializes bytes through the pooled buffer's `BufMut` boundary.
+pub(super) fn write_pooled(buffer: &mut PooledBufMut, mut bytes: &[u8]) {
+    while !bytes.is_empty() {
+        let written = {
+            let chunk = buffer.chunk_mut();
+            let written = chunk.len().min(bytes.len());
+            chunk[..written].copy_from_slice(&bytes[..written]);
+            written
+        };
+        // SAFETY: the preceding copy initialized exactly `written` bytes.
+        unsafe { buffer.advance_mut(written) };
+        bytes = &bytes[written..];
+    }
 }
 
 /// Polls one reservation future with an explicit waker.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/virtual_memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/virtual_memory.rs
@@ -275,9 +275,10 @@ impl VirtualRange {
     ///
     /// # Safety
     ///
-    /// The complete subrange must be prepared, exclusively owned by a claim
-    /// that passed the `Active` gate, and retained until the pointer is no
-    /// longer used.
+    /// The complete subrange must remain prepared until the pointer is no
+    /// longer used. Mutable access requires exclusive claim ownership.
+    /// Immutable access requires initialized owner coverage that prevents
+    /// deactivation for the complete access.
     pub(super) unsafe fn ptr_for_range(
         &self,
         offset: usize,

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -1155,10 +1155,11 @@ struct AddressRange {
 ```
 
 `BlockRegistry` publishes claim order and address classification as one immutable generation.
-Optimistic claim scans load `slots_in_claim_order` without taking `ArenaState`. An incoming
-immutable view uses binary search over `address_ranges` and accepts a match only when its complete
-checked range lies within one slot. The integer bounds classify addresses only; carrier pointers
-are always derived from `VirtualRange`.
+Optimistic claim scans load `slots_in_claim_order` without taking `ArenaState`. Address
+classification uses binary search over `address_ranges` and accepts a match only when its complete
+checked range lies within one slot. The integer bounds supply metadata only; carrier pointers are
+always derived from `VirtualRange`. Classification does not widen the range-limited provenance of
+an incoming immutable view.
 
 Generation construction rejects address overflow, overlap, or an invalid slot index. Growth rebuilds
 and publishes both arrays while holding `ArenaState`. Return goes directly to the slot recorded by
@@ -1785,16 +1786,13 @@ struct CarrierRun {
     slot_id: u32,
     // Index of the run's first carrier within the slot.
     first_carrier: u32,
-    // Start of the contiguous writable run.
-    ptr: NonNull<MaybeUninit<u8>>,
-    // Total byte capacity of the run.
-    capacity: usize,
     // Per-carrier ownership in ascending address order.
-    carriers: VecDeque<WritableCarrier>,
+    carriers: Vec<WritableCarrier>,
 }
 
 struct WritableCarrier {
-    guard: Arc<CarrierGuard>,
+    // None after publication transfers the carrier's final mutable hold.
+    guard: Option<Arc<CarrierGuard>>,
     // Unique mutable authority over the carrier's unpublished suffix.
     writable: ExclusiveRange,
     // Initialized prefix within `writable`.
@@ -1809,12 +1807,16 @@ struct ExclusiveRange {
 struct BufferCursor {
     run: usize,
     carrier: usize,
-    offset: usize,
 }
 ```
 
 `SmallVec` is an inline-storage optimization. Its capacity does not limit acquisition or
 fragmentation and may change without changing the ownership contract.
+
+Carrier entries remain positionally stable while the buffer lives. Publishing a carrier's complete
+remaining range takes its guard and leaves an empty metadata entry; the buffer then retains no
+ownership or charge for that carrier, and cursor normalization skips the entry. Stable entries keep
+publication from shifting the write cursor while later growth appends carriers.
 
 `ExclusiveRange` is linear and private. It cannot be cloned. Its consuming split operations produce
 disjoint ranges, so publication can remove an initialized prefix while retaining exclusive mutable
@@ -2027,8 +2029,8 @@ pub struct SegmentedBytes {
 
 #[derive(Clone)]
 struct Segment {
-    // Stable slot identity used only to validate presentation adjacency.
-    slot_id: Option<u32>,
+    // Concrete slot proving common pointer provenance before coalescing.
+    slot: Option<Arc<BlockSlot>>,
     // Start and length of one contiguous initialized presentation range.
     ptr: NonNull<u8>,
     len: usize,
@@ -2050,16 +2052,16 @@ enum Hold {
     View(Bytes),
 }
 
-struct SegmentedBytesBuilder<'a> {
-    // Resolves incoming views against stable slot ranges during construction.
-    arena: &'a Arena,
+struct SegmentedBytesBuilder {
+    // Optional pool used to recover canonical pointers for opaque views.
+    pool: Option<Arc<PoolInner>>,
     // Presentation ranges assembled so far.
     segments: VecDeque<Segment>,
     // Sum of the assembled presentation lengths.
     remaining: usize,
 }
 
-impl<'a> SegmentedBytesBuilder<'a> {
+impl SegmentedBytesBuilder {
     fn push_segmented(&mut self, buffer: SegmentedBytes);
     fn push_view(&mut self, view: Bytes);
     fn finish(self) -> SegmentedBytes;
@@ -2069,10 +2071,9 @@ impl<'a> SegmentedBytesBuilder<'a> {
 `Hold::Pooled` retains storage frozen directly from `PooledBufMut`. `Hold::View` retains an existing
 immutable producer view, whether pool-backed or foreign. `push_segmented` consumes the input's
 remaining segments and their existing holds; it does not reconstruct ownership from pointers.
-`PooledBufMut::freeze` constructs pooled segments directly. The private builder resolves the
-complete range of `push_view` with a binary search over the registry generation's sorted address
-ranges; the finished value retains no builder borrow. Owner boundaries need not be presentation
-boundaries:
+`PooledBufMut::freeze` constructs pooled segments directly with stable slot identity and pointers
+derived from the slot's `VirtualRange`. Owner boundaries need not be presentation boundaries for
+those direct pooled ranges:
 
 ```text
 one Segment, assuming 64 KiB carriers: contiguous presentation [0..192 KiB]
@@ -2084,15 +2085,23 @@ one Segment, assuming 64 KiB carriers: contiguous presentation [0..192 KiB]
        owner A              owner B              owner C
 ```
 
-Construction extends the previous segment only when both ranges have the same known `slot_id` and
-the previous range ends at the next range's pointer. Stable block-slot address ranges make this
-test unambiguous, and the owners keep every byte in the merged range live. A foreign view has
-`slot_id: None` and starts a new segment even if its address happens to be adjacent.
+Construction extends the previous segment only when both ranges identify the same concrete
+`BlockSlot` by `Arc::ptr_eq`, the previous range ends at the next range's pointer, and both pointers
+retain provenance derived from that slot's stable `VirtualRange`. A pool-local numeric slot index is
+not sufficient identity. The owners keep every byte in the merged range live.
 
-Address lookup on an incoming `Bytes` supplies presentation metadata only. It cannot prove that the
-view is the final owner or recover the acquisition's accounting provenance. Pool-backed incoming
-views therefore remain `Hold::View(Bytes)`; construction never creates another `CarrierGuard` or
-clears a bitmap bit from an address.
+An opaque `Bytes` remains `Hold::View(Bytes)` and never authorizes physical or accounting return.
+When the builder has the pool that may have produced the view, integer address classification can
+locate a complete range within one concrete `BlockSlot`. Classification does not widen the
+range-limited provenance of `Bytes::as_ptr()`. Instead, the builder derives a new checked pointer
+from that slot's `VirtualRange` provenance root while the original `Bytes` remains the initialized
+immutable owner. Pool-produced byte owners keep their carrier bits live, so trim cannot deactivate
+the range while any classified view remains.
+
+Classified views may coalesce with adjacent classified or direct pooled ranges from the same
+concrete slot. A foreign view, a view from another pool, or a range crossing a slot boundary remains
+an independent segment. Construction never creates another `CarrierGuard` or clears a bitmap bit
+from an address.
 
 **Alternative: Recover carrier ownership from incoming views.** Rejected: an unseen clone or slice
 may still retain the original owner. Returning the carrier from pointer metadata would make live
@@ -2202,8 +2211,10 @@ pool-independent one-segment value and retains the supplied `Bytes` as its owner
 - **O6: Immutable ownership.** Clones, slices, and separate windows share carrier charges without
   duplicating them. Freeze returns wholly unused carriers and retains partial carriers only through
   initialized ranges.
-- **O7: Segment ownership.** Ordered holds cover every unconsumed byte. Coalescing requires a known
-  equal slot and pointer adjacency; incoming views never authorize physical or accounting return.
+- **O7: Segment ownership.** Ordered holds cover every unconsumed byte. Coalescing requires direct
+  pooled ranges or classified opaque views with equal concrete slot identity, slot-rooted
+  provenance, and pointer adjacency. Unclassified views remain separate segments and no view
+  authorizes physical or accounting return.
 - **O8: Read cursors.** `Buf::advance` releases only crossed holds, `chunks_vectored` respects
   destination capacity, and clones retain independent cursors and owners.
 - **O9: Contiguous conversion and unsafe access.** Zero-copy conversion retains source charges.
@@ -3231,7 +3242,7 @@ initialized, and the synchronization that excludes mutation or reclamation.
 | Construct `ContiguousOwner`             | Ordered owners cover every byte in the contiguous range for the complete owner lifetime                                   |
 | Form `&[u8]`, `IoSlice`, or I/O source  | The referenced range is initialized and retained for the complete borrow or asynchronous operation                        |
 | Implement `Send` or `Sync`              | Moving or sharing the type cannot duplicate mutable authority; every shared pointer names immutable synchronized storage  |
-| Coalesce adjacent presentation ranges   | Both ranges have the same known stable slot and pointer adjacency; retained owners cover the merged range                 |
+| Coalesce adjacent presentation ranges   | Both pointers derive from the same stable slot, are adjacent, and retained owners cover the merged range                 |
 | Clear bits after gate failure           | The protected incarnation and bitmap remain allocated outside the block's inaccessible `VirtualRange`                     |
 | Make a block inaccessible or discard it | The claim-trim gate confirmed all-free, prepared accounting no longer includes it, and the slot retains address ownership |
 
@@ -3353,6 +3364,7 @@ section; one property may discharge several contracts.
 | O3         | Failed growth preserves bytes, cursors, and writable capacity         | Failure injection and Miri at every growth commit step | Append runs before the complete acquisition commits     |
 | O1, O6     | One carrier returns once after its final view, slice, and suffix drop | Guard-level Loom and arbitrary drop-order tests        | Create one return guard per view or per run             |
 | O7         | Segment owners cover every unconsumed byte                            | Property tests over builder input and cursor movement  | Merge unknown or nonadjacent ranges                     |
+| O7, P2     | Classified views use concrete slot identity and slot-rooted provenance | Strict-provenance Miri over same-slot, cross-carrier, foreign, and cross-pool views | Extend `Bytes::as_ptr()` or classify by pool-local slot index |
 | O8         | `Buf` never reports an empty chunk while bytes remain                 | Generic-consumer property test                         | Leave the cursor on an exhausted segment boundary       |
 | O4         | Mutable and publication cursors normalize across carriers             | Generic `BufMut` and repeated-publication tests        | Leave either cursor on an exhausted carrier boundary    |
 | O4, O5     | Publication never crosses `initialized_chunk`                         | Miri and boundary tests over every carrier split       | Bound publication by total initialized length           |

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -602,6 +602,7 @@ impl Future for ReserveFuture {
 pub enum ReserveError {
     InvalidSize,
     PhysicalPreparationFailed,
+    MetadataAllocationFailed,
     CapacityOverflow,
 }
 ```
@@ -609,6 +610,9 @@ pub enum ReserveError {
 `try_reserve` attempts one immediate grant. It returns `Ok(None)` when an older waiter exists or the
 request is not immediately eligible. It may allocate reservation state and prepare physical
 capacity when it grants. A zero-byte request returns `ReserveError::InvalidSize`.
+`PhysicalPreparationFailed` reports virtual-storage preparation. `MetadataAllocationFailed` reports
+failure to reserve queue, registry, bitmap, claim, or ownership metadata. Both leave admission and
+ownership state unchanged.
 
 `reserve` creates a `ReserveFuture` without entering admission. The future's first poll converts the
 request to a carrier count and performs one admission operation:
@@ -815,6 +819,7 @@ pub enum AcquireError {
     ReservationCapacityExceeded,
     CapacityOverflow,
     PhysicalAllocationFailed,
+    MetadataAllocationFailed,
 }
 ```
 
@@ -835,8 +840,9 @@ reservation has closed.
 `ReservationCapacityExceeded` means carrier rounding would exceed the reservation's remaining
 direct-acquisition authority. `CapacityOverflow` means the request cannot be represented by pool
 geometry or packed accounting. `PhysicalAllocationFailed` means physical storage could not be
-prepared. These errors expose no partial initial buffer. Failed buffer growth preserves its
-initialized bytes, publication state, and prior writable capacity.
+prepared. `MetadataAllocationFailed` means ownership metadata could not reserve required capacity.
+These errors expose no partial initial buffer. Failed buffer growth preserves its initialized
+bytes, publication state, and prior writable capacity.
 
 Reserved growth never switches to unreserved acquisition or expands its envelope.
 `ReservationCapacityExceeded` leaves the existing buffer unchanged. Its caller may retain the
@@ -2668,6 +2674,7 @@ Recoverable resource failures remain local:
 | ------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | Invalid capacity, geometry, or counter range      | Pool construction fails before publishing a handle                                    |
 | Virtual-range reservation                         | That growth or acquisition attempt fails                                              |
+| Ownership metadata reservation                    | That growth or acquisition attempt fails without exposing partial ownership            |
 | Reservation preparation                           | That request fails; reusable capacity prepared before the failure remains available   |
 | Reserved or unreserved acquisition                | The complete debit rolls back; no partial writable buffer escapes                     |
 | Whole-range protection                            | The block enters its nonclaimable recovery state outside prepared capacity            |


### PR DESCRIPTION
## Summary

This is the fourth implementation PR in the [buffer-pool design and implementation series](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/165). It turns the carrier ownership returned by [#169](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/169) into writable buffers, immutable `Bytes`, and segmented immutable values.

The series is:

1. [Buffer-pool design](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/165)
2. [Physical-storage foundation](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/166)
3. [Arena acquisition and growth](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/167)
4. [Admission and pool composition](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/169)
5. **This PR: Mutable buffers and segmented delivery**
6. Maintenance, configuration, and operations
7. Scheduler and download integration
8. Upload staging and retry integration

This PR is stacked on #169 and does not change transfer-manager behavior. `AggregatedBytes` remains in the active download path until the integration PR.

## Why

#169 ends acquisition with charged ownership of fixed-size carriers. Transfer code still needs a safe byte lifecycle on top of that ownership: write into uninitialized storage, grow a value without moving bytes, publish initialized ranges to immutable consumers, and return each carrier after its final owner is gone.

This PR supplies that layer. `PooledBufMut` provides mutable writing and growth, while `SegmentedBytes` presents physically separate immutable ranges through `bytes::Buf`. Together they preserve pool ownership from acquisition through final consumption without requiring a gather copy.

The corresponding sections in design PR #165 are **Mutable buffer acquisition and growth**, **Ownership and delivery**, **Publication and accounting**, and Appendix C's **Safety and platform obligations**.

## Overview

One value moves through the new types as follows:

```text
BufferPool::acquire(...)
        |
        | charged carrier ownership
        v
PooledBufMut
        |
        +-- write and grow through BufMut
        |
        +-- publish_prefix() ------> Bytes
        |
        `-- freeze() -------------> SegmentedBytes
                                          |
                                          +-- read through Buf
                                          `-- final owners return carriers
```

### Mutable writing and growth

`BufferPool::acquire` and `BufferPool::acquire_unreserved` now return `PooledBufMut`. Acquisition commits the complete accounting debit and physical claim before mutable storage is exposed. The mutable buffer groups neighboring carriers into runs, preserves their logical byte order, and gives each carrier one exclusive writable range.

`PooledBufMut` implements `bytes::BufMut`. `chunk_mut()` exposes only the current carrier's uninitialized suffix, and `advance_mut()` marks written bytes initialized. `len()` counts initialized unpublished bytes. `remaining_mut()` counts retained uninitialized capacity.

`reserve(min_writable)` guarantees that at least `min_writable` bytes remain writable. It uses the existing tail before acquiring the carrier-rounded shortfall:

```text
carrier 0                  carrier 1
+------------------------+ +------------------------+
| initialized            | | initialized | writable |
+------------------------+ +------------------------+
                                      ^ reuse this tail first
```

Each buffer retains its original growth authority. Reserved buffers continue to debit their reservation, and unreserved buffers continue to use pool authority. A closed or exhausted reservation cannot force a buffer into unreserved growth. Allocation failure leaves existing bytes, cursors, capacity, and authority unchanged.

`PhysicalPreparationFailed` and `PhysicalAllocationFailed` report virtual-storage failure. `MetadataAllocationFailed` reports fallible queue or ownership-metadata allocation. No partial grant, acquisition, or growth result escapes either failure class.

### Publication and consumption

`publish_prefix(count)` transfers one contiguous initialized prefix into owner-backed `Bytes` without copying. The immutable owner keeps the carrier and its accounting charge live. If publication consumes only part of a carrier, the mutable buffer retains the disjoint suffix.

`freeze()` ends growth and transfers every remaining initialized range into `SegmentedBytes`. Wholly unused carriers return immediately. The result implements `bytes::Buf`:

- `chunk()` exposes the unconsumed front segment.
- `chunks_vectored()` emits one `IoSlice` per presentation segment.
- `advance()` releases each crossed owner boundary.
- `into_contiguous()` avoids copying for zero or one segment and gathers multiple segments only when explicitly requested.

Adjacent carrier ranges from the same block can be exposed as one contiguous `Buf` chunk, avoiding another `IoSlice`. Each carrier still has a separate guard, so advancing past its bytes can release it while later bytes remain unread, provided no clone retains it:

```text
one presentation segment
+------------------------+------------------------+
| owner: carrier 0       | owner: carrier 1       |
+------------------------+------------------------+
                         ^ advance here releases carrier 0
```

Clones have independent read cursors and share the underlying owners. A carrier returns exactly once, after its final mutable or immutable owner is gone.

### Safety boundary

The mutable buffer exposes only uninitialized storage under exclusive authority. Publication removes that range from mutable authority before constructing an immutable owner. Every immutable slice retains the owner that keeps its mapping prepared and its carrier bit live.

Pointer adjacency alone is not sufficient to merge immutable ranges. A merged slice is formed only when both pointers derive from the same concrete `BlockSlot`. Direct pooled ranges retain that slot identity. A pool-aware builder can also classify a complete pool-backed `Bytes` view, derive a fresh pointer from the slot's `VirtualRange`, and retain the original `Bytes` as the initialized owner. Foreign, cross-pool, and cross-slot views remain separate.

Strict-provenance Miri exercises the mutable range splits, publication, direct and classified coalescing, cross-pool rejection, consumption, and contiguous conversion paths. Loom uses the production ownership transitions to model concurrent final drops of frozen clones and of published and frozen ranges sharing one carrier.

## How to review

This two-carrier example shows the ownership handoffs across the main path:

```text
1. acquire(carrier_size + 3)

   carrier 0: [ writable ................................ ]
   carrier 1: [ writable ................................ ]

2. BufMut::put_slice(carrier_size + 3 bytes)

   carrier 0: [ initialized ............................. ]
   carrier 1: [ initialized ][ writable tail ............ ]

3. publish_prefix(carrier_size)

   Bytes:      [ carrier 0 initialized bytes ] + guard 0
   PooledBuf:  [ carrier 1 initialized ][ writable tail ] + guard 1

4. freeze()

   Bytes:           still owns guard 0
   SegmentedBytes:  owns guard 1; unused tail is discarded

5. advance and drop

   Crossing each owner boundary releases that guard.
   The final guard drop returns the physical bit before its accounting charge.
```

The corresponding implementation trace begins where `BufferPool::acquire` passes completed guards to `PooledBufMut::try_new`. Follow writes through the `BufMut` implementation, then follow `publish_prefix` into `PooledWindow` and `freeze` into `SegmentedBytesBuilder`. Finally, follow `SegmentedBytes::advance` as it removes crossed owner ranges.

After the normal path, inspect one failed growth. `PooledBufMut::reserve` acquires and groups the shortfall into staged runs before modifying the existing buffer. Failure at any metadata boundary drops the staged guards, restores reservation and aggregate authority, and leaves the original runs and cursors usable.

Finish at the unsafe boundaries rather than starting there. Check that each pointer-producing operation names the owner that keeps the range live, that segment coalescing requires concrete slot identity, and that opaque views retain their original `Bytes` owner after classification.

## Future

The next PR adds maintenance, idle retention, cleanup retry, shutdown, default geometry, and operational metrics without changing transfer behavior. The planned initial Hyper integration will copy ordinary Hyper chunks into `PooledBufMut`; it does not require address classification. A later receive-provider mode can preserve pool-backed `Bytes` across Hyper's opaque boundary and use pool-aware coalescing.
