### PR TITLE
target every span and event

### DIFF
--- a/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/fs.rs
@@ -203,7 +203,7 @@ impl FsWalker {
             });
         }
 
-        tracing::debug!(
+        tracing::debug!(target: crate::telemetry::TARGET_TRANSFER,
             ?root,
             follow_symlinks = self.follow_symlinks,
             max_depth = self.max_depth,
@@ -465,7 +465,7 @@ impl FsWalk {
             }
             if let Some(err) = self.pending_errors.pop_front() {
                 if !err.is_fatal() {
-                    tracing::warn!(
+                    tracing::warn!(target: crate::telemetry::TARGET_TRANSFER,
                         path = ?err.path(),
                         kind = ?err.kind(),
                         "skipping entry",
@@ -705,7 +705,7 @@ impl FsWalk {
             result.subdirs.sort_by(|a, b| a.path.cmp(&b.path));
         }
 
-        tracing::trace!(
+        tracing::trace!(target: crate::telemetry::TARGET_TRANSFER,
             ?dir,
             files = result.files.len(),
             subdirs = result.subdirs.len(),

--- a/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
+++ b/aws-sdk-s3-transfer-manager/src/io/walk/s3.rs
@@ -108,7 +108,7 @@ impl S3Walker {
     #[must_use]
     pub fn walk(self, ctx: S3WalkContext) -> S3Walk {
         if ctx.bucket.kind() == BucketType::Express {
-            tracing::warn!(
+            tracing::warn!(target: crate::telemetry::TARGET_TRANSFER,
                 bucket = %ctx.bucket.name(),
                 kind = ?ctx.bucket.kind(),
                 "directory bucket detected; listing results may not be lexicographically sorted"
@@ -117,7 +117,7 @@ impl S3Walker {
 
         let initial_prefix = self.prefix.clone().unwrap_or_default();
 
-        tracing::debug!(
+        tracing::debug!(target: crate::telemetry::TARGET_TRANSFER,
             bucket = %ctx.bucket.name(),
             kind = ?ctx.bucket.kind(),
             prefix = %initial_prefix,
@@ -377,7 +377,7 @@ impl S3Walk {
                     Ok(page) => {
                         self.initial_first_page_pending = false;
 
-                        tracing::trace!(
+                        tracing::trace!(target: crate::telemetry::TARGET_TRANSFER,
                             %prefix,
                             objects = page.objects.len(),
                             common_prefixes = page.common_prefixes.len(),

--- a/aws-sdk-s3-transfer-manager/src/lib.rs
+++ b/aws-sdk-s3-transfer-manager/src/lib.rs
@@ -70,8 +70,8 @@
 //! | Target | Covers |
 //! |---|---|
 //! | `aws_sdk_s3_transfer_manager::transfer` | transfer lifecycle, per-request spans, directory walking |
-//! | `aws_sdk_s3_transfer_manager::execution` | work dispatch, completion, panics, submission handoff |
-//! | `aws_sdk_s3_transfer_manager::scheduling` | scheduler capacity, worker growth, memory-budget admission |
+//! | `aws_sdk_s3_transfer_manager::execution` | per-work-item dispatch, completion, and panics |
+//! | `aws_sdk_s3_transfer_manager::scheduling` | scheduler capacity, worker growth, submission handoff, memory-budget admission |
 //! | `aws_sdk_s3_transfer_manager::concurrency` | concurrency-controller decisions |
 //!
 //! To follow transfer activity without the scheduling and dispatch streams:

--- a/aws-sdk-s3-transfer-manager/src/lib.rs
+++ b/aws-sdk-s3-transfer-manager/src/lib.rs
@@ -60,6 +60,29 @@
 //! * [`upload`](crate::Client::upload) - upload a single object
 //! * [`download_objects`](crate::Client::download_objects) - download an entire bucket or prefix to a local directory
 //! * [`upload_objects`](crate::Client::upload_objects) - upload an entire local directory to a bucket
+//!
+//! # Logging
+//!
+//! Logs and spans are emitted through `tracing`. Rather than one target per module,
+//! events and spans are grouped onto four targets by concern, so a filter can select a
+//! concern without naming internal module paths:
+//!
+//! | Target | Covers |
+//! |---|---|
+//! | `aws_sdk_s3_transfer_manager::transfer` | transfer lifecycle, per-request spans, directory walking |
+//! | `aws_sdk_s3_transfer_manager::execution` | work dispatch, completion, panics, submission handoff |
+//! | `aws_sdk_s3_transfer_manager::scheduling` | scheduler capacity, worker growth, memory-budget admission |
+//! | `aws_sdk_s3_transfer_manager::concurrency` | concurrency-controller decisions |
+//!
+//! To follow transfer activity without the scheduling and dispatch streams:
+//!
+//! ```text
+//! RUST_LOG=info,aws_sdk_s3_transfer_manager::transfer=debug
+//! ```
+//!
+//! Work executes on separate threads, so spans from one transfer do not nest under a
+//! single parent span. Where a line names a transfer it does so with a `tid` field rather
+//! than by nesting; the poll and execute spans that bracket every work item both carry one.
 
 /// Error types emitted by `aws-sdk-s3-transfer-manager`
 pub mod error;

--- a/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/body.rs
@@ -82,7 +82,7 @@ impl SinkWrite for FileSink {
     fn preallocate(&self, len: u64) {
         if self.owns_file {
             if let Err(e) = crate::io::fs::preallocate(&self.file, len) {
-                tracing::warn!(error = %e, "failed to preallocate file space");
+                tracing::warn!(target: crate::telemetry::TARGET_TRANSFER, error = %e, "failed to preallocate file space");
             }
         }
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/builders.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/builders.rs
@@ -22,11 +22,14 @@ impl DownloadFluentBuilder {
     }
 
     /// Initiate a download transfer for a single object
-    #[tracing::instrument(skip_all, level = "debug", name = "initiate-download", fields(
-        bucket = self.inner.bucket.as_deref().unwrap_or_default(),
-        key = self.inner.key.as_deref().unwrap_or_default(),
-    ))]
     pub fn initiate(self) -> Result<DownloadHandle, crate::error::Error> {
+        let _span = tracing::debug_span!(
+            target: crate::telemetry::TARGET_TRANSFER,
+            "initiate-download",
+            bucket = self.inner.bucket.as_deref().unwrap_or_default(),
+            key = self.inner.key.as_deref().unwrap_or_default(),
+        )
+        .entered();
         let input = self.inner.build()?;
         crate::operation::download::Download::orchestrate(self.handle, input, false)
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download/discovery.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/discovery.rs
@@ -89,17 +89,23 @@ pub(super) async fn discover_obj(
 ) -> Result<ObjectDiscovery, crate::error::Error> {
     let configured_part_size = transfer.ctx().handle.download_part_size_bytes();
     let strategy = ObjectDiscoveryStrategy::from_request(input)?;
-    tracing::trace!("discovering object with strategy {:?}", strategy);
+    tracing::trace!(target: crate::telemetry::TARGET_TRANSFER, "discovering object with strategy {:?}", strategy);
     let user_explicit_part_size = transfer.ctx().handle.user_set_part_size();
     let mut discovery = match strategy {
         ObjectDiscoveryStrategy::HeadObject => {
             discover_obj_with_head(transfer, input)
-                .instrument(tracing::debug_span!("send-head-object-for-discovery"))
+                .instrument(tracing::debug_span!(
+                    target: crate::telemetry::TARGET_TRANSFER,
+                    "send-head-object-for-discovery"
+                ))
                 .await
         }
         ObjectDiscoveryStrategy::RangedGet(range) => {
             discover_obj_with_get(transfer, input, range)
-                .instrument(tracing::debug_span!("send-ranged-get-for-discovery"))
+                .instrument(tracing::debug_span!(
+                    target: crate::telemetry::TARGET_TRANSFER,
+                    "send-ranged-get-for-discovery"
+                ))
                 .await
         }
     }?;
@@ -137,7 +143,7 @@ pub(super) async fn discover_obj(
             .map(|len| len as u64)
             .filter(|&len| len != 0)
             .unwrap_or(configured_part_size);
-        tracing::debug!(
+        tracing::debug!(target: crate::telemetry::TARGET_TRANSFER,
             configured_part_size,
             stored_part_size,
             "realigned multipart download to stored part size for validation"
@@ -146,7 +152,7 @@ pub(super) async fn discover_obj(
         discovery = aligned;
     }
 
-    tracing::trace!(
+    tracing::trace!(target: crate::telemetry::TARGET_TRANSFER,
         remaining = ?discovery.remaining,
         initial_chunk = discovery.initial_chunk.is_some(),
         effective_part_size = discovery.effective_part_size,

--- a/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/handle.rs
@@ -63,13 +63,13 @@ impl DownloadHandleInner {
         let id = self.transfer.id();
 
         if ctx.is_failed() {
-            tracing::debug!(tid = %ctx.id, "join: cancelling and waiting for idle");
+            tracing::debug!(target: crate::telemetry::TARGET_TRANSFER, tid = %ctx.id, "join: cancelling and waiting for idle");
             ctx.handle
                 .scheduler
                 .cancel_transfer(id)
                 .wait_for_idle()
                 .await;
-            tracing::debug!(tid = %ctx.id, "join: idle, returning error");
+            tracing::debug!(target: crate::telemetry::TARGET_TRANSFER, tid = %ctx.id, "join: idle, returning error");
             // take the actual error (only we should do this)
             let err = ctx.take_error().expect("error taken outside of join()");
             return Err(err);

--- a/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download/transfer.rs
@@ -45,6 +45,20 @@ pub(crate) enum DownloadWork {
     DrainResident,
 }
 
+impl crate::transfer::WorkData for DownloadWork {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Discovery => "discovery",
+            Self::GetObjectRange { .. } => "get-object-range",
+            Self::DrainResident => "drain-resident",
+        }
+    }
+}
+
 /// Bytes in the next chunk sliced from `remaining` at `part_size`: the reservation
 /// size for that chunk. Peek only — does not advance `remaining`.
 fn chunk_len(remaining: &std::ops::RangeInclusive<u64>, part_size: u64) -> usize {
@@ -237,10 +251,10 @@ impl DownloadTransfer {
     /// - `PollWork::Ready { .. }` - work available to execute
     /// - `PollWork::Pending` - waiting for in-flight work to complete
     /// - `PollWork::Done` - transfer complete
-    #[tracing::instrument(level = "debug", skip(self), fields(tid = %self.id()))]
     pub(crate) fn poll_work(&self) -> PollWork {
+        let _span = self.inner.ctx.poll_span();
         if !self.inner.ctx.is_active() {
-            tracing::debug!("not active, returning Done");
+            tracing::debug!(target: crate::telemetry::TARGET_TRANSFER, "not active, returning Done");
             return PollWork::Done;
         }
 
@@ -525,7 +539,6 @@ impl DownloadTransfer {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self, work), fields(tid = %self.id(), work = ?work.data))]
     pub(crate) async fn execute(&self, work: &mut IoRequest) -> WorkOutcome {
         let data = work.data_mut::<DownloadWork>();
         match data {
@@ -1072,6 +1085,8 @@ impl DownloadTransfer {
     ) -> WorkOutcome {
         tracing::debug!(
             target: crate::telemetry::TARGET_TRANSFER,
+            tid = %self.inner.ctx.id,
+            %error,
             "download failed",
         );
         let classification = crate::scheduler::classify_error(&error);

--- a/aws-sdk-s3-transfer-manager/src/operation/download_objects/builders.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download_objects/builders.rs
@@ -33,12 +33,15 @@ impl DownloadObjectsFluentBuilder {
     }
 
     /// Initiate download of multiple objects.
-    #[tracing::instrument(skip_all, level = "debug", name = "initiate-download-objects", fields(
-        bucket = self.inner.bucket.as_deref().unwrap_or_default(),
-        destination = self.inner.destination.as_deref().map(|p| p.to_str().unwrap_or_default()).unwrap_or_default(),
-        key_prefix = self.inner.key_prefix.as_deref().unwrap_or_default(),
-    ))]
     pub fn initiate(self) -> Result<DownloadObjectsHandle, crate::error::Error> {
+        let _span = tracing::debug_span!(
+            target: crate::telemetry::TARGET_TRANSFER,
+            "initiate-download-objects",
+            bucket = self.inner.bucket.as_deref().unwrap_or_default(),
+            destination = self.inner.destination.as_deref().map(|p| p.to_str().unwrap_or_default()).unwrap_or_default(),
+            key_prefix = self.inner.key_prefix.as_deref().unwrap_or_default(),
+        )
+        .entered();
         let input = self.inner.build()?;
         crate::operation::download_objects::DownloadObjects::orchestrate(self.handle, input)
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/download_objects/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/download_objects/transfer.rs
@@ -66,6 +66,19 @@ pub(crate) enum DownloadObjectsWork {
     JoinChildren { batch: Option<ReapingBatch> },
 }
 
+impl crate::transfer::WorkData for DownloadObjectsWork {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::AdvanceWalker { .. } => "advance-walker",
+            Self::JoinChildren { .. } => "join-children",
+        }
+    }
+}
+
 impl std::fmt::Debug for DownloadObjectsWork {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -338,6 +351,7 @@ impl DownloadObjectsTransfer {
     /// accumulating. Walk and spawn are skipped when inactive, so cancel/fail
     /// stops new work while in-flight drains.
     pub(crate) fn poll_work(&self) -> PollWork {
+        let _span = self.inner.ctx.poll_span();
         let mut state = self.inner.state.lock();
 
         // 1: Walk (refill). `dispatch_walk` gates on the low-water mark, so it
@@ -716,14 +730,7 @@ impl DownloadObjectsTransfer {
     // -----------------------------------------------------------------------
 
     pub(crate) async fn execute(&self, work: &mut IoRequest) -> WorkOutcome {
-        let data = work
-            .data
-            .as_mut()
-            .expect("work data must be set")
-            .as_any_mut()
-            .downcast_mut::<DownloadObjectsWork>()
-            .expect("work data must be DownloadObjectsWork");
-
+        let data = work.data_mut::<DownloadObjectsWork>();
         match data {
             DownloadObjectsWork::AdvanceWalker { walk } => {
                 self.execute_advance_walker(*walk.take().unwrap()).await

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/builders.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/builders.rs
@@ -25,12 +25,14 @@ impl UploadFluentBuilder {
     }
 
     /// Initiate an upload transfer for a single object
-    #[tracing::instrument(skip_all, level = "debug", name = "initiate-upload", fields(
-        bucket = self.inner.bucket.as_deref().unwrap_or_default(),
-        key = self.inner.key.as_deref().unwrap_or_default(),
-    ))]
-
     pub fn initiate(self) -> Result<UploadHandle, crate::error::Error> {
+        let _span = tracing::debug_span!(
+            target: crate::telemetry::TARGET_TRANSFER,
+            "initiate-upload",
+            bucket = self.inner.bucket.as_deref().unwrap_or_default(),
+            key = self.inner.key.as_deref().unwrap_or_default(),
+        )
+        .entered();
         let input = self.inner.build()?;
         crate::operation::upload::Upload::orchestrate(self.handle, input)
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/handle.rs
@@ -179,7 +179,10 @@ impl UploadHandle {
                             .bucket_partition_override(self.transfer.request().bucket()),
                     )
                     .send()
-                    .instrument(tracing::debug_span!("send-abort-multipart-upload"))
+                    .instrument(tracing::debug_span!(
+                        target: crate::telemetry::TARGET_TRANSFER,
+                        "send-abort-multipart-upload"
+                    ))
                     .await?;
 
                     Ok(AbortedUpload {

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/input/convert.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/input/convert.rs
@@ -156,7 +156,7 @@ pub(crate) fn copy_fields_to_upload_part_request(
         // Warn if user is passing a checksum value, but the upload isn't doing checksums.
         // We can't just set a checksum header, because we don't know what algorithm to use.
         if checksum_value.is_some() {
-            tracing::warn!("Ignoring part checksum provided during upload, because no ChecksumStrategy is specified");
+            tracing::warn!(target: crate::telemetry::TARGET_TRANSFER, "Ignoring part checksum provided during upload, because no ChecksumStrategy is specified");
         }
     }
 

--- a/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload/transfer.rs
@@ -60,6 +60,21 @@ pub(crate) enum UploadWork {
     PutObject { stream: Option<InputStream> },
 }
 
+impl crate::transfer::WorkData for UploadWork {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::CreateMPU => "create-mpu",
+            Self::UploadPart => "upload-part",
+            Self::CompleteMPU => "complete-mpu",
+            Self::PutObject { .. } => "put-object",
+        }
+    }
+}
+
 /// Maximum number of parts that a single S3 multipart upload supports
 const MAX_PARTS: u64 = 10_000;
 
@@ -181,6 +196,7 @@ impl UploadTransfer {
     /// - `PollWork::Pending` - waiting for in-flight work to complete
     /// - `PollWork::Done` - transfer complete
     pub(crate) fn poll_work(&self) -> PollWork {
+        let _span = self.inner.ctx.poll_span();
         if !self.inner.ctx.is_active() {
             return PollWork::Done;
         }
@@ -302,7 +318,10 @@ impl UploadTransfer {
                     .bucket_partition_override(self.inner.request.bucket()),
             )
             .send()
-            .instrument(tracing::debug_span!("send-create-multipart-upload"))
+            .instrument(tracing::debug_span!(
+                target: crate::telemetry::TARGET_TRANSFER,
+                "send-create-multipart-upload"
+            ))
             .await
         {
             Ok(resp) => resp,
@@ -346,7 +365,7 @@ impl UploadTransfer {
             None => PartPlan::Unknown,
         };
 
-        tracing::trace!("upload request using multipart upload with part size: {part_size} bytes");
+        tracing::trace!(target: crate::telemetry::TARGET_TRANSFER, "upload request using multipart upload with part size: {part_size} bytes");
 
         let part_reader = Arc::new(
             match PartReaderBuilder::new()
@@ -405,12 +424,15 @@ impl UploadTransfer {
 
         let data = match part_reader
             .next_part()
-            .instrument(tracing::debug_span!("read-upload-body"))
+            .instrument(tracing::debug_span!(
+                target: crate::telemetry::TARGET_TRANSFER,
+                "read-upload-body"
+            ))
             .await
         {
             Ok(Some(data)) => data,
             Ok(None) => {
-                tracing::trace!("part_reader exhausted");
+                tracing::trace!(target: crate::telemetry::TARGET_TRANSFER, "part_reader exhausted");
                 return self.on_end_of_stream(&part_reader).await;
             }
             Err(e) => return self.fail(e.into()),
@@ -530,7 +552,11 @@ impl UploadTransfer {
                     )
                     .disable_payload_signing()
                     .send()
-                    .instrument(tracing::debug_span!("send-upload-part", part_number))
+                    .instrument(tracing::debug_span!(
+                        target: crate::telemetry::TARGET_TRANSFER,
+                        "send-upload-part",
+                        part_number
+                    ))
                     .await
                     .map_err(|e| crate::retry::GuardError::Inner(crate::error::Error::from(e)))
             }
@@ -669,7 +695,10 @@ impl UploadTransfer {
                     )
                     .disable_payload_signing()
                     .send()
-                    .instrument(tracing::debug_span!("send-put-object"))
+                    .instrument(tracing::debug_span!(
+                        target: crate::telemetry::TARGET_TRANSFER,
+                        "send-put-object"
+                    ))
                     .await
                     .map_err(|e| crate::retry::GuardError::Inner(e.into()))
             }
@@ -814,11 +843,28 @@ impl UploadTransfer {
                     .bucket_partition_override(self.inner.request.bucket()),
             )
             .send()
-            .instrument(tracing::debug_span!("send-complete-multipart-upload"))
+            .instrument(tracing::debug_span!(
+                target: crate::telemetry::TARGET_TRANSFER,
+                "send-complete-multipart-upload"
+            ))
             .await
         {
             Ok(resp) => resp,
-            Err(e) => return self.fail(e.into()),
+            Err(e) => {
+                // Carries the upload id, which is in scope only here: without it the
+                // operator has no handle on the upload S3 is still holding parts for.
+                // `Error: Display` renders its own context only, so the reason is taken
+                // through the source chain -- a transport failure carries no service
+                // code and would otherwise log no reason at all.
+                let error = Error::from(e);
+                tracing::warn!(
+                    target: crate::telemetry::TARGET_TRANSFER,
+                    %upload_id,
+                    reason = %aws_smithy_types::error::display::DisplayErrorContext(&error),
+                    "complete multipart upload failed",
+                );
+                return self.fail(error);
+            }
         };
 
         let result = response_builder
@@ -837,6 +883,7 @@ impl UploadTransfer {
     fn fail(&self, error: Error) -> WorkOutcome {
         tracing::debug!(
             target: crate::telemetry::TARGET_TRANSFER,
+            tid = %self.inner.ctx.id,
             %error,
             "upload failed",
         );

--- a/aws-sdk-s3-transfer-manager/src/operation/upload_objects/builders.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload_objects/builders.rs
@@ -34,12 +34,15 @@ impl UploadObjectsFluentBuilder {
     }
 
     /// Initiate upload of multiple objects.
-    #[tracing::instrument(skip_all, level = "debug", name = "initiate-upload-objects", fields(
-        bucket = self.inner.bucket.as_deref().unwrap_or_default(),
-        source = self.inner.source.as_deref().map(|p| p.to_str().unwrap_or_default()).unwrap_or_default(),
-        key_prefix = self.inner.key_prefix.as_deref().unwrap_or_default(),
-    ))]
     pub fn initiate(self) -> Result<UploadObjectsHandle, crate::error::Error> {
+        let _span = tracing::debug_span!(
+            target: crate::telemetry::TARGET_TRANSFER,
+            "initiate-upload-objects",
+            bucket = self.inner.bucket.as_deref().unwrap_or_default(),
+            source = self.inner.source.as_deref().map(|p| p.to_str().unwrap_or_default()).unwrap_or_default(),
+            key_prefix = self.inner.key_prefix.as_deref().unwrap_or_default(),
+        )
+        .entered();
         let input = self.inner.build()?;
         crate::operation::upload_objects::UploadObjects::orchestrate(self.handle, input)
     }

--- a/aws-sdk-s3-transfer-manager/src/operation/upload_objects/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/operation/upload_objects/transfer.rs
@@ -74,6 +74,19 @@ pub(crate) enum UploadObjectsWork {
     JoinChildren { batch: Option<ReapingBatch> },
 }
 
+impl crate::transfer::WorkData for UploadObjectsWork {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::AdvanceWalker { .. } => "advance-walker",
+            Self::JoinChildren { .. } => "join-children",
+        }
+    }
+}
+
 pub(crate) struct ChildTransfer {
     source_path: PathBuf,
     key: String,
@@ -484,6 +497,7 @@ impl UploadObjectsTransfer {
     /// accumulating. Walk and spawn are skipped when inactive so cancel/fail
     /// stops new work while in-flight drains.
     pub(crate) fn poll_work(&self) -> PollWork {
+        let _span = self.inner.ctx.poll_span();
         let active = self.inner.ctx.is_active();
         let mut state = self.inner.state.lock();
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/managed.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/managed.rs
@@ -20,6 +20,7 @@ use aws_smithy_runtime_api::client::dns::{DnsFuture, ResolveDns};
 use aws_smithy_runtime_api::client::http::{http_client_fn, HttpClient, SharedHttpClient};
 use futures_util::FutureExt;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
 use super::topology::Cpu;
 use super::Topology;
@@ -120,18 +121,21 @@ enum ExecuteResult {
 async fn execute_work(work: &mut ScheduledWork, scheduler: &Scheduler) -> ExecuteResult {
     scheduler.on_dispatch();
     let tid = work.descriptor.id();
+    let work_kind = work.item.kind();
     work.descriptor.work_started();
 
     if work.descriptor.is_terminal() {
-        tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, %tid, "skipped (terminal)");
+        tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, %tid, work = work_kind, "skipped (terminal)");
         return ExecuteResult::Completed(WorkOutcome::Cancelled, Duration::ZERO);
     }
 
-    tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, %tid, "executing");
+    tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, %tid, work = work_kind, "executing");
     let transfer = work.descriptor.transfer();
     let started = Instant::now();
 
     let token = transfer.ctx().cancellation_token().clone();
+    // Not a child of the span that initiated the transfer: dispatch crosses a
+    // thread, so `tid` is what ties this span back to its transfer.
     let outcome = AssertUnwindSafe(async {
         tokio::select! {
             biased;
@@ -140,15 +144,21 @@ async fn execute_work(work: &mut ScheduledWork, scheduler: &Scheduler) -> Execut
         }
     })
     .catch_unwind()
+    .instrument(tracing::debug_span!(
+        target: crate::telemetry::TARGET_EXECUTION,
+        "execute",
+        tid = %tid,
+        work = work_kind
+    ))
     .await;
 
     match outcome {
         Ok(outcome) => {
-            tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, %tid, ?outcome, "completed");
+            tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, %tid, work = work_kind, ?outcome, "completed");
             ExecuteResult::Completed(outcome, started.elapsed())
         }
         Err(_panic) => {
-            tracing::error!(target: crate::telemetry::TARGET_EXECUTION, %tid, "panic in transfer execute");
+            tracing::error!(target: crate::telemetry::TARGET_EXECUTION, %tid, work = work_kind, "panic in transfer execute");
             ExecuteResult::Panicked
         }
     }

--- a/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/memory.rs
@@ -189,13 +189,13 @@ impl MemoryBudget {
         assert!(chunk_bytes > 0, "chunk_bytes must be > 0");
         let capacity = (capacity_bytes / chunk_bytes).max(1) as u64;
         if capacity_bytes < chunk_bytes {
-            tracing::debug!(
+            tracing::debug!(target: crate::telemetry::TARGET_SCHEDULING,
                 requested_bytes = capacity_bytes,
                 chunk_bytes,
                 "memory budget below one chunk; raised to a single chunk"
             );
         }
-        tracing::debug!(
+        tracing::debug!(target: crate::telemetry::TARGET_SCHEDULING,
             capacity_chunks = capacity,
             chunk_bytes,
             "memory budget resolved"

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -138,7 +138,7 @@ fn auto_budget(ram: Option<usize>) -> usize {
 /// [`MachineProfile`].
 pub(crate) fn mem_for_fraction(ram_bytes: Option<usize>, fraction: f64) -> usize {
     if !(fraction.is_finite() && fraction > 0.0) || fraction > 1.0 {
-        tracing::debug!(
+        tracing::debug!(target: crate::telemetry::TARGET_SCHEDULING,
             requested = fraction,
             "memory budget fraction outside (0.0, 1.0]; clamping"
         );

--- a/aws-sdk-s3-transfer-manager/src/runtime/sync/submission.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/sync/submission.rs
@@ -184,7 +184,7 @@ impl<T> SubmissionQueue<T> {
         let mut parked = false;
         while state.flushing {
             if !parked {
-                tracing::trace!(target: crate::telemetry::TARGET_EXECUTION,
+                tracing::trace!(target: crate::telemetry::TARGET_SCHEDULING,
                     phase = "enter_blocked",
                     pending = state.pending,
                     "enter blocked on flush in progress"
@@ -194,7 +194,7 @@ impl<T> SubmissionQueue<T> {
             state = self.not_flushing.wait(state);
         }
         if parked {
-            tracing::trace!(target: crate::telemetry::TARGET_EXECUTION,
+            tracing::trace!(target: crate::telemetry::TARGET_SCHEDULING,
                 phase = "enter_unblocked",
                 pending = state.pending,
                 "enter unblocked"
@@ -255,7 +255,7 @@ impl<'a, T> Submission<'a, T> {
             state.flushing = true;
             drop(state);
             let count = sq.tail.swap(0, Ordering::Relaxed).min(sq.capacity);
-            tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, phase = "flush_start", count, "submission flush starting");
+            tracing::trace!(target: crate::telemetry::TARGET_SCHEDULING, phase = "flush_start", count, "submission flush starting");
             Some(SubmissionGuard { sq, count, next: 0 })
         } else {
             // Deliberately not logging the no-flush path: it fires on every
@@ -357,7 +357,7 @@ impl<T> Drop for SubmissionGuard<'_, T> {
         let mut state = self.sq.state.lock();
         state.flushing = false;
         self.sq.not_flushing.notify_all();
-        tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, phase = "flush_end", "submission flush complete");
+        tracing::trace!(target: crate::telemetry::TARGET_SCHEDULING, phase = "flush_end", "submission flush complete");
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/sync/submission.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/sync/submission.rs
@@ -184,7 +184,7 @@ impl<T> SubmissionQueue<T> {
         let mut parked = false;
         while state.flushing {
             if !parked {
-                tracing::trace!(
+                tracing::trace!(target: crate::telemetry::TARGET_EXECUTION,
                     phase = "enter_blocked",
                     pending = state.pending,
                     "enter blocked on flush in progress"
@@ -194,7 +194,7 @@ impl<T> SubmissionQueue<T> {
             state = self.not_flushing.wait(state);
         }
         if parked {
-            tracing::trace!(
+            tracing::trace!(target: crate::telemetry::TARGET_EXECUTION,
                 phase = "enter_unblocked",
                 pending = state.pending,
                 "enter unblocked"
@@ -255,7 +255,7 @@ impl<'a, T> Submission<'a, T> {
             state.flushing = true;
             drop(state);
             let count = sq.tail.swap(0, Ordering::Relaxed).min(sq.capacity);
-            tracing::trace!(phase = "flush_start", count, "submission flush starting");
+            tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, phase = "flush_start", count, "submission flush starting");
             Some(SubmissionGuard { sq, count, next: 0 })
         } else {
             // Deliberately not logging the no-flush path: it fires on every
@@ -357,7 +357,7 @@ impl<T> Drop for SubmissionGuard<'_, T> {
         let mut state = self.sq.state.lock();
         state.flushing = false;
         self.sq.not_flushing.notify_all();
-        tracing::trace!(phase = "flush_end", "submission flush complete");
+        tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, phase = "flush_end", "submission flush complete");
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/tokio_mt.rs
@@ -12,6 +12,7 @@ use std::sync::Weak;
 use std::time::{Duration, Instant};
 
 use futures_util::FutureExt;
+use tracing::Instrument;
 
 mod worker_pool;
 
@@ -173,22 +174,25 @@ async fn worker_loop(pool: Arc<WorkerPool>, handle: Weak<crate::client::Handle>)
         h.scheduler.on_dispatch();
 
         let tid = work.descriptor.id();
+        let work_kind = work.item.kind();
         work.descriptor.work_started();
 
         // Skip execution if transfer already terminal (failed/cancelled by another work item)
         if work.descriptor.is_terminal() {
-            tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, wid, %tid, "skipped (terminal)");
+            tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, wid, %tid, work = work_kind, "skipped (terminal)");
             pool.complete();
             h.scheduler
                 .on_completion(work, WorkOutcome::Cancelled, Duration::ZERO);
             continue;
         }
 
-        tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, wid, %tid, "executing");
+        tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, wid, %tid, work = work_kind, "executing");
         let transfer = work.descriptor.transfer();
         let started = Instant::now();
 
         let token = transfer.ctx().cancellation_token().clone();
+        // Not a child of the span that initiated the transfer: dispatch crosses a
+        // thread, so `tid` is what ties this span back to its transfer.
         let outcome = AssertUnwindSafe(async {
             tokio::select! {
                 biased;
@@ -197,19 +201,25 @@ async fn worker_loop(pool: Arc<WorkerPool>, handle: Weak<crate::client::Handle>)
             }
         })
         .catch_unwind()
+        .instrument(tracing::debug_span!(
+            target: crate::telemetry::TARGET_EXECUTION,
+            "execute",
+            tid = %tid,
+            work = work_kind
+        ))
         .await;
 
         let outcome = match outcome {
             Ok(outcome) => outcome,
             Err(_panic) => {
-                tracing::error!(target: crate::telemetry::TARGET_EXECUTION, wid, %tid, "panic in transfer execute");
+                tracing::error!(target: crate::telemetry::TARGET_EXECUTION, wid, %tid, work = work_kind, "panic in transfer execute");
                 pool.complete();
                 h.scheduler.on_panic(work);
                 continue;
             }
         };
 
-        tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, wid, %tid, ?outcome, "completed");
+        tracing::trace!(target: crate::telemetry::TARGET_EXECUTION, wid, %tid, work = work_kind, ?outcome, "completed");
 
         let elapsed = started.elapsed();
         pool.complete();

--- a/aws-sdk-s3-transfer-manager/src/telemetry.rs
+++ b/aws-sdk-s3-transfer-manager/src/telemetry.rs
@@ -9,7 +9,7 @@
 //!
 //! ```text
 //! RUST_LOG=aws_sdk_s3_transfer_manager::concurrency=debug   # adaptive algorithm decisions
-//! RUST_LOG=aws_sdk_s3_transfer_manager::scheduling=debug    # scheduler + memory-budget capacity
+//! RUST_LOG=aws_sdk_s3_transfer_manager::scheduling=debug    # scheduler, submission, memory budget
 //! RUST_LOG=aws_sdk_s3_transfer_manager::execution=trace     # per-work-item execute/complete
 //! RUST_LOG=aws_sdk_s3_transfer_manager::transfer=debug      # transfer lifecycle events
 //! ```
@@ -22,8 +22,9 @@ use std::time::Duration;
 /// Adaptive concurrency controller: phase transitions, target changes, probe results.
 pub(crate) const TARGET_CONCURRENCY: &str = "aws_sdk_s3_transfer_manager::concurrency";
 
-/// Scheduler capacity decisions, worker pool growth, and memory-budget admission
-/// (reserve/grant/release flow, and saturation edges where a reserve parks).
+/// Scheduler capacity decisions, worker pool growth, the batched submission handoff to the
+/// runtime, and memory-budget admission (reserve/grant/release flow, and saturation edges
+/// where a reserve parks). Batch-scoped, unlike [`TARGET_EXECUTION`].
 pub(crate) const TARGET_SCHEDULING: &str = "aws_sdk_s3_transfer_manager::scheduling";
 
 /// Per-work-item execution: dispatch, complete, skip, panic.

--- a/aws-sdk-s3-transfer-manager/src/transfer.rs
+++ b/aws-sdk-s3-transfer-manager/src/transfer.rs
@@ -130,16 +130,15 @@ pub(crate) trait Transfer: Send + Sync + std::fmt::Debug {
 pub(crate) type BoxTransfer = Box<dyn Transfer>;
 
 /// Opaque work data carried by work items. Each state machine defines its own type.
-/// The scheduler never inspects this; it ferries it across the scheduling boundary
-/// for the transfer to reclaim via `IoRequest::data_mut::<T>()`.
+/// The scheduler does not interpret the payload; it ferries it across the scheduling
+/// boundary for the transfer to reclaim via `IoRequest::data_mut::<T>()`.
 pub(crate) trait WorkData: Any + Send + std::fmt::Debug {
     fn as_any_mut(&mut self) -> &mut dyn Any;
-}
 
-impl<T: Any + Send + std::fmt::Debug> WorkData for T {
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
+    /// Which work this is, as a telemetry label. The `&'static str` return admits only
+    /// literals, so the field's cardinality stays bounded by the impl however large the
+    /// payload grows -- unlike a `Debug` rendering, which carries the payload with it.
+    fn kind(&self) -> &'static str;
 }
 
 /// Unique identifier for a transfer, with optional parent for hierarchy
@@ -171,6 +170,11 @@ impl IoRequest {
             .as_any_mut()
             .downcast_mut::<T>()
             .expect("work data type mismatch")
+    }
+
+    /// Telemetry label for the carried work, or `"none"` when it carries none.
+    pub(crate) fn kind(&self) -> &'static str {
+        self.data.as_deref().map_or("none", |data| data.kind())
     }
 }
 
@@ -527,6 +531,18 @@ impl TransferContext {
     /// Returns the context and a receiver for terminal state notification.
     pub(crate) fn new(handle: Arc<crate::client::Handle>) -> (Self, StateMachineTerminalReceiver) {
         Self::new_inner(handle, next_transfer_id())
+    }
+
+    /// Span covering one [`poll_work`](Transfer::poll_work) turn, entered for the
+    /// caller's scope. Every operation's poll opens the same span, so it is created
+    /// here rather than once per state machine.
+    pub(crate) fn poll_span(&self) -> tracing::span::EnteredSpan {
+        tracing::debug_span!(
+            target: crate::telemetry::TARGET_TRANSFER,
+            "poll-work",
+            tid = %self.id
+        )
+        .entered()
     }
 
     /// Returns a context + receiver for a child transfer linked to `parent_id`.

--- a/aws-sdk-s3-transfer-manager/tests/span_targets_test.rs
+++ b/aws-sdk-s3-transfer-manager/tests/span_targets_test.rs
@@ -1,0 +1,460 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Spans must appear under a filter that names only this crate's telemetry targets.
+//!
+//! A span whose target defaults to `module_path!()` is invisible to such a filter, so
+//! these assertions are about the target each span carries, not about the span existing.
+//! Which of the four targets a span belongs on is a separate question from whether it
+//! carries one; only the latter is asserted here.
+//!
+//! Everything runs as one test, in phases, against one shared capture. The capture is a single
+//! global accumulator, so concurrent tests reading it would be one test with nondeterministic
+//! ordering, and a count taken over the union can be satisfied by a sibling's spans instead of
+//! the operation under test. Each phase therefore asserts against only the spans recorded after
+//! its own mark, and only for a transfer id not seen in an earlier phase.
+
+use aws_config::Region;
+use aws_sdk_s3::operation::complete_multipart_upload::CompleteMultipartUploadOutput;
+use aws_sdk_s3::operation::create_multipart_upload::CreateMultipartUploadOutput;
+use aws_sdk_s3::operation::get_object::GetObjectOutput;
+use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Output;
+use aws_sdk_s3::operation::upload_part::UploadPartOutput;
+use aws_sdk_s3_transfer_manager::types::{ConcurrencyMode, PartSize};
+use aws_smithy_mocks::{mock, mock_client, RuleMode};
+use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
+use aws_smithy_runtime_api::http::StatusCode;
+use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::byte_stream::ByteStream;
+use bytes::Bytes;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex, OnceLock};
+use tracing::span::Attributes;
+use tracing::Id;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::{EnvFilter, Layer};
+
+/// The four targets declared in `telemetry.rs`. A span carrying anything else is
+/// invisible to an operator filtering on this crate's concerns.
+const TARGETS: [&str; 4] = [
+    "aws_sdk_s3_transfer_manager::transfer",
+    "aws_sdk_s3_transfer_manager::execution",
+    "aws_sdk_s3_transfer_manager::scheduling",
+    "aws_sdk_s3_transfer_manager::concurrency",
+];
+
+/// All four curated targets at `debug`, everything else at `info`. A span left on a
+/// module-path target is suppressed by the leading `info` directive, which is the
+/// condition this test exists to catch.
+///
+/// `execution` is included here but is deliberately absent from the integration
+/// harness's default filter, which treats per-work-item detail as opt-in. So this is
+/// the filter of an operator who asked for that detail, not the default one — the
+/// `execute` span is expected to be invisible without it.
+const CURATED_FILTER: &str = "info,\
+    aws_sdk_s3_transfer_manager::concurrency=debug,\
+    aws_sdk_s3_transfer_manager::scheduling=debug,\
+    aws_sdk_s3_transfer_manager::execution=debug,\
+    aws_sdk_s3_transfer_manager::transfer=debug";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SeenSpan {
+    name: &'static str,
+    target: &'static str,
+    /// Rendered `work` field, when the span carries one.
+    work: Option<String>,
+    /// Rendered `tid`, when the span belongs to a specific transfer. Spans from one
+    /// transfer do not nest, so this is what attributes a span to a transfer.
+    tid: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SeenEvent {
+    target: &'static str,
+    level: tracing::Level,
+    /// Every field and the message, rendered — enough to assert what a line carries.
+    rendered: String,
+}
+
+#[derive(Debug, Default)]
+struct Log {
+    spans: Vec<SeenSpan>,
+    events: Vec<SeenEvent>,
+}
+
+type Captured = Arc<Mutex<Log>>;
+
+/// Records every span created while installed. Spans are created on managed threads and
+/// tokio workers, not just the test thread, so this is installed globally rather than
+/// with the thread-local `set_default` (which is why
+/// `aws_smithy_runtime::test_util::capture_test_logs` cannot be reused here).
+struct SpanCapture(Captured);
+
+impl<S: tracing::Subscriber> Layer<S> for SpanCapture {
+    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+        #[derive(Default)]
+        struct Fields {
+            work: Option<String>,
+            tid: Option<String>,
+        }
+        impl Fields {
+            fn set(&mut self, name: &str, value: String) {
+                match name {
+                    "work" => self.work = Some(value),
+                    "tid" => self.tid = Some(value),
+                    _ => {}
+                }
+            }
+        }
+        impl tracing::field::Visit for Fields {
+            fn record_debug(&mut self, f: &tracing::field::Field, v: &dyn std::fmt::Debug) {
+                self.set(f.name(), format!("{v:?}"));
+            }
+            fn record_str(&mut self, f: &tracing::field::Field, v: &str) {
+                self.set(f.name(), v.to_owned());
+            }
+        }
+        let mut fields = Fields::default();
+        attrs.record(&mut fields);
+
+        let meta = attrs.metadata();
+        self.0.lock().unwrap().spans.push(SeenSpan {
+            name: meta.name(),
+            target: meta.target(),
+            work: fields.work,
+            tid: fields.tid,
+        });
+    }
+
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        struct Render(String);
+        impl tracing::field::Visit for Render {
+            fn record_debug(&mut self, f: &tracing::field::Field, v: &dyn std::fmt::Debug) {
+                self.0.push_str(&format!(" {}={v:?}", f.name()));
+            }
+            fn record_str(&mut self, f: &tracing::field::Field, v: &str) {
+                self.0.push_str(&format!(" {}={v}", f.name()));
+            }
+        }
+        let mut render = Render(String::new());
+        event.record(&mut render);
+        let meta = event.metadata();
+        self.0.lock().unwrap().events.push(SeenEvent {
+            target: meta.target(),
+            level: *meta.level(),
+            rendered: render.0,
+        });
+    }
+}
+
+/// The one global subscriber for this test binary.
+fn captured() -> &'static Captured {
+    static CAPTURED: OnceLock<Captured> = OnceLock::new();
+    CAPTURED.get_or_init(|| {
+        let buf: Captured = Arc::new(Mutex::new(Log::default()));
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new(CURATED_FILTER))
+            .with(SpanCapture(buf.clone()));
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("no other subscriber in this test binary");
+        buf
+    })
+}
+
+/// How much has been recorded so far. A phase asserts against the tail past its own mark,
+/// so nothing an earlier phase produced can satisfy a later phase.
+#[derive(Copy, Clone)]
+struct Mark {
+    spans: usize,
+    events: usize,
+}
+
+fn mark() -> Mark {
+    let log = captured().lock().unwrap();
+    Mark {
+        spans: log.spans.len(),
+        events: log.events.len(),
+    }
+}
+
+fn spans_since(m: Mark) -> Vec<SeenSpan> {
+    let log = captured().lock().unwrap();
+    log.spans[m.spans..].to_vec()
+}
+
+fn events_since(m: Mark) -> Vec<SeenEvent> {
+    let log = captured().lock().unwrap();
+    log.events[m.events..].to_vec()
+}
+
+fn all_spans() -> Vec<SeenSpan> {
+    captured().lock().unwrap().spans.clone()
+}
+
+/// Transfer ids that opened a `poll-work` span in `spans`.
+fn poll_tids(spans: &[SeenSpan]) -> HashSet<String> {
+    spans
+        .iter()
+        .filter(|s| s.name == "poll-work")
+        .filter_map(|s| s.tid.clone())
+        .collect()
+}
+
+/// Assert the operation driven since `m` opened a `poll-work` span for a transfer of its
+/// own, and record that transfer as seen.
+///
+/// The scheduler may poll an earlier phase's transfer once more after it goes terminal, so
+/// a phase's tail is not exclusively its own. Requiring an id *not seen before* excludes
+/// those stragglers: a fresh id can only belong to a transfer this phase created. That is
+/// what makes this per-operation rather than a count over the union.
+fn assert_opened_its_own_poll_span(op: &str, m: Mark, seen: &mut HashSet<String>) {
+    let tail = spans_since(m);
+    let in_tail = poll_tids(&tail);
+    let fresh: HashSet<String> = in_tail.difference(seen).cloned().collect();
+    assert!(
+        !fresh.is_empty(),
+        "`{op}` opened no poll-work span for a transfer of its own; poll tids in its tail: \
+         {in_tail:?}, already seen: {seen:?}"
+    );
+    seen.extend(fresh);
+}
+
+fn tm(s3: aws_sdk_s3::Client, part_size: u64) -> aws_sdk_s3_transfer_manager::Client {
+    let config = aws_sdk_s3_transfer_manager::Config::builder()
+        .client(s3)
+        .part_size(PartSize::Target(part_size))
+        // Pinned so a body of a few parts takes the multipart path; the default 16 MiB
+        // threshold would route it to a single PutObject and skip the part work entirely.
+        .multipart_threshold(PartSize::Target(part_size))
+        .concurrency(ConcurrencyMode::Explicit(1))
+        .build();
+    aws_sdk_s3_transfer_manager::Client::new(config)
+}
+
+fn s3_config_defaults(builder: aws_sdk_s3::config::Builder) -> aws_sdk_s3::config::Builder {
+    builder
+        .region(Region::from_static("us-west-2"))
+        .with_test_defaults()
+}
+
+const PART_SIZE: u64 = 5 * 1024 * 1024;
+
+/// Every span this crate emits is on one of the four telemetry targets; each of the four
+/// operations opens a poll span for its own transfer; the execute span names its work with
+/// a compact discriminant; and a failed `CompleteMultipartUpload` warns with the upload id
+/// and the reason.
+#[tokio::test]
+async fn spans_carry_a_telemetry_target_across_all_operations() {
+    let _ = captured();
+    // Transfers whose poll span an earlier phase already accounted for.
+    let mut polled = HashSet::new();
+
+    // --- multipart upload: create / upload-part / complete, plus the initiate span ---
+    let m = mark();
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output(|| {
+        CreateMultipartUploadOutput::builder()
+            .upload_id("span-test")
+            .build()
+    });
+    let upload_part =
+        mock!(aws_sdk_s3::Client::upload_part).then_output(|| UploadPartOutput::builder().build());
+    let complete_mpu = mock!(aws_sdk_s3::Client::complete_multipart_upload)
+        .then_output(|| CompleteMultipartUploadOutput::builder().build());
+    let up_client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[create_mpu, upload_part, complete_mpu],
+        s3_config_defaults
+    );
+    tm(up_client, PART_SIZE)
+        .upload()
+        .bucket("test-bucket")
+        .key("big.dat")
+        .body(Bytes::from(vec![0u8; (PART_SIZE * 2) as usize]).into())
+        .initiate()
+        .expect("upload initiated")
+        .join()
+        .await
+        .expect("upload completed");
+    assert_opened_its_own_poll_span("upload", m, &mut polled);
+
+    // --- single-object download ---
+    let m = mark();
+    let data = Bytes::from_static(b"span target test payload");
+    let get_object = mock!(aws_sdk_s3::Client::get_object).then_output({
+        let data = data.clone();
+        move || {
+            GetObjectOutput::builder()
+                .body(ByteStream::from(data.clone()))
+                .content_length(data.len() as i64)
+                .content_range(format!("bytes 0-{}/{}", data.len() - 1, data.len()))
+                .e_tag("span-etag")
+                .build()
+        }
+    });
+    let down_client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[get_object],
+        s3_config_defaults
+    );
+    let mut handle = tm(down_client, PART_SIZE)
+        .download()
+        .bucket("test-bucket")
+        .key("small.dat")
+        .initiate()
+        .expect("download initiated");
+    test_common::drain(&mut handle)
+        .await
+        .expect("download drained");
+    assert_opened_its_own_poll_span("download", m, &mut polled);
+
+    // --- both directory operations, with nothing to transfer ---
+    // An empty source directory and an empty listing make no S3 calls, and the initiate
+    // span plus the poll span are produced regardless.
+    let empty_dir = tempfile::tempdir().expect("temp dir");
+    let list = mock!(aws_sdk_s3::Client::list_objects_v2)
+        .then_output(|| ListObjectsV2Output::builder().build());
+    let list_client = mock_client!(aws_sdk_s3, RuleMode::MatchAny, &[list], s3_config_defaults);
+    let dir_tm = tm(list_client, PART_SIZE);
+
+    let m = mark();
+    dir_tm
+        .upload_objects()
+        .bucket("test-bucket")
+        .source(empty_dir.path())
+        .initiate()
+        .expect("upload_objects initiated")
+        .join()
+        .await
+        .expect("upload_objects completed");
+    assert_opened_its_own_poll_span("upload_objects", m, &mut polled);
+
+    let m = mark();
+    dir_tm
+        .download_objects()
+        .bucket("test-bucket")
+        .destination(empty_dir.path())
+        .initiate()
+        .expect("download_objects initiated")
+        .join()
+        .await
+        .expect("download_objects completed");
+    assert_opened_its_own_poll_span("download_objects", m, &mut polled);
+
+    let spans = all_spans();
+    assert!(
+        !spans.is_empty(),
+        "no spans captured under the curated filter"
+    );
+
+    // (a) no span leaked a module-path target.
+    let stray: Vec<_> = spans
+        .iter()
+        .filter(|s| !TARGETS.contains(&s.target))
+        .collect();
+    assert!(
+        stray.is_empty(),
+        "spans on a target outside the curated set (they vanish under an operator filter): {stray:?}"
+    );
+
+    // (b) each operation's entry point and the shared execute span are present.
+    let names: HashSet<&str> = spans.iter().map(|s| s.name).collect();
+    for expected in [
+        "initiate-upload",
+        "initiate-download",
+        "initiate-upload-objects",
+        "initiate-download-objects",
+        "poll-work",
+        "execute",
+        "upload-part",
+        "send-upload-part",
+        "download-part",
+    ] {
+        assert!(
+            names.contains(expected),
+            "span `{expected}` missing under the curated filter; captured: {names:?}"
+        );
+    }
+
+    // (c) the execute span names its work compactly rather than debug-formatting the work
+    // enum, and covers upload, which had no execute span before.
+    let work_labels: HashSet<String> = spans
+        .iter()
+        .filter(|s| s.name == "execute")
+        .filter_map(|s| s.work.clone())
+        .collect();
+    assert!(
+        !work_labels.is_empty(),
+        "no execute span carried a `work` field"
+    );
+    for label in &work_labels {
+        assert!(
+            !label.contains('{') && !label.contains('('),
+            "`work` should be a compact discriminant, got a debug rendering: {label}"
+        );
+    }
+    assert!(
+        work_labels.contains("upload-part"),
+        "expected an execute span for upload work; got {work_labels:?}"
+    );
+
+    // --- (d) a failed CompleteMultipartUpload must warn with the upload id and the
+    // reason. Without the id an operator cannot abort or inspect the upload S3 still holds
+    // parts for; without the reason the line says only that something failed.
+    let m = mark();
+    let upload_id = "orphaned-upload-id";
+    let create_mpu = mock!(aws_sdk_s3::Client::create_multipart_upload).then_output(move || {
+        CreateMultipartUploadOutput::builder()
+            .upload_id(upload_id)
+            .build()
+    });
+    let upload_part =
+        mock!(aws_sdk_s3::Client::upload_part).then_output(|| UploadPartOutput::builder().build());
+    let complete_mpu =
+        mock!(aws_sdk_s3::Client::complete_multipart_upload).then_http_response(|| {
+            HttpResponse::new(
+                StatusCode::try_from(500).unwrap(),
+                SdkBody::from("<Error><Code>InternalError</Code></Error>"),
+            )
+        });
+    let client = mock_client!(
+        aws_sdk_s3,
+        RuleMode::MatchAny,
+        &[create_mpu, upload_part, complete_mpu],
+        s3_config_defaults
+    );
+    tm(client, PART_SIZE)
+        .upload()
+        .bucket("test-bucket")
+        .key("orphan.dat")
+        .body(Bytes::from(vec![7u8; (PART_SIZE * 2) as usize]).into())
+        .initiate()
+        .expect("upload initiated")
+        .join()
+        .await
+        .expect_err("a failing CompleteMultipartUpload must fail the upload");
+
+    let warnings: Vec<SeenEvent> = events_since(m)
+        .into_iter()
+        .filter(|e| e.level == tracing::Level::WARN)
+        .collect();
+    let warned = warnings
+        .iter()
+        .find(|e| {
+            e.target == "aws_sdk_s3_transfer_manager::transfer" && e.rendered.contains(upload_id)
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a WARN on the transfer target carrying upload id `{upload_id}`; \
+                 saw: {warnings:?}"
+            )
+        });
+    assert!(
+        warned.rendered.contains("InternalError"),
+        "the warning must name the failure reason, not only that it failed: {}",
+        warned.rendered
+    );
+}


### PR DESCRIPTION
## Summary

Most spans passed no `target` — 14 of 21 sites — so it defaulted to the module path and they disappeared under a filter naming only this crate's telemetry targets, as did most events. Coverage was uneven too: only single-object download had poll and execute spans, and that execute span debug-formatted the whole work enum per item.

Every span and event now carries a target explicitly, and no `#[instrument]` attributes remain — the attribute takes a string or bare ident for `target`, not a path, and the ident form would mean bumping `tracing`. The execute span moves into the two runtime dispatch loops so all four operations get one by construction, each operation opens a poll span, and `WorkData::kind()` replaces `work = ?work.data` with a `&'static str` per variant, dropping the blanket impl so the compiler demands a label per work type. The two single-object terminal-failure events also carry `tid` now.

Two things go past span targets and are easy to drop if you'd rather: a failed `CompleteMultipartUpload` warns with the upload id and reason, having logged neither before; and a `# Logging` section in the crate docs names the four targets with an example filter.

Not here: no event changes level, and spans still don't nest across the dispatch boundary — `tid` is the correlation key.

## Test plan

- [x] fmt / clippy clean under `-Dwarnings`; 642 lib + 19 suites + 11 doc tests; loom 41/41. miri left to CI
