### PR TITLE
buffer pool: maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       - dial9-build
       - miri
       - loom
+      - freebsd-test
     steps:
       - run: exit 0
 
@@ -173,6 +174,30 @@ jobs:
         run: cargo check --workspace
         env:
           RUSTFLAGS: "" # remove -Dwarnings
+
+  freebsd-test:
+    name: Test FreeBSD 14.4
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs: basics
+    steps:
+      - uses: actions/checkout@v4
+      - name: test transfer-manager on FreeBSD
+        uses: vmactions/freebsd-vm@83b151f58c6047089f4c80eb5ba2039d158ce093 # v1.5.3
+        with:
+          release: '14.4'
+          envs: RUST_BACKTRACE RUSTFLAGS
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg install -y cmake curl ninja perl5 pkgconf
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh
+            sh rustup.sh -y --profile minimal --default-toolchain ${{ env.rust_stable }}
+          run: |
+            set -eux
+            . "$HOME/.cargo/env"
+            export CMAKE_GENERATOR=Ninja
+            cargo test -p aws-sdk-s3-transfer-manager --lib
 
   check-external-types:
     name: check-external-types (${{ matrix.os }})

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -35,6 +35,7 @@ use block::BlockError;
 use config::ResolvedPoolConfig;
 pub(crate) use config::{BufferPoolBuildError, MemoryCapacity};
 use geometry::{GeometryError, PoolGeometry};
+use maintenance::MaintenanceCoordinator;
 use metrics::{MemoryMetricState, MemoryMetrics};
 use pooled_buf::GrowthAuthority;
 pub(crate) use pooled_buf::PooledBufMut;
@@ -195,6 +196,8 @@ struct PoolInner {
     coverage: CoverageState,
     /// Stable virtual ranges and physical carrier ownership.
     arena: Arena,
+    /// Lazy idle reclamation and mapping-cleanup worker.
+    maintenance: MaintenanceCoordinator,
     /// Per-pool failure injection and test-only observations.
     #[cfg(test)]
     test_hooks: TestHooks,
@@ -212,6 +215,7 @@ impl PoolInner {
             admission: Mutex::new(AdmissionState::new(configured_capacity)),
             coverage: CoverageState::new(),
             arena: Arena::new(geometry, optimistic_scan_words)?,
+            maintenance: MaintenanceCoordinator::new(),
             #[cfg(test)]
             test_hooks: TestHooks::new(),
         })
@@ -443,6 +447,12 @@ impl PoolInner {
             wakers
         };
         wake_all(wakers);
+    }
+}
+
+impl Drop for PoolInner {
+    fn drop(&mut self) {
+        self.maintenance.shutdown();
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -36,7 +36,7 @@ use config::ResolvedPoolConfig;
 pub(crate) use config::{BufferPoolBuildError, MemoryCapacity};
 use geometry::{GeometryError, PoolGeometry};
 use maintenance::MaintenanceCoordinator;
-use metrics::{MemoryMetricState, MemoryMetrics};
+use metrics::{MemoryDiagnostics, MemoryMetricState, MemoryMetrics};
 use pooled_buf::GrowthAuthority;
 pub(crate) use pooled_buf::PooledBufMut;
 pub(crate) use segmented_bytes::SegmentedBytes;
@@ -116,6 +116,25 @@ impl BufferPool {
     /// Returns one coherent sample of this pool's memory state.
     pub(crate) fn metrics(&self) -> MemoryMetrics {
         self.inner.memory_metrics()
+    }
+
+    /// Returns operational counters and a scanned lifecycle sample.
+    pub(crate) fn diagnostics(&self) -> MemoryDiagnostics {
+        MemoryDiagnostics::from_snapshots(
+            self.inner.arena.diagnostics(),
+            self.inner.arena.lifecycle_snapshot(),
+            self.inner.maintenance.diagnostics(),
+        )
+    }
+
+    /// Invalidates pending idle reclamation when managed work starts.
+    pub(crate) fn record_managed_activity(&self) {
+        self.inner.maintenance.record_activity();
+    }
+
+    /// Arms idle reclamation after the scheduler becomes globally idle.
+    pub(crate) fn record_global_idle(&self) {
+        self.inner.maintenance.record_idle(&self.inner);
     }
 
     /// Returns the fixed writable allocation unit in bytes.
@@ -215,7 +234,10 @@ impl PoolInner {
             admission: Mutex::new(AdmissionState::new(configured_capacity)),
             coverage: CoverageState::new(),
             arena: Arena::new(geometry, optimistic_scan_words)?,
-            maintenance: MaintenanceCoordinator::new(),
+            maintenance: MaintenanceCoordinator::new(
+                configured_capacity,
+                geometry.carriers_per_block(),
+            ),
             #[cfg(test)]
             test_hooks: TestHooks::new(),
         })
@@ -288,6 +310,7 @@ impl PoolInner {
         };
         if let Err(error) = pool.arena.prepare_to(admission, floor) {
             admission.rollback_acquisition(&pool.coverage, count);
+            Self::request_cleanup_after_arena_error(pool, &error);
             return Err(map_preparation_error(error));
         }
         Ok(())
@@ -374,9 +397,10 @@ impl PoolInner {
     ) -> Result<Reservation, ReserveError> {
         let coverage = pool.coverage.snapshot();
         let target = admission.grant_target(coverage, envelope)?;
-        pool.arena
-            .prepare_to(admission, target)
-            .map_err(map_preparation_error)?;
+        if let Err(error) = pool.arena.prepare_to(admission, target) {
+            Self::request_cleanup_after_arena_error(pool, &error);
+            return Err(map_preparation_error(error));
+        }
         admission.commit_grant(&pool.coverage, envelope)?;
         Ok(Reservation::new(Arc::clone(pool), envelope))
     }
@@ -447,6 +471,19 @@ impl PoolInner {
             wakers
         };
         wake_all(wakers);
+    }
+
+    /// Schedules recovery when block preparation leaves a slot nonclaimable.
+    fn request_cleanup_after_arena_error(pool: &Arc<Self>, error: &ArenaError) {
+        if !error.cleanup_required() {
+            return;
+        }
+        tracing::warn!(
+            target: crate::telemetry::TARGET_MEMORY,
+            error = %error,
+            "buffer-pool preparation failed; mapping cleanup was scheduled"
+        );
+        pool.maintenance.request_cleanup(pool);
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -23,6 +23,7 @@ mod segmented_bytes;
 mod test_util;
 mod virtual_memory;
 
+use crate::types::MemoryBudgetConfig;
 use acquisition::acquire_count;
 pub(crate) use acquisition::AcquireError;
 use admission::{
@@ -32,8 +33,8 @@ use admission::{
 pub(crate) use admission::{Reservation, ReserveError, ReserveFuture};
 use arena::{Arena, ArenaError};
 use block::BlockError;
-use config::ResolvedPoolConfig;
-pub(crate) use config::{BufferPoolBuildError, MemoryCapacity};
+pub(crate) use config::BufferPoolBuildError;
+use config::PoolConfig;
 use geometry::{GeometryError, PoolGeometry};
 use maintenance::MaintenanceCoordinator;
 use metrics::{MemoryDiagnostics, MemoryMetricState, MemoryMetrics};
@@ -56,10 +57,10 @@ impl BufferPool {
     /// Capacity and geometry are fixed before publication. Construction does
     /// not reserve virtual ranges, prepare backing, or start maintenance.
     pub(crate) fn from_capacity(
-        capacity: MemoryCapacity,
+        capacity: MemoryBudgetConfig,
         detected_memory: Option<usize>,
     ) -> Result<Self, BufferPoolBuildError> {
-        let resolved = ResolvedPoolConfig::resolve(capacity, detected_memory)?;
+        let resolved = PoolConfig::resolve(capacity, detected_memory)?;
         Ok(Self::from_parts(
             resolved.geometry,
             resolved.configured_capacity,
@@ -120,9 +121,9 @@ impl BufferPool {
 
     /// Returns operational counters and a scanned lifecycle sample.
     pub(crate) fn diagnostics(&self) -> MemoryDiagnostics {
-        MemoryDiagnostics::from_snapshots(
+        MemoryDiagnostics::from_samples(
             self.inner.arena.diagnostics(),
-            self.inner.arena.lifecycle_snapshot(),
+            self.inner.arena.sample_lifecycle(),
             self.inner.maintenance.diagnostics(),
         )
     }
@@ -135,11 +136,6 @@ impl BufferPool {
     /// Arms idle reclamation after the scheduler becomes globally idle.
     pub(crate) fn record_global_idle(&self) {
         self.inner.maintenance.record_idle(&self.inner);
-    }
-
-    /// Returns the fixed writable allocation unit in bytes.
-    pub(crate) fn carrier_size(&self) -> usize {
-        self.inner.geometry.carrier_size()
     }
 
     /// Acquires at least `min_bytes` under one reservation.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -15,6 +15,7 @@ mod arena;
 mod block;
 mod config;
 mod geometry;
+mod maintenance;
 mod metrics;
 mod pooled_buf;
 mod segmented_bytes;

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool.rs
@@ -13,6 +13,7 @@ mod acquisition;
 mod admission;
 mod arena;
 mod block;
+mod config;
 mod geometry;
 mod metrics;
 mod pooled_buf;
@@ -30,6 +31,8 @@ use admission::{
 pub(crate) use admission::{Reservation, ReserveError, ReserveFuture};
 use arena::{Arena, ArenaError};
 use block::BlockError;
+use config::ResolvedPoolConfig;
+pub(crate) use config::{BufferPoolBuildError, MemoryCapacity};
 use geometry::{GeometryError, PoolGeometry};
 use metrics::{MemoryMetricState, MemoryMetrics};
 use pooled_buf::GrowthAuthority;
@@ -46,6 +49,23 @@ pub(crate) struct BufferPool {
 }
 
 impl BufferPool {
+    /// Constructs an empty pool from capacity policy and detected memory.
+    ///
+    /// Capacity and geometry are fixed before publication. Construction does
+    /// not reserve virtual ranges, prepare backing, or start maintenance.
+    pub(crate) fn from_capacity(
+        capacity: MemoryCapacity,
+        detected_memory: Option<usize>,
+    ) -> Result<Self, BufferPoolBuildError> {
+        let resolved = ResolvedPoolConfig::resolve(capacity, detected_memory)?;
+        Ok(Self::from_parts(
+            resolved.geometry,
+            resolved.configured_capacity,
+            resolved.optimistic_scan_words,
+        )
+        .unwrap_or_else(|_| invariant_violation("validated pool configuration was rejected")))
+    }
+
     /// Constructs a pool from checked geometry and internal configuration.
     ///
     /// Invalid capacity indicates an internal configuration defect. Public
@@ -94,6 +114,11 @@ impl BufferPool {
     /// Returns one coherent sample of this pool's memory state.
     pub(crate) fn metrics(&self) -> MemoryMetrics {
         self.inner.memory_metrics()
+    }
+
+    /// Returns the fixed writable allocation unit in bytes.
+    pub(crate) fn carrier_size(&self) -> usize {
+        self.inner.geometry.carrier_size()
     }
 
     /// Acquires at least `min_bytes` under one reservation.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/acquisition.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/acquisition.rs
@@ -284,7 +284,10 @@ pub(super) fn acquire_count(
                     .unwrap_or_else(|| invariant_violation("pending acquisition lost its claim")),
             )
         };
-        fallback.map_err(map_arena_error)?;
+        if let Err(error) = fallback {
+            PoolInner::request_cleanup_after_arena_error(pool, &error);
+            return Err(map_arena_error(error));
+        }
     }
 
     pending.finish()

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
@@ -16,7 +16,9 @@ use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering as DiagnosticOrdering};
 
 use super::admission::AdmissionGuard;
-use super::block::{BlockError, BlockSlot, CarrierAllocation, ProvisionalBits};
+use super::block::{
+    BlockError, BlockSlot, CarrierAllocation, ProvisionalBits, TrimBlocked, TrimCleanup,
+};
 use super::geometry::PoolGeometry;
 use super::{invariant_violation, CarrierCount};
 use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
@@ -109,6 +111,64 @@ impl Arena {
         });
         self.diagnostics.record_trim_slots_scanned(scanned);
         candidate
+    }
+
+    /// Starts cleanup for one free block without crossing `floor`.
+    ///
+    /// Selection remains a hint. Each candidate is rechecked through the
+    /// claim-trim gate while admission owns prepared-capacity serialization.
+    pub(super) fn start_trim(
+        &self,
+        admission: &mut AdmissionGuard<'_>,
+        floor: CarrierCount,
+    ) -> ArenaTrim {
+        let generation = self.registry_generation();
+        let mut scanned = 0;
+        for slot in generation.slots_in_claim_order() {
+            scanned += 1;
+            if !slot.appears_free() {
+                continue;
+            }
+            match BlockSlot::start_trim(slot, admission.prepared_capacity_mut(), floor) {
+                Ok(cleanup) => {
+                    self.diagnostics.record_trim_slots_scanned(scanned);
+                    return ArenaTrim::Started(cleanup);
+                }
+                Err(TrimBlocked::FloorViolation) => {
+                    self.diagnostics.record_trim_slots_scanned(scanned);
+                    return ArenaTrim::Blocked;
+                }
+                Err(TrimBlocked::NotPrepared | TrimBlocked::Busy | TrimBlocked::CleanupPending) => {
+                }
+            }
+        }
+        self.diagnostics.record_trim_slots_scanned(scanned);
+        ArenaTrim::Blocked
+    }
+
+    /// Retries pending cleanup in the current registry generation.
+    ///
+    /// Returns `true` only when every slot reports no remaining cleanup work.
+    pub(super) fn retry_cleanup(&self) -> bool {
+        let generation = self.registry_generation();
+        let mut complete = true;
+        for slot in generation.slots_in_claim_order() {
+            match slot.retry_cleanup() {
+                Ok(false) => {}
+                Ok(true) => self.diagnostics.record_cleanup_retry(),
+                Err(_) => {
+                    self.diagnostics.record_cleanup_retry();
+                    self.diagnostics.record_cleanup_failure();
+                    complete = false;
+                }
+            }
+        }
+        complete
+    }
+
+    /// Records one block whose prepared capacity and backing were reclaimed.
+    pub(super) fn record_block_reclaimed(&self) {
+        self.diagnostics.record_block_reclaimed();
     }
 
     /// Returns one private arena diagnostic sample.
@@ -522,6 +582,12 @@ struct ArenaDiagnostics {
     rolled_back_carriers: AtomicU64,
     /// Slots inspected while selecting trim candidates.
     trim_slots_scanned: AtomicU64,
+    /// Blocks removed from prepared capacity and successfully reclaimed.
+    blocks_reclaimed: AtomicU64,
+    /// Pending mapping-cleanup operations retried.
+    cleanup_retries: AtomicU64,
+    /// Mapping-cleanup attempts that remain pending.
+    cleanup_failures: AtomicU64,
 }
 
 impl ArenaDiagnostics {
@@ -558,6 +624,21 @@ impl ArenaDiagnostics {
         saturating_add(&self.trim_slots_scanned, diagnostic_count(slots));
     }
 
+    /// Records one successfully reclaimed block.
+    fn record_block_reclaimed(&self) {
+        saturating_add(&self.blocks_reclaimed, 1);
+    }
+
+    /// Records one pending cleanup operation attempted by recovery.
+    fn record_cleanup_retry(&self) {
+        saturating_add(&self.cleanup_retries, 1);
+    }
+
+    /// Records one cleanup attempt that remains pending.
+    fn record_cleanup_failure(&self) {
+        saturating_add(&self.cleanup_failures, 1);
+    }
+
     /// Loads one relaxed diagnostic sample.
     fn snapshot(&self) -> ArenaDiagnosticSnapshot {
         ArenaDiagnosticSnapshot {
@@ -568,6 +649,9 @@ impl ArenaDiagnostics {
             block_ranges_reserved: self.block_ranges_reserved.load(DiagnosticOrdering::Relaxed),
             rolled_back_carriers: self.rolled_back_carriers.load(DiagnosticOrdering::Relaxed),
             trim_slots_scanned: self.trim_slots_scanned.load(DiagnosticOrdering::Relaxed),
+            blocks_reclaimed: self.blocks_reclaimed.load(DiagnosticOrdering::Relaxed),
+            cleanup_retries: self.cleanup_retries.load(DiagnosticOrdering::Relaxed),
+            cleanup_failures: self.cleanup_failures.load(DiagnosticOrdering::Relaxed),
         }
     }
 }
@@ -589,6 +673,20 @@ pub(super) struct ArenaDiagnosticSnapshot {
     pub(super) rolled_back_carriers: u64,
     /// Slots inspected while selecting trim candidates.
     pub(super) trim_slots_scanned: u64,
+    /// Blocks removed from prepared capacity and successfully reclaimed.
+    pub(super) blocks_reclaimed: u64,
+    /// Pending mapping-cleanup operations retried.
+    pub(super) cleanup_retries: u64,
+    /// Mapping-cleanup attempts that remain pending.
+    pub(super) cleanup_failures: u64,
+}
+
+/// Result of scanning the registry for one trim candidate.
+pub(super) enum ArenaTrim {
+    /// One block passed the claim-trim gate and owns cleanup authority.
+    Started(TrimCleanup),
+    /// No block could be removed without waiting for state to change.
+    Blocked,
 }
 
 /// Adds a diagnostic value without wrapping.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
@@ -125,6 +125,7 @@ impl Arena {
     ) -> ArenaTrim {
         let generation = self.registry_generation();
         let mut scanned = 0;
+        let mut result = ArenaTrim::Blocked;
         for slot in generation.slots_in_claim_order() {
             scanned += 1;
             if !slot.appears_free() {
@@ -132,19 +133,16 @@ impl Arena {
             }
             match BlockSlot::start_trim(slot, admission.prepared_capacity_mut(), floor) {
                 Ok(cleanup) => {
-                    self.diagnostics.record_trim_slots_scanned(scanned);
-                    return ArenaTrim::Started(cleanup);
+                    result = ArenaTrim::Started(cleanup);
+                    break;
                 }
-                Err(TrimBlocked::FloorViolation) => {
-                    self.diagnostics.record_trim_slots_scanned(scanned);
-                    return ArenaTrim::Blocked;
-                }
+                Err(TrimBlocked::FloorViolation) => break,
                 Err(TrimBlocked::NotPrepared | TrimBlocked::Busy | TrimBlocked::CleanupPending) => {
                 }
             }
         }
         self.diagnostics.record_trim_slots_scanned(scanned);
-        ArenaTrim::Blocked
+        result
     }
 
     /// Retries pending cleanup in the current registry generation.
@@ -183,28 +181,32 @@ impl Arena {
         self.diagnostics.snapshot()
     }
 
-    /// Scans slot lifecycle state for private diagnostics and test audits.
-    pub(super) fn lifecycle_snapshot(&self) -> ArenaLifecycleSnapshot {
+    /// Reconstructs lifecycle state across the current registry generation.
+    ///
+    /// Concurrent claims and returns may span individual slot samples.
+    /// Operational diagnostics therefore use this as a best-effort view;
+    /// externally quiescent tests may use it for exact reconciliation.
+    pub(super) fn sample_lifecycle(&self) -> ArenaLifecycleSample {
         let generation = self.registry_generation();
-        let mut snapshot = ArenaLifecycleSnapshot::default();
+        let mut sample = ArenaLifecycleSample::default();
         for slot in generation.slots_in_claim_order() {
-            let block = slot.lifecycle_snapshot();
-            snapshot.prepared_capacity = snapshot
+            let block = slot.sample_lifecycle();
+            sample.prepared_capacity = sample
                 .prepared_capacity
                 .checked_add(block.prepared_capacity)
                 .unwrap_or_else(|| invariant_violation("arena prepared diagnostic overflow"));
-            snapshot.live_carriers = snapshot
+            sample.live_carriers = sample
                 .live_carriers
                 .checked_add(block.live_carriers)
                 .unwrap_or_else(|| invariant_violation("arena live diagnostic overflow"));
             if block.cleanup_pending {
-                snapshot.cleanup_pending_blocks = snapshot
+                sample.cleanup_pending_blocks = sample
                     .cleanup_pending_blocks
                     .checked_add(1)
                     .unwrap_or_else(|| invariant_violation("arena cleanup diagnostic overflow"));
             }
         }
-        snapshot
+        sample
     }
 
     /// Prepares capacity through `target` under admission serialization.
@@ -723,9 +725,12 @@ pub(super) struct ArenaDiagnosticSnapshot {
     pub(super) cleanup_failures: u64,
 }
 
-/// Slot state sampled independently of monotonic arena counters.
+/// Lifecycle state reconstructed across one arena registry generation.
+///
+/// Individual block samples need not represent one atomic instant while the
+/// pool is active.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub(super) struct ArenaLifecycleSnapshot {
+pub(super) struct ArenaLifecycleSample {
     /// Capacity represented by prepared active incarnations.
     pub(super) prepared_capacity: CarrierCount,
     /// Valid bitmap bits owned by claims or carrier guards.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/arena.rs
@@ -20,6 +20,7 @@ use super::block::{
     BlockError, BlockSlot, CarrierAllocation, ProvisionalBits, TrimBlocked, TrimCleanup,
 };
 use super::geometry::PoolGeometry;
+use super::virtual_memory::VirtualMemoryOperation;
 use super::{invariant_violation, CarrierCount};
 use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
 use crate::runtime::sync::sync::{Arc, Mutex};
@@ -156,9 +157,15 @@ impl Arena {
             match slot.retry_cleanup() {
                 Ok(false) => {}
                 Ok(true) => self.diagnostics.record_cleanup_retry(),
-                Err(_) => {
+                Err(error) => {
                     self.diagnostics.record_cleanup_retry();
                     self.diagnostics.record_cleanup_failure();
+                    tracing::warn!(
+                        target: crate::telemetry::TARGET_MEMORY,
+                        slot_id = slot.id(),
+                        error = ?error,
+                        "buffer-pool mapping cleanup retry failed"
+                    );
                     complete = false;
                 }
             }
@@ -174,6 +181,30 @@ impl Arena {
     /// Returns one private arena diagnostic sample.
     pub(super) fn diagnostics(&self) -> ArenaDiagnosticSnapshot {
         self.diagnostics.snapshot()
+    }
+
+    /// Scans slot lifecycle state for private diagnostics and test audits.
+    pub(super) fn lifecycle_snapshot(&self) -> ArenaLifecycleSnapshot {
+        let generation = self.registry_generation();
+        let mut snapshot = ArenaLifecycleSnapshot::default();
+        for slot in generation.slots_in_claim_order() {
+            let block = slot.lifecycle_snapshot();
+            snapshot.prepared_capacity = snapshot
+                .prepared_capacity
+                .checked_add(block.prepared_capacity)
+                .unwrap_or_else(|| invariant_violation("arena prepared diagnostic overflow"));
+            snapshot.live_carriers = snapshot
+                .live_carriers
+                .checked_add(block.live_carriers)
+                .unwrap_or_else(|| invariant_violation("arena live diagnostic overflow"));
+            if block.cleanup_pending {
+                snapshot.cleanup_pending_blocks = snapshot
+                    .cleanup_pending_blocks
+                    .checked_add(1)
+                    .unwrap_or_else(|| invariant_violation("arena cleanup diagnostic overflow"));
+            }
+        }
+        snapshot
     }
 
     /// Prepares capacity through `target` under admission serialization.
@@ -383,6 +414,17 @@ pub(super) enum ArenaError {
         /// Second overlapping range end.
         second_end: usize,
     },
+}
+
+impl ArenaError {
+    /// Returns whether this failure left an inactive slot needing recovery.
+    pub(super) fn cleanup_required(&self) -> bool {
+        matches!(
+            self,
+            Self::Block(BlockError::VirtualMemory(error))
+                if error.operation() == VirtualMemoryOperation::Prepare
+        )
+    }
 }
 
 impl fmt::Display for ArenaError {
@@ -679,6 +721,17 @@ pub(super) struct ArenaDiagnosticSnapshot {
     pub(super) cleanup_retries: u64,
     /// Mapping-cleanup attempts that remain pending.
     pub(super) cleanup_failures: u64,
+}
+
+/// Slot state sampled independently of monotonic arena counters.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct ArenaLifecycleSnapshot {
+    /// Capacity represented by prepared active incarnations.
+    pub(super) prepared_capacity: CarrierCount,
+    /// Valid bitmap bits owned by claims or carrier guards.
+    pub(super) live_carriers: CarrierCount,
+    /// Slots blocked by trim or mapping recovery.
+    pub(super) cleanup_pending_blocks: usize,
 }
 
 /// Result of scanning the registry for one trim candidate.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -1033,8 +1033,13 @@ impl BlockSlot {
         self.range.inject_failure_once(operation);
     }
 
-    /// Samples mapping, cleanup, and bitmap state for diagnostics.
-    pub(super) fn lifecycle_snapshot(&self) -> BlockLifecycleSnapshot {
+    /// Samples this slot's mapping, cleanup, and bitmap state.
+    ///
+    /// The mapping lock stabilizes lifecycle transitions, but claims and
+    /// returns may change bitmap ownership while it is counted. Consumers may
+    /// treat the result as authoritative only when the pool is externally
+    /// quiescent.
+    pub(super) fn sample_lifecycle(&self) -> BlockLifecycleSample {
         let mapping = self.mapping.lock();
         let current = self.current.load();
         let live_carriers = current
@@ -1094,7 +1099,7 @@ impl BlockSlot {
             }
         };
 
-        BlockLifecycleSnapshot {
+        BlockLifecycleSample {
             prepared_capacity,
             live_carriers,
             cleanup_pending,
@@ -1102,8 +1107,8 @@ impl BlockSlot {
     }
 }
 
-/// One diagnostic sample from a block slot.
-pub(super) struct BlockLifecycleSnapshot {
+/// Independently reconstructed lifecycle state for one block slot.
+pub(super) struct BlockLifecycleSample {
     /// Capacity represented by a prepared active incarnation.
     pub(super) prepared_capacity: CarrierCount,
     /// Valid bitmap bits currently owned by claims or carrier guards.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -780,9 +780,10 @@ impl BlockSlot {
     ///
     /// Pool maintenance calls this after a cleanup operation records pending
     /// work. A slot with no pending work returns success without changing
-    /// state. Failure leaves the slot nonclaimable and identifies the required
+    /// state. The result is `true` when this call attempted pending platform
+    /// work. Failure leaves the slot nonclaimable and identifies the required
     /// retry.
-    pub(super) fn retry_cleanup(&self) -> Result<(), CleanupRetry> {
+    pub(super) fn retry_cleanup(&self) -> Result<bool, CleanupRetry> {
         let mut mapping = self.mapping.lock();
         match *mapping {
             MappingState::Prepared => {
@@ -791,7 +792,7 @@ impl BlockSlot {
                     invariant_violation("prepared mapping has no current incarnation");
                 };
                 match incarnation.state.load(Ordering::Acquire) {
-                    IncarnationState::Active | IncarnationState::Draining => return Ok(()),
+                    IncarnationState::Active | IncarnationState::Draining => return Ok(false),
                     IncarnationState::Dead => {
                         invariant_violation("prepared mapping has a dead current incarnation")
                     }
@@ -803,7 +804,7 @@ impl BlockSlot {
                 if self.current.load().as_ref().is_some() {
                     invariant_violation("inactive mapping has a current incarnation");
                 }
-                return Ok(());
+                return Ok(false);
             }
             MappingState::Reserved {
                 reclaim_pending: true,
@@ -816,7 +817,7 @@ impl BlockSlot {
                         *mapping = MappingState::Reserved {
                             reclaim_pending: false,
                         };
-                        Ok(())
+                        Ok(true)
                     }
                     Err(error) => Err(CleanupRetry::ReclaimPending(error)),
                 };
@@ -845,7 +846,7 @@ impl BlockSlot {
         *mapping = MappingState::Reserved {
             reclaim_pending: false,
         };
-        self.finish_inactive_cleanup(&mut mapping)
+        self.finish_inactive_cleanup(&mut mapping).map(|()| true)
     }
 
     /// Retires a draining incarnation after the range becomes inaccessible.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/block.rs
@@ -1032,6 +1032,84 @@ impl BlockSlot {
     pub(super) fn inject_failure_once(&self, operation: VirtualMemoryOperation) {
         self.range.inject_failure_once(operation);
     }
+
+    /// Samples mapping, cleanup, and bitmap state for diagnostics.
+    pub(super) fn lifecycle_snapshot(&self) -> BlockLifecycleSnapshot {
+        let mapping = self.mapping.lock();
+        let current = self.current.load();
+        let live_carriers = current
+            .as_ref()
+            .map(|incarnation| {
+                incarnation
+                    .in_use
+                    .iter()
+                    .enumerate()
+                    .map(|(word_index, word)| {
+                        let valid = bitmap_word_mask(self.geometry, word_index);
+                        CarrierCount::new(
+                            (word.load(Ordering::Acquire) & valid).count_ones() as usize
+                        )
+                    })
+                    .fold(CarrierCount::ZERO, |total, count| {
+                        total.checked_add(count).unwrap_or_else(|| {
+                            invariant_violation("block live-carrier diagnostic overflow")
+                        })
+                    })
+            })
+            .unwrap_or(CarrierCount::ZERO);
+
+        let (prepared_capacity, cleanup_pending) = match *mapping {
+            MappingState::Prepared => {
+                let Some(incarnation) = current.as_ref() else {
+                    invariant_violation("prepared mapping has no current incarnation");
+                };
+                match incarnation.state.load(Ordering::Acquire) {
+                    IncarnationState::Active => (self.carrier_count(), false),
+                    IncarnationState::Draining => (CarrierCount::ZERO, true),
+                    IncarnationState::Dead => {
+                        invariant_violation("prepared mapping has a dead incarnation")
+                    }
+                }
+            }
+            MappingState::Reserved { reclaim_pending } => {
+                if current.as_ref().is_some() {
+                    invariant_violation("reserved mapping retains a current incarnation");
+                }
+                (CarrierCount::ZERO, reclaim_pending)
+            }
+            MappingState::ActivationRecoveryPending => {
+                if current.as_ref().is_some() {
+                    invariant_violation("activation recovery retains a current incarnation");
+                }
+                (CarrierCount::ZERO, true)
+            }
+            MappingState::DeactivationRecoveryPending => {
+                let Some(incarnation) = current.as_ref() else {
+                    invariant_violation("deactivation recovery lost its current incarnation");
+                };
+                if incarnation.state.load(Ordering::Acquire) != IncarnationState::Draining {
+                    invariant_violation("deactivation recovery has a non-draining incarnation");
+                }
+                (CarrierCount::ZERO, true)
+            }
+        };
+
+        BlockLifecycleSnapshot {
+            prepared_capacity,
+            live_carriers,
+            cleanup_pending,
+        }
+    }
+}
+
+/// One diagnostic sample from a block slot.
+pub(super) struct BlockLifecycleSnapshot {
+    /// Capacity represented by a prepared active incarnation.
+    pub(super) prepared_capacity: CarrierCount,
+    /// Valid bitmap bits currently owned by claims or carrier guards.
+    pub(super) live_carriers: CarrierCount,
+    /// Whether trim or mapping recovery keeps the slot nonclaimable.
+    pub(super) cleanup_pending: bool,
 }
 
 /// Result of one bounded block claim.

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/config.rs
@@ -30,6 +30,12 @@ const AUTO_CAPACITY_MAX_BYTES: u64 = 32 * 1024 * 1024 * 1024;
 /// Automatic capacity when effective memory cannot be detected.
 const AUTO_CAPACITY_FALLBACK_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
+/// Explicit fraction bits stored by an IEEE 754 binary64 value.
+const F64_FRACTION_BITS: u32 = 52;
+
+/// Exponent bias used by an IEEE 754 binary64 value.
+const F64_EXPONENT_BIAS: u32 = 1023;
+
 /// Configured memory policy for one buffer pool.
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -146,15 +152,44 @@ fn resolve_capacity_bytes(
                 .map_err(|_| BufferPoolBuildError::CapacityOverflow),
         },
         MemoryCapacity::Fraction(fraction) => {
-            if !(fraction.is_finite() && 0.0 < fraction && fraction <= 1.0) {
+            if !(0.0 < fraction && fraction <= 1.0) {
                 return Err(BufferPoolBuildError::InvalidCapacity);
             }
             let detected =
                 detected_memory.ok_or(BufferPoolBuildError::MemoryDetectionUnavailable)?;
-            Ok((detected as f64 * fraction) as usize)
+            Ok(floor_fraction_of(detected, fraction))
         }
         MemoryCapacity::Limit(bytes) => Ok(bytes),
     }
+}
+
+/// Multiplies an integer by a checked fraction without rounding above it.
+///
+/// A normal binary64 value is `significand * 2^(exponent - 1023 - 52)`.
+/// Multiplying the integer significand in `u128` and shifting right therefore
+/// computes the exact floor instead of rounding the intermediate `f64`.
+fn floor_fraction_of(total: usize, fraction: f64) -> usize {
+    debug_assert!(0.0 < fraction && fraction <= 1.0);
+
+    let bits = fraction.to_bits();
+    let exponent = ((bits >> F64_FRACTION_BITS) & 0x7ff) as u32;
+    let stored_fraction = bits & ((1_u64 << F64_FRACTION_BITS) - 1);
+    let (significand, shift) = if exponent == 0 {
+        (
+            u128::from(stored_fraction),
+            F64_EXPONENT_BIAS + F64_FRACTION_BITS - 1,
+        )
+    } else {
+        (
+            u128::from(stored_fraction | (1_u64 << F64_FRACTION_BITS)),
+            F64_EXPONENT_BIAS + F64_FRACTION_BITS - exponent,
+        )
+    };
+    let product = (total as u128) * significand;
+    if shift >= u128::BITS {
+        return 0;
+    }
+    (product >> shift) as usize
 }
 
 #[cfg(test)]
@@ -211,6 +246,22 @@ mod tests {
     }
 
     #[test]
+    fn test_fraction_rejects_zero_before_capacity_resolution() {
+        assert_eq!(
+            resolve_capacity_bytes(MemoryCapacity::Fraction(0.0), Some(GIB)),
+            Err(BufferPoolBuildError::InvalidCapacity)
+        );
+    }
+
+    #[test]
+    fn test_fraction_accepts_the_inclusive_upper_bound() {
+        assert_eq!(
+            resolve_capacity_bytes(MemoryCapacity::Fraction(1.0), Some(GIB)),
+            Ok(GIB)
+        );
+    }
+
+    #[test]
     fn test_fraction_rounds_down_to_complete_carriers() {
         let resolved = ResolvedPoolConfig::resolve_for_page(
             MemoryCapacity::Fraction(0.5),
@@ -219,6 +270,27 @@ mod tests {
         )
         .unwrap();
         assert_eq!(resolved.configured_capacity.get() * 64 * 1024, GIB / 2);
+    }
+
+    #[test]
+    fn test_fraction_does_not_round_above_the_exact_binary_fraction() {
+        let resolved = ResolvedPoolConfig::resolve_for_page(
+            MemoryCapacity::Fraction(0.3333333333333333),
+            Some(1_074_266_112),
+            4096,
+        )
+        .unwrap();
+        assert_eq!(resolved.configured_capacity, CarrierCount::new(5463));
+    }
+
+    #[test]
+    fn test_tiny_fraction_resolves_below_one_carrier_without_panicking() {
+        let capacity = MemoryCapacity::Fraction(1e-30);
+        assert_eq!(resolve_capacity_bytes(capacity, Some(GIB)), Ok(0));
+        assert_eq!(
+            ResolvedPoolConfig::resolve_for_page(capacity, Some(GIB), 4096),
+            Err(BufferPoolBuildError::InvalidCapacity)
+        );
     }
 
     #[test]
@@ -251,6 +323,15 @@ mod tests {
         assert_eq!(resolved.geometry.carrier_size(), 128 * 1024);
         assert_eq!(resolved.geometry.block_size(), 8 * 1024 * 1024);
         assert_eq!(resolved.configured_capacity, CarrierCount::new(2));
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_capacity_accepts_the_exact_packed_carrier_limit() {
+        let bytes = u32::MAX as usize * 64 * 1024;
+        let resolved =
+            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Limit(bytes), None, 4096).unwrap();
+        assert_eq!(resolved.configured_capacity, MAX_PACKED_CARRIERS);
     }
 
     #[cfg(target_pointer_width = "64")]

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/config.rs
@@ -11,15 +11,21 @@ use super::admission::MAX_PACKED_CARRIERS;
 use super::geometry::PoolGeometry;
 use super::virtual_memory::page_size;
 use super::CarrierCount;
+use crate::types::MemoryBudgetConfig;
 
 /// Default carrier size before runtime page-size alignment.
-const DEFAULT_CARRIER_BYTES: usize = 64 * 1024;
+const DEFAULT_CARRIER_BYTES: usize = 16 * 1024;
 
-/// Number of carriers prepared and reclaimed as one block.
-const DEFAULT_BLOCK_CARRIERS: usize = 64;
+/// Target bytes prepared and reclaimed as one block.
+///
+/// Pools configured below this value use their complete carrier-rounded
+/// capacity as one block.
+const DEFAULT_BLOCK_BYTES: usize = 128 * 1024 * 1024;
 
-/// Maximum bitmap words inspected by one optimistic claim.
-const DEFAULT_OPTIMISTIC_SCAN_WORDS: usize = 8;
+/// Target byte range represented by one optimistic bitmap scan.
+///
+/// The actual reach rounds up to a complete bitmap word.
+const DEFAULT_OPTIMISTIC_SCAN_BYTES: usize = 32 * 1024 * 1024;
 
 /// Fraction of detected memory selected by automatic capacity.
 const AUTO_CAPACITY_DIVISOR: usize = 4;
@@ -35,19 +41,6 @@ const F64_FRACTION_BITS: u32 = 52;
 
 /// Exponent bias used by an IEEE 754 binary64 value.
 const F64_EXPONENT_BIAS: u32 = 1023;
-
-/// Configured memory policy for one buffer pool.
-#[non_exhaustive]
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
-pub(crate) enum MemoryCapacity {
-    /// Use one quarter of detected effective memory, capped at 32 GiB.
-    #[default]
-    Auto,
-    /// Use a fraction of detected effective memory.
-    Fraction(f64),
-    /// Use an explicit byte ceiling without memory detection.
-    Limit(usize),
-}
 
 /// Failure to resolve capacity and geometry before pool publication.
 #[non_exhaustive]
@@ -82,9 +75,9 @@ impl fmt::Display for BufferPoolBuildError {
 
 impl std::error::Error for BufferPoolBuildError {}
 
-/// Fully checked inputs for constructing an empty pool.
+/// Checked geometry and accounting inputs for constructing an empty pool.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) struct ResolvedPoolConfig {
+pub(super) struct PoolConfig {
     /// Page, carrier, block, and bitmap dimensions.
     pub(super) geometry: PoolGeometry,
     /// Normal admission ceiling in complete carriers.
@@ -93,10 +86,10 @@ pub(super) struct ResolvedPoolConfig {
     pub(super) optimistic_scan_words: usize,
 }
 
-impl ResolvedPoolConfig {
+impl PoolConfig {
     /// Resolves capacity against detected memory and runtime page geometry.
     pub(super) fn resolve(
-        capacity: MemoryCapacity,
+        capacity: MemoryBudgetConfig,
         detected_memory: Option<usize>,
     ) -> Result<Self, BufferPoolBuildError> {
         let page_size = page_size().map_err(|_| BufferPoolBuildError::UnsupportedPageGeometry)?;
@@ -104,8 +97,8 @@ impl ResolvedPoolConfig {
     }
 
     /// Resolves capacity against explicit page geometry.
-    fn resolve_for_page(
-        capacity: MemoryCapacity,
+    pub(super) fn resolve_for_page(
+        capacity: MemoryBudgetConfig,
         detected_memory: Option<usize>,
         page_size: usize,
     ) -> Result<Self, BufferPoolBuildError> {
@@ -113,11 +106,6 @@ impl ResolvedPoolConfig {
             .div_ceil(page_size)
             .checked_mul(page_size)
             .ok_or(BufferPoolBuildError::CapacityOverflow)?;
-        let block_size = carrier_size
-            .checked_mul(DEFAULT_BLOCK_CARRIERS)
-            .ok_or(BufferPoolBuildError::CapacityOverflow)?;
-        let geometry = PoolGeometry::new(page_size, block_size, carrier_size)
-            .map_err(|_| BufferPoolBuildError::UnsupportedPageGeometry)?;
 
         let bytes = resolve_capacity_bytes(capacity, detected_memory)?;
         let carriers = bytes / carrier_size;
@@ -128,22 +116,32 @@ impl ResolvedPoolConfig {
         if configured_capacity > MAX_PACKED_CARRIERS {
             return Err(BufferPoolBuildError::CapacityOverflow);
         }
+        let target_block_carriers = (DEFAULT_BLOCK_BYTES / carrier_size).max(1);
+        let block_carriers = target_block_carriers.min(configured_capacity.get());
+        let block_size = carrier_size
+            .checked_mul(block_carriers)
+            .ok_or(BufferPoolBuildError::CapacityOverflow)?;
+        let geometry = PoolGeometry::new(page_size, block_size, carrier_size)
+            .map_err(|_| BufferPoolBuildError::UnsupportedPageGeometry)?;
+        let optimistic_scan_words = DEFAULT_OPTIMISTIC_SCAN_BYTES
+            .div_ceil(carrier_size)
+            .div_ceil(u64::BITS as usize);
 
         Ok(Self {
             geometry,
             configured_capacity,
-            optimistic_scan_words: DEFAULT_OPTIMISTIC_SCAN_WORDS,
+            optimistic_scan_words,
         })
     }
 }
 
 /// Resolves one capacity policy to bytes before carrier rounding.
 fn resolve_capacity_bytes(
-    capacity: MemoryCapacity,
+    capacity: MemoryBudgetConfig,
     detected_memory: Option<usize>,
 ) -> Result<usize, BufferPoolBuildError> {
     match capacity {
-        MemoryCapacity::Auto => match detected_memory {
+        MemoryBudgetConfig::Auto => match detected_memory {
             Some(bytes) => {
                 let maximum = usize::try_from(AUTO_CAPACITY_MAX_BYTES).unwrap_or(usize::MAX);
                 Ok((bytes / AUTO_CAPACITY_DIVISOR).min(maximum))
@@ -151,7 +149,7 @@ fn resolve_capacity_bytes(
             None => usize::try_from(AUTO_CAPACITY_FALLBACK_BYTES)
                 .map_err(|_| BufferPoolBuildError::CapacityOverflow),
         },
-        MemoryCapacity::Fraction(fraction) => {
+        MemoryBudgetConfig::Fraction(fraction) => {
             if !(0.0 < fraction && fraction <= 1.0) {
                 return Err(BufferPoolBuildError::InvalidCapacity);
             }
@@ -159,7 +157,7 @@ fn resolve_capacity_bytes(
                 detected_memory.ok_or(BufferPoolBuildError::MemoryDetectionUnavailable)?;
             Ok(floor_fraction_of(detected, fraction))
         }
-        MemoryCapacity::Limit(bytes) => Ok(bytes),
+        MemoryBudgetConfig::Limit(bytes) => Ok(bytes),
     }
 }
 
@@ -202,31 +200,37 @@ mod tests {
     #[test]
     fn test_auto_uses_quarter_of_detected_memory() {
         let resolved =
-            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Auto, Some(2 * GIB), 4096)
-                .unwrap();
-        assert_eq!(resolved.configured_capacity.get() * 64 * 1024, GIB / 2);
+            PoolConfig::resolve_for_page(MemoryBudgetConfig::Auto, Some(2 * GIB), 4096).unwrap();
+        assert_eq!(
+            resolved.configured_capacity.get() * DEFAULT_CARRIER_BYTES,
+            GIB / 2
+        );
     }
 
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn test_auto_caps_large_machines() {
         let resolved =
-            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Auto, Some(768 * GIB), 4096)
-                .unwrap();
-        assert_eq!(resolved.configured_capacity.get() * 64 * 1024, 32 * GIB);
+            PoolConfig::resolve_for_page(MemoryBudgetConfig::Auto, Some(768 * GIB), 4096).unwrap();
+        assert_eq!(
+            resolved.configured_capacity.get() * DEFAULT_CARRIER_BYTES,
+            32 * GIB
+        );
     }
 
     #[test]
     fn test_auto_uses_fallback_without_detection() {
-        let resolved =
-            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Auto, None, 4096).unwrap();
-        assert_eq!(resolved.configured_capacity.get() * 64 * 1024, 2 * GIB);
+        let resolved = PoolConfig::resolve_for_page(MemoryBudgetConfig::Auto, None, 4096).unwrap();
+        assert_eq!(
+            resolved.configured_capacity.get() * DEFAULT_CARRIER_BYTES,
+            2 * GIB
+        );
     }
 
     #[test]
     fn test_fraction_requires_detection() {
         assert_eq!(
-            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Fraction(0.5), None, 4096),
+            PoolConfig::resolve_for_page(MemoryBudgetConfig::Fraction(0.5), None, 4096),
             Err(BufferPoolBuildError::MemoryDetectionUnavailable)
         );
     }
@@ -235,8 +239,8 @@ mod tests {
     fn test_fraction_rejects_invalid_values() {
         for fraction in [f64::NAN, f64::INFINITY, -0.5, 0.0, 1.5] {
             assert_eq!(
-                ResolvedPoolConfig::resolve_for_page(
-                    MemoryCapacity::Fraction(fraction),
+                PoolConfig::resolve_for_page(
+                    MemoryBudgetConfig::Fraction(fraction),
                     Some(GIB),
                     4096,
                 ),
@@ -248,7 +252,7 @@ mod tests {
     #[test]
     fn test_fraction_rejects_zero_before_capacity_resolution() {
         assert_eq!(
-            resolve_capacity_bytes(MemoryCapacity::Fraction(0.0), Some(GIB)),
+            resolve_capacity_bytes(MemoryBudgetConfig::Fraction(0.0), Some(GIB)),
             Err(BufferPoolBuildError::InvalidCapacity)
         );
     }
@@ -256,47 +260,47 @@ mod tests {
     #[test]
     fn test_fraction_accepts_the_inclusive_upper_bound() {
         assert_eq!(
-            resolve_capacity_bytes(MemoryCapacity::Fraction(1.0), Some(GIB)),
+            resolve_capacity_bytes(MemoryBudgetConfig::Fraction(1.0), Some(GIB)),
             Ok(GIB)
         );
     }
 
     #[test]
     fn test_fraction_rounds_down_to_complete_carriers() {
-        let resolved = ResolvedPoolConfig::resolve_for_page(
-            MemoryCapacity::Fraction(0.5),
-            Some(GIB + 1),
-            4096,
-        )
-        .unwrap();
-        assert_eq!(resolved.configured_capacity.get() * 64 * 1024, GIB / 2);
+        let resolved =
+            PoolConfig::resolve_for_page(MemoryBudgetConfig::Fraction(0.5), Some(GIB + 1), 4096)
+                .unwrap();
+        assert_eq!(
+            resolved.configured_capacity.get() * DEFAULT_CARRIER_BYTES,
+            GIB / 2
+        );
     }
 
     #[test]
     fn test_fraction_does_not_round_above_the_exact_binary_fraction() {
-        let resolved = ResolvedPoolConfig::resolve_for_page(
-            MemoryCapacity::Fraction(0.3333333333333333),
+        let resolved = PoolConfig::resolve_for_page(
+            MemoryBudgetConfig::Fraction(0.3333333333333333),
             Some(1_074_266_112),
             4096,
         )
         .unwrap();
-        assert_eq!(resolved.configured_capacity, CarrierCount::new(5463));
+        assert_eq!(resolved.configured_capacity, CarrierCount::new(21855));
     }
 
     #[test]
     fn test_tiny_fraction_resolves_below_one_carrier_without_panicking() {
-        let capacity = MemoryCapacity::Fraction(1e-30);
-        assert_eq!(resolve_capacity_bytes(capacity, Some(GIB)), Ok(0));
+        let capacity = MemoryBudgetConfig::Fraction(1e-30);
+        assert_eq!(resolve_capacity_bytes(capacity.clone(), Some(GIB)), Ok(0));
         assert_eq!(
-            ResolvedPoolConfig::resolve_for_page(capacity, Some(GIB), 4096),
+            PoolConfig::resolve_for_page(capacity, Some(GIB), 4096),
             Err(BufferPoolBuildError::InvalidCapacity)
         );
     }
 
     #[test]
     fn test_limit_rounds_down_to_complete_carriers() {
-        let resolved = ResolvedPoolConfig::resolve_for_page(
-            MemoryCapacity::Limit(64 * 1024 + 123),
+        let resolved = PoolConfig::resolve_for_page(
+            MemoryBudgetConfig::Limit(DEFAULT_CARRIER_BYTES + 123),
             None,
             4096,
         )
@@ -307,47 +311,108 @@ mod tests {
     #[test]
     fn test_capacity_below_one_carrier_is_rejected() {
         assert_eq!(
-            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Limit(64 * 1024 - 1), None, 4096),
+            PoolConfig::resolve_for_page(
+                MemoryBudgetConfig::Limit(DEFAULT_CARRIER_BYTES - 1),
+                None,
+                4096,
+            ),
             Err(BufferPoolBuildError::InvalidCapacity)
         );
     }
 
     #[test]
     fn test_carrier_rounds_up_to_large_runtime_page() {
-        let resolved = ResolvedPoolConfig::resolve_for_page(
-            MemoryCapacity::Limit(256 * 1024),
-            None,
-            128 * 1024,
-        )
-        .unwrap();
+        let resolved =
+            PoolConfig::resolve_for_page(MemoryBudgetConfig::Limit(256 * 1024), None, 128 * 1024)
+                .unwrap();
         assert_eq!(resolved.geometry.carrier_size(), 128 * 1024);
-        assert_eq!(resolved.geometry.block_size(), 8 * 1024 * 1024);
+        assert_eq!(resolved.geometry.block_size(), 256 * 1024);
         assert_eq!(resolved.configured_capacity, CarrierCount::new(2));
+    }
+
+    #[test]
+    fn test_block_size_is_independent_of_carrier_bitmap_width() {
+        let resolved =
+            PoolConfig::resolve_for_page(MemoryBudgetConfig::Limit(GIB), None, 4096).unwrap();
+
+        assert_eq!(resolved.geometry.carrier_size(), 16 * 1024);
+        assert_eq!(resolved.geometry.block_size(), 128 * 1024 * 1024);
+        assert_eq!(
+            resolved.geometry.carriers_per_block(),
+            CarrierCount::new(8192)
+        );
+        assert_eq!(resolved.geometry.bitmap_words(), 128);
+    }
+
+    #[test]
+    fn test_optimistic_scan_preserves_its_byte_reach_across_page_geometry() {
+        for page_size in [4096, 128 * 1024] {
+            let resolved =
+                PoolConfig::resolve_for_page(MemoryBudgetConfig::Limit(GIB), None, page_size)
+                    .unwrap();
+            let carrier_size = resolved.geometry.carrier_size();
+            let scan_bytes = resolved.optimistic_scan_words * u64::BITS as usize * carrier_size;
+
+            assert!(scan_bytes >= DEFAULT_OPTIMISTIC_SCAN_BYTES);
+            assert!(scan_bytes - DEFAULT_OPTIMISTIC_SCAN_BYTES < u64::BITS as usize * carrier_size);
+        }
+    }
+
+    #[test]
+    fn test_eight_mibibyte_claim_uses_optimistic_path_after_preparation() {
+        const PART_BYTES: usize = 8 * 1024 * 1024;
+
+        let pool = BufferPool::from_capacity(MemoryBudgetConfig::Limit(GIB), None).unwrap();
+        let prepared = pool
+            .acquire_unreserved(pool.inner.geometry.carrier_size())
+            .unwrap();
+        drop(prepared);
+        let fallbacks_before = pool.diagnostics().serialized_fallbacks;
+
+        let part = pool.acquire_unreserved(PART_BYTES).unwrap();
+
+        assert_eq!(pool.diagnostics().serialized_fallbacks, fallbacks_before);
+        drop(part);
+    }
+
+    #[test]
+    fn test_block_size_is_capped_by_small_configured_capacity() {
+        let resolved =
+            PoolConfig::resolve_for_page(MemoryBudgetConfig::Limit(8 * 1024 * 1024), None, 4096)
+                .unwrap();
+
+        assert_eq!(resolved.geometry.block_size(), 8 * 1024 * 1024);
+        assert_eq!(
+            resolved.geometry.carriers_per_block(),
+            resolved.configured_capacity
+        );
     }
 
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn test_capacity_accepts_the_exact_packed_carrier_limit() {
-        let bytes = u32::MAX as usize * 64 * 1024;
+        let bytes = u32::MAX as usize * DEFAULT_CARRIER_BYTES;
         let resolved =
-            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Limit(bytes), None, 4096).unwrap();
+            PoolConfig::resolve_for_page(MemoryBudgetConfig::Limit(bytes), None, 4096).unwrap();
         assert_eq!(resolved.configured_capacity, MAX_PACKED_CARRIERS);
     }
 
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn test_capacity_rejects_packed_carrier_overflow() {
-        let bytes = (u32::MAX as usize + 1) * 64 * 1024;
+        let bytes = (u32::MAX as usize + 1) * DEFAULT_CARRIER_BYTES;
         assert_eq!(
-            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Limit(bytes), None, 4096),
+            PoolConfig::resolve_for_page(MemoryBudgetConfig::Limit(bytes), None, 4096),
             Err(BufferPoolBuildError::CapacityOverflow)
         );
     }
 
     #[test]
     fn test_pool_construction_prepares_no_capacity() {
-        let pool = BufferPool::from_capacity(MemoryCapacity::Limit(GIB), Some(8 * GIB)).unwrap();
-        assert_eq!(pool.carrier_size(), 64 * 1024);
+        let pool =
+            BufferPool::from_capacity(MemoryBudgetConfig::Limit(GIB), Some(8 * GIB)).unwrap();
+        assert_eq!(pool.inner.geometry.carrier_size(), DEFAULT_CARRIER_BYTES);
+        assert_eq!(pool.inner.geometry.block_size(), DEFAULT_BLOCK_BYTES);
         assert_eq!(pool.metrics().configured_capacity_bytes(), GIB as u64);
         assert_eq!(pool.metrics().prepared_capacity_bytes(), 0);
     }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/config.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/config.rs
@@ -1,0 +1,273 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Checked capacity policy and storage defaults for one buffer pool.
+
+use std::fmt;
+
+use super::admission::MAX_PACKED_CARRIERS;
+use super::geometry::PoolGeometry;
+use super::virtual_memory::page_size;
+use super::CarrierCount;
+
+/// Default carrier size before runtime page-size alignment.
+const DEFAULT_CARRIER_BYTES: usize = 64 * 1024;
+
+/// Number of carriers prepared and reclaimed as one block.
+const DEFAULT_BLOCK_CARRIERS: usize = 64;
+
+/// Maximum bitmap words inspected by one optimistic claim.
+const DEFAULT_OPTIMISTIC_SCAN_WORDS: usize = 8;
+
+/// Fraction of detected memory selected by automatic capacity.
+const AUTO_CAPACITY_DIVISOR: usize = 4;
+
+/// Maximum automatic capacity in bytes.
+const AUTO_CAPACITY_MAX_BYTES: u64 = 32 * 1024 * 1024 * 1024;
+
+/// Automatic capacity when effective memory cannot be detected.
+const AUTO_CAPACITY_FALLBACK_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Configured memory policy for one buffer pool.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub(crate) enum MemoryCapacity {
+    /// Use one quarter of detected effective memory, capped at 32 GiB.
+    #[default]
+    Auto,
+    /// Use a fraction of detected effective memory.
+    Fraction(f64),
+    /// Use an explicit byte ceiling without memory detection.
+    Limit(usize),
+}
+
+/// Failure to resolve capacity and geometry before pool publication.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BufferPoolBuildError {
+    /// Capacity is invalid or resolves below one carrier.
+    InvalidCapacity,
+    /// The selected capacity policy requires unavailable memory detection.
+    MemoryDetectionUnavailable,
+    /// Capacity or geometry exceeds its internal representation.
+    CapacityOverflow,
+    /// Runtime page geometry cannot produce a supported pool layout.
+    UnsupportedPageGeometry,
+}
+
+impl fmt::Display for BufferPoolBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidCapacity => f.write_str("buffer-pool capacity is invalid"),
+            Self::MemoryDetectionUnavailable => {
+                f.write_str("effective memory could not be detected")
+            }
+            Self::CapacityOverflow => {
+                f.write_str("buffer-pool capacity exceeds its representation")
+            }
+            Self::UnsupportedPageGeometry => {
+                f.write_str("runtime page geometry cannot support the buffer pool")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BufferPoolBuildError {}
+
+/// Fully checked inputs for constructing an empty pool.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ResolvedPoolConfig {
+    /// Page, carrier, block, and bitmap dimensions.
+    pub(super) geometry: PoolGeometry,
+    /// Normal admission ceiling in complete carriers.
+    pub(super) configured_capacity: CarrierCount,
+    /// Optimistic bitmap words inspected before serialized fallback.
+    pub(super) optimistic_scan_words: usize,
+}
+
+impl ResolvedPoolConfig {
+    /// Resolves capacity against detected memory and runtime page geometry.
+    pub(super) fn resolve(
+        capacity: MemoryCapacity,
+        detected_memory: Option<usize>,
+    ) -> Result<Self, BufferPoolBuildError> {
+        let page_size = page_size().map_err(|_| BufferPoolBuildError::UnsupportedPageGeometry)?;
+        Self::resolve_for_page(capacity, detected_memory, page_size.get())
+    }
+
+    /// Resolves capacity against explicit page geometry.
+    fn resolve_for_page(
+        capacity: MemoryCapacity,
+        detected_memory: Option<usize>,
+        page_size: usize,
+    ) -> Result<Self, BufferPoolBuildError> {
+        let carrier_size = DEFAULT_CARRIER_BYTES
+            .div_ceil(page_size)
+            .checked_mul(page_size)
+            .ok_or(BufferPoolBuildError::CapacityOverflow)?;
+        let block_size = carrier_size
+            .checked_mul(DEFAULT_BLOCK_CARRIERS)
+            .ok_or(BufferPoolBuildError::CapacityOverflow)?;
+        let geometry = PoolGeometry::new(page_size, block_size, carrier_size)
+            .map_err(|_| BufferPoolBuildError::UnsupportedPageGeometry)?;
+
+        let bytes = resolve_capacity_bytes(capacity, detected_memory)?;
+        let carriers = bytes / carrier_size;
+        if carriers == 0 {
+            return Err(BufferPoolBuildError::InvalidCapacity);
+        }
+        let configured_capacity = CarrierCount::new(carriers);
+        if configured_capacity > MAX_PACKED_CARRIERS {
+            return Err(BufferPoolBuildError::CapacityOverflow);
+        }
+
+        Ok(Self {
+            geometry,
+            configured_capacity,
+            optimistic_scan_words: DEFAULT_OPTIMISTIC_SCAN_WORDS,
+        })
+    }
+}
+
+/// Resolves one capacity policy to bytes before carrier rounding.
+fn resolve_capacity_bytes(
+    capacity: MemoryCapacity,
+    detected_memory: Option<usize>,
+) -> Result<usize, BufferPoolBuildError> {
+    match capacity {
+        MemoryCapacity::Auto => match detected_memory {
+            Some(bytes) => {
+                let maximum = usize::try_from(AUTO_CAPACITY_MAX_BYTES).unwrap_or(usize::MAX);
+                Ok((bytes / AUTO_CAPACITY_DIVISOR).min(maximum))
+            }
+            None => usize::try_from(AUTO_CAPACITY_FALLBACK_BYTES)
+                .map_err(|_| BufferPoolBuildError::CapacityOverflow),
+        },
+        MemoryCapacity::Fraction(fraction) => {
+            if !(fraction.is_finite() && 0.0 < fraction && fraction <= 1.0) {
+                return Err(BufferPoolBuildError::InvalidCapacity);
+            }
+            let detected =
+                detected_memory.ok_or(BufferPoolBuildError::MemoryDetectionUnavailable)?;
+            Ok((detected as f64 * fraction) as usize)
+        }
+        MemoryCapacity::Limit(bytes) => Ok(bytes),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::buffer_pool::BufferPool;
+
+    const GIB: usize = 1024 * 1024 * 1024;
+
+    #[test]
+    fn test_auto_uses_quarter_of_detected_memory() {
+        let resolved =
+            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Auto, Some(2 * GIB), 4096)
+                .unwrap();
+        assert_eq!(resolved.configured_capacity.get() * 64 * 1024, GIB / 2);
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn test_auto_caps_large_machines() {
+        let resolved =
+            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Auto, Some(768 * GIB), 4096)
+                .unwrap();
+        assert_eq!(resolved.configured_capacity.get() * 64 * 1024, 32 * GIB);
+    }
+
+    #[test]
+    fn test_auto_uses_fallback_without_detection() {
+        let resolved =
+            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Auto, None, 4096).unwrap();
+        assert_eq!(resolved.configured_capacity.get() * 64 * 1024, 2 * GIB);
+    }
+
+    #[test]
+    fn test_fraction_requires_detection() {
+        assert_eq!(
+            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Fraction(0.5), None, 4096),
+            Err(BufferPoolBuildError::MemoryDetectionUnavailable)
+        );
+    }
+
+    #[test]
+    fn test_fraction_rejects_invalid_values() {
+        for fraction in [f64::NAN, f64::INFINITY, -0.5, 0.0, 1.5] {
+            assert_eq!(
+                ResolvedPoolConfig::resolve_for_page(
+                    MemoryCapacity::Fraction(fraction),
+                    Some(GIB),
+                    4096,
+                ),
+                Err(BufferPoolBuildError::InvalidCapacity)
+            );
+        }
+    }
+
+    #[test]
+    fn test_fraction_rounds_down_to_complete_carriers() {
+        let resolved = ResolvedPoolConfig::resolve_for_page(
+            MemoryCapacity::Fraction(0.5),
+            Some(GIB + 1),
+            4096,
+        )
+        .unwrap();
+        assert_eq!(resolved.configured_capacity.get() * 64 * 1024, GIB / 2);
+    }
+
+    #[test]
+    fn test_limit_rounds_down_to_complete_carriers() {
+        let resolved = ResolvedPoolConfig::resolve_for_page(
+            MemoryCapacity::Limit(64 * 1024 + 123),
+            None,
+            4096,
+        )
+        .unwrap();
+        assert_eq!(resolved.configured_capacity, CarrierCount::new(1));
+    }
+
+    #[test]
+    fn test_capacity_below_one_carrier_is_rejected() {
+        assert_eq!(
+            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Limit(64 * 1024 - 1), None, 4096),
+            Err(BufferPoolBuildError::InvalidCapacity)
+        );
+    }
+
+    #[test]
+    fn test_carrier_rounds_up_to_large_runtime_page() {
+        let resolved = ResolvedPoolConfig::resolve_for_page(
+            MemoryCapacity::Limit(256 * 1024),
+            None,
+            128 * 1024,
+        )
+        .unwrap();
+        assert_eq!(resolved.geometry.carrier_size(), 128 * 1024);
+        assert_eq!(resolved.geometry.block_size(), 8 * 1024 * 1024);
+        assert_eq!(resolved.configured_capacity, CarrierCount::new(2));
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn test_capacity_rejects_packed_carrier_overflow() {
+        let bytes = (u32::MAX as usize + 1) * 64 * 1024;
+        assert_eq!(
+            ResolvedPoolConfig::resolve_for_page(MemoryCapacity::Limit(bytes), None, 4096),
+            Err(BufferPoolBuildError::CapacityOverflow)
+        );
+    }
+
+    #[test]
+    fn test_pool_construction_prepares_no_capacity() {
+        let pool = BufferPool::from_capacity(MemoryCapacity::Limit(GIB), Some(8 * GIB)).unwrap();
+        assert_eq!(pool.carrier_size(), 64 * 1024);
+        assert_eq!(pool.metrics().configured_capacity_bytes(), GIB as u64);
+        assert_eq!(pool.metrics().prepared_capacity_bytes(), 0);
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
@@ -7,13 +7,15 @@
 //!
 //! [`MaintenanceState`] converts explicit activity, deadline, and completion
 //! events into serialized maintenance actions. Pool and platform operations
-//! execute outside this state machine.
+//! execute outside this state machine. The worker retains only control state
+//! and a weak pool reference while waiting.
 
 use std::time::{Duration, Instant};
 
 use super::admission::AdmissionGuard;
 use super::arena::ArenaTrim;
 use super::{CarrierCount, PoolInner};
+use crate::runtime::sync::sync::atomic::{AtomicU64, Ordering as DiagnosticOrdering};
 use crate::runtime::sync::sync::{Arc, Condvar, Mutex};
 
 #[cfg(not(all(test, s3_tm_loom)))]
@@ -81,8 +83,14 @@ impl MaintenancePass {
 
 /// Lazy worker owner embedded in the pool lifetime domain.
 pub(super) struct MaintenanceCoordinator {
+    /// Immutable normal admission ceiling copied at pool construction.
+    configured_capacity: CarrierCount,
+    /// Immutable whole-block carrier count copied from pool geometry.
+    block_capacity: CarrierCount,
     /// State and wakeup primitive retained independently by the worker.
     control: Arc<MaintenanceControl>,
+    /// Counters that observe worker behavior without controlling it.
+    diagnostics: Arc<MaintenanceDiagnostics>,
     /// Serialized worker creation and final join authority.
     #[cfg(not(all(test, s3_tm_loom)))]
     worker: Mutex<Option<thread::JoinHandle<()>>>,
@@ -90,9 +98,12 @@ pub(super) struct MaintenanceCoordinator {
 
 impl MaintenanceCoordinator {
     /// Creates an idle coordinator without starting a thread.
-    pub(super) fn new() -> Self {
+    pub(super) fn new(configured_capacity: CarrierCount, block_capacity: CarrierCount) -> Self {
         Self {
+            configured_capacity,
+            block_capacity,
             control: Arc::new(MaintenanceControl::new()),
+            diagnostics: Arc::new(MaintenanceDiagnostics::default()),
             #[cfg(not(all(test, s3_tm_loom)))]
             worker: Mutex::new(None),
         }
@@ -111,7 +122,9 @@ impl MaintenanceCoordinator {
 
     /// Requests recovery for a failed mapping cleanup operation.
     pub(super) fn request_cleanup(&self, pool: &Arc<PoolInner>) {
-        self.control.state.lock().request_cleanup(Instant::now());
+        if self.control.state.lock().request_cleanup(Instant::now()) {
+            self.diagnostics.record_cleanup_request();
+        }
         self.ensure_worker(pool);
         self.control.wake.notify_all();
     }
@@ -130,9 +143,10 @@ impl MaintenanceCoordinator {
             }
         }
 
-        let configured_capacity = pool.admission.lock().ledger.configured_capacity;
-        let block_capacity = pool.geometry.carriers_per_block();
+        let configured_capacity = self.configured_capacity;
+        let block_capacity = self.block_capacity;
         let control = Arc::clone(&self.control);
+        let diagnostics = Arc::clone(&self.diagnostics);
         let weak_pool = Arc::downgrade(pool);
 
         #[cfg(test)]
@@ -142,12 +156,37 @@ impl MaintenanceCoordinator {
         } else {
             thread::Builder::new()
                 .name(WORKER_NAME.to_owned())
-                .spawn(move || worker_loop(control, weak_pool, configured_capacity, block_capacity))
+                .spawn(move || {
+                    worker_loop(
+                        control,
+                        diagnostics,
+                        weak_pool,
+                        configured_capacity,
+                        block_capacity,
+                    )
+                })
         };
 
         match spawned {
-            Ok(handle) => *worker = Some(handle),
-            Err(_) => self.control.state.lock().disable(),
+            Ok(handle) => {
+                self.diagnostics.record_worker_start();
+                tracing::debug!(
+                    target: crate::telemetry::TARGET_MEMORY,
+                    worker = WORKER_NAME,
+                    "started buffer-pool maintenance worker"
+                );
+                *worker = Some(handle);
+            }
+            Err(error) => {
+                self.diagnostics.record_worker_start_failure();
+                tracing::warn!(
+                    target: crate::telemetry::TARGET_MEMORY,
+                    worker = WORKER_NAME,
+                    error = %error,
+                    "buffer-pool maintenance is disabled after worker creation failed"
+                );
+                self.control.state.lock().disable();
+            }
         }
     }
 
@@ -169,14 +208,32 @@ impl MaintenanceCoordinator {
             return;
         }
         #[cfg(not(all(test, s3_tm_loom)))]
-        let _ = worker.join();
+        if worker.join().is_err() {
+            tracing::warn!(
+                target: crate::telemetry::TARGET_MEMORY,
+                worker = WORKER_NAME,
+                "buffer-pool maintenance worker terminated unexpectedly"
+            );
+        }
     }
 
-    /// Arms an idle deadline with explicit timing for deterministic tests.
+    /// Arms an idle deadline from caller-supplied clock input.
     fn record_idle_after(&self, pool: &Arc<PoolInner>, now: Instant, timeout: Duration) {
-        self.control.state.lock().record_idle(now, timeout);
+        if self.control.state.lock().record_idle(now, timeout) {
+            self.diagnostics.record_idle_deadline();
+            tracing::debug!(
+                target: crate::telemetry::TARGET_MEMORY,
+                timeout_millis = timeout.as_millis(),
+                "armed buffer-pool idle reclamation"
+            );
+        }
         self.ensure_worker(pool);
         self.control.wake.notify_all();
+    }
+
+    /// Returns one relaxed operational diagnostic sample.
+    pub(super) fn diagnostics(&self) -> MaintenanceDiagnosticSnapshot {
+        self.diagnostics.snapshot()
     }
 
     /// Returns whether a worker handle has been published.
@@ -224,6 +281,82 @@ impl MaintenanceControl {
             wake: Condvar::new(),
         }
     }
+}
+
+/// Counters that never participate in maintenance decisions.
+#[derive(Default)]
+struct MaintenanceDiagnostics {
+    /// Scheduler-global idle intervals that armed a new deadline.
+    idle_deadlines: AtomicU64,
+    /// Successfully created maintenance workers.
+    worker_starts: AtomicU64,
+    /// Worker creation failures that disabled maintenance.
+    worker_start_failures: AtomicU64,
+    /// Reclaim actions executed by the worker.
+    reclaim_passes: AtomicU64,
+    /// Reclaim actions that remained blocked after a bounded pass.
+    reclaim_retries: AtomicU64,
+    /// Cleanup generations requested after a mapping failure.
+    cleanup_requests: AtomicU64,
+}
+
+impl MaintenanceDiagnostics {
+    /// Records one newly armed idle deadline.
+    fn record_idle_deadline(&self) {
+        saturating_add(&self.idle_deadlines, 1);
+    }
+
+    /// Records successful worker creation.
+    fn record_worker_start(&self) {
+        saturating_add(&self.worker_starts, 1);
+    }
+
+    /// Records a worker creation failure.
+    fn record_worker_start_failure(&self) {
+        saturating_add(&self.worker_start_failures, 1);
+    }
+
+    /// Records one bounded reclaim action and whether it needs retry.
+    fn record_reclaim_pass(&self, outcome: MaintenanceOutcome) {
+        saturating_add(&self.reclaim_passes, 1);
+        if outcome == MaintenanceOutcome::Retry {
+            saturating_add(&self.reclaim_retries, 1);
+        }
+    }
+
+    /// Records a new cleanup request generation.
+    fn record_cleanup_request(&self) {
+        saturating_add(&self.cleanup_requests, 1);
+    }
+
+    /// Loads one relaxed diagnostic sample.
+    fn snapshot(&self) -> MaintenanceDiagnosticSnapshot {
+        MaintenanceDiagnosticSnapshot {
+            idle_deadlines: self.idle_deadlines.load(DiagnosticOrdering::Relaxed),
+            worker_starts: self.worker_starts.load(DiagnosticOrdering::Relaxed),
+            worker_start_failures: self.worker_start_failures.load(DiagnosticOrdering::Relaxed),
+            reclaim_passes: self.reclaim_passes.load(DiagnosticOrdering::Relaxed),
+            reclaim_retries: self.reclaim_retries.load(DiagnosticOrdering::Relaxed),
+            cleanup_requests: self.cleanup_requests.load(DiagnosticOrdering::Relaxed),
+        }
+    }
+}
+
+/// Private snapshot of maintenance scheduling and worker behavior.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct MaintenanceDiagnosticSnapshot {
+    /// Scheduler-global idle intervals that armed a new deadline.
+    pub(super) idle_deadlines: u64,
+    /// Successfully created maintenance workers.
+    pub(super) worker_starts: u64,
+    /// Worker creation failures that disabled maintenance.
+    pub(super) worker_start_failures: u64,
+    /// Reclaim actions executed by the worker.
+    pub(super) reclaim_passes: u64,
+    /// Reclaim actions that remained blocked after a bounded pass.
+    pub(super) reclaim_retries: u64,
+    /// Cleanup generations requested after a mapping failure.
+    pub(super) cleanup_requests: u64,
 }
 
 /// Deadline armed for one scheduler-idle interval.
@@ -300,16 +433,17 @@ impl MaintenanceState {
     /// Arms one deadline for the current global-idle interval.
     ///
     /// Repeated idle observations in the same activity epoch preserve the
-    /// original deadline and cannot extend cache retention.
-    pub(super) fn record_idle(&mut self, now: Instant, idle_timeout: Duration) {
+    /// original deadline and cannot extend cache retention. Returns `true`
+    /// when this call arms a new deadline.
+    pub(super) fn record_idle(&mut self, now: Instant, idle_timeout: Duration) -> bool {
         if self.stopping || self.disabled || self.reclaim.is_some() {
-            return;
+            return false;
         }
         if self
             .idle_deadline
             .is_some_and(|deadline| deadline.epoch == self.activity_epoch)
         {
-            return;
+            return false;
         }
         let expires_at = now
             .checked_add(idle_timeout)
@@ -318,12 +452,14 @@ impl MaintenanceState {
             epoch: self.activity_epoch,
             expires_at,
         });
+        true
     }
 
     /// Requests mapping cleanup without losing a concurrent newer request.
-    pub(super) fn request_cleanup(&mut self, now: Instant) {
+    /// Returns `true` when this call publishes a new cleanup generation.
+    pub(super) fn request_cleanup(&mut self, now: Instant) -> bool {
         if self.stopping || self.disabled {
-            return;
+            return false;
         }
         let generation = self.next_cleanup_generation;
         self.next_cleanup_generation = self.next_cleanup_generation.wrapping_add(1);
@@ -331,6 +467,7 @@ impl MaintenanceState {
             generation,
             eligible_at: now,
         });
+        true
     }
 
     /// Returns one due action without consuming its request.
@@ -460,6 +597,7 @@ impl MaintenanceState {
 #[cfg(not(all(test, s3_tm_loom)))]
 fn worker_loop(
     control: Arc<MaintenanceControl>,
+    diagnostics: Arc<MaintenanceDiagnostics>,
     pool: Weak<PoolInner>,
     configured_capacity: CarrierCount,
     block_capacity: CarrierCount,
@@ -477,10 +615,14 @@ fn worker_loop(
         let pass = pool.execute_maintenance(action);
         drop(pool);
 
+        if matches!(action, MaintenanceAction::Reclaim { .. }) {
+            diagnostics.record_reclaim_pass(pass.outcome);
+        }
+
         let now = Instant::now();
         let mut state = control.state.lock();
-        if pass.cleanup_pending {
-            state.request_cleanup(now);
+        if pass.cleanup_pending && state.request_cleanup(now) {
+            diagnostics.record_cleanup_request();
         }
         state.finish_action(action, pass.outcome, now, RETRY_DELAY);
         let stopping = state.is_stopping();
@@ -490,6 +632,15 @@ fn worker_loop(
             return;
         }
     }
+}
+
+/// Adds a diagnostic value without wrapping.
+fn saturating_add(counter: &AtomicU64, value: u64) {
+    let _ = counter.fetch_update(
+        DiagnosticOrdering::Relaxed,
+        DiagnosticOrdering::Relaxed,
+        |current| Some(current.saturating_add(value)),
+    );
 }
 
 /// Waits until one action is due or final destruction requests stop.
@@ -576,8 +727,21 @@ impl PoolInner {
                 };
             };
             match cleanup.finish() {
-                Ok(()) => self.arena.record_block_reclaimed(),
-                Err(_) => cleanup_pending = true,
+                Ok(()) => {
+                    self.arena.record_block_reclaimed();
+                    tracing::debug!(
+                        target: crate::telemetry::TARGET_MEMORY,
+                        "reclaimed one buffer-pool block"
+                    );
+                }
+                Err(error) => {
+                    cleanup_pending = true;
+                    tracing::warn!(
+                        target: crate::telemetry::TARGET_MEMORY,
+                        error = ?error,
+                        "buffer-pool block cleanup remains pending"
+                    );
+                }
             }
         }
     }
@@ -858,6 +1022,7 @@ mod tests {
         assert_eq!(cleanup, MaintenancePass::new(MaintenanceOutcome::Complete));
         assert_eq!(pool.inner.arena.diagnostics().cleanup_retries, 2);
         assert_eq!(pool.inner.arena.diagnostics().cleanup_failures, 1);
+        pool.assert_quiescent_zero();
         let reused = pool.acquire_unreserved(carrier_size).unwrap();
         drop(reused);
     }
@@ -875,6 +1040,9 @@ mod tests {
             Some(WORKER_NAME)
         );
         assert_eq!(pool.maintenance_spawn_attempts(), 1);
+        let diagnostics = pool.diagnostics();
+        assert_eq!(diagnostics.worker_starts, 1);
+        assert_eq!(diagnostics.cleanup_requests, 1);
     }
 
     #[test]
@@ -889,8 +1057,15 @@ mod tests {
             Duration::from_millis(10),
         );
 
-        wait_until(|| pool.metrics().prepared_capacity_bytes() == (carrier_size * 2) as u64);
+        wait_until(|| {
+            pool.metrics().prepared_capacity_bytes() == (carrier_size * 2) as u64
+                && pool.diagnostics().reclaim_passes == 1
+        });
         assert_eq!(pool.maintenance_spawn_attempts(), 1);
+        let diagnostics = pool.diagnostics();
+        assert_eq!(diagnostics.idle_deadlines, 1);
+        assert_eq!(diagnostics.reclaim_passes, 1);
+        assert_eq!(diagnostics.reclaim_retries, 0);
     }
 
     #[test]
@@ -926,6 +1101,7 @@ mod tests {
         assert!(pool.inner.maintenance.is_disabled());
         assert!(!pool.inner.maintenance.worker_started());
         assert_eq!(pool.maintenance_spawn_attempts(), 1);
+        assert_eq!(pool.diagnostics().worker_start_failures, 1);
 
         pool.inner.maintenance.record_idle(&pool.inner);
         assert_eq!(pool.maintenance_spawn_attempts(), 1);
@@ -958,6 +1134,64 @@ mod tests {
 
         wait_until(|| weak.strong_count() == 0);
         assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn test_scheduler_hooks_arm_and_cancel_one_idle_epoch() {
+        let (pool, _) = test_pool(1, 1);
+
+        pool.record_global_idle();
+        assert!(pool
+            .inner
+            .maintenance
+            .control
+            .state
+            .lock()
+            .next_wake()
+            .is_some());
+        assert_eq!(pool.diagnostics().idle_deadlines, 1);
+
+        pool.record_managed_activity();
+        assert!(pool
+            .inner
+            .maintenance
+            .control
+            .state
+            .lock()
+            .next_wake()
+            .is_none());
+        assert_eq!(pool.diagnostics().idle_deadlines, 1);
+    }
+
+    #[test]
+    fn test_preparation_failure_schedules_cleanup_and_quiesces() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let owned = pool.acquire_unreserved(carrier_size).unwrap();
+        drop(owned);
+        let slot = pool
+            .inner
+            .arena
+            .select_trim_candidate()
+            .expect("free prepared slot");
+        let reclaimed = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
+            epoch: 0,
+            target: CarrierCount::ZERO,
+        });
+        assert_eq!(reclaimed.outcome, MaintenanceOutcome::Complete);
+        pool.assert_quiescent_zero();
+
+        slot.inject_failure_once(VirtualMemoryOperation::Prepare);
+        assert!(matches!(
+            pool.acquire_unreserved(carrier_size),
+            Err(super::super::AcquireError::PhysicalAllocationFailed)
+        ));
+
+        wait_until(|| pool.diagnostics().cleanup_retries == 1);
+        let diagnostics = pool.diagnostics();
+        assert_eq!(diagnostics.cleanup_requests, 1);
+        assert_eq!(diagnostics.cleanup_failures, 0);
+        assert_eq!(diagnostics.cleanup_pending_blocks, 0);
+        pool.assert_quiescent_zero();
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
@@ -24,7 +24,7 @@ use std::{io, sync::Weak};
 #[cfg(not(all(test, s3_tm_loom)))]
 use crate::runtime::sync::thread;
 
-/// Fraction of the configured block ceiling retained after an idle deadline.
+/// Divisor applied before retention rounds down to complete blocks.
 const IDLE_RETENTION_DIVISOR: usize = 4;
 
 /// Initial cache-hysteresis interval after scheduler-global idle.
@@ -33,8 +33,8 @@ const IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 /// Delay before retrying blocked reclamation or mapping cleanup.
 const RETRY_DELAY: Duration = Duration::from_secs(1);
 
-/// Operating-system thread name used by the pool maintenance worker.
-const WORKER_NAME: &str = "s3-tm-memory";
+/// Operating-system thread name used by pool maintenance.
+const MAINTENANCE_THREAD_NAME: &str = "s3-tm-memory";
 
 /// One maintenance operation authorized by the control state.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -155,7 +155,7 @@ impl MaintenanceCoordinator {
             Err(io::Error::other("injected maintenance worker failure"))
         } else {
             thread::Builder::new()
-                .name(WORKER_NAME.to_owned())
+                .name(MAINTENANCE_THREAD_NAME.to_owned())
                 .spawn(move || {
                     worker_loop(
                         control,
@@ -169,23 +169,21 @@ impl MaintenanceCoordinator {
 
         match spawned {
             Ok(handle) => {
-                self.diagnostics.record_worker_start();
                 tracing::debug!(
                     target: crate::telemetry::TARGET_MEMORY,
-                    worker = WORKER_NAME,
+                    worker = MAINTENANCE_THREAD_NAME,
                     "started buffer-pool maintenance worker"
                 );
                 *worker = Some(handle);
             }
             Err(error) => {
-                self.diagnostics.record_worker_start_failure();
+                self.control.state.lock().disable();
                 tracing::warn!(
                     target: crate::telemetry::TARGET_MEMORY,
-                    worker = WORKER_NAME,
+                    worker = MAINTENANCE_THREAD_NAME,
                     error = %error,
                     "buffer-pool maintenance is disabled after worker creation failed"
                 );
-                self.control.state.lock().disable();
             }
         }
     }
@@ -211,7 +209,7 @@ impl MaintenanceCoordinator {
         if worker.join().is_err() {
             tracing::warn!(
                 target: crate::telemetry::TARGET_MEMORY,
-                worker = WORKER_NAME,
+                worker = MAINTENANCE_THREAD_NAME,
                 "buffer-pool maintenance worker terminated unexpectedly"
             );
         }
@@ -231,9 +229,13 @@ impl MaintenanceCoordinator {
         self.control.wake.notify_all();
     }
 
-    /// Returns one relaxed operational diagnostic sample.
+    /// Returns one operational diagnostic sample.
+    ///
+    /// Cumulative counters use relaxed loads. Reading permanent-disable state
+    /// briefly acquires maintenance control.
     pub(super) fn diagnostics(&self) -> MaintenanceDiagnosticSnapshot {
-        self.diagnostics.snapshot()
+        self.diagnostics
+            .snapshot(self.control.state.lock().is_disabled())
     }
 
     /// Returns whether a worker handle has been published.
@@ -288,10 +290,6 @@ impl MaintenanceControl {
 struct MaintenanceDiagnostics {
     /// Scheduler-global idle intervals that armed a new deadline.
     idle_deadlines: AtomicU64,
-    /// Successfully created maintenance workers.
-    worker_starts: AtomicU64,
-    /// Worker creation failures that disabled maintenance.
-    worker_start_failures: AtomicU64,
     /// Reclaim actions executed by the worker.
     reclaim_passes: AtomicU64,
     /// Reclaim actions that remained blocked after a bounded pass.
@@ -304,16 +302,6 @@ impl MaintenanceDiagnostics {
     /// Records one newly armed idle deadline.
     fn record_idle_deadline(&self) {
         saturating_add(&self.idle_deadlines, 1);
-    }
-
-    /// Records successful worker creation.
-    fn record_worker_start(&self) {
-        saturating_add(&self.worker_starts, 1);
-    }
-
-    /// Records a worker creation failure.
-    fn record_worker_start_failure(&self) {
-        saturating_add(&self.worker_start_failures, 1);
     }
 
     /// Records one bounded reclaim action and whether it needs retry.
@@ -330,11 +318,10 @@ impl MaintenanceDiagnostics {
     }
 
     /// Loads one relaxed diagnostic sample.
-    fn snapshot(&self) -> MaintenanceDiagnosticSnapshot {
+    fn snapshot(&self, maintenance_disabled: bool) -> MaintenanceDiagnosticSnapshot {
         MaintenanceDiagnosticSnapshot {
             idle_deadlines: self.idle_deadlines.load(DiagnosticOrdering::Relaxed),
-            worker_starts: self.worker_starts.load(DiagnosticOrdering::Relaxed),
-            worker_start_failures: self.worker_start_failures.load(DiagnosticOrdering::Relaxed),
+            maintenance_disabled,
             reclaim_passes: self.reclaim_passes.load(DiagnosticOrdering::Relaxed),
             reclaim_retries: self.reclaim_retries.load(DiagnosticOrdering::Relaxed),
             cleanup_requests: self.cleanup_requests.load(DiagnosticOrdering::Relaxed),
@@ -347,10 +334,8 @@ impl MaintenanceDiagnostics {
 pub(super) struct MaintenanceDiagnosticSnapshot {
     /// Scheduler-global idle intervals that armed a new deadline.
     pub(super) idle_deadlines: u64,
-    /// Successfully created maintenance workers.
-    pub(super) worker_starts: u64,
-    /// Worker creation failures that disabled maintenance.
-    pub(super) worker_start_failures: u64,
+    /// Whether worker creation failed and permanently disabled maintenance.
+    pub(super) maintenance_disabled: bool,
     /// Reclaim actions executed by the worker.
     pub(super) reclaim_passes: u64,
     /// Reclaim actions that remained blocked after a bounded pass.
@@ -612,7 +597,7 @@ fn worker_loop(
 
         #[cfg(test)]
         pool.test_hooks.wait_after_maintenance_upgrade();
-        let pass = pool.execute_maintenance(action);
+        let pass = execute_maintenance(&pool, action);
         drop(pool);
 
         if matches!(action, MaintenanceAction::Reclaim { .. }) {
@@ -686,68 +671,66 @@ fn maintenance_spawn_failure_injected(_pool: &PoolInner) -> bool {
     false
 }
 
-impl PoolInner {
-    /// Executes one maintenance action without holding maintenance control.
-    pub(super) fn execute_maintenance(&self, action: MaintenanceAction) -> MaintenancePass {
-        match action {
-            MaintenanceAction::RetryCleanup { .. } => {
-                if self.arena.retry_cleanup() {
-                    MaintenancePass::new(MaintenanceOutcome::Complete)
-                } else {
-                    MaintenancePass::new(MaintenanceOutcome::Retry)
-                }
+/// Executes one maintenance action without holding maintenance control.
+pub(super) fn execute_maintenance(pool: &PoolInner, action: MaintenanceAction) -> MaintenancePass {
+    match action {
+        MaintenanceAction::RetryCleanup { .. } => {
+            if pool.arena.retry_cleanup() {
+                MaintenancePass::new(MaintenanceOutcome::Complete)
+            } else {
+                MaintenancePass::new(MaintenanceOutcome::Retry)
             }
-            MaintenanceAction::Reclaim { target, .. } => self.reclaim_to(target),
         }
+        MaintenanceAction::Reclaim { target, .. } => reclaim_to(pool, target),
     }
+}
 
-    /// Reclaims complete free blocks until the target or a blocker is reached.
-    fn reclaim_to(&self, target: CarrierCount) -> MaintenancePass {
-        let mut cleanup_pending = false;
-        loop {
-            let trim = {
-                let mut admission = AdmissionGuard::new(self.admission.lock());
-                if admission.prepared_capacity() <= target {
-                    return MaintenancePass {
-                        outcome: MaintenanceOutcome::Complete,
-                        cleanup_pending,
-                    };
-                }
-                let admission_floor = admission
-                    .acquisition_floor(&self.coverage)
-                    .unwrap_or_else(|_| super::invariant_violation("maintenance floor overflow"));
-                let floor = std::cmp::max(target, admission_floor);
-                self.arena.start_trim(&mut admission, floor)
-            };
-
-            let ArenaTrim::Started(cleanup) = trim else {
+/// Reclaims complete free blocks until the target or a blocker is reached.
+fn reclaim_to(pool: &PoolInner, target: CarrierCount) -> MaintenancePass {
+    let mut cleanup_pending = false;
+    loop {
+        let trim = {
+            let mut admission = AdmissionGuard::new(pool.admission.lock());
+            if admission.prepared_capacity() <= target {
                 return MaintenancePass {
-                    outcome: MaintenanceOutcome::Retry,
+                    outcome: MaintenanceOutcome::Complete,
                     cleanup_pending,
                 };
+            }
+            let admission_floor = admission
+                .acquisition_floor(&pool.coverage)
+                .unwrap_or_else(|_| super::invariant_violation("maintenance floor overflow"));
+            let floor = std::cmp::max(target, admission_floor);
+            pool.arena.start_trim(&mut admission, floor)
+        };
+
+        let ArenaTrim::Started(cleanup) = trim else {
+            return MaintenancePass {
+                outcome: MaintenanceOutcome::Retry,
+                cleanup_pending,
             };
-            match cleanup.finish() {
-                Ok(()) => {
-                    self.arena.record_block_reclaimed();
-                    tracing::debug!(
-                        target: crate::telemetry::TARGET_MEMORY,
-                        "reclaimed one buffer-pool block"
-                    );
-                }
-                Err(error) => {
-                    cleanup_pending = true;
-                    tracing::warn!(
-                        target: crate::telemetry::TARGET_MEMORY,
-                        error = ?error,
-                        "buffer-pool block cleanup remains pending"
-                    );
-                }
+        };
+        match cleanup.finish() {
+            Ok(()) => {
+                pool.arena.record_block_reclaimed();
+                tracing::debug!(
+                    target: crate::telemetry::TARGET_MEMORY,
+                    "reclaimed one buffer-pool block"
+                );
+            }
+            Err(error) => {
+                cleanup_pending = true;
+                tracing::warn!(
+                    target: crate::telemetry::TARGET_MEMORY,
+                    error = ?error,
+                    "buffer-pool block cleanup remains pending"
+                );
             }
         }
     }
 }
 
-/// Computes one whole-block retention target for an idle epoch.
+/// Computes a whole-block target no greater than the configured retention fraction.
 fn idle_retention_target(
     configured_capacity: CarrierCount,
     block_capacity: CarrierCount,
@@ -756,7 +739,7 @@ fn idle_retention_target(
         return CarrierCount::ZERO;
     }
     let configured_blocks = configured_capacity.get().div_ceil(block_capacity.get());
-    let retained_blocks = configured_blocks.div_ceil(IDLE_RETENTION_DIVISOR);
+    let retained_blocks = configured_blocks / IDLE_RETENTION_DIVISOR;
     CarrierCount::new(
         retained_blocks
             .checked_mul(block_capacity.get())
@@ -767,8 +750,10 @@ fn idle_retention_target(
 #[cfg(all(test, not(s3_tm_loom)))]
 mod tests {
     use super::*;
+    use crate::runtime::buffer_pool::config::PoolConfig;
     use crate::runtime::buffer_pool::test_util::test_pool;
     use crate::runtime::buffer_pool::virtual_memory::VirtualMemoryOperation;
+    use crate::types::MemoryBudgetConfig;
     use std::sync::Barrier;
 
     const IDLE: Duration = Duration::from_secs(10);
@@ -817,18 +802,46 @@ mod tests {
     }
 
     #[test]
-    fn test_idle_target_rounds_to_complete_blocks() {
+    fn test_idle_target_rounds_down_to_complete_blocks() {
         let start = Instant::now();
         let mut state = MaintenanceState::new();
         state.record_idle(start, IDLE);
 
         assert_eq!(
-            state.next_action(start + IDLE, carriers(70), carriers(64)),
+            state.next_action(start + IDLE, carriers(257), carriers(64)),
             Some(MaintenanceAction::Reclaim {
                 epoch: 0,
                 target: carriers(64),
             })
         );
+    }
+
+    #[test]
+    fn test_production_geometry_reclaims_small_pools_after_idle() {
+        const MIB: usize = 1024 * 1024;
+
+        for (capacity_bytes, retained_bytes) in [
+            (64 * MIB, 0),
+            (128 * MIB, 0),
+            (200 * MIB, 0),
+            (256 * MIB, 0),
+            (512 * MIB, 128 * MIB),
+            (1024 * MIB, 256 * MIB),
+        ] {
+            let config =
+                PoolConfig::resolve_for_page(MemoryBudgetConfig::Limit(capacity_bytes), None, 4096)
+                    .unwrap();
+            let target = idle_retention_target(
+                config.configured_capacity,
+                config.geometry.carriers_per_block(),
+            );
+
+            assert_eq!(
+                target.get() * config.geometry.carrier_size(),
+                retained_bytes,
+                "capacity {capacity_bytes}"
+            );
+        }
     }
 
     #[test]
@@ -935,10 +948,13 @@ mod tests {
         let owned = pool.acquire_unreserved(carrier_size * 8).unwrap();
         drop(owned);
 
-        let pass = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
-            epoch: 0,
-            target: carriers(2),
-        });
+        let pass = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: carriers(2),
+            },
+        );
 
         assert_eq!(pass, MaintenancePass::new(MaintenanceOutcome::Complete));
         assert_eq!(
@@ -953,17 +969,23 @@ mod tests {
         let (pool, carrier_size) = test_pool(2, 2);
         let owned = pool.acquire_unreserved(carrier_size).unwrap();
 
-        let blocked = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
-            epoch: 0,
-            target: CarrierCount::ZERO,
-        });
+        let blocked = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: CarrierCount::ZERO,
+            },
+        );
         assert_eq!(blocked, MaintenancePass::new(MaintenanceOutcome::Retry));
 
         drop(owned);
-        let complete = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
-            epoch: 0,
-            target: CarrierCount::ZERO,
-        });
+        let complete = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: CarrierCount::ZERO,
+            },
+        );
         assert_eq!(complete, MaintenancePass::new(MaintenanceOutcome::Complete));
         assert_eq!(pool.metrics().prepared_capacity_bytes(), 0);
     }
@@ -976,10 +998,13 @@ mod tests {
             .unwrap()
             .expect("reservation");
 
-        let blocked = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
-            epoch: 0,
-            target: CarrierCount::ZERO,
-        });
+        let blocked = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: CarrierCount::ZERO,
+            },
+        );
         assert_eq!(blocked.outcome, MaintenanceOutcome::Retry);
         assert_eq!(
             pool.metrics().prepared_capacity_bytes(),
@@ -987,10 +1012,13 @@ mod tests {
         );
 
         drop(reservation);
-        let complete = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
-            epoch: 0,
-            target: CarrierCount::ZERO,
-        });
+        let complete = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: CarrierCount::ZERO,
+            },
+        );
         assert_eq!(complete.outcome, MaintenanceOutcome::Complete);
         assert_eq!(pool.metrics().prepared_capacity_bytes(), 0);
     }
@@ -1007,25 +1035,30 @@ mod tests {
             .expect("free prepared slot");
         slot.inject_failure_once(VirtualMemoryOperation::Deactivate);
 
-        let trim = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
-            epoch: 0,
-            target: CarrierCount::ZERO,
-        });
+        let trim = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: CarrierCount::ZERO,
+            },
+        );
         assert_eq!(trim.outcome, MaintenanceOutcome::Complete);
         assert!(trim.cleanup_pending);
         assert_eq!(pool.metrics().prepared_capacity_bytes(), 0);
 
         slot.inject_failure_once(VirtualMemoryOperation::Deactivate);
-        let retry = pool
-            .inner
-            .execute_maintenance(MaintenanceAction::RetryCleanup { generation: 1 });
+        let retry = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::RetryCleanup { generation: 1 },
+        );
         assert_eq!(retry, MaintenancePass::new(MaintenanceOutcome::Retry));
         assert_eq!(pool.inner.arena.diagnostics().cleanup_retries, 1);
         assert_eq!(pool.inner.arena.diagnostics().cleanup_failures, 1);
 
-        let cleanup = pool
-            .inner
-            .execute_maintenance(MaintenanceAction::RetryCleanup { generation: 1 });
+        let cleanup = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::RetryCleanup { generation: 1 },
+        );
         assert_eq!(cleanup, MaintenancePass::new(MaintenanceOutcome::Complete));
         assert_eq!(pool.inner.arena.diagnostics().cleanup_retries, 2);
         assert_eq!(pool.inner.arena.diagnostics().cleanup_failures, 1);
@@ -1044,11 +1077,11 @@ mod tests {
         assert!(pool.inner.maintenance.worker_started());
         assert_eq!(
             pool.inner.maintenance.worker_name().as_deref(),
-            Some(WORKER_NAME)
+            Some(MAINTENANCE_THREAD_NAME)
         );
         assert_eq!(pool.maintenance_spawn_attempts(), 1);
         let diagnostics = pool.diagnostics();
-        assert_eq!(diagnostics.worker_starts, 1);
+        assert!(!diagnostics.maintenance_disabled);
         assert_eq!(diagnostics.cleanup_requests, 1);
     }
 
@@ -1108,7 +1141,7 @@ mod tests {
         assert!(pool.inner.maintenance.is_disabled());
         assert!(!pool.inner.maintenance.worker_started());
         assert_eq!(pool.maintenance_spawn_attempts(), 1);
-        assert_eq!(pool.diagnostics().worker_start_failures, 1);
+        assert!(pool.diagnostics().maintenance_disabled);
 
         pool.inner.maintenance.record_idle(&pool.inner);
         assert_eq!(pool.maintenance_spawn_attempts(), 1);
@@ -1180,10 +1213,13 @@ mod tests {
             .arena
             .select_trim_candidate()
             .expect("free prepared slot");
-        let reclaimed = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
-            epoch: 0,
-            target: CarrierCount::ZERO,
-        });
+        let reclaimed = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: CarrierCount::ZERO,
+            },
+        );
         assert_eq!(reclaimed.outcome, MaintenanceOutcome::Complete);
         pool.assert_quiescent_zero();
 
@@ -1279,12 +1315,13 @@ mod loom_tests {
 
             let reclaiming = pool.clone();
             let reclaim = thread::spawn(move || {
-                reclaiming
-                    .inner
-                    .execute_maintenance(MaintenanceAction::Reclaim {
+                execute_maintenance(
+                    &reclaiming.inner,
+                    MaintenanceAction::Reclaim {
                         epoch: 0,
                         target: CarrierCount::ZERO,
-                    })
+                    },
+                )
             });
             let claiming = pool.clone();
             let claim = thread::spawn(move || claiming.acquire_unreserved(carrier_size));

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
@@ -1,0 +1,500 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Idle reclamation policy and maintenance-worker coordination.
+//!
+//! [`MaintenanceState`] converts explicit activity, deadline, and completion
+//! events into serialized maintenance actions. Pool and platform operations
+//! execute outside this state machine.
+
+use std::time::{Duration, Instant};
+
+use super::CarrierCount;
+
+/// Fraction of the configured block ceiling retained after an idle deadline.
+const IDLE_RETENTION_DIVISOR: usize = 4;
+
+/// One maintenance operation authorized by the control state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum MaintenanceAction {
+    /// Retry pending mapping protection or backing discard.
+    RetryCleanup {
+        /// Cleanup generation observed when the action was issued.
+        generation: u64,
+    },
+    /// Reclaim free blocks down to one fixed target.
+    Reclaim {
+        /// Activity epoch that authorized this reclaim pass.
+        epoch: u64,
+        /// Prepared capacity retained for the complete idle epoch.
+        target: CarrierCount,
+    },
+}
+
+/// Result of one bounded maintenance pass.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum MaintenanceOutcome {
+    /// No eligible work remains for this request.
+    Complete,
+    /// Eligible work may appear or recover after a bounded delay.
+    Retry,
+}
+
+/// Deadline armed for one scheduler-idle interval.
+#[derive(Clone, Copy, Debug)]
+struct IdleDeadline {
+    /// Activity epoch current when global idle was observed.
+    epoch: u64,
+    /// Earliest time at which reclamation may start.
+    expires_at: Instant,
+}
+
+/// Reclaim request whose target remains fixed across retries.
+#[derive(Clone, Copy, Debug)]
+struct ReclaimRequest {
+    /// Activity epoch current when the idle deadline expired.
+    epoch: u64,
+    /// Whole-block capacity retained by this request.
+    target: CarrierCount,
+    /// Earliest time at which another pass may run.
+    eligible_at: Instant,
+}
+
+/// Cleanup request protected against completion of an older pass.
+#[derive(Clone, Copy, Debug)]
+struct CleanupRequest {
+    /// Monotonic request generation.
+    generation: u64,
+    /// Earliest time at which another pass may run.
+    eligible_at: Instant,
+}
+
+/// Serialized idle, retry, disable, and stop policy.
+pub(super) struct MaintenanceState {
+    /// Generation changed by every managed-activity transition.
+    activity_epoch: u64,
+    /// Pending scheduler-idle deadline.
+    idle_deadline: Option<IdleDeadline>,
+    /// Pending reclaim request with a stable retention target.
+    reclaim: Option<ReclaimRequest>,
+    /// Latest mapping-cleanup request.
+    cleanup: Option<CleanupRequest>,
+    /// Generation assigned to the next cleanup request.
+    next_cleanup_generation: u64,
+    /// Final destruction has requested worker termination.
+    stopping: bool,
+    /// Thread creation failed and maintenance is permanently disabled.
+    disabled: bool,
+}
+
+impl MaintenanceState {
+    /// Creates enabled maintenance state with no pending work.
+    pub(super) fn new() -> Self {
+        Self {
+            activity_epoch: 0,
+            idle_deadline: None,
+            reclaim: None,
+            cleanup: None,
+            next_cleanup_generation: 1,
+            stopping: false,
+            disabled: false,
+        }
+    }
+
+    /// Invalidates idle reclamation after new managed work begins.
+    ///
+    /// Cleanup recovery is independent of scheduler activity and remains
+    /// pending.
+    pub(super) fn record_activity(&mut self) {
+        self.activity_epoch = self.activity_epoch.wrapping_add(1);
+        self.idle_deadline = None;
+        self.reclaim = None;
+    }
+
+    /// Arms one deadline for the current global-idle interval.
+    ///
+    /// Repeated idle observations in the same activity epoch preserve the
+    /// original deadline and cannot extend cache retention.
+    pub(super) fn record_idle(&mut self, now: Instant, idle_timeout: Duration) {
+        if self.stopping || self.disabled || self.reclaim.is_some() {
+            return;
+        }
+        if self
+            .idle_deadline
+            .is_some_and(|deadline| deadline.epoch == self.activity_epoch)
+        {
+            return;
+        }
+        let expires_at = now
+            .checked_add(idle_timeout)
+            .unwrap_or_else(|| super::invariant_violation("maintenance idle deadline overflow"));
+        self.idle_deadline = Some(IdleDeadline {
+            epoch: self.activity_epoch,
+            expires_at,
+        });
+    }
+
+    /// Requests mapping cleanup without losing a concurrent newer request.
+    pub(super) fn request_cleanup(&mut self, now: Instant) {
+        if self.stopping || self.disabled {
+            return;
+        }
+        let generation = self.next_cleanup_generation;
+        self.next_cleanup_generation = self.next_cleanup_generation.wrapping_add(1);
+        self.cleanup = Some(CleanupRequest {
+            generation,
+            eligible_at: now,
+        });
+    }
+
+    /// Returns one due action without consuming its request.
+    ///
+    /// Cleanup has priority because a pending protection recovery can keep a
+    /// complete block unavailable to ordinary allocation.
+    pub(super) fn next_action(
+        &mut self,
+        now: Instant,
+        configured_capacity: CarrierCount,
+        block_capacity: CarrierCount,
+    ) -> Option<MaintenanceAction> {
+        if self.stopping || self.disabled {
+            return None;
+        }
+
+        if let Some(cleanup) = self.cleanup {
+            if cleanup.eligible_at <= now {
+                return Some(MaintenanceAction::RetryCleanup {
+                    generation: cleanup.generation,
+                });
+            }
+        }
+
+        if let Some(deadline) = self.idle_deadline {
+            if deadline.expires_at <= now {
+                self.idle_deadline = None;
+                if deadline.epoch == self.activity_epoch {
+                    self.reclaim = Some(ReclaimRequest {
+                        epoch: deadline.epoch,
+                        target: idle_retention_target(configured_capacity, block_capacity),
+                        eligible_at: now,
+                    });
+                }
+            }
+        }
+
+        self.reclaim
+            .filter(|request| request.eligible_at <= now)
+            .map(|request| MaintenanceAction::Reclaim {
+                epoch: request.epoch,
+                target: request.target,
+            })
+    }
+
+    /// Records an action result and schedules bounded retry when required.
+    ///
+    /// Completion from an obsolete action leaves newer work unchanged.
+    pub(super) fn finish_action(
+        &mut self,
+        action: MaintenanceAction,
+        outcome: MaintenanceOutcome,
+        now: Instant,
+        retry_delay: Duration,
+    ) {
+        let eligible_at = now
+            .checked_add(retry_delay)
+            .unwrap_or_else(|| super::invariant_violation("maintenance retry deadline overflow"));
+        match action {
+            MaintenanceAction::RetryCleanup { generation } => {
+                let Some(request) = self.cleanup.as_mut() else {
+                    return;
+                };
+                if request.generation != generation {
+                    return;
+                }
+                match outcome {
+                    MaintenanceOutcome::Complete => self.cleanup = None,
+                    MaintenanceOutcome::Retry => request.eligible_at = eligible_at,
+                }
+            }
+            MaintenanceAction::Reclaim { epoch, target } => {
+                let Some(request) = self.reclaim.as_mut() else {
+                    return;
+                };
+                if request.epoch != epoch || request.target != target {
+                    return;
+                }
+                match outcome {
+                    MaintenanceOutcome::Complete => self.reclaim = None,
+                    MaintenanceOutcome::Retry => request.eligible_at = eligible_at,
+                }
+            }
+        }
+    }
+
+    /// Permanently disables maintenance after worker creation fails.
+    pub(super) fn disable(&mut self) {
+        self.disabled = true;
+        self.idle_deadline = None;
+        self.reclaim = None;
+        self.cleanup = None;
+    }
+
+    /// Cancels pending work and requests worker termination.
+    pub(super) fn stop(&mut self) {
+        self.stopping = true;
+        self.idle_deadline = None;
+        self.reclaim = None;
+        self.cleanup = None;
+    }
+
+    /// Returns whether final destruction requested termination.
+    pub(super) fn is_stopping(&self) -> bool {
+        self.stopping
+    }
+
+    /// Returns the earliest time at which pending work can change state.
+    pub(super) fn next_wake(&self) -> Option<Instant> {
+        [
+            self.cleanup.map(|request| request.eligible_at),
+            self.reclaim.map(|request| request.eligible_at),
+            self.idle_deadline.map(|deadline| deadline.expires_at),
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+    }
+}
+
+/// Computes one whole-block retention target for an idle epoch.
+fn idle_retention_target(
+    configured_capacity: CarrierCount,
+    block_capacity: CarrierCount,
+) -> CarrierCount {
+    if configured_capacity == CarrierCount::ZERO || block_capacity == CarrierCount::ZERO {
+        return CarrierCount::ZERO;
+    }
+    let configured_blocks = configured_capacity.get().div_ceil(block_capacity.get());
+    let retained_blocks = configured_blocks.div_ceil(IDLE_RETENTION_DIVISOR);
+    CarrierCount::new(
+        retained_blocks
+            .checked_mul(block_capacity.get())
+            .unwrap_or_else(|| super::invariant_violation("idle retention target overflow")),
+    )
+}
+
+#[cfg(all(test, not(s3_tm_loom)))]
+mod tests {
+    use super::*;
+
+    const IDLE: Duration = Duration::from_secs(10);
+    const RETRY: Duration = Duration::from_secs(2);
+
+    fn carriers(value: usize) -> CarrierCount {
+        CarrierCount::new(value)
+    }
+
+    #[test]
+    fn test_repeated_idle_does_not_extend_the_deadline() {
+        let start = Instant::now();
+        let mut state = MaintenanceState::new();
+        state.record_idle(start, IDLE);
+        state.record_idle(start + Duration::from_secs(5), IDLE);
+
+        assert_eq!(
+            state.next_action(start + IDLE, carriers(256), carriers(64)),
+            Some(MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: carriers(64),
+            })
+        );
+    }
+
+    #[test]
+    fn test_activity_invalidates_a_stale_idle_deadline() {
+        let start = Instant::now();
+        let mut state = MaintenanceState::new();
+        state.record_idle(start, IDLE);
+        state.record_activity();
+
+        assert_eq!(
+            state.next_action(start + IDLE, carriers(256), carriers(64)),
+            None
+        );
+    }
+
+    #[test]
+    fn test_idle_target_rounds_to_complete_blocks() {
+        let start = Instant::now();
+        let mut state = MaintenanceState::new();
+        state.record_idle(start, IDLE);
+
+        assert_eq!(
+            state.next_action(start + IDLE, carriers(70), carriers(64)),
+            Some(MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: carriers(64),
+            })
+        );
+    }
+
+    #[test]
+    fn test_reclaim_retry_keeps_the_epoch_target() {
+        let start = Instant::now();
+        let mut state = MaintenanceState::new();
+        state.record_idle(start, IDLE);
+        let action = state
+            .next_action(start + IDLE, carriers(256), carriers(64))
+            .unwrap();
+        state.finish_action(action, MaintenanceOutcome::Retry, start + IDLE, RETRY);
+
+        assert_eq!(
+            state.next_action(start + IDLE + RETRY, carriers(64), carriers(64)),
+            Some(MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: carriers(64),
+            })
+        );
+    }
+
+    #[test]
+    fn test_activity_cancels_a_pending_reclaim_retry() {
+        let start = Instant::now();
+        let mut state = MaintenanceState::new();
+        state.record_idle(start, IDLE);
+        let action = state
+            .next_action(start + IDLE, carriers(256), carriers(64))
+            .unwrap();
+        state.finish_action(action, MaintenanceOutcome::Retry, start + IDLE, RETRY);
+        state.record_activity();
+
+        assert_eq!(
+            state.next_action(start + IDLE + RETRY, carriers(256), carriers(64)),
+            None
+        );
+    }
+
+    #[test]
+    fn test_new_cleanup_request_survives_old_completion() {
+        let start = Instant::now();
+        let mut state = MaintenanceState::new();
+        state.request_cleanup(start);
+        let old = state.next_action(start, carriers(1), carriers(1)).unwrap();
+        state.request_cleanup(start);
+        state.finish_action(old, MaintenanceOutcome::Complete, start, RETRY);
+
+        assert!(matches!(
+            state.next_action(start, carriers(1), carriers(1)),
+            Some(MaintenanceAction::RetryCleanup { generation: 2 })
+        ));
+    }
+
+    #[test]
+    fn test_cleanup_retry_is_delayed_and_has_priority() {
+        let start = Instant::now();
+        let mut state = MaintenanceState::new();
+        state.record_idle(start, Duration::ZERO);
+        state.request_cleanup(start);
+        let cleanup = state
+            .next_action(start, carriers(256), carriers(64))
+            .unwrap();
+        assert!(matches!(cleanup, MaintenanceAction::RetryCleanup { .. }));
+        state.finish_action(cleanup, MaintenanceOutcome::Retry, start, RETRY);
+
+        assert!(matches!(
+            state.next_action(start, carriers(256), carriers(64)),
+            Some(MaintenanceAction::Reclaim { .. })
+        ));
+        assert!(matches!(
+            state.next_action(start + RETRY, carriers(256), carriers(64)),
+            Some(MaintenanceAction::RetryCleanup { .. })
+        ));
+    }
+
+    #[test]
+    fn test_disable_and_stop_cancel_all_work() {
+        let start = Instant::now();
+        for stop in [false, true] {
+            let mut state = MaintenanceState::new();
+            state.record_idle(start, Duration::ZERO);
+            state.request_cleanup(start);
+            if stop {
+                state.stop();
+                assert!(state.is_stopping());
+            } else {
+                state.disable();
+            }
+            assert_eq!(state.next_wake(), None);
+            assert_eq!(state.next_action(start, carriers(1), carriers(1)), None);
+        }
+    }
+}
+
+#[cfg(all(test, s3_tm_loom))]
+mod loom_tests {
+    use super::*;
+    use crate::runtime::sync::sync::{Arc, Mutex};
+    use crate::runtime::sync::thread;
+
+    #[test]
+    fn test_activity_and_deadline_expiry_share_one_epoch_order() {
+        loom::model(|| {
+            let start = Instant::now();
+            let state = Arc::new(Mutex::new(MaintenanceState::new()));
+            state.lock().record_idle(start, Duration::ZERO);
+
+            let active = Arc::clone(&state);
+            let activity = thread::spawn(move || active.lock().record_activity());
+            let expiring = Arc::clone(&state);
+            let expiry = thread::spawn(move || {
+                expiring
+                    .lock()
+                    .next_action(start, CarrierCount::new(4), CarrierCount::new(1))
+            });
+
+            activity.join().unwrap();
+            let _ = expiry.join().unwrap();
+            assert_eq!(
+                state.lock().next_action(
+                    start + Duration::from_secs(1),
+                    CarrierCount::new(4),
+                    CarrierCount::new(1),
+                ),
+                None
+            );
+        });
+    }
+
+    #[test]
+    fn test_cleanup_completion_cannot_erase_a_new_request() {
+        loom::model(|| {
+            let start = Instant::now();
+            let state = Arc::new(Mutex::new(MaintenanceState::new()));
+            state.lock().request_cleanup(start);
+            let action = state
+                .lock()
+                .next_action(start, CarrierCount::new(1), CarrierCount::new(1))
+                .unwrap();
+
+            let requesting = Arc::clone(&state);
+            let request = thread::spawn(move || requesting.lock().request_cleanup(start));
+            let finishing = Arc::clone(&state);
+            let finish = thread::spawn(move || {
+                finishing.lock().finish_action(
+                    action,
+                    MaintenanceOutcome::Complete,
+                    start,
+                    Duration::ZERO,
+                )
+            });
+
+            request.join().unwrap();
+            finish.join().unwrap();
+            let next = state
+                .lock()
+                .next_action(start, CarrierCount::new(1), CarrierCount::new(1));
+            assert!(next.is_some());
+        });
+    }
+}

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
@@ -14,9 +14,25 @@ use std::time::{Duration, Instant};
 use super::admission::AdmissionGuard;
 use super::arena::ArenaTrim;
 use super::{CarrierCount, PoolInner};
+use crate::runtime::sync::sync::{Arc, Condvar, Mutex};
+
+#[cfg(not(all(test, s3_tm_loom)))]
+use std::{io, sync::Weak};
+
+#[cfg(not(all(test, s3_tm_loom)))]
+use crate::runtime::sync::thread;
 
 /// Fraction of the configured block ceiling retained after an idle deadline.
 const IDLE_RETENTION_DIVISOR: usize = 4;
+
+/// Initial cache-hysteresis interval after scheduler-global idle.
+const IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Delay before retrying blocked reclamation or mapping cleanup.
+const RETRY_DELAY: Duration = Duration::from_secs(1);
+
+/// Operating-system thread name used by the pool maintenance worker.
+const WORKER_NAME: &str = "s3-tm-memory";
 
 /// One maintenance operation authorized by the control state.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -59,6 +75,153 @@ impl MaintenancePass {
         Self {
             outcome,
             cleanup_pending: false,
+        }
+    }
+}
+
+/// Lazy worker owner embedded in the pool lifetime domain.
+pub(super) struct MaintenanceCoordinator {
+    /// State and wakeup primitive retained independently by the worker.
+    control: Arc<MaintenanceControl>,
+    /// Serialized worker creation and final join authority.
+    #[cfg(not(all(test, s3_tm_loom)))]
+    worker: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+impl MaintenanceCoordinator {
+    /// Creates an idle coordinator without starting a thread.
+    pub(super) fn new() -> Self {
+        Self {
+            control: Arc::new(MaintenanceControl::new()),
+            #[cfg(not(all(test, s3_tm_loom)))]
+            worker: Mutex::new(None),
+        }
+    }
+
+    /// Invalidates a pending idle epoch without starting the worker.
+    pub(super) fn record_activity(&self) {
+        self.control.state.lock().record_activity();
+        self.control.wake.notify_all();
+    }
+
+    /// Arms reclamation after scheduler-global idle.
+    pub(super) fn record_idle(&self, pool: &Arc<PoolInner>) {
+        self.record_idle_after(pool, Instant::now(), IDLE_TIMEOUT);
+    }
+
+    /// Requests recovery for a failed mapping cleanup operation.
+    pub(super) fn request_cleanup(&self, pool: &Arc<PoolInner>) {
+        self.control.state.lock().request_cleanup(Instant::now());
+        self.ensure_worker(pool);
+        self.control.wake.notify_all();
+    }
+
+    /// Starts the worker at most once while maintenance remains enabled.
+    #[cfg(not(all(test, s3_tm_loom)))]
+    fn ensure_worker(&self, pool: &Arc<PoolInner>) {
+        let mut worker = self.worker.lock();
+        if worker.is_some() {
+            return;
+        }
+        {
+            let state = self.control.state.lock();
+            if state.is_stopping() || state.is_disabled() {
+                return;
+            }
+        }
+
+        let configured_capacity = pool.admission.lock().ledger.configured_capacity;
+        let block_capacity = pool.geometry.carriers_per_block();
+        let control = Arc::clone(&self.control);
+        let weak_pool = Arc::downgrade(pool);
+
+        #[cfg(test)]
+        pool.test_hooks.record_maintenance_spawn_attempt();
+        let spawned = if maintenance_spawn_failure_injected(pool) {
+            Err(io::Error::other("injected maintenance worker failure"))
+        } else {
+            thread::Builder::new()
+                .name(WORKER_NAME.to_owned())
+                .spawn(move || worker_loop(control, weak_pool, configured_capacity, block_capacity))
+        };
+
+        match spawned {
+            Ok(handle) => *worker = Some(handle),
+            Err(_) => self.control.state.lock().disable(),
+        }
+    }
+
+    /// Leaves wall-clock execution outside the Loom state model.
+    #[cfg(all(test, s3_tm_loom))]
+    fn ensure_worker(&self, _pool: &Arc<PoolInner>) {}
+
+    /// Cancels maintenance and joins a worker owned by another thread.
+    pub(super) fn shutdown(&mut self) {
+        self.control.state.lock().stop();
+        self.control.wake.notify_all();
+
+        #[cfg(not(all(test, s3_tm_loom)))]
+        let Some(worker) = self.worker.lock().take() else {
+            return;
+        };
+        #[cfg(not(all(test, s3_tm_loom)))]
+        if worker.thread().id() == thread::current().id() {
+            return;
+        }
+        #[cfg(not(all(test, s3_tm_loom)))]
+        let _ = worker.join();
+    }
+
+    /// Arms an idle deadline with explicit timing for deterministic tests.
+    fn record_idle_after(&self, pool: &Arc<PoolInner>, now: Instant, timeout: Duration) {
+        self.control.state.lock().record_idle(now, timeout);
+        self.ensure_worker(pool);
+        self.control.wake.notify_all();
+    }
+
+    /// Returns whether a worker handle has been published.
+    #[cfg(test)]
+    fn worker_started(&self) -> bool {
+        #[cfg(not(s3_tm_loom))]
+        {
+            self.worker.lock().is_some()
+        }
+        #[cfg(s3_tm_loom)]
+        {
+            false
+        }
+    }
+
+    /// Returns the published worker name.
+    #[cfg(all(test, not(s3_tm_loom)))]
+    fn worker_name(&self) -> Option<String> {
+        self.worker
+            .lock()
+            .as_ref()
+            .and_then(|worker| worker.thread().name().map(str::to_owned))
+    }
+
+    /// Returns whether thread creation permanently disabled maintenance.
+    #[cfg(test)]
+    fn is_disabled(&self) -> bool {
+        self.control.state.lock().is_disabled()
+    }
+}
+
+/// Wait state retained by the worker without retaining pool storage.
+struct MaintenanceControl {
+    /// Serialized policy state.
+    state: Mutex<MaintenanceState>,
+    /// Deadline, request, and shutdown wakeups.
+    wake: Condvar,
+}
+
+impl MaintenanceControl {
+    /// Creates control state with no pending work.
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(MaintenanceState::new()),
+            wake: Condvar::new(),
         }
     }
 }
@@ -275,6 +438,11 @@ impl MaintenanceState {
         self.stopping
     }
 
+    /// Returns whether worker creation permanently disabled maintenance.
+    pub(super) fn is_disabled(&self) -> bool {
+        self.disabled
+    }
+
     /// Returns the earliest time at which pending work can change state.
     pub(super) fn next_wake(&self) -> Option<Instant> {
         [
@@ -286,6 +454,85 @@ impl MaintenanceState {
         .flatten()
         .min()
     }
+}
+
+/// Runs due maintenance while retaining only control state between passes.
+#[cfg(not(all(test, s3_tm_loom)))]
+fn worker_loop(
+    control: Arc<MaintenanceControl>,
+    pool: Weak<PoolInner>,
+    configured_capacity: CarrierCount,
+    block_capacity: CarrierCount,
+) {
+    loop {
+        let Some(action) = wait_for_action(&control, configured_capacity, block_capacity) else {
+            return;
+        };
+        let Some(pool) = pool.upgrade() else {
+            return;
+        };
+
+        #[cfg(test)]
+        pool.test_hooks.wait_after_maintenance_upgrade();
+        let pass = pool.execute_maintenance(action);
+        drop(pool);
+
+        let now = Instant::now();
+        let mut state = control.state.lock();
+        if pass.cleanup_pending {
+            state.request_cleanup(now);
+        }
+        state.finish_action(action, pass.outcome, now, RETRY_DELAY);
+        let stopping = state.is_stopping();
+        drop(state);
+        control.wake.notify_all();
+        if stopping {
+            return;
+        }
+    }
+}
+
+/// Waits until one action is due or final destruction requests stop.
+#[cfg(not(all(test, s3_tm_loom)))]
+fn wait_for_action(
+    control: &MaintenanceControl,
+    configured_capacity: CarrierCount,
+    block_capacity: CarrierCount,
+) -> Option<MaintenanceAction> {
+    let mut state = control.state.lock();
+    loop {
+        if state.is_stopping() {
+            return None;
+        }
+
+        let now = Instant::now();
+        if let Some(action) = state.next_action(now, configured_capacity, block_capacity) {
+            return Some(action);
+        }
+
+        state = match state.next_wake() {
+            Some(deadline) => {
+                let timeout = deadline.saturating_duration_since(now);
+                if timeout.is_zero() {
+                    continue;
+                }
+                control.wake.wait_timeout(state, timeout).0
+            }
+            None => control.wake.wait(state),
+        };
+    }
+}
+
+/// Returns whether a test requested one worker-creation failure.
+#[cfg(all(test, not(s3_tm_loom)))]
+fn maintenance_spawn_failure_injected(pool: &PoolInner) -> bool {
+    pool.test_hooks.take_maintenance_spawn_failure()
+}
+
+/// Compiles worker failure injection out of production builds.
+#[cfg(not(test))]
+fn maintenance_spawn_failure_injected(_pool: &PoolInner) -> bool {
+    false
 }
 
 impl PoolInner {
@@ -358,9 +605,19 @@ mod tests {
     use super::*;
     use crate::runtime::buffer_pool::test_util::test_pool;
     use crate::runtime::buffer_pool::virtual_memory::VirtualMemoryOperation;
+    use std::sync::Barrier;
 
     const IDLE: Duration = Duration::from_secs(10);
     const RETRY: Duration = Duration::from_secs(2);
+
+    /// Waits for one worker-owned state transition without choosing its order.
+    fn wait_until(mut predicate: impl FnMut() -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !predicate() {
+            assert!(Instant::now() < deadline, "maintenance worker timed out");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
 
     fn carriers(value: usize) -> CarrierCount {
         CarrierCount::new(value)
@@ -604,6 +861,104 @@ mod tests {
         let reused = pool.acquire_unreserved(carrier_size).unwrap();
         drop(reused);
     }
+
+    #[test]
+    fn test_cleanup_request_starts_one_named_worker_lazily() {
+        let (pool, _) = test_pool(1, 1);
+        assert!(!pool.inner.maintenance.worker_started());
+
+        pool.inner.maintenance.request_cleanup(&pool.inner);
+
+        assert!(pool.inner.maintenance.worker_started());
+        assert_eq!(
+            pool.inner.maintenance.worker_name().as_deref(),
+            Some(WORKER_NAME)
+        );
+        assert_eq!(pool.maintenance_spawn_attempts(), 1);
+    }
+
+    #[test]
+    fn test_idle_deadline_wakes_worker_and_reclaims() {
+        let (pool, carrier_size) = test_pool(1, 8);
+        let owned = pool.acquire_unreserved(carrier_size * 8).unwrap();
+        drop(owned);
+
+        pool.inner.maintenance.record_idle_after(
+            &pool.inner,
+            Instant::now(),
+            Duration::from_millis(10),
+        );
+
+        wait_until(|| pool.metrics().prepared_capacity_bytes() == (carrier_size * 2) as u64);
+        assert_eq!(pool.maintenance_spawn_attempts(), 1);
+    }
+
+    #[test]
+    fn test_concurrent_requests_publish_one_worker() {
+        const CALLERS: usize = 8;
+
+        let (pool, _) = test_pool(1, 1);
+        let barrier = Arc::new(Barrier::new(CALLERS));
+        let mut callers = Vec::new();
+        for _ in 0..CALLERS {
+            let pool = pool.clone();
+            let barrier = Arc::clone(&barrier);
+            callers.push(std::thread::spawn(move || {
+                barrier.wait();
+                pool.inner.maintenance.request_cleanup(&pool.inner);
+            }));
+        }
+        for caller in callers {
+            caller.join().unwrap();
+        }
+
+        assert!(pool.inner.maintenance.worker_started());
+        assert_eq!(pool.maintenance_spawn_attempts(), 1);
+    }
+
+    #[test]
+    fn test_spawn_failure_disables_only_maintenance() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        pool.inject_maintenance_spawn_failure();
+
+        pool.inner.maintenance.request_cleanup(&pool.inner);
+
+        assert!(pool.inner.maintenance.is_disabled());
+        assert!(!pool.inner.maintenance.worker_started());
+        assert_eq!(pool.maintenance_spawn_attempts(), 1);
+
+        pool.inner.maintenance.record_idle(&pool.inner);
+        assert_eq!(pool.maintenance_spawn_attempts(), 1);
+        let owned = pool.acquire_unreserved(carrier_size).unwrap();
+        drop(owned);
+    }
+
+    #[test]
+    fn test_waiting_worker_does_not_retain_the_pool() {
+        let (pool, _) = test_pool(1, 1);
+        pool.inner.maintenance.request_cleanup(&pool.inner);
+        let weak = Arc::downgrade(&pool.inner);
+
+        drop(pool);
+
+        wait_until(|| weak.strong_count() == 0);
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn test_worker_final_owner_does_not_join_itself() {
+        let (pool, _) = test_pool(1, 1);
+        let pause = pool.pause_maintenance_after_upgrade();
+        pool.inner.maintenance.request_cleanup(&pool.inner);
+        wait_until(|| pause.entered());
+        let weak = Arc::downgrade(&pool.inner);
+
+        drop(pool);
+        pause.release();
+
+        wait_until(|| weak.strong_count() == 0);
+        assert!(weak.upgrade().is_none());
+    }
 }
 
 #[cfg(all(test, s3_tm_loom))]
@@ -697,6 +1052,47 @@ mod loom_tests {
             let owned = claim.join().unwrap().unwrap();
             drop(owned);
             assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
+        });
+    }
+
+    #[test]
+    fn test_stop_and_wait_share_the_control_mutex() {
+        loom::model(|| {
+            let control = Arc::new(MaintenanceControl::new());
+            let waiting = Arc::clone(&control);
+            let waiter = thread::spawn(move || {
+                let state = waiting.state.lock();
+                if state.is_stopping() {
+                    return;
+                }
+                let state = waiting.wake.wait(state);
+                assert!(state.is_stopping());
+            });
+
+            control.state.lock().stop();
+            control.wake.notify_all();
+            waiter.join().unwrap();
+        });
+    }
+
+    #[test]
+    fn test_disable_cannot_publish_due_work() {
+        loom::model(|| {
+            let state = Arc::new(Mutex::new(MaintenanceState::new()));
+            let disabling = Arc::clone(&state);
+            let disable = thread::spawn(move || disabling.lock().disable());
+            let requesting = Arc::clone(&state);
+            let request = thread::spawn(move || {
+                requesting.lock().request_cleanup(Instant::now());
+            });
+
+            disable.join().unwrap();
+            request.join().unwrap();
+            let mut state = state.lock();
+            assert_eq!(
+                state.next_action(Instant::now(), CarrierCount::new(1), CarrierCount::new(1),),
+                None
+            );
         });
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
@@ -11,7 +11,9 @@
 
 use std::time::{Duration, Instant};
 
-use super::CarrierCount;
+use super::admission::AdmissionGuard;
+use super::arena::ArenaTrim;
+use super::{CarrierCount, PoolInner};
 
 /// Fraction of the configured block ceiling retained after an idle deadline.
 const IDLE_RETENTION_DIVISOR: usize = 4;
@@ -40,6 +42,25 @@ pub(super) enum MaintenanceOutcome {
     Complete,
     /// Eligible work may appear or recover after a bounded delay.
     Retry,
+}
+
+/// Result of executing one policy action against pool state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct MaintenancePass {
+    /// Whether the action needs another bounded attempt.
+    pub(super) outcome: MaintenanceOutcome,
+    /// Whether mapping cleanup must run independently of reclamation.
+    pub(super) cleanup_pending: bool,
+}
+
+impl MaintenancePass {
+    /// Constructs a pass result without cleanup recovery.
+    fn new(outcome: MaintenanceOutcome) -> Self {
+        Self {
+            outcome,
+            cleanup_pending: false,
+        }
+    }
 }
 
 /// Deadline armed for one scheduler-idle interval.
@@ -267,6 +288,54 @@ impl MaintenanceState {
     }
 }
 
+impl PoolInner {
+    /// Executes one maintenance action without holding maintenance control.
+    pub(super) fn execute_maintenance(&self, action: MaintenanceAction) -> MaintenancePass {
+        match action {
+            MaintenanceAction::RetryCleanup { .. } => {
+                if self.arena.retry_cleanup() {
+                    MaintenancePass::new(MaintenanceOutcome::Complete)
+                } else {
+                    MaintenancePass::new(MaintenanceOutcome::Retry)
+                }
+            }
+            MaintenanceAction::Reclaim { target, .. } => self.reclaim_to(target),
+        }
+    }
+
+    /// Reclaims complete free blocks until the target or a blocker is reached.
+    fn reclaim_to(&self, target: CarrierCount) -> MaintenancePass {
+        let mut cleanup_pending = false;
+        loop {
+            let trim = {
+                let mut admission = AdmissionGuard::new(self.admission.lock());
+                if admission.prepared_capacity() <= target {
+                    return MaintenancePass {
+                        outcome: MaintenanceOutcome::Complete,
+                        cleanup_pending,
+                    };
+                }
+                let admission_floor = admission
+                    .acquisition_floor(&self.coverage)
+                    .unwrap_or_else(|_| super::invariant_violation("maintenance floor overflow"));
+                let floor = std::cmp::max(target, admission_floor);
+                self.arena.start_trim(&mut admission, floor)
+            };
+
+            let ArenaTrim::Started(cleanup) = trim else {
+                return MaintenancePass {
+                    outcome: MaintenanceOutcome::Retry,
+                    cleanup_pending,
+                };
+            };
+            match cleanup.finish() {
+                Ok(()) => self.arena.record_block_reclaimed(),
+                Err(_) => cleanup_pending = true,
+            }
+        }
+    }
+}
+
 /// Computes one whole-block retention target for an idle epoch.
 fn idle_retention_target(
     configured_capacity: CarrierCount,
@@ -287,6 +356,8 @@ fn idle_retention_target(
 #[cfg(all(test, not(s3_tm_loom)))]
 mod tests {
     use super::*;
+    use crate::runtime::buffer_pool::test_util::test_pool;
+    use crate::runtime::buffer_pool::virtual_memory::VirtualMemoryOperation;
 
     const IDLE: Duration = Duration::from_secs(10);
     const RETRY: Duration = Duration::from_secs(2);
@@ -429,11 +500,116 @@ mod tests {
             assert_eq!(state.next_action(start, carriers(1), carriers(1)), None);
         }
     }
+
+    #[test]
+    fn test_reclaim_trims_free_blocks_to_the_fixed_target() {
+        let (pool, carrier_size) = test_pool(2, 8);
+        let owned = pool.acquire_unreserved(carrier_size * 8).unwrap();
+        drop(owned);
+
+        let pass = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
+            epoch: 0,
+            target: carriers(2),
+        });
+
+        assert_eq!(pass, MaintenancePass::new(MaintenanceOutcome::Complete));
+        assert_eq!(
+            pool.inner.admission.lock().ledger.prepared_capacity,
+            carriers(2)
+        );
+        assert_eq!(pool.inner.arena.diagnostics().blocks_reclaimed, 3);
+    }
+
+    #[test]
+    fn test_reclaim_retries_while_live_ownership_blocks_trim() {
+        let (pool, carrier_size) = test_pool(2, 2);
+        let owned = pool.acquire_unreserved(carrier_size).unwrap();
+
+        let blocked = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
+            epoch: 0,
+            target: CarrierCount::ZERO,
+        });
+        assert_eq!(blocked, MaintenancePass::new(MaintenanceOutcome::Retry));
+
+        drop(owned);
+        let complete = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
+            epoch: 0,
+            target: CarrierCount::ZERO,
+        });
+        assert_eq!(complete, MaintenancePass::new(MaintenanceOutcome::Complete));
+        assert_eq!(pool.metrics().prepared_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_reclaim_preserves_the_current_admission_floor() {
+        let (pool, carrier_size) = test_pool(2, 4);
+        let reservation = pool
+            .try_reserve(carrier_size * 3)
+            .unwrap()
+            .expect("reservation");
+
+        let blocked = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
+            epoch: 0,
+            target: CarrierCount::ZERO,
+        });
+        assert_eq!(blocked.outcome, MaintenanceOutcome::Retry);
+        assert_eq!(
+            pool.metrics().prepared_capacity_bytes(),
+            (carrier_size * 4) as u64
+        );
+
+        drop(reservation);
+        let complete = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
+            epoch: 0,
+            target: CarrierCount::ZERO,
+        });
+        assert_eq!(complete.outcome, MaintenanceOutcome::Complete);
+        assert_eq!(pool.metrics().prepared_capacity_bytes(), 0);
+    }
+
+    #[test]
+    fn test_failed_trim_requests_cleanup_without_restoring_prepared_capacity() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let owned = pool.acquire_unreserved(carrier_size).unwrap();
+        drop(owned);
+        let slot = pool
+            .inner
+            .arena
+            .select_trim_candidate()
+            .expect("free prepared slot");
+        slot.inject_failure_once(VirtualMemoryOperation::Deactivate);
+
+        let trim = pool.inner.execute_maintenance(MaintenanceAction::Reclaim {
+            epoch: 0,
+            target: CarrierCount::ZERO,
+        });
+        assert_eq!(trim.outcome, MaintenanceOutcome::Complete);
+        assert!(trim.cleanup_pending);
+        assert_eq!(pool.metrics().prepared_capacity_bytes(), 0);
+
+        slot.inject_failure_once(VirtualMemoryOperation::Deactivate);
+        let retry = pool
+            .inner
+            .execute_maintenance(MaintenanceAction::RetryCleanup { generation: 1 });
+        assert_eq!(retry, MaintenancePass::new(MaintenanceOutcome::Retry));
+        assert_eq!(pool.inner.arena.diagnostics().cleanup_retries, 1);
+        assert_eq!(pool.inner.arena.diagnostics().cleanup_failures, 1);
+
+        let cleanup = pool
+            .inner
+            .execute_maintenance(MaintenanceAction::RetryCleanup { generation: 1 });
+        assert_eq!(cleanup, MaintenancePass::new(MaintenanceOutcome::Complete));
+        assert_eq!(pool.inner.arena.diagnostics().cleanup_retries, 2);
+        assert_eq!(pool.inner.arena.diagnostics().cleanup_failures, 1);
+        let reused = pool.acquire_unreserved(carrier_size).unwrap();
+        drop(reused);
+    }
 }
 
 #[cfg(all(test, s3_tm_loom))]
 mod loom_tests {
     use super::*;
+    use crate::runtime::buffer_pool::test_util::test_single_carrier_pool;
     use crate::runtime::sync::sync::{Arc, Mutex};
     use crate::runtime::sync::thread;
 
@@ -495,6 +671,32 @@ mod loom_tests {
                 .lock()
                 .next_action(start, CarrierCount::new(1), CarrierCount::new(1));
             assert!(next.is_some());
+        });
+    }
+
+    #[test]
+    fn test_claim_and_reclaim_compose_through_the_pool() {
+        loom::model(|| {
+            let (pool, carrier_size) = test_single_carrier_pool(1);
+            let initial = pool.acquire_unreserved(carrier_size).unwrap();
+            drop(initial);
+
+            let reclaiming = pool.clone();
+            let reclaim = thread::spawn(move || {
+                reclaiming
+                    .inner
+                    .execute_maintenance(MaintenanceAction::Reclaim {
+                        epoch: 0,
+                        target: CarrierCount::ZERO,
+                    })
+            });
+            let claiming = pool.clone();
+            let claim = thread::spawn(move || claiming.acquire_unreserved(carrier_size));
+
+            let _ = reclaim.join().unwrap();
+            let owned = claim.join().unwrap().unwrap();
+            drop(owned);
+            assert_eq!(pool.metrics().charged_capacity_bytes(), 0);
         });
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/maintenance.rs
@@ -837,15 +837,22 @@ mod tests {
         let mut state = MaintenanceState::new();
         state.record_idle(start, IDLE);
         let action = state
-            .next_action(start + IDLE, carriers(256), carriers(64))
+            .next_action(start + IDLE, carriers(1024), carriers(64))
             .unwrap();
+        assert_eq!(
+            action,
+            MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: carriers(256),
+            }
+        );
         state.finish_action(action, MaintenanceOutcome::Retry, start + IDLE, RETRY);
 
         assert_eq!(
             state.next_action(start + IDLE + RETRY, carriers(64), carriers(64)),
             Some(MaintenanceAction::Reclaim {
                 epoch: 0,
-                target: carriers(64),
+                target: carriers(256),
             })
         );
     }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/metrics.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/metrics.rs
@@ -5,6 +5,8 @@
 
 //! Stable memory-pressure metrics derived from one admission sample.
 
+use super::arena::{ArenaDiagnosticSnapshot, ArenaLifecycleSnapshot};
+use super::maintenance::MaintenanceDiagnosticSnapshot;
 use super::CarrierCount;
 
 /// Point-in-time memory state for one shared pool domain.
@@ -39,6 +41,84 @@ pub(super) struct MemoryMetricState {
     pub(super) queued_reservations: usize,
     /// Cumulative requests that entered the FIFO.
     pub(super) parked_reservations_total: u64,
+}
+
+/// Operational counters and lifecycle state for one shared pool domain.
+///
+/// This crate-private snapshot is intentionally separate from stable memory
+/// metrics. It may scan block state and is intended for diagnostics, tests,
+/// and rare tracing rather than allocator decisions.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MemoryDiagnostics {
+    /// Bitmap-owned carriers observed across the arena.
+    pub(crate) live_carriers: usize,
+    /// Prepared carriers reconstructed from active block incarnations.
+    pub(crate) prepared_carriers: usize,
+    /// Blocks unavailable while trim or mapping recovery remains pending.
+    pub(crate) cleanup_pending_blocks: usize,
+    /// Bitmap words charged to completed optimistic scans.
+    pub(crate) optimistic_scan_words: u64,
+    /// Optimistic scans that returned incomplete ownership.
+    pub(crate) optimistic_misses: u64,
+    /// Partial claims that entered serialized fallback.
+    pub(crate) serialized_fallbacks: u64,
+    /// Blocks successfully prepared.
+    pub(crate) blocks_prepared: u64,
+    /// Stable virtual ranges added to the registry.
+    pub(crate) block_ranges_reserved: u64,
+    /// Provisional carriers returned by incomplete claim batches.
+    pub(crate) rolled_back_carriers: u64,
+    /// Slots inspected while selecting trim candidates.
+    pub(crate) trim_slots_scanned: u64,
+    /// Blocks successfully reclaimed.
+    pub(crate) blocks_reclaimed: u64,
+    /// Pending mapping cleanup operations retried.
+    pub(crate) cleanup_retries: u64,
+    /// Cleanup retry attempts that remained pending.
+    pub(crate) cleanup_failures: u64,
+    /// Scheduler-global idle intervals that armed a deadline.
+    pub(crate) idle_deadlines: u64,
+    /// Successfully created maintenance workers.
+    pub(crate) worker_starts: u64,
+    /// Worker creation failures that disabled maintenance.
+    pub(crate) worker_start_failures: u64,
+    /// Reclaim actions executed by the worker.
+    pub(crate) reclaim_passes: u64,
+    /// Reclaim actions that remained blocked after a pass.
+    pub(crate) reclaim_retries: u64,
+    /// Cleanup generations requested after mapping failures.
+    pub(crate) cleanup_requests: u64,
+}
+
+impl MemoryDiagnostics {
+    /// Composes independent arena and maintenance diagnostic samples.
+    pub(super) fn from_snapshots(
+        arena: ArenaDiagnosticSnapshot,
+        lifecycle: ArenaLifecycleSnapshot,
+        maintenance: MaintenanceDiagnosticSnapshot,
+    ) -> Self {
+        Self {
+            live_carriers: lifecycle.live_carriers.get(),
+            prepared_carriers: lifecycle.prepared_capacity.get(),
+            cleanup_pending_blocks: lifecycle.cleanup_pending_blocks,
+            optimistic_scan_words: arena.optimistic_scan_words,
+            optimistic_misses: arena.optimistic_misses,
+            serialized_fallbacks: arena.serialized_fallbacks,
+            blocks_prepared: arena.blocks_prepared,
+            block_ranges_reserved: arena.block_ranges_reserved,
+            rolled_back_carriers: arena.rolled_back_carriers,
+            trim_slots_scanned: arena.trim_slots_scanned,
+            blocks_reclaimed: arena.blocks_reclaimed,
+            cleanup_retries: arena.cleanup_retries,
+            cleanup_failures: arena.cleanup_failures,
+            idle_deadlines: maintenance.idle_deadlines,
+            worker_starts: maintenance.worker_starts,
+            worker_start_failures: maintenance.worker_start_failures,
+            reclaim_passes: maintenance.reclaim_passes,
+            reclaim_retries: maintenance.reclaim_retries,
+            cleanup_requests: maintenance.cleanup_requests,
+        }
+    }
 }
 
 impl MemoryMetrics {

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/metrics.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/metrics.rs
@@ -3,9 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! Stable memory-pressure metrics derived from one admission sample.
+//! Memory state and operational diagnostics for one pool.
+//!
+//! [`MemoryMetrics`] is one admission-serialized accounting sample suitable
+//! for capacity decisions. [`MemoryDiagnostics`] combines cumulative counters
+//! with a best-effort arena scan and is intended for operational explanation,
+//! tests, and rare tracing.
 
-use super::arena::{ArenaDiagnosticSnapshot, ArenaLifecycleSnapshot};
+use super::arena::{ArenaDiagnosticSnapshot, ArenaLifecycleSample};
 use super::maintenance::MaintenanceDiagnosticSnapshot;
 use super::CarrierCount;
 
@@ -50,51 +55,52 @@ pub(super) struct MemoryMetricState {
 /// and rare tracing rather than allocator decisions.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct MemoryDiagnostics {
-    /// Bitmap-owned carriers observed across the arena.
+    /// Carrier bitmap bits owned by provisional claims or live guards.
+    ///
+    /// Concurrent claims and returns may change this value during the arena
+    /// scan. It is exact when the pool is externally quiescent.
     pub(crate) live_carriers: usize,
-    /// Prepared carriers reconstructed from active block incarnations.
+    /// Claimable carriers backed by prepared active block incarnations.
     pub(crate) prepared_carriers: usize,
-    /// Blocks unavailable while trim or mapping recovery remains pending.
+    /// Blocks unavailable until trim or mapping recovery completes.
     pub(crate) cleanup_pending_blocks: usize,
-    /// Bitmap words charged to completed optimistic scans.
+    /// Cumulative bitmap words inspected by optimistic acquisition.
     pub(crate) optimistic_scan_words: u64,
-    /// Optimistic scans that returned incomplete ownership.
+    /// Cumulative optimistic acquisitions that needed more carriers.
     pub(crate) optimistic_misses: u64,
-    /// Partial claims that entered serialized fallback.
+    /// Cumulative partial claims completed through serialized fallback.
     pub(crate) serialized_fallbacks: u64,
-    /// Blocks successfully prepared.
+    /// Cumulative blocks made claimable.
     pub(crate) blocks_prepared: u64,
-    /// Stable virtual ranges added to the registry.
+    /// Cumulative stable virtual ranges reserved for new block slots.
     pub(crate) block_ranges_reserved: u64,
-    /// Provisional carriers returned by incomplete claim batches.
+    /// Cumulative provisional carriers rolled back before ownership transfer.
     pub(crate) rolled_back_carriers: u64,
-    /// Slots inspected while selecting trim candidates.
+    /// Cumulative slots inspected by trim selection.
     pub(crate) trim_slots_scanned: u64,
-    /// Blocks successfully reclaimed.
+    /// Cumulative blocks removed from prepared capacity.
     pub(crate) blocks_reclaimed: u64,
-    /// Pending mapping cleanup operations retried.
+    /// Cumulative pending mapping transitions retried.
     pub(crate) cleanup_retries: u64,
-    /// Cleanup retry attempts that remained pending.
+    /// Cumulative cleanup retries that still failed.
     pub(crate) cleanup_failures: u64,
-    /// Scheduler-global idle intervals that armed a deadline.
+    /// Cumulative scheduler-global idle intervals that armed a deadline.
     pub(crate) idle_deadlines: u64,
-    /// Successfully created maintenance workers.
-    pub(crate) worker_starts: u64,
-    /// Worker creation failures that disabled maintenance.
-    pub(crate) worker_start_failures: u64,
-    /// Reclaim actions executed by the worker.
+    /// Whether worker creation failed and permanently disabled maintenance.
+    pub(crate) maintenance_disabled: bool,
+    /// Cumulative reclaim passes executed by maintenance.
     pub(crate) reclaim_passes: u64,
-    /// Reclaim actions that remained blocked after a pass.
+    /// Cumulative reclaim passes that remained blocked.
     pub(crate) reclaim_retries: u64,
-    /// Cleanup generations requested after mapping failures.
+    /// Cumulative cleanup generations requested after mapping failures.
     pub(crate) cleanup_requests: u64,
 }
 
 impl MemoryDiagnostics {
     /// Composes independent arena and maintenance diagnostic samples.
-    pub(super) fn from_snapshots(
+    pub(super) fn from_samples(
         arena: ArenaDiagnosticSnapshot,
-        lifecycle: ArenaLifecycleSnapshot,
+        lifecycle: ArenaLifecycleSample,
         maintenance: MaintenanceDiagnosticSnapshot,
     ) -> Self {
         Self {
@@ -112,8 +118,7 @@ impl MemoryDiagnostics {
             cleanup_retries: arena.cleanup_retries,
             cleanup_failures: arena.cleanup_failures,
             idle_deadlines: maintenance.idle_deadlines,
-            worker_starts: maintenance.worker_starts,
-            worker_start_failures: maintenance.worker_start_failures,
+            maintenance_disabled: maintenance.maintenance_disabled,
             reclaim_passes: maintenance.reclaim_passes,
             reclaim_retries: maintenance.reclaim_retries,
             cleanup_requests: maintenance.cleanup_requests,
@@ -167,6 +172,10 @@ impl MemoryMetrics {
     }
 
     /// Returns capacity whose physical preparation completed.
+    ///
+    /// Preparation rounds its current floor up to whole blocks and may exceed
+    /// that floor by less than one block. Idle-only admission overage may also
+    /// place prepared capacity above the normal configured ceiling.
     pub(crate) fn prepared_capacity_bytes(&self) -> u64 {
         self.prepared_capacity_bytes
     }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
@@ -22,6 +22,27 @@ use super::geometry::PoolGeometry;
 use super::virtual_memory::page_size;
 use super::{BufferPool, CarrierCount, PoolInner, PooledBufMut};
 
+/// Independently reconstructed state for a quiescent pool.
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct PoolAudit {
+    /// Complete open reservation envelopes.
+    pub(super) active_planned_demand: CarrierCount,
+    /// Open-envelope capacity not occupied by an acquisition.
+    pub(super) available_coverage: CarrierCount,
+    /// Charges outside open-envelope coverage.
+    pub(super) uncovered_charges: CarrierCount,
+    /// Aggregate acquisition charges reconstructed from accounting.
+    pub(super) charged_capacity: CarrierCount,
+    /// Prepared capacity serialized by admission.
+    pub(super) prepared_capacity: CarrierCount,
+    /// Valid live bits reconstructed from block incarnations.
+    pub(super) live_carriers: CarrierCount,
+    /// Reservation futures linked in FIFO order.
+    pub(super) queued_reservations: usize,
+    /// Blocks unavailable while trim or mapping recovery remains pending.
+    pub(super) cleanup_pending_blocks: usize,
+}
+
 /// Waker state that records each wake through the active atomic backend.
 struct CountingWake {
     count: Arc<AtomicUsize>,
@@ -190,6 +211,64 @@ impl BufferPool {
             .test_hooks
             .maintenance_spawn_attempts
             .load(Ordering::Acquire)
+    }
+
+    /// Reconstructs and validates all load-bearing pool accounting.
+    ///
+    /// No claim, return, reservation, or maintenance operation may overlap
+    /// this audit. Holding admission stabilizes planned demand and prepared
+    /// capacity; external quiescence stabilizes lock-free bitmap ownership.
+    pub(super) fn audit_quiescent(&self) -> PoolAudit {
+        let admission = self.inner.admission.lock();
+        let coverage = self.inner.coverage.snapshot();
+        admission.ledger.assert_invariants(coverage);
+        let lifecycle = self.inner.arena.lifecycle_snapshot();
+
+        let covered_charges = admission
+            .ledger
+            .active_planned_demand
+            .checked_sub(coverage.available)
+            .expect("available coverage exceeds active planned demand");
+        let charged_capacity = covered_charges
+            .checked_add(coverage.uncovered)
+            .expect("quiescent charged capacity overflowed");
+
+        assert_eq!(
+            lifecycle.prepared_capacity, admission.ledger.prepared_capacity,
+            "prepared accounting disagrees with active block incarnations"
+        );
+        assert_eq!(
+            lifecycle.live_carriers, charged_capacity,
+            "aggregate charges disagree with live carrier bits"
+        );
+
+        PoolAudit {
+            active_planned_demand: admission.ledger.active_planned_demand,
+            available_coverage: coverage.available,
+            uncovered_charges: coverage.uncovered,
+            charged_capacity,
+            prepared_capacity: admission.ledger.prepared_capacity,
+            live_carriers: lifecycle.live_carriers,
+            queued_reservations: admission.waiters.len(),
+            cleanup_pending_blocks: lifecycle.cleanup_pending_blocks,
+        }
+    }
+
+    /// Asserts that no accounting, physical ownership, or cleanup remains.
+    pub(super) fn assert_quiescent_zero(&self) {
+        assert_eq!(
+            self.audit_quiescent(),
+            PoolAudit {
+                active_planned_demand: CarrierCount::ZERO,
+                available_coverage: CarrierCount::ZERO,
+                uncovered_charges: CarrierCount::ZERO,
+                charged_capacity: CarrierCount::ZERO,
+                prepared_capacity: CarrierCount::ZERO,
+                live_carriers: CarrierCount::ZERO,
+                queued_reservations: 0,
+                cleanup_pending_blocks: 0,
+            }
+        );
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
@@ -22,9 +22,12 @@ use super::geometry::PoolGeometry;
 use super::virtual_memory::page_size;
 use super::{BufferPool, CarrierCount, PoolInner, PooledBufMut};
 
-/// Independently reconstructed state for a quiescent pool.
+/// Result of reconciling externally stabilized pool state.
+///
+/// The pool may retain live reservations and owners. Quiescence means only
+/// that no operation mutates the state while the audit reconstructs it.
 #[derive(Debug, Eq, PartialEq)]
-pub(super) struct PoolAudit {
+pub(super) struct PoolAuditReport {
     /// Complete open reservation envelopes.
     pub(super) active_planned_demand: CarrierCount,
     /// Open-envelope capacity not occupied by an acquisition.
@@ -218,7 +221,7 @@ impl BufferPool {
     /// No claim, return, reservation, or maintenance operation may overlap
     /// this audit. Holding admission stabilizes planned demand and prepared
     /// capacity; external quiescence stabilizes lock-free bitmap ownership.
-    pub(super) fn audit_quiescent(&self) -> PoolAudit {
+    pub(super) fn audit_quiescent(&self) -> PoolAuditReport {
         let (
             active_planned_demand,
             available_coverage,
@@ -231,7 +234,7 @@ impl BufferPool {
             let admission = self.inner.admission.lock();
             let coverage = self.inner.coverage.snapshot();
             admission.ledger.assert_invariants(coverage);
-            let lifecycle = self.inner.arena.lifecycle_snapshot();
+            let lifecycle = self.inner.arena.sample_lifecycle();
 
             let covered_charges = admission
                 .ledger
@@ -261,7 +264,7 @@ impl BufferPool {
             "aggregate charges disagree with live carrier bits"
         );
 
-        PoolAudit {
+        PoolAuditReport {
             active_planned_demand,
             available_coverage,
             uncovered_charges,
@@ -277,7 +280,7 @@ impl BufferPool {
     pub(super) fn assert_quiescent_zero(&self) {
         assert_eq!(
             self.audit_quiescent(),
-            PoolAudit {
+            PoolAuditReport {
                 active_planned_demand: CarrierCount::ZERO,
                 available_coverage: CarrierCount::ZERO,
                 uncovered_charges: CarrierCount::ZERO,
@@ -385,10 +388,12 @@ pub(super) fn poll_reserve(
 }
 
 #[cfg(not(s3_tm_loom))]
-mod audit_tests {
+mod tests {
     use std::panic::{catch_unwind, AssertUnwindSafe};
 
     use super::super::admission::MAX_PACKED_CARRIERS;
+    use super::super::maintenance::{execute_maintenance, MaintenanceAction, MaintenanceOutcome};
+    use super::super::virtual_memory::VirtualMemoryOperation;
     use super::*;
 
     #[test]
@@ -402,7 +407,7 @@ mod audit_tests {
 
         assert_eq!(
             pool.audit_quiescent(),
-            PoolAudit {
+            PoolAuditReport {
                 active_planned_demand: CarrierCount::new(3),
                 available_coverage: CarrierCount::new(1),
                 uncovered_charges: CarrierCount::ZERO,
@@ -457,5 +462,65 @@ mod audit_tests {
             "audit accepted inconsistent ownership accounting"
         );
         drop(owned);
+    }
+
+    #[test]
+    fn test_audit_reports_a_queued_reservation() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let reservation = pool
+            .try_reserve(carrier_size)
+            .unwrap()
+            .expect("reservation");
+        let mut queued = pool.reserve(carrier_size);
+        let (waker, _) = counting_waker();
+        assert!(matches!(poll_reserve(&mut queued, &waker), Poll::Pending));
+
+        assert_eq!(
+            pool.audit_quiescent(),
+            PoolAuditReport {
+                active_planned_demand: CarrierCount::new(1),
+                available_coverage: CarrierCount::new(1),
+                uncovered_charges: CarrierCount::ZERO,
+                charged_capacity: CarrierCount::ZERO,
+                prepared_capacity: CarrierCount::new(1),
+                live_carriers: CarrierCount::ZERO,
+                queued_reservations: 1,
+                cleanup_pending_blocks: 0,
+            }
+        );
+
+        drop(queued);
+        drop(reservation);
+    }
+
+    #[test]
+    fn test_audit_reports_pending_mapping_cleanup() {
+        let (pool, carrier_size) = test_pool(1, 1);
+        let owned = pool.acquire_unreserved(carrier_size).unwrap();
+        drop(owned);
+        let slot = pool
+            .inner
+            .arena
+            .select_trim_candidate()
+            .expect("free prepared slot");
+        slot.inject_failure_once(VirtualMemoryOperation::Deactivate);
+
+        let pass = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::Reclaim {
+                epoch: 0,
+                target: CarrierCount::ZERO,
+            },
+        );
+        assert_eq!(pass.outcome, MaintenanceOutcome::Complete);
+        assert!(pass.cleanup_pending);
+        assert_eq!(pool.audit_quiescent().cleanup_pending_blocks, 1);
+
+        let retry = execute_maintenance(
+            &pool.inner,
+            MaintenanceAction::RetryCleanup { generation: 1 },
+        );
+        assert_eq!(retry.outcome, MaintenanceOutcome::Complete);
+        pool.assert_quiescent_zero();
     }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
@@ -13,8 +13,9 @@ use std::task::{Context, Poll, Waker};
 
 use bytes::BufMut;
 
-use crate::runtime::sync::sync::atomic::{AtomicUsize, Ordering};
-use crate::runtime::sync::sync::Arc;
+use crate::runtime::sync::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use crate::runtime::sync::sync::{Arc, Mutex};
+use crate::runtime::sync::thread;
 
 use super::admission::{Reservation, ReserveError, ReserveFuture};
 use super::geometry::PoolGeometry;
@@ -40,6 +41,12 @@ impl Wake for CountingWake {
 pub(super) struct TestHooks {
     /// Remaining metadata boundaries before one acquisition failure.
     acquisition_allocation_failure: AtomicUsize,
+    /// Fails the next maintenance worker creation when set.
+    maintenance_spawn_failure: AtomicBool,
+    /// Number of maintenance worker creation attempts.
+    maintenance_spawn_attempts: AtomicUsize,
+    /// Optional one-shot pause after the worker upgrades its weak pool owner.
+    maintenance_pause: Mutex<Option<Arc<MaintenancePause>>>,
 }
 
 impl TestHooks {
@@ -47,6 +54,9 @@ impl TestHooks {
     pub(super) fn new() -> Self {
         Self {
             acquisition_allocation_failure: AtomicUsize::new(0),
+            maintenance_spawn_failure: AtomicBool::new(false),
+            maintenance_spawn_attempts: AtomicUsize::new(0),
+            maintenance_pause: Mutex::new(None),
         }
     }
 
@@ -72,6 +82,61 @@ impl TestHooks {
             )
             .is_ok_and(|previous| previous == 1)
     }
+
+    /// Records one serialized maintenance worker creation attempt.
+    pub(super) fn record_maintenance_spawn_attempt(&self) {
+        self.maintenance_spawn_attempts
+            .fetch_add(1, Ordering::AcqRel);
+    }
+
+    /// Consumes one injected maintenance worker creation failure.
+    pub(super) fn take_maintenance_spawn_failure(&self) -> bool {
+        self.maintenance_spawn_failure.swap(false, Ordering::AcqRel)
+    }
+
+    /// Pauses once after the worker obtains temporary strong pool ownership.
+    pub(super) fn wait_after_maintenance_upgrade(&self) {
+        let pause = self.maintenance_pause.lock().take();
+        if let Some(pause) = pause {
+            pause.wait();
+        }
+    }
+}
+
+/// Test-controlled pause in the worker's temporary ownership window.
+pub(super) struct MaintenancePause {
+    /// Set after the worker upgrades its weak pool owner.
+    entered: AtomicBool,
+    /// Set by the test to permit maintenance execution.
+    released: AtomicBool,
+}
+
+impl MaintenancePause {
+    /// Creates a closed pause gate.
+    fn new() -> Self {
+        Self {
+            entered: AtomicBool::new(false),
+            released: AtomicBool::new(false),
+        }
+    }
+
+    /// Blocks the worker until the test releases the gate.
+    fn wait(&self) {
+        self.entered.store(true, Ordering::Release);
+        while !self.released.load(Ordering::Acquire) {
+            thread::yield_now();
+        }
+    }
+
+    /// Returns whether the worker entered the temporary ownership window.
+    pub(super) fn entered(&self) -> bool {
+        self.entered.load(Ordering::Acquire)
+    }
+
+    /// Releases the worker.
+    pub(super) fn release(&self) {
+        self.released.store(true, Ordering::Release);
+    }
 }
 
 impl BufferPool {
@@ -89,6 +154,42 @@ impl BufferPool {
             .acquisition_allocation_failure
             .load(Ordering::Acquire)
             != 0
+    }
+
+    /// Fails the next maintenance worker creation.
+    pub(super) fn inject_maintenance_spawn_failure(&self) {
+        assert!(
+            !self
+                .inner
+                .test_hooks
+                .maintenance_spawn_failure
+                .swap(true, Ordering::AcqRel),
+            "a maintenance spawn failure is already pending"
+        );
+    }
+
+    /// Installs a one-shot pause after weak pool ownership is upgraded.
+    pub(super) fn pause_maintenance_after_upgrade(&self) -> Arc<MaintenancePause> {
+        let pause = Arc::new(MaintenancePause::new());
+        let previous = self
+            .inner
+            .test_hooks
+            .maintenance_pause
+            .lock()
+            .replace(Arc::clone(&pause));
+        assert!(
+            previous.is_none(),
+            "a maintenance pause is already installed"
+        );
+        pause
+    }
+
+    /// Returns maintenance worker creation attempts.
+    pub(super) fn maintenance_spawn_attempts(&self) -> usize {
+        self.inner
+            .test_hooks
+            .maintenance_spawn_attempts
+            .load(Ordering::Acquire)
     }
 }
 

--- a/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/buffer_pool/test_util.rs
@@ -219,22 +219,41 @@ impl BufferPool {
     /// this audit. Holding admission stabilizes planned demand and prepared
     /// capacity; external quiescence stabilizes lock-free bitmap ownership.
     pub(super) fn audit_quiescent(&self) -> PoolAudit {
-        let admission = self.inner.admission.lock();
-        let coverage = self.inner.coverage.snapshot();
-        admission.ledger.assert_invariants(coverage);
-        let lifecycle = self.inner.arena.lifecycle_snapshot();
+        let (
+            active_planned_demand,
+            available_coverage,
+            uncovered_charges,
+            charged_capacity,
+            prepared_capacity,
+            queued_reservations,
+            lifecycle,
+        ) = {
+            let admission = self.inner.admission.lock();
+            let coverage = self.inner.coverage.snapshot();
+            admission.ledger.assert_invariants(coverage);
+            let lifecycle = self.inner.arena.lifecycle_snapshot();
 
-        let covered_charges = admission
-            .ledger
-            .active_planned_demand
-            .checked_sub(coverage.available)
-            .expect("available coverage exceeds active planned demand");
-        let charged_capacity = covered_charges
-            .checked_add(coverage.uncovered)
-            .expect("quiescent charged capacity overflowed");
+            let covered_charges = admission
+                .ledger
+                .active_planned_demand
+                .checked_sub(coverage.available)
+                .expect("available coverage exceeds active planned demand");
+            let charged_capacity = covered_charges
+                .checked_add(coverage.uncovered)
+                .expect("quiescent charged capacity overflowed");
+            (
+                admission.ledger.active_planned_demand,
+                coverage.available,
+                coverage.uncovered,
+                charged_capacity,
+                admission.ledger.prepared_capacity,
+                admission.waiters.len(),
+                lifecycle,
+            )
+        };
 
         assert_eq!(
-            lifecycle.prepared_capacity, admission.ledger.prepared_capacity,
+            lifecycle.prepared_capacity, prepared_capacity,
             "prepared accounting disagrees with active block incarnations"
         );
         assert_eq!(
@@ -243,13 +262,13 @@ impl BufferPool {
         );
 
         PoolAudit {
-            active_planned_demand: admission.ledger.active_planned_demand,
-            available_coverage: coverage.available,
-            uncovered_charges: coverage.uncovered,
+            active_planned_demand,
+            available_coverage,
+            uncovered_charges,
             charged_capacity,
-            prepared_capacity: admission.ledger.prepared_capacity,
+            prepared_capacity,
             live_carriers: lifecycle.live_carriers,
-            queued_reservations: admission.waiters.len(),
+            queued_reservations,
             cleanup_pending_blocks: lifecycle.cleanup_pending_blocks,
         }
     }
@@ -363,4 +382,80 @@ pub(super) fn poll_reserve(
 ) -> Poll<Result<Reservation, ReserveError>> {
     let mut context = Context::from_waker(waker);
     Pin::new(future).poll(&mut context)
+}
+
+#[cfg(not(s3_tm_loom))]
+mod audit_tests {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    use super::super::admission::MAX_PACKED_CARRIERS;
+    use super::*;
+
+    #[test]
+    fn test_audit_reconciles_nonzero_reservation_and_ownership() {
+        let (pool, carrier_size) = test_pool(2, 8);
+        let reservation = pool
+            .try_reserve(carrier_size * 3)
+            .unwrap()
+            .expect("reservation");
+        let owned = pool.acquire(&reservation, carrier_size * 2).unwrap();
+
+        assert_eq!(
+            pool.audit_quiescent(),
+            PoolAudit {
+                active_planned_demand: CarrierCount::new(3),
+                available_coverage: CarrierCount::new(1),
+                uncovered_charges: CarrierCount::ZERO,
+                charged_capacity: CarrierCount::new(2),
+                prepared_capacity: CarrierCount::new(4),
+                live_carriers: CarrierCount::new(2),
+                queued_reservations: 0,
+                cleanup_pending_blocks: 0,
+            }
+        );
+
+        drop(owned);
+        drop(reservation);
+    }
+
+    #[test]
+    fn test_audit_rejects_prepared_accounting_mismatch() {
+        let (pool, carrier_size) = test_pool(2, 4);
+        let owned = pool.acquire_unreserved(carrier_size).unwrap();
+        let prepared = pool.audit_quiescent().prepared_capacity;
+        {
+            let mut admission = pool.inner.admission.lock();
+            admission.ledger.prepared_capacity = CarrierCount::new(1);
+        }
+
+        let result = catch_unwind(AssertUnwindSafe(|| pool.audit_quiescent()));
+
+        pool.inner.admission.lock().ledger.prepared_capacity = prepared;
+        assert!(
+            result.is_err(),
+            "audit accepted inconsistent prepared state"
+        );
+        drop(owned);
+    }
+
+    #[test]
+    fn test_audit_rejects_live_ownership_mismatch() {
+        let (pool, carrier_size) = test_pool(2, 4);
+        let owned = pool.acquire_unreserved(carrier_size).unwrap();
+        let count = CarrierCount::new(1);
+        let returned = pool.inner.coverage.release(count);
+        assert_eq!(returned.uncovered_removed, count);
+
+        let result = catch_unwind(AssertUnwindSafe(|| pool.audit_quiescent()));
+
+        pool.inner
+            .coverage
+            .debit(count, MAX_PACKED_CARRIERS)
+            .unwrap();
+        assert!(
+            result.is_err(),
+            "audit accepted inconsistent ownership accounting"
+        );
+        drop(owned);
+    }
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -210,12 +210,13 @@ pub(crate) fn available_ram() -> Option<usize> {
 #[cfg(target_os = "freebsd")]
 pub(crate) fn available_ram() -> Option<usize> {
     // hw.physmem is physical memory in bytes.
-    // Ref: sysctl(3) <https://man.freebsd.org/cgi/man.cgi?query=sysctl&sektion=3>
+    // Ref: sysctlbyname(3)
+    // <https://man.freebsd.org/cgi/man.cgi?query=sysctlbyname&sektion=3>
     let mut bytes: u64 = 0;
     let mut len = std::mem::size_of::<u64>();
-    // SAFETY: sysctlbyname writes at most `len` bytes into `bytes`; the name is
-    // a valid nul-terminated string and no new value is supplied.
-    let rc = unsafe {
+    // SAFETY: `bytes` is writable for the input value of `len`; `hw.physmem`
+    // is nul-terminated, and null `newp` with zero `newlen` performs a read.
+    let result = unsafe {
         libc::sysctlbyname(
             c"hw.physmem".as_ptr(),
             (&mut bytes as *mut u64).cast(),
@@ -224,11 +225,10 @@ pub(crate) fn available_ram() -> Option<usize> {
             0,
         )
     };
-    if rc == 0 && bytes > 0 {
-        usize::try_from(bytes).ok()
-    } else {
-        None
+    if result != 0 || len != std::mem::size_of::<u64>() || bytes == 0 {
+        return None;
     }
+    usize::try_from(bytes).ok()
 }
 
 #[cfg(target_os = "macos")]
@@ -907,7 +907,12 @@ mod tests {
         );
     }
 
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "windows"
+    ))]
     #[test]
     #[cfg_attr(
         miri,

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -185,8 +185,11 @@ fn round_pow2(n: usize) -> usize {
     }
 }
 
-/// Usable RAM: the smaller of the process memory limit and physical RAM where
-/// the platform exposes both values. `None` reports detection failure.
+/// Usable RAM from Linux-compatible procfs and cgroup interfaces.
+///
+/// Android exposes the same kernel interfaces even though its runtime page
+/// size and userspace environment may differ from a conventional Linux host.
+/// The smaller of physical memory and the process limit wins when both exist.
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub(crate) fn available_ram() -> Option<usize> {
     match (meminfo_total(), cgroup_mem_limit()) {

--- a/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/platform.rs
@@ -185,10 +185,9 @@ fn round_pow2(n: usize) -> usize {
     }
 }
 
-/// Usable RAM: the smaller of the cgroup memory limit and physical RAM. Linux
-/// only; `None` elsewhere or on a read failure, in which case the caller falls
-/// back to a conservative default.
-#[cfg(target_os = "linux")]
+/// Usable RAM: the smaller of the process memory limit and physical RAM where
+/// the platform exposes both values. `None` reports detection failure.
+#[cfg(any(target_os = "android", target_os = "linux"))]
 pub(crate) fn available_ram() -> Option<usize> {
     match (meminfo_total(), cgroup_mem_limit()) {
         (Some(total), Some(cgroup)) => Some(total.min(cgroup)),
@@ -197,9 +196,39 @@ pub(crate) fn available_ram() -> Option<usize> {
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows"
+)))]
 pub(crate) fn available_ram() -> Option<usize> {
     None
+}
+
+#[cfg(target_os = "freebsd")]
+pub(crate) fn available_ram() -> Option<usize> {
+    // hw.physmem is physical memory in bytes.
+    // Ref: sysctl(3) <https://man.freebsd.org/cgi/man.cgi?query=sysctl&sektion=3>
+    let mut bytes: u64 = 0;
+    let mut len = std::mem::size_of::<u64>();
+    // SAFETY: sysctlbyname writes at most `len` bytes into `bytes`; the name is
+    // a valid nul-terminated string and no new value is supplied.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            c"hw.physmem".as_ptr(),
+            (&mut bytes as *mut u64).cast(),
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc == 0 && bytes > 0 {
+        usize::try_from(bytes).ok()
+    } else {
+        None
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -245,7 +274,7 @@ pub(crate) fn available_ram() -> Option<usize> {
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 fn meminfo_total() -> Option<usize> {
     parse_meminfo_total(&std::fs::read_to_string("/proc/meminfo").ok()?)
 }
@@ -260,7 +289,7 @@ fn meminfo_total() -> Option<usize> {
 /// Refs: cgroups(7) /proc/[pid]/cgroup <https://man7.org/linux/man-pages/man7/cgroups.7.html>;
 /// cgroup v2 memory.max <https://docs.kernel.org/admin-guide/cgroup-v2.html>;
 /// cgroup v1 memory.limit_in_bytes <https://docs.kernel.org/admin-guide/cgroup-v1/memory.html>
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 fn cgroup_mem_limit() -> Option<usize> {
     let proc_cgroup = std::fs::read_to_string("/proc/self/cgroup").ok()?;
     let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").unwrap_or_default();
@@ -271,7 +300,7 @@ fn cgroup_mem_limit() -> Option<usize> {
 /// Read each candidate limit file and return the smallest real limit; "max" and
 /// the v1 unlimited sentinel are ignored ("max" via `parse_cgroup_limit`, the
 /// sentinel via `min` with physical RAM in `available_ram`).
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "android", target_os = "linux"))]
 fn min_limit(files: &[PathBuf]) -> Option<usize> {
     files
         .iter()
@@ -284,7 +313,7 @@ fn min_limit(files: &[PathBuf]) -> Option<usize> {
 /// this value in kB.
 ///
 /// Ref: proc_meminfo(5) <https://man7.org/linux/man-pages/man5/proc_meminfo.5.html>
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg_attr(not(any(target_os = "android", target_os = "linux")), allow(dead_code))]
 fn parse_meminfo_total(meminfo: &str) -> Option<usize> {
     let line = meminfo.lines().find(|l| l.starts_with("MemTotal:"))?;
     line.split_whitespace()
@@ -297,7 +326,7 @@ fn parse_meminfo_total(meminfo: &str) -> Option<usize> {
 /// Parse a cgroup memory-limit value into bytes. "max" (v2 unlimited) yields
 /// `None`. The v1 unlimited sentinel is a huge number that `available_ram`
 /// discards via `min` with physical RAM, so it needs no special case.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg_attr(not(any(target_os = "android", target_os = "linux")), allow(dead_code))]
 fn parse_cgroup_limit(raw: &str) -> Option<usize> {
     let raw = raw.trim();
     if raw == "max" {
@@ -308,7 +337,7 @@ fn parse_cgroup_limit(raw: &str) -> Option<usize> {
 
 /// `memory.max` candidate paths for the cgroup v2 unified hierarchy, leaf-first.
 /// Empty when this process has no v2 cgroup line.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg_attr(not(any(target_os = "android", target_os = "linux")), allow(dead_code))]
 fn cgroup_v2_files(proc_cgroup: &str, mountinfo: &str) -> Vec<PathBuf> {
     let Some(path) = cgroup_v2_path(proc_cgroup) else {
         return Vec::new();
@@ -320,7 +349,7 @@ fn cgroup_v2_files(proc_cgroup: &str, mountinfo: &str) -> Vec<PathBuf> {
 
 /// `memory.limit_in_bytes` candidate paths for the cgroup v1 memory controller,
 /// leaf-first. Empty when this process has no v1 memory cgroup line.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg_attr(not(any(target_os = "android", target_os = "linux")), allow(dead_code))]
 fn cgroup_v1_files(proc_cgroup: &str, mountinfo: &str) -> Vec<PathBuf> {
     let Some(path) = cgroup_v1_memory_path(proc_cgroup) else {
         return Vec::new();
@@ -331,7 +360,7 @@ fn cgroup_v1_files(proc_cgroup: &str, mountinfo: &str) -> Vec<PathBuf> {
 }
 
 /// The cgroup path from a v2 unified line (`0::<path>`).
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg_attr(not(any(target_os = "android", target_os = "linux")), allow(dead_code))]
 fn cgroup_v2_path(proc_cgroup: &str) -> Option<String> {
     proc_cgroup.lines().find_map(|line| {
         let mut fields = line.splitn(3, ':');
@@ -344,7 +373,7 @@ fn cgroup_v2_path(proc_cgroup: &str) -> Option<String> {
 
 /// The cgroup path from the v1 line whose controllers include `memory`
 /// (`<id>:<controllers>:<path>`).
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg_attr(not(any(target_os = "android", target_os = "linux")), allow(dead_code))]
 fn cgroup_v1_memory_path(proc_cgroup: &str) -> Option<String> {
     proc_cgroup.lines().find_map(|line| {
         let mut fields = line.splitn(3, ':');
@@ -361,7 +390,7 @@ fn cgroup_v1_memory_path(proc_cgroup: &str) -> Option<String> {
 /// into `<...> mountpoint options [optional]` and `<fstype> <source> <superopts>`.
 ///
 /// Ref: proc_pid_mountinfo(5) <https://man7.org/linux/man-pages/man5/proc_pid_mountinfo.5.html>
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg_attr(not(any(target_os = "android", target_os = "linux")), allow(dead_code))]
 fn mountinfo_mount(mountinfo: &str, fstype: &str, super_opt: Option<&str>) -> Option<String> {
     mountinfo.lines().find_map(|line| {
         let (left, right) = line.split_once(" - ")?;
@@ -382,7 +411,7 @@ fn mountinfo_mount(mountinfo: &str, fstype: &str, super_opt: Option<&str>) -> Op
 
 /// Limit-file paths from `<mount><cgroup_path>` up to `<mount>`, leaf-first, so a
 /// tighter parent limit is included.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[cfg_attr(not(any(target_os = "android", target_os = "linux")), allow(dead_code))]
 fn walk_paths(mount: &str, cgroup_path: &str, filename: &str) -> Vec<PathBuf> {
     let mount = Path::new(mount);
     let rel = cgroup_path.trim_start_matches('/');

--- a/aws-sdk-s3-transfer-manager/src/runtime/sync/loom.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/sync/loom.rs
@@ -6,6 +6,8 @@
 //! Loom-backed wrappers that present the same API surface as the sibling `std`
 //! module. Active only under `#[cfg(all(test, loom))]`.
 
+use std::time::Duration;
+
 // ---------------------------------------------------------------------------
 // Mutex / MutexGuard / Condvar — thin wrappers that unwrap poisoned locks
 // ---------------------------------------------------------------------------
@@ -33,6 +35,15 @@ impl Condvar {
 
     pub(crate) fn wait<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
         self.0.wait(guard).unwrap()
+    }
+
+    pub(crate) fn wait_timeout<'a, T>(
+        &self,
+        guard: MutexGuard<'a, T>,
+        timeout: Duration,
+    ) -> (MutexGuard<'a, T>, bool) {
+        let (guard, result) = self.0.wait_timeout(guard, timeout).unwrap();
+        (guard, result.timed_out())
     }
 
     pub(crate) fn notify_one(&self) {
@@ -65,5 +76,5 @@ pub(crate) mod sync {
 }
 
 pub(crate) mod thread {
-    pub(crate) use loom::thread::{spawn, JoinHandle};
+    pub(crate) use loom::thread::{current, spawn, yield_now, Builder, JoinHandle};
 }

--- a/aws-sdk-s3-transfer-manager/src/runtime/sync/std.rs
+++ b/aws-sdk-s3-transfer-manager/src/runtime/sync/std.rs
@@ -12,6 +12,7 @@
 
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
+use std::time::Duration;
 
 // ---------------------------------------------------------------------------
 // UnsafeCell — closure-based API matching loom::cell::UnsafeCell
@@ -129,6 +130,15 @@ impl Condvar {
         guard
     }
 
+    pub(crate) fn wait_timeout<'a, T>(
+        &self,
+        mut guard: MutexGuard<'a, T>,
+        timeout: Duration,
+    ) -> (MutexGuard<'a, T>, bool) {
+        let result = self.1.wait_for(&mut guard.1, timeout);
+        (guard, result.timed_out())
+    }
+
     pub(crate) fn notify_one(&self) {
         self.1.notify_one();
     }
@@ -149,6 +159,15 @@ impl Condvar {
 
     pub(crate) fn wait<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
         MutexGuard(self.0.wait(guard.0).expect("poisoned"))
+    }
+
+    pub(crate) fn wait_timeout<'a, T>(
+        &self,
+        guard: MutexGuard<'a, T>,
+        timeout: Duration,
+    ) -> (MutexGuard<'a, T>, bool) {
+        let (guard, result) = self.0.wait_timeout(guard.0, timeout).expect("poisoned");
+        (MutexGuard(guard), result.timed_out())
     }
 
     pub(crate) fn notify_one(&self) {
@@ -181,5 +200,5 @@ pub(crate) mod sync {
 }
 
 pub(crate) mod thread {
-    pub(crate) use std::thread::{spawn, JoinHandle};
+    pub(crate) use std::thread::{current, spawn, yield_now, Builder, JoinHandle};
 }

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -1632,8 +1632,12 @@ configured_block_ceiling =
     round_up_to_whole_blocks(configured_capacity)
 
 idle_retention_target =
-    round_up_to_whole_blocks(configured_block_ceiling * 25%)
+    round_down_to_whole_blocks(configured_block_ceiling * 25%)
 ```
+
+Pools whose configured ceiling spans fewer than four blocks retain no warm block after the idle
+deadline. This preserves reclamation for small pools instead of letting one block consume the
+complete retention allowance.
 
 Prepared capacity above `configured_block_ceiling` is aggregate excess. It is not attached to
 particular blocks. Any free block is eligible while both conditions remain true:
@@ -2082,7 +2086,7 @@ derived from the slot's `VirtualRange`. Owner boundaries need not be presentatio
 those direct pooled ranges:
 
 ```text
-one Segment, assuming 64 KiB carriers: contiguous presentation [0..192 KiB]
+one Segment, using 64 KiB carriers for illustration: contiguous presentation [0..192 KiB]
 
 +--------------------+--------------------+--------------------+
 |      0..64 KiB     |    64..128 KiB    |   128..192 KiB    |
@@ -2466,7 +2470,7 @@ The public capacity policy has three forms:
 
 ```rust
 #[non_exhaustive]
-pub enum MemoryCapacity {
+pub enum MemoryBudgetConfig {
     Auto,
     Fraction(f64),
     Limit(usize),
@@ -2481,7 +2485,7 @@ pub enum BufferPoolBuildError {
 }
 
 pub struct BufferPoolBuilder {
-    capacity: MemoryCapacity,
+    memory_budget: MemoryBudgetConfig,
 }
 
 impl BufferPool {
@@ -2492,10 +2496,17 @@ impl BufferPool {
 }
 
 impl BufferPoolBuilder {
-    pub fn capacity(self, capacity: MemoryCapacity) -> Self;
+    pub fn memory_budget(self, budget: MemoryBudgetConfig) -> Self;
     pub fn build(self) -> Result<BufferPool, BufferPoolBuildError>;
 }
 ```
+
+`MemoryBudgetConfig` is the only public automatic, fractional, or explicit byte policy. The
+transfer manager and an explicitly constructed pool accept the same type; pooled storage does not
+introduce a second capacity enum. Until pool integration, the existing transfer-manager path keeps
+its public clamping behavior while direct pool construction uses the checked rules below.
+Integration must select one documented resolution contract before both surfaces are public
+together.
 
 Pool construction resolves the policy after selecting carrier geometry. Effective memory is the
 smaller of physical memory and a process or container memory limit where the platform exposes one.
@@ -2570,13 +2581,13 @@ impl TransferManagerMetrics {
 }
 ```
 
-`MemoryConfig::Auto` is the default. It constructs a pool with `MemoryCapacity::Auto`. `Explicit`
+`MemoryConfig::Auto` is the default. It constructs a pool with `MemoryBudgetConfig::Auto`. `Explicit`
 installs the supplied handle in the transfer manager. The caller can retain another clone for a
 cache or another component:
 
 ```rust
 let pool = BufferPool::builder()
-    .capacity(MemoryCapacity::Limit(8 * 1024 * 1024 * 1024))
+    .memory_budget(MemoryBudgetConfig::Limit(8 * 1024 * 1024 * 1024))
     .build()?;
 
 let transfer_manager = TransferManager::builder()
@@ -2732,6 +2743,10 @@ impl MemoryMetrics {
     pub fn admission_overage_bytes(&self) -> u64;
 
     /// Capacity whose mapping, placement, and registration are complete.
+    ///
+    /// Preparation rounds its current floor up to whole blocks and may exceed
+    /// that floor by less than one block. Idle-only admission overage may also
+    /// place prepared capacity above the normal configured ceiling.
     pub fn prepared_capacity_bytes(&self) -> u64;
 
     /// Reservation requests retained in FIFO order.
@@ -2752,6 +2767,10 @@ Configured capacity, planned demand, charged capacity, overage, prepared capacit
 therefore form one coherent admission sample. It does not scan live bitmaps or add a carrier-return
 counter to the common path. Values are carrier-rounded bytes and exclude foreign `Bytes`, protocol
 scratch, copied contiguous output, and other process memory.
+
+Prepared capacity follows whole-block geometry and the current admission floor. Block rounding may
+raise it by less than one block beyond that floor. It can exceed configured capacity either through
+that rounding or because an idle-only grant raised admission above the normal ceiling.
 
 `parked_reservations_total` is copied from the admission state in the same sample. It increments
 saturating exactly once when a request first enters the FIFO and never decrements on grant or
@@ -2925,6 +2944,11 @@ size, and block size must be a whole number of carriers. Smaller carriers reduce
 tail waste but increase bitmap operations, ownership transitions, scatter width, and carrier
 returns.
 
+The initial implementation uses a 16 KiB carrier before runtime page-size alignment and a 128 MiB
+target block. Pools configured below 128 MiB use their complete carrier-rounded capacity as one
+block. Block size is configured in bytes; carrier count and bitmap width are derived geometry, not
+policy inputs.
+
 Block size controls mapping amortization, all-free scan length, reclaim granularity, and how much
 capacity one long-lived carrier can keep prepared. Geometry selection must account for small
 objects, large multipart transfers, mixed upload and download traffic, intended core counts, and
@@ -2936,15 +2960,24 @@ contracts.
 ### Scan and reclamation constants
 
 The optimistic scan budget, idle timeout, and cleanup retry cadence are selected by measurement.
-The scan budget trades lock-free work against entry into serialized fallback. Because fallback
-holds admission serialization during its registry-wide scan, the budget also controls exposure to
-registry-sized admission stalls. Registry size bounds fallback scan work. The idle timeout trades
-retained RSS against repeated preparation across traffic bursts. Retry cadence trades cleanup
-latency against repeated platform calls while a block remains unavailable.
+The initial scan target covers 32 MiB at any carrier size, rounded up to a complete bitmap word. At
+the default geometry an 8 MiB part therefore occupies one quarter of the scan window rather than
+requiring every observed bit to be free. The scan budget trades lock-free work against entry into
+serialized fallback. Because fallback holds admission serialization during its registry-wide scan,
+the budget also controls exposure to registry-sized admission stalls. Registry size bounds fallback
+scan work. The idle timeout trades retained RSS against repeated preparation across traffic bursts.
+Retry cadence trades cleanup latency against repeated platform calls while a block remains
+unavailable.
 
 Measurements must include mixed object sizes, burst and sustained traffic, idle gaps, allocation
 failure, high core counts, and aggregate rates on target hardware. These constants do not change
 the exhaustive serialized fallback, idle-epoch invalidation, or fail-closed cleanup contracts.
+
+The baseline reclaims after scheduler-global idle. Sustained low demand that never reaches global
+idle may therefore retain peak prepared capacity. A later policy may arm reclamation when
+reservation demand remains below its recent peak without changing the worker, admission floor, or
+trim gate. That trigger belongs at scheduler or reservation frequency rather than on every carrier
+return.
 
 ## Future Work
 

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -2604,8 +2604,11 @@ worker:
 
 ```rust
 struct MaintenanceCoordinator {
+    configured_capacity: CarrierCount,
+    block_capacity: CarrierCount,
     control: Arc<MaintenanceControl>,
-    thread: OnceLock<JoinHandle<()>>,
+    diagnostics: Arc<MaintenanceDiagnostics>,
+    worker: Mutex<Option<JoinHandle<()>>>,
 }
 
 struct MaintenanceControl {
@@ -2616,8 +2619,9 @@ struct MaintenanceControl {
 struct MaintenanceState {
     activity_epoch: u64,
     idle_deadline: Option<IdleDeadline>,
-    reclaim_requested: bool,
-    cleanup_requested: bool,
+    reclaim: Option<ReclaimRequest>,
+    cleanup: Option<CleanupRequest>,
+    next_cleanup_generation: u64,
     stopping: bool,
     disabled: bool,
 }
@@ -2638,6 +2642,11 @@ The first deadline or cleanup request starts the thread. The worker owns
 due, it releases the control mutex, upgrades the weak pool reference for one pass, and drops that
 strong reference before waiting again. The control block contains no admission, arena, slot, or
 mapping state.
+
+The coordinator copies immutable configured and block capacity at construction, so worker startup
+does not enter admission. Its worker mutex serializes concurrent first signals and lets final
+destruction take the join handle exactly once. Diagnostics are atomic observations and do not
+participate in policy or lifecycle decisions.
 
 After releasing the temporary strong reference, the worker accesses no pool state. A thread-creation
 failure disables maintenance and reports degraded reclamation. Admission, acquisition, and owner


### PR DESCRIPTION
## Summary

This PR gives the buffer pool an owner for work that must happen after allocation: checked construction, idle block reclamation, recovery from failed mapping cleanup, and memory diagnostics. Pool construction remains lazy. It selects capacity and geometry but reserves no virtual ranges, prepares no backing, and starts no thread.

This is the maintenance layer in the buffer-pool series:

- [#165](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/165): design
- [#166](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/166): virtual-memory and block foundation
- [#167](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/167): arena acquisition and growth
- [#169](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/169): admission and pool composition
- [#170](https://github.com/awslabs/aws-s3-transfer-manager-rs/pull/170): mutable buffers and segmented immutable ownership
- **This PR:** configuration, reclamation, cleanup recovery, and diagnostics

The design authority is `docs/design/memory.md` as inherited by this branch, especially **Capacity configuration**, **Idle epochs and reclamation**, **Shutdown and destruction**, and **Metrics and observability**. The design PR is linked above because those sections are not yet present on `main`.

## Why

Returning the last owner clears a carrier's bitmap bit, but it does not make the containing block inaccessible or release its backing. Without maintenance, a pool that reached a high prepared capacity would retain that capacity for its complete lifetime. A failed protection or discard operation can also leave a block deliberately nonclaimable; ordinary allocation must not guess whether that mapping is safe to reuse.

The scheduler knows when the transfer manager becomes globally idle. This PR uses that low-frequency event to retain warm capacity across short gaps, then reclaim complete free blocks without adding work to every carrier return. Mapping failures use the same worker for bounded recovery.

## Overview

### Capacity and geometry

`MemoryBudgetConfig` is the single `Auto`, `Fraction`, or `Limit` policy used to construct a pool. `PoolConfig` resolves that policy against detected effective memory and runtime page size, then produces checked accounting and storage geometry.

The provisional defaults are a 16 KiB carrier and a 128 MiB target block. Runtime page size may increase the carrier size, and pools configured below 128 MiB use their complete carrier-rounded capacity as one block. Block bytes are policy; carriers per block and bitmap words are derived. This keeps the reclamation extent independent of bitmap representation and allows common multipart payloads to fit within one stable provenance range.

`Auto` selects one quarter of detected effective memory with a 32 GiB ceiling and a 2 GiB fallback when detection is unavailable. `Fraction` requires detected memory and uses an exact binary64 floor so capacity never rounds above the requested share. `Limit` bypasses detection.

The optimistic scan target is also byte-denominated. It covers at least 32 MiB after rounding to complete bitmap words, so an 8 MiB acquisition uses one quarter of the default scan window instead of requiring every observed carrier to be free.

The pool and the existing transfer-manager path now share the `MemoryBudgetConfig` type but do not yet share resolution behavior. The existing public path retains its documented clamping rules; this staged pool uses the checked rules above. Production integration must converge them on one public contract.

### Idle epochs and reclamation

Global idle starts a reclaim epoch. New managed work invalidates that epoch before it can reclaim against stale demand.

```text
BufferPool::record_global_idle()
    |
    +-- arm one 30-second deadline for the current activity epoch
    |
    +-- BufferPool::record_managed_activity() before expiry
    |       `-- invalidate the deadline and any reclaim retry
    |
    `-- deadline expires
            `-- capture one whole-block retention target for this epoch
                    `-- execute bounded reclaim passes until complete or blocked
```

The target takes one quarter of the configured whole-block ceiling, rounds down to complete blocks, and remains fixed across retries. A pool spanning fewer than four blocks therefore retains no warm block after the deadline instead of making reclamation a no-op. Each pass recomputes the current admission floor, so a stale target cannot reclaim capacity promised to reservations or held by owners.

Reclaim separates authorization from platform work:

```text
under admission serialization:
    recompute current floor
    select and recheck one all-free block
    remove that block from prepared capacity

without admission or maintenance-control locks:
    make the range inaccessible
    discard backing
```

Selection is only a hint. `BlockSlot::start_trim` remains the authority that closes the claim-trim gate and verifies the floor. A concurrent claim therefore either keeps the block active or loses its provisional bits before trim proceeds.

### Cleanup recovery and worker lifetime

A failed mapping transition leaves the affected slot nonclaimable and publishes a cleanup request. Cleanup generations prevent completion of an older retry from erasing newer work, and cleanup runs before idle reclaim because a failed protection transition can strand otherwise reusable capacity.

The first idle deadline or cleanup request starts one named maintenance thread. The worker waits on serialized state plus a condition variable, which coalesces repeated activity, deadlines, cleanup generations, and shutdown into current state instead of queueing stale events. It retains a `Weak<PoolInner>` while waiting, so maintenance alone cannot keep the pool alive. Final destruction requests a stop, wakes the worker, and joins it unless the worker temporarily owns the final pool reference and is performing its own teardown.

Thread creation failure disables maintenance without disabling allocation. The failure is logged under the memory telemetry target and reported as `maintenance_disabled` in diagnostics.

### Metrics and diagnostics

`BufferPool::metrics()` reads configured, promised, owned, prepared, and queued capacity under admission serialization. These values form one accounting sample. Preparation rounds its current floor up to complete blocks, adding less than one block beyond that floor; idle-only admission overage can also place prepared capacity above the normal configured ceiling.

`BufferPool::diagnostics()` answers different operational questions: whether claims are missing optimistic scans, whether fallback or rollback is frequent, how often blocks are prepared or reclaimed, how expensive trim selection is, and whether mapping cleanup or the worker is degraded. It briefly locks maintenance control to read permanent-disable state; its lifecycle fields come from a best-effort arena scan while the pool is active. Test audits make the same reconstruction authoritative only after the caller establishes quiescence.

## How to review

1. Follow `BufferPool::from_capacity` into `PoolConfig::resolve` and `PoolInner::new`. This establishes the memory policy, independent carrier and block geometry, and the guarantee that construction allocates no ranges or worker.
2. Follow `BufferPool::record_global_idle` and `BufferPool::record_managed_activity` into `MaintenanceState`. The state machine turns explicit scheduler events and time into reclaim or cleanup actions while rejecting stale epochs and cleanup completions.
3. Continue through `MaintenanceCoordinator::ensure_worker`, `wait_for_action`, and `worker_loop`. This shows lazy creation, condition-variable wakeups, weak pool ownership, spawn failure, and final shutdown before pool operations enter the picture.
4. Read `execute_maintenance`, `reclaim_to`, `Arena::start_trim`, and `TrimCleanup::finish` as one path. The important boundary is where admission authorizes removal and releases its lock before protection and discard.
5. Finish with `BlockSlot::sample_lifecycle`, `MemoryMetrics`, `MemoryDiagnostics`, and `PoolAuditReport`. These distinguish coherent accounting from a concurrent operational sample and from an exact externally quiescent audit.

The colocated state-machine tests exercise stale epochs, fixed retry targets, cleanup-generation races, disable, and stop. The native worker tests exercise timed wakeup, concurrent start, spawn failure, weak retention, and final-owner teardown. Loom composes claim, return, trim, cleanup, and shutdown transitions. Failure injection demonstrates that failed mapping transitions remain unavailable until recovery, while deliberate audit mismatches prove that the global reconciliation rejects accounting drift.

## Future

Global idle is the first reclamation trigger. Sustained demand that falls from a peak without reaching zero may retain peak prepared capacity. A later utilization-decay policy can reuse the same worker, admission floor, trim gate, and retry machinery if workload measurements show that retention matters in practice.

Carrier, block, and scan defaults remain measurement choices. The hardening pass will compare geometry using optimistic-hit and serialized-fallback rates, segment count, opaque-`Bytes` copies, mapping cost, reclaim behavior, and retained RSS, and will expand native platform qualification beyond the current Linux, macOS, Windows, and FreeBSD coverage.

The next integration PR will replace the legacy `MemoryBudget` path with this pool, settle one resolution contract for `MemoryBudgetConfig`, carry reservations through scheduler dispatch, copy ordinary Hyper frames into pooled staging, and expose the resulting memory state through the production transfer-manager surface.
