### PR TITLE
chore: update dial9 to 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
  "console-subscriber",
  "crossbeam-skiplist",
  "crossbeam-utils",
- "dial9-tokio-telemetry",
+ "dial9",
  "fastrand",
  "futures-test",
  "futures-util",
@@ -1437,10 +1437,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "dial9-macro"
-version = "0.3.6"
+name = "dial9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f80ae5390c164835234fa3a74a4518b301958d9ca281b360227b19cc915058"
+checksum = "49b11bce55173f77d9003cce8f129b4af889a4639005c53c3498cef933bc895c"
+dependencies = [
+ "bon",
+ "dial9-core",
+ "dial9-macro",
+ "dial9-metrique",
+ "dial9-perf-self-profile",
+ "dial9-tokio-telemetry",
+ "dial9-trace-format",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8cbbc8955394be626249a3b52ddd6bf664373661eaeae70d87eb12bf6f20b6"
+dependencies = [
+ "arc-swap",
+ "bon",
+ "bytes",
+ "crossbeam-queue",
+ "dial9-trace-format",
+ "flate2",
+ "futures-util",
+ "libc",
+ "metrique",
+ "metrique-timesource",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
+name = "dial9-macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4177b8f8bf95d8e3769c1aad596f5d6fb231953a45c4c3d2a5946fe8e4ec327b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1448,40 +1487,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "dial9-perf-self-profile"
-version = "0.4.2"
+name = "dial9-metrique"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea8bce5b976270f836d6c2e0c1b62f9b0434697f410e4bf5e4f976d9ba63df9"
+checksum = "d42fe0e3e14e8780c4ecf9ee14c183dbcb9b1ae3612cc9a689e7dc83b13adef1"
+dependencies = [
+ "dial9-core",
+ "dial9-trace-format",
+ "metrique",
+ "metrique-writer",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-perf-self-profile"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f65948455c504bf08576c7b5cfe93bfcaa486d661dc4ee85c2a6309ab89629"
 dependencies = [
  "blazesym",
+ "bytes",
  "crossbeam-utils",
+ "dial9-core",
  "dial9-trace-format",
  "libc",
  "perf-event-data",
  "perf-event-open-sys2",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "dial9-tokio-telemetry"
-version = "0.3.10"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45521f70d67ff82b19ffddb55c7f039ee24c44a172aeb03ec2142f1808ae8562"
+checksum = "af1244091367c805b5d98a6a590f8ab992efda06e6d2560a6967ef898ffd30a2"
 dependencies = [
- "arc-swap",
  "bon",
  "bytes",
- "crossbeam-queue",
- "dial9-macro",
+ "dial9-core",
  "dial9-perf-self-profile",
  "dial9-trace-format",
  "flate2",
  "futures-util",
  "hostname",
  "libc",
- "metrique",
  "metrique-timesource",
- "metrique-writer",
  "pin-project-lite",
  "serde",
  "serde_json",
@@ -1493,20 +1545,22 @@ dependencies = [
 
 [[package]]
 name = "dial9-trace-format"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a60dd9af8e5870e8114cc4fe60dd9191fbb7e83d935f8430d7799f34dc64f05"
+checksum = "86083b7240114b2d0da4a7e9d041571d80ca3b1f92ae0ec794f1be21709daa6a"
 dependencies = [
  "dial9-trace-format-derive",
  "serde",
+ "typeid",
 ]
 
 [[package]]
 name = "dial9-trace-format-derive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e3c490d25dbf14ab5397fbbb3a467dcf763ac3733722c3f3cc86cc0d6753b0"
+checksum = "9309248f12e414d88bcc9505f78b0c9ed47f79c5b62db611493e19a612cdc9d6"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -2494,47 +2548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,12 +2736,11 @@ dependencies = [
 
 [[package]]
 name = "metrique"
-version = "0.1.25"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2638fb6c2325d3e35c7b0d1ce49cf8ce74b89b7439d4dc5ce1c9fff0f7fa18a1"
+checksum = "d2e394c63e2d1a30aeb3b9392ecf3439d8475d2df810a8f4f6e66d6866754017"
 dependencies = [
  "itoa",
- "jiff",
  "metrique-core",
  "metrique-macro",
  "metrique-service-metrics",
@@ -2737,15 +2749,14 @@ dependencies = [
  "metrique-writer-core",
  "metrique-writer-macro",
  "ryu",
- "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "metrique-core"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b99ea3484ab9afe6337413bacc842d516e65623a476699f9873803028e6a9e"
+checksum = "8bd60ab3f5d8e13e36aa1d1dd9cc4920012dd21a25bd7311ae3c39810648e068"
 dependencies = [
  "itertools 0.14.0",
  "metrique-writer-core",
@@ -2766,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "metrique-service-metrics"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb71714973a9ba53d609a577311aae4d8beb7df37869b5a92cb777a3f4c905b8"
+checksum = "24ee17caa35f83b730a83c8fa8f7a9aaa61a0becc7a71feb5bfb854bc75440d7"
 dependencies = [
  "metrique-writer",
 ]
@@ -2781,9 +2792,9 @@ checksum = "d607939211e4eaaa8cd35394fa5e57faffb7390d0ac513b39992edcaf3cc526c"
 
 [[package]]
 name = "metrique-writer"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f770fe8a45a7c2f285c7ce81b9364e0e5604cbb7daf693fef1f624bf8f0bf8"
+checksum = "82cdde44d241dab7fc8b7a32e0eb5dae6cd28f8de80b59f9a1e9f2f0b05e485e"
 dependencies = [
  "ahash",
  "crossbeam-queue",
@@ -2802,9 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "metrique-writer-core"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0b67a72a8849987122ca8ceacaf81d47eaba36cd673767fc3742a086dd04ac"
+checksum = "e57379b7ee2272efaeaaa6de062503563e57333b24aadc7f2255b3d602899e8b"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -3167,15 +3178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3217,6 +3219,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -4268,6 +4279,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,10 +4488,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "web-time",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -4656,6 +4713,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4817,6 +4884,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/aws-sdk-s3-transfer-manager/Cargo.toml
+++ b/aws-sdk-s3-transfer-manager/Cargo.toml
@@ -39,10 +39,10 @@ fastrand = "2.4"
 hdrhistogram = "7"
 http-body-1x = { package = "http-body", version = "1" }
 same-file = "1.0.6"
-dial9-tokio-telemetry = { version = "0.3", optional = true, features = ["cpu-profiling"] }
+dial9 = { version = "0.5", optional = true, features = ["tokio", "cpu-profiling"] }
 
 [features]
-dial9 = ["dep:dial9-tokio-telemetry"]
+dial9 = ["dep:dial9"]
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["uio", "fs", "resource"] }

--- a/aws-sdk-s3-transfer-manager/README.md
+++ b/aws-sdk-s3-transfer-manager/README.md
@@ -128,7 +128,7 @@ let response = handle.join().await?;
 
 ## Building the `cp` example with dial9 runtime tracing
 
-The `cp` example supports optional [dial9-tokio-telemetry](https://github.com/dial9-rs/dial9-tokio-telemetry) instrumentation for tracing all internal worker runtimes. This is useful for diagnosing hangs, load imbalance, and poll latency issues.
+The `cp` example supports optional [dial9](https://github.com/dial9-rs/dial9) instrumentation for tracing all internal worker runtimes. This is useful for diagnosing hangs, load imbalance, and poll latency issues.
 
 ```sh
 RUSTFLAGS="--cfg tokio_unstable" cargo build --features dial9 --example cp --release
@@ -140,7 +140,7 @@ Then run with `--trace-dir` to enable tracing:
 ./target/release/examples/cp s3://bucket/key /tmp/download --trace-dir /tmp/traces
 ```
 
-Trace files are written to the specified directory and can be viewed with the [dial9 viewer](https://github.com/dial9-rs/dial9-tokio-telemetry/tree/main/dial9-viewer). Each worker runtime appears as worker 0..N in the trace.
+Trace files are written to the specified directory and can be viewed with the [dial9 viewer](https://github.com/dial9-rs/dial9/tree/main/dial9-viewer). Each worker runtime appears as worker 0..N in the trace.
 
 The `S3FIO_TRACE_DIR` environment variable can also be used instead of `--trace-dir`.
 

--- a/aws-sdk-s3-transfer-manager/examples/cp.rs
+++ b/aws-sdk-s3-transfer-manager/examples/cp.rs
@@ -464,28 +464,21 @@ async fn run(args: Args) -> Result<(), BoxError> {
         .trace_dir
         .or_else(|| std::env::var("S3FIO_TRACE_DIR").ok());
     #[cfg(feature = "dial9")]
-    let telemetry_guard = if let Some(ref trace_dir) = trace_dir {
-        use dial9_tokio_telemetry::telemetry::{RotatingWriter, TelemetryCore};
+    let recorder = if let Some(ref trace_dir) = trace_dir {
+        use dial9::DiskBuffer;
         let _ = std::fs::create_dir_all(trace_dir);
-        let writer = RotatingWriter::builder()
-            .base_path(format!("{trace_dir}/trace.bin"))
+        let writer = DiskBuffer::builder()
+            .base_path(trace_dir)
             .max_file_size(64 * 1024 * 1024)
             .max_total_size(512 * 1024 * 1024)
             .build()
             .expect("failed to create trace writer");
-        let cpu_profiling = if args.cpu_profiling {
-            Some(dial9_tokio_telemetry::telemetry::cpu_profile::CpuProfilingConfig::default())
-        } else {
-            None
-        };
-        let guard = TelemetryCore::builder()
-            .writer(writer)
-            .trace_path(format!("{trace_dir}/trace.bin"))
-            .maybe_cpu_profiling(cpu_profiling)
-            .build()
-            .expect("failed to create telemetry session");
-        guard.enable();
-        Some(guard)
+        let mut builder = dial9::recorder(writer);
+        if args.cpu_profiling {
+            use dial9::RecorderPerfExt;
+            builder = builder.with_cpu_profiling(dial9::cpu::CpuProfilingConfig::default());
+        }
+        Some(builder.build())
     } else {
         None
     };
@@ -508,8 +501,8 @@ async fn run(args: Args) -> Result<(), BoxError> {
     }
 
     #[cfg(feature = "dial9")]
-    if let Some(guard) = telemetry_guard {
-        config_loader = config_loader.telemetry_guard(guard);
+    if let Some(ref recorder) = recorder {
+        config_loader = config_loader.dial9_handle(recorder.handle().clone());
     }
 
     let tm_config = config_loader.load().await;
@@ -585,6 +578,13 @@ async fn run(args: Args) -> Result<(), BoxError> {
         } else {
             println!("{json}");
         }
+    }
+
+    // Drop the client first so its worker runtimes flush, then drain.
+    #[cfg(feature = "dial9")]
+    if let Some(recorder) = recorder {
+        drop(tm);
+        recorder.graceful_shutdown(time::Duration::from_secs(10));
     }
 
     Ok(())

--- a/aws-sdk-s3-transfer-manager/src/client.rs
+++ b/aws-sdk-s3-transfer-manager/src/client.rs
@@ -253,7 +253,7 @@ impl Client {
         // 2. Build Handle with Arc::new_cyclic so scheduler and runtime
         //    can hold Weak<Handle> without creating a reference cycle.
         #[cfg(feature = "dial9")]
-        let telemetry_guard = config.take_telemetry_guard().map(std::sync::Arc::new);
+        let dial9_handle = config.take_dial9_handle();
 
         // Resolve the budget once from the same detected RAM: it sizes the
         // Handle's MemoryBudget.
@@ -266,8 +266,8 @@ impl Client {
                     #[allow(unused_mut)]
                     let mut builder = ManagedThreadRuntime::builder(weak_handle.clone());
                     #[cfg(feature = "dial9")]
-                    if let Some(guard) = telemetry_guard {
-                        builder = builder.telemetry_guard(guard);
+                    if let Some(handle) = dial9_handle {
+                        builder = builder.dial9_handle(handle);
                     }
                     Arc::new(builder.build())
                 }

--- a/aws-sdk-s3-transfer-manager/src/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/config.rs
@@ -81,7 +81,7 @@ pub struct Config {
     /// (bypassing the loader); consumers then fall back to cheap local detection.
     machine_profile: Option<crate::runtime::platform::MachineProfile>,
     #[cfg(feature = "dial9")]
-    pub(crate) telemetry_guard: Option<dial9_tokio_telemetry::telemetry::TelemetryGuard>,
+    pub(crate) dial9_handle: Option<dial9::Dial9Handle>,
 }
 
 impl Config {
@@ -147,12 +147,10 @@ impl Config {
             .expect("s3 client source already taken")
     }
 
-    /// Take the telemetry guard, if set.
+    /// Take the dial9 handle, if set.
     #[cfg(feature = "dial9")]
-    pub(crate) fn take_telemetry_guard(
-        &mut self,
-    ) -> Option<dial9_tokio_telemetry::telemetry::TelemetryGuard> {
-        self.telemetry_guard.take()
+    pub(crate) fn take_dial9_handle(&mut self) -> Option<dial9::Dial9Handle> {
+        self.dial9_handle.take()
     }
 }
 
@@ -170,7 +168,7 @@ pub struct Builder {
     s3_client_config: Option<S3ClientConfig>,
     machine_profile: Option<crate::runtime::platform::MachineProfile>,
     #[cfg(feature = "dial9")]
-    telemetry_guard: Option<dial9_tokio_telemetry::telemetry::TelemetryGuard>,
+    dial9_handle: Option<dial9::Dial9Handle>,
 }
 
 impl Builder {
@@ -297,15 +295,18 @@ impl Builder {
         self
     }
 
-    /// Set a dial9 telemetry guard for runtime tracing.
+    /// Set a dial9 handle for runtime tracing.
     ///
-    /// When set, each managed worker runtime will be traced via dial9-tokio-telemetry.
+    /// When set, each managed worker runtime is attached to the handle's
+    /// recorder. The caller keeps the recorder itself, and should drop
+    /// this client before calling [`Recorder::graceful_shutdown`],
+    /// so the workers flush into the trace.
+    ///
+    /// [`Recorder::handle`]: dial9::Recorder::handle
+    /// [`Recorder::graceful_shutdown`]: dial9::Recorder::graceful_shutdown
     #[cfg(feature = "dial9")]
-    pub fn telemetry_guard(
-        mut self,
-        guard: dial9_tokio_telemetry::telemetry::TelemetryGuard,
-    ) -> Self {
-        self.telemetry_guard = Some(guard);
+    pub fn dial9_handle(mut self, handle: dial9::Dial9Handle) -> Self {
+        self.dial9_handle = Some(handle);
         self
     }
 
@@ -338,7 +339,7 @@ impl Builder {
             s3_client_source: Some(s3_client_source),
             machine_profile: self.machine_profile,
             #[cfg(feature = "dial9")]
-            telemetry_guard: self.telemetry_guard,
+            dial9_handle: self.dial9_handle,
         }
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/config/loader.rs
+++ b/aws-sdk-s3-transfer-manager/src/config/loader.rs
@@ -77,13 +77,10 @@ impl ConfigLoader {
         self
     }
 
-    /// Set a dial9 telemetry guard for runtime tracing.
+    /// Set a dial9 handle for runtime tracing.
     #[cfg(feature = "dial9")]
-    pub fn telemetry_guard(
-        mut self,
-        guard: dial9_tokio_telemetry::telemetry::TelemetryGuard,
-    ) -> Self {
-        self.builder = self.builder.telemetry_guard(guard);
+    pub fn dial9_handle(mut self, handle: dial9::Dial9Handle) -> Self {
+        self.builder = self.builder.dial9_handle(handle);
         self
     }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/managed.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/managed.rs
@@ -192,9 +192,7 @@ impl ManagedThreadRuntime {
         handle: Weak<crate::client::Handle>,
         topology: Topology,
         pin_threads: bool,
-        #[cfg(feature = "dial9")] telemetry_guard: Option<
-            std::sync::Arc<dial9_tokio_telemetry::telemetry::TelemetryGuard>,
-        >,
+        #[cfg(feature = "dial9")] dial9_handle: Option<dial9::Dial9Handle>,
     ) -> Self {
         let shutdown_token = CancellationToken::new();
 
@@ -209,7 +207,7 @@ impl ManagedThreadRuntime {
 
                 let resolver = dns_resolver.clone();
                 #[cfg(feature = "dial9")]
-                let telemetry_guard = telemetry_guard.clone();
+                let dial9_handle = dial9_handle.clone();
 
                 let join_handle = std::thread::Builder::new()
                     .name(format!("s3-tm-{}", id))
@@ -218,12 +216,16 @@ impl ManagedThreadRuntime {
                         builder.enable_all().max_blocking_threads(1);
 
                         #[cfg(feature = "dial9")]
-                        let rt = if let Some(ref guard) = telemetry_guard {
-                            let (rt, _handle) = guard
-                                .trace_runtime(format!("s3-tm-{}", cpu_index))
-                                .build(builder)
-                                .expect("failed to create traced tokio runtime");
-                            rt
+                        let rt = if let Some(ref handle) = dial9_handle {
+                            use dial9::{Dial9HandleTokioExt, TokioAttachOptions};
+                            handle
+                                .attach_tokio_runtime(
+                                    builder,
+                                    TokioAttachOptions::builder()
+                                        .runtime_name(format!("s3-tm-{}", cpu_index))
+                                        .build(),
+                                )
+                                .expect("failed to create traced tokio runtime")
                         } else {
                             builder
                                 .build()
@@ -303,7 +305,7 @@ pub(crate) struct ManagedThreadRuntimeBuilder {
     topology: Option<Topology>,
     pin_threads: bool,
     #[cfg(feature = "dial9")]
-    telemetry_guard: Option<std::sync::Arc<dial9_tokio_telemetry::telemetry::TelemetryGuard>>,
+    dial9_handle: Option<dial9::Dial9Handle>,
 }
 
 impl ManagedThreadRuntimeBuilder {
@@ -313,17 +315,14 @@ impl ManagedThreadRuntimeBuilder {
             topology: None,
             pin_threads: false,
             #[cfg(feature = "dial9")]
-            telemetry_guard: None,
+            dial9_handle: None,
         }
     }
 
-    /// Set a dial9 telemetry guard for tracing per-thread runtimes.
+    /// Set the dial9 handle each per-thread runtime is attached to.
     #[cfg(feature = "dial9")]
-    pub(crate) fn telemetry_guard(
-        mut self,
-        guard: std::sync::Arc<dial9_tokio_telemetry::telemetry::TelemetryGuard>,
-    ) -> Self {
-        self.telemetry_guard = Some(guard);
+    pub(crate) fn dial9_handle(mut self, handle: dial9::Dial9Handle) -> Self {
+        self.dial9_handle = Some(handle);
         self
     }
 
@@ -357,7 +356,7 @@ impl ManagedThreadRuntimeBuilder {
             topology,
             self.pin_threads,
             #[cfg(feature = "dial9")]
-            self.telemetry_guard,
+            self.dial9_handle,
         )
     }
 }


### PR DESCRIPTION
Upgrades dial9 0.3 -> 0.5

We recently released dial9 v0.5, which includes big API changes and a swap in dependencies (dial9 instead of dial9-tokio-telemetry). I've used this project as one of the examples for testing the new APIs, so I figured I could submit a PR with the update. It does include breaking changes for s3tm to let me know how you want to go about those.

I didn't have a lot of context on s3tm before this so let me know if I'm missing anything.

## Changes

0.5 removed `Dial9Config` and `TelemetryCore`. Users now build a `Recorder` and attach a Tokio runtime to it (see [release page](https://github.com/dial9-rs/dial9/releases/tag/dial9-v0.5.0)):

- `dial9-tokio-telemetry` -> `dial9` with the `tokio` and `cpu-profiling` features
- `RotatingWriter` -> `DiskBuffer`, and `base_path` is now a directory, no longer a filename.
- `guard.trace_runtime(name).build(builder)` -> `handle.attach_tokio_runtime(builder, options)`

### Breaking

`config::Builder::telemetry_guard` and `ConfigLoader::telemetry_guard` are now `dial9_handle` and take a `Dial9Handle` instead of a `TelemetryGuard`. `TelemetryGuard` no longer exists in 0.5, since those signatures had to change either way, I'm renaming them to match the type now.

`--cfg tokio_unstable` is no longer required to build, but I'm leaving it in for CI and the README, since it is what gives full task coverage.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
